### PR TITLE
chore: remove unused .prettierrc

### DIFF
--- a/apps/storefront/src/types/.prettierrc
+++ b/apps/storefront/src/types/.prettierrc
@@ -1,5 +1,0 @@
-{
-  "printWidth": 100,
-  "singleQuote": true,
-  "trailingComma": "all"
-}

--- a/apps/storefront/src/utils/.prettierrc
+++ b/apps/storefront/src/utils/.prettierrc
@@ -1,5 +1,0 @@
-{
-  "printWidth": 100,
-  "singleQuote": true,
-  "trailingComma": "all"
-}


### PR DESCRIPTION


## What?

Remove unused prettierrc files.

## Why?

These are no longer necessary, the configuration is set in package.json

## Testing / Proof

n/a

## How can this change be undone in case of failure?
Revert

@bigcommerce/b2b-buyer-portal
