### PR TITLE
refactor(request): move api specific logic outside the fetch method

### DIFF
--- a/apps/storefront/src/shared/service/bc/api/cart.ts
+++ b/apps/storefront/src/shared/service/bc/api/cart.ts
@@ -2,23 +2,45 @@ import { baseUrl } from '../../../../utils/basicConfig';
 import B3Request from '../../request/b3Fetch';
 import { RequestType } from '../../request/base';
 
+interface Carts {
+  detail?: string;
+}
+
+const rejectResponsesWithDetail = (res: Carts) => {
+  if (res?.detail) {
+    return Promise.reject(res);
+  }
+
+  return Promise.resolve(res);
+};
+
 export const createCartHeadless = (data: CustomFieldItems) =>
-  B3Request.post(`${baseUrl}/api/storefront/carts`, RequestType.BCRest, data);
+  B3Request.post(`${baseUrl}/api/storefront/carts`, RequestType.BCRest, data).then(
+    rejectResponsesWithDetail,
+  );
 
 export const getCartInfo = () =>
-  B3Request.get(`${baseUrl}/api/storefront/carts`, RequestType.BCRest);
+  B3Request.get(`${baseUrl}/api/storefront/carts`, RequestType.BCRest).then(
+    rejectResponsesWithDetail,
+  );
 
 export const createCart = (data: CustomFieldItems) =>
-  B3Request.post(`${baseUrl}/api/storefront/carts`, RequestType.BCGraphql, data);
+  B3Request.post(`${baseUrl}/api/storefront/carts`, RequestType.BCGraphql, data).then(
+    rejectResponsesWithDetail,
+  );
 
 export const addProductToCart = (data: CustomFieldItems, cartId: string) =>
-  B3Request.post(`${baseUrl}/api/storefront/carts/${cartId}/items`, RequestType.BCRest, data);
+  B3Request.post(`${baseUrl}/api/storefront/carts/${cartId}/items`, RequestType.BCRest, data).then(
+    rejectResponsesWithDetail,
+  );
 
 export const getCartInfoWithOptions = () =>
   B3Request.get(
     `${baseUrl}/api/storefront/carts?include=lineItems.digitalItems.options,lineItems.physicalItems.options`,
     RequestType.BCRest,
-  );
+  ).then(rejectResponsesWithDetail);
 
 export const deleteCart = (cartId: string) =>
-  B3Request.delete(`${baseUrl}/api/storefront/carts/${cartId}`, RequestType.BCRest);
+  B3Request.delete(`${baseUrl}/api/storefront/carts/${cartId}`, RequestType.BCRest).then(
+    rejectResponsesWithDetail,
+  );

--- a/apps/storefront/src/shared/service/request/fetch.ts
+++ b/apps/storefront/src/shared/service/request/fetch.ts
@@ -1,22 +1,16 @@
-import { snackbar } from '@/utils';
-
-import { RequestType } from './base';
-
 const originFetch = window.fetch;
 
-const responseResult = (path: string, res: any, resolve: any, init: any) => {
-  if (path.includes('current.jwt')) return res.text();
-
+const responseResult = (res: Response, resolve: (val?: unknown) => void, init: RequestInit) => {
   if (init.method === 'DELETE') {
     resolve();
   }
   return res.json();
 };
 
-function b3Fetch(path: string, init: any, type?: string, customMessage = false) {
+function b3Fetch(path: string, init: RequestInit): any {
   return new Promise((resolve, reject) => {
     originFetch(path, init)
-      .then((res: Response) => responseResult(path, res, resolve, init))
+      .then((res: Response) => responseResult(res, resolve, init))
       .then(async (res) => {
         if (res?.code === 500) {
           const data = res?.data || {};
@@ -24,28 +18,8 @@ function b3Fetch(path: string, init: any, type?: string, customMessage = false) 
           reject(message);
           return;
         }
-        if (type === RequestType.BCRest && path.includes('api/storefront/carts')) {
-          if (res?.detail) {
-            reject(res);
-          }
-        }
-        if (type === RequestType.B2BGraphql) {
-          const errors = res?.errors?.length ? res.errors[0] : {};
-          const { message = '', extensions = {} } = errors;
-          if (extensions.code === 40101) {
-            window.location.href = '#/login?loginFlag=3&showTip=false';
-            snackbar.error(message);
-          } else if (message) {
-            reject(message);
-            if (!customMessage) {
-              snackbar.error(message);
-            }
-          } else {
-            resolve(res.data);
-          }
-        } else {
-          resolve(res);
-        }
+
+        resolve(res);
       })
       .catch((err: Error) => {
         reject(err);


### PR DESCRIPTION
## What?

Move logic that is specific to a particular type of endpoint outside the generic fetch function.

## Why?

This type of coupling is messy, making it hard to reason about the way fetch works.
Moving this out makes each execution path easier to follow.

## Testing / Proof

When I learn how to run the functional tests, I will.
For the most part, this is just copy/paste.

## How can this change be undone in case of failure?

Revert.

@bigcommerce/b2b-buyer-portal
