### PR TITLE
fix: deployment instructions and env variable for assets

### DIFF
--- a/apps/storefront/.env-example
+++ b/apps/storefront/.env-example
@@ -1,9 +1,29 @@
-VITE_B2B_URL=http://localhost:9000
-VITE_B2B_SOCKET_URL=http://localhost:9000
-VITE_TRANSLATION_SERVICE_URL=http://localhost:5000
+# URL of the B2B API, if doing local development, this should be the URL of the local B2B API with its own port
+VITE_B2B_URL=https://api.bundleb2b.net
+
+# URL of the B2B Socket - this should be the same as the B2B API URL
+VITE_B2B_SOCKET_URL=https://api.bundleb2b.net
+
+# URL of the B2B Translation Service - if doing local development, try with localhost:5000 or check the service URL
+VITE_TRANSLATION_SERVICE_URL=https://api.bundleb2b.net
+
+# CHANNEL ID of the storefront, if your store is multi-storefront, you can use this to specify the storefront - otherwise leave as 1
 VITE_CHANNEL_ID=1
-VITE_STORE_HASH=store_hash
+
+# Store hash of the storefront, this is the unique identifier of the storefront
+VITE_STORE_HASH="<YOUR_STORE_HASH>"
+
+# Captcha Site Key for the storefront 
 VITE_CATPCHA_SETKEY=captcha_setkey
-VITE_B2B_CLIENT_ID=client_id
-VITE_LOCAL_DEBUG="FALSE"
-VITE_LOCAL_GRAPHQL_ORIGIN="https://b2b-tunnel-<port>.bundleb2b.net"
+
+# Client ID issued by B2B Edition for the storefront
+VITE_B2B_CLIENT_ID=qxvapwlk4fbb9dyogdcxk9o50d9jqjo
+
+# Set this to TRUE to debug in your default storefront
+VITE_LOCAL_DEBUG=FALSE
+
+# URL where the GraphQL is hosted, usually the same one as B2B_URL_API. If the GraphQL API is hosted locally, set this to the local URL
+VITE_LOCAL_GRAPHQL_ORIGIN=https://api.bundleb2b.net
+
+# For building the app, set this to the absolute path where the compiled assets will be hosted
+VITE_ASSETS_ABSOLUTE_PATH="<YOUR_ASSETS_ABSOLUTE_PATH>"

--- a/apps/storefront/vite.config.ts
+++ b/apps/storefront/vite.config.ts
@@ -34,8 +34,11 @@ export default defineConfig(({ mode }) => {
         }
       ) {
         if (type === 'asset') {
+          const isCustom = env.VITE_ASSETS_ABSOLUTE_PATH !== undefined
           const name = filename.split('assets/')[1]
-          return `${assetsAbsolutePath[mode]}${name}`
+          return isCustom
+            ? `${env.VITE_ASSETS_ABSOLUTE_PATH}${name}`
+            : `${assetsAbsolutePath[mode]}${name}`
         }
 
         return undefined


### PR DESCRIPTION
## What?

Deployment instructions for external customers.

## Why?

Currently, BP external devs can't build a custom buyer portal as the vite build will autocomplete the path to the users domain name. This effort aims to provide a solution to the developers by: 


- Changing our example env values, point to production by default.
- Providing docs on how to deploy currently. **Note: This will change in the future and hopefully will take less manual by disabling B2B script injection and letting you write a BC script from a script template**

## Testing / Proof
Successful build

<img width="1078" alt="Screenshot 2024-04-17 at 4 22 15 p m" src="https://github.com/bigcommerce/b2b-buyer-portal/assets/140021227/8e8f1dd9-cb2f-44a1-adb7-38f6ba286b2c">

Custom domain in compiled index.js:
![image](https://github.com/bigcommerce/b2b-buyer-portal/assets/140021227/8cc9d60a-8253-46e8-9b74-5ac655b007d0)


## How can this change be undone in case of failure?
Revert
ping {suggested reviewers}
