### PR TITLE
fix: memoize b3lang to avoid re-renders

### DIFF
--- a/apps/storefront/src/pages/orderDetail/OrderDetail.tsx
+++ b/apps/storefront/src/pages/orderDetail/OrderDetail.tsx
@@ -257,7 +257,7 @@ function OrderDetail() {
             >
               {b3Lang('orderDetail.orderId', { orderId })}
               {b3Lang('orderDetail.purchaseOrderNumber', {
-                purchaseOrderNumber: poNumber,
+                purchaseOrderNumber: poNumber ?? '',
               })}
             </Typography>
             <OrderStatus code={status} text={getOrderStatusLabel(status)} />

--- a/apps/storefront/src/pages/orderDetail/components/OrderAction.tsx
+++ b/apps/storefront/src/pages/orderDetail/components/OrderAction.tsx
@@ -315,7 +315,7 @@ export default function OrderAction(props: OrderActionProps) {
       city,
     } = billingAddress || {};
     const paymentAddress = {
-      paymentMethod: b3Lang('orderDetail.paymentMethod', { paymentMethod }),
+      paymentMethod: b3Lang('orderDetail.paymentMethod', { paymentMethod: paymentMethod ?? '' }),
       name: b3Lang('orderDetail.customerName', { firstName, lastName }),
       company: getCompanyName(company),
       street: street1,

--- a/apps/storefront/src/pages/registered/RegisteredBCToB2B.tsx
+++ b/apps/storefront/src/pages/registered/RegisteredBCToB2B.tsx
@@ -456,7 +456,7 @@ export default function RegisteredBCToB2B(props: RegisteredProps) {
       setError(attachmentsFilesFiled.name, {
         type: 'required',
         message: b3Lang('global.validate.required', {
-          label: attachmentsFilesFiled.label,
+          label: attachmentsFilesFiled.label ?? '',
         }),
       });
 

--- a/apps/storefront/src/pages/registered/RegisteredDetail.tsx
+++ b/apps/storefront/src/pages/registered/RegisteredDetail.tsx
@@ -190,7 +190,7 @@ export default function RegisteredDetail(props: RegisteredDetailProps) {
         setError(attachmentsFilesFiled.name, {
           type: 'required',
           message: b3Lang('global.validate.required', {
-            label: attachmentsFilesFiled.label,
+            label: attachmentsFilesFiled.label ?? '',
           }),
         });
 

--- a/apps/storefront/src/pages/registered/RegisteredFinish.tsx
+++ b/apps/storefront/src/pages/registered/RegisteredFinish.tsx
@@ -39,7 +39,7 @@ export default function RegisteredFinish(props: {
       return isAutoApproval ? (
         <StyleTipContainer>
           {b3Lang('global.registerFinish.autoApproved.tip', {
-            storeName,
+            storeName: storeName ?? '',
           })}
         </StyleTipContainer>
       ) : (
@@ -71,7 +71,7 @@ export default function RegisteredFinish(props: {
       return (
         <StyleTipContainer>
           {b3Lang('global.registerFinish.bcSuccess.tip', {
-            storeName,
+            storeName: storeName ?? '',
           })}
         </StyleTipContainer>
       );

--- a/apps/storefront/src/utils/b3DateFormat/index.ts
+++ b/apps/storefront/src/utils/b3DateFormat/index.ts
@@ -4,13 +4,15 @@ import { store } from '@/store/reducer.js';
 
 import DateFormatter from './php-date-format.js';
 
-type DisplatyType = 'display' | 'extendedDisplay';
+type DisplayType = 'display' | 'extendedDisplay';
 
 const fmt = new DateFormatter();
 
+type Handler = 'formatDate' | 'parseDate';
+
 const formatCreator =
-  (displayType: DisplatyType, handler: string, useOffset = true) =>
-  (timestamp: string | number, isDateStr = false) => {
+  (displayType: DisplayType, handler: Handler, useOffset = true) =>
+  (timestamp: string | number, isDateStr = false): string | number | Date => {
     const { timeFormat } = store.getState().storeInfo;
     const dateFormat = merge(
       {
@@ -21,6 +23,7 @@ const formatCreator =
       },
       timeFormat,
     );
+
     const display = dateFormat[displayType];
 
     if (!timestamp) return '';
@@ -38,7 +41,7 @@ const formatCreator =
       case 'parseDate':
         return fmt.parseDate(dateObject, display) || '';
       default:
-        return null;
+        throw new Error('Invalid value');
     }
   };
 

--- a/packages/lang/useB3Lang.ts
+++ b/packages/lang/useB3Lang.ts
@@ -1,26 +1,22 @@
+import { useCallback } from 'react';
 import { useIntl } from 'react-intl';
 
 export type LangFormatFunction = (
   id: string,
-  // TODO: If we pass `undefined | null`, the translation will probably be not correct.
-  // Ensure code using the values parameter do not pass `undefined | null`.
-  values?: Record<string, string | number | Date | undefined | null>,
+  values?: Record<string, string | number | Date>,
 ) => string;
 
 export const useB3Lang: () => LangFormatFunction = () => {
   const intl = useIntl();
 
-  return (id, values) => {
-    if (!id) {
-      return '';
-    }
+  return useCallback(
+    (id, values) => {
+      if (!id) {
+        return '';
+      }
 
-    return intl.formatMessage(
-      {
-        id,
-        defaultMessage: id,
-      },
-      values,
-    );
-  };
+      return intl.formatMessage({ id, defaultMessage: id }, values);
+    },
+    [intl],
+  );
 };


### PR DESCRIPTION
## What?

Wrap the b3lang function in a `useCallback` to avoid re-renders.

## Why?

A lot of the re-renders that the app suffers are due to the b3lang function not being memoized.

After this change we should be able to remove some of the ignores for `react-hooks/exhaustive-deps`.

## Testing / Proof

This is a fairly innocuous change.

## How can this change be undone in case of failure?

Revert this PR.

@bigcommerce/b2b-buyer-portal
