### PR TITLE
fix: add role=progressbar for loading indicators

### DIFF
--- a/apps/storefront/src/components/loading/Loading.tsx
+++ b/apps/storefront/src/components/loading/Loading.tsx
@@ -24,6 +24,7 @@ function Loading({ backColor }: LoadingProps) {
       }}
     >
       <Typography
+        role="progressbar"
         sx={{
           position: 'absolute',
           top: '50%',

--- a/apps/storefront/src/components/spin/B3Sping.tsx
+++ b/apps/storefront/src/components/spin/B3Sping.tsx
@@ -44,9 +44,12 @@ export default function B3Sping(props: B3SpingProps) {
     <SpinContext isFlex={isFlex} height={spinningHeight}>
       {isSpinning && (
         <SpinCenter background={background} isMobile={isMobile} transparency={transparency}>
-          {!isCloseLoading && <CircularProgress size={size || 40} thickness={thickness || 2} />}
+          {!isCloseLoading && (
+            <CircularProgress role="progressbar" size={size || 40} thickness={thickness || 2} />
+          )}
           {tip && (
             <SpinTip
+              role="progressbar"
               style={{
                 color: primaryColor,
               }}


### PR DESCRIPTION
## What?

- add role=progressbar to loading indicators / text

## Why?

- allows our e2e test to properly wait
- follows the [accessibility standards](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/progressbar_role)

## Testing / Proof



## How can this change be undone in case of failure?

Revert

@bigcommerce/b2b-buyer-portal
