### PR TITLE
fix: use lodash-es in QuoteDetails instead of lodash

### DIFF
--- a/apps/storefront/src/pages/quote/QuoteDetail.tsx
+++ b/apps/storefront/src/pages/quote/QuoteDetail.tsx
@@ -3,8 +3,7 @@ import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import { useB3Lang } from '@b3/lang';
 import { Box, Button, Grid } from '@mui/material';
 import copy from 'copy-to-clipboard';
-// eslint-disable-next-line import/no-extraneous-dependencies
-import { get } from 'lodash';
+import { get } from 'lodash-es';
 
 import B3Sping from '@/components/spin/B3Sping';
 import { useMobile } from '@/hooks';


### PR DESCRIPTION
## What?

Use `get` from `lodash-es` instead of `lodash`.

## Why?

Using the `-es` version allows vite to tree shake lodash, reducing the size of this module dramatically.

## Testing / Proof

Before:
<img width="683" alt="image" src="https://github.com/bigcommerce/b2b-buyer-portal/assets/4542735/d407336f-5a1f-4204-895a-e9640305093c">

After:
<img width="352" alt="image" src="https://github.com/bigcommerce/b2b-buyer-portal/assets/4542735/1fb92e15-47ff-4b97-aef1-db554f568ba6">


## How can this change be undone in case of failure?

Revert this PR

@bigcommerce/b2b-buyer-portal
