### PR TITLE
fix: update CODEOWNERs to point to bigcommerce team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @B3BC/buyer-portal
+* @bigcommerce/b2b-buyer-portal


### PR DESCRIPTION
## What?

- update `CODEOWNERS` file to use the bigcommerce org team

## Why?

- currently github says the CODEOWNERS file is invalid.

## Testing / Proof

### Before:
![image](https://github.com/bigcommerce/b2b-buyer-portal/assets/95306190/69798e86-66fe-4bbb-94b6-2f262dbb3bcd)
### After:
![image](https://github.com/bigcommerce/b2b-buyer-portal/assets/95306190/8bdd07d6-0c61-4dce-8e4f-62287fa917fc)

## How can this change be undone in case of failure?

Revert PR

ping @bigcommerce/b2b-buyer-portal 