### PR TITLE
refactor: use useRef instead of useState to define dropdown/popover targets

### DIFF
--- a/apps/storefront/src/components/B3DropDown.tsx
+++ b/apps/storefront/src/components/B3DropDown.tsx
@@ -1,4 +1,4 @@
-import { MouseEvent, useState } from 'react';
+import { useRef, useState } from 'react';
 import { useB3Lang } from '@b3/lang';
 import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
 import ArrowDropUpIcon from '@mui/icons-material/ArrowDropUp';
@@ -32,28 +32,16 @@ export default function B3DropDown<T>({
   value,
   handleItemClick,
 }: B3DropDownProps<T>) {
-  const [open, setOpen] = useState<null | HTMLElement>(null);
+  const [isMobile] = useMobile();
+  const [isOpen, setIsOpen] = useState(false);
+  const ref = useRef<HTMLDivElement | null>(null);
   const b3Lang = useB3Lang();
 
-  const handleClick = (event: MouseEvent<HTMLElement>) => {
-    setOpen(event.currentTarget);
-  };
-
-  const handleCloseMenuClick = () => {
-    setOpen(null);
+  const close = () => {
+    setIsOpen(false);
   };
 
   const keyName = config?.name || 'name';
-
-  const [isMobile] = useMobile();
-
-  const sx = isMobile
-    ? {
-        width: 'auto',
-      }
-    : {
-        width: width || '155px',
-      };
 
   return (
     <Box
@@ -62,7 +50,8 @@ export default function B3DropDown<T>({
       }}
     >
       <ListItemButton
-        onClick={handleClick}
+        ref={ref}
+        onClick={() => setIsOpen(true)}
         sx={{
           pr: 0,
         }}
@@ -76,11 +65,11 @@ export default function B3DropDown<T>({
             },
           }}
         />
-        {open ? <ArrowDropUpIcon /> : <ArrowDropDownIcon />}
+        {isOpen ? <ArrowDropUpIcon /> : <ArrowDropDownIcon />}
       </ListItemButton>
       <Menu
-        anchorEl={open}
-        open={Boolean(open)}
+        anchorEl={ref.current}
+        open={isOpen}
         anchorOrigin={{
           vertical: 'bottom',
           horizontal: 'right',
@@ -91,7 +80,7 @@ export default function B3DropDown<T>({
         }}
         id="customized-menu"
         keepMounted
-        onClose={handleCloseMenuClick}
+        onClose={close}
         sx={{
           '& .MuiList-root.MuiList-padding.MuiMenu-list': {
             pt: isMobile ? 0 : '8px',
@@ -107,11 +96,11 @@ export default function B3DropDown<T>({
               <MenuItem
                 sx={{
                   color,
-                  ...sx,
+                  width: isMobile ? 'auto' : width || '155px',
                 }}
                 key={name}
                 onClick={() => {
-                  handleCloseMenuClick();
+                  close();
                   handleItemClick(item);
                 }}
               >

--- a/apps/storefront/src/components/button/CustomButton.tsx
+++ b/apps/storefront/src/components/button/CustomButton.tsx
@@ -1,4 +1,4 @@
-import { MouseEvent } from 'react';
+import { forwardRef, MouseEvent } from 'react';
 import { Button, ButtonProps, SxProps } from '@mui/material';
 
 interface CustomButtonProps extends ButtonProps {
@@ -8,17 +8,21 @@ interface CustomButtonProps extends ButtonProps {
   children: React.ReactNode;
 }
 
-function CustomButton({ onClick, sx, children, ...rest }: CustomButtonProps) {
-  return (
-    <Button
-      {...rest}
-      sx={{
-        ...(sx || {}),
-      }}
-      onClick={onClick}
-    >
-      {children}
-    </Button>
-  );
-}
+const CustomButton = forwardRef<HTMLButtonElement, CustomButtonProps>(
+  ({ onClick, sx, children, ...rest }, ref) => {
+    return (
+      <Button
+        ref={ref}
+        {...rest}
+        sx={{
+          ...(sx || {}),
+        }}
+        onClick={onClick}
+      >
+        {children}
+      </Button>
+    );
+  },
+);
+
 export default CustomButton;

--- a/apps/storefront/src/components/upload/BulkUploadTable.tsx
+++ b/apps/storefront/src/components/upload/BulkUploadTable.tsx
@@ -1,4 +1,4 @@
-import { MouseEvent, useState } from 'react';
+import { useRef, useState } from 'react';
 import { InsertDriveFile, MoreHoriz } from '@mui/icons-material';
 import { Box, Button, Link, Menu, MenuItem, Tab, Tabs, Typography } from '@mui/material';
 import { styled } from '@mui/material/styles';
@@ -129,18 +129,16 @@ function BulkUploadTable(props: BulkUploadTableProps) {
 
   const errorProduct = fileDatas?.errorProduct || [];
   const validProduct = fileDatas?.validProduct || [];
-  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
-  const [open, setOpen] = useState<boolean>(Boolean(anchorEl));
+  const ref = useRef<HTMLButtonElement | null>(null);
+  const [isOpen, setIsOpen] = useState(false);
   const [activeTab, setActiveTab] = useState<string>(errorProduct.length > 0 ? 'error' : 'valid');
 
-  const handleOpenBtnList = (e: MouseEvent<HTMLButtonElement>) => {
-    setAnchorEl(e.currentTarget);
-    setOpen(true);
+  const handleOpenBtnList = () => {
+    setIsOpen(true);
   };
 
   const handleClose = () => {
-    setAnchorEl(null);
-    setOpen(false);
+    setIsOpen(false);
   };
 
   const handleRemoveCsv = () => {
@@ -203,8 +201,9 @@ function BulkUploadTable(props: BulkUploadTableProps) {
           sx={{
             color: 'rgba(0, 0, 0, 0.54)',
           }}
-          onClick={(e) => {
-            handleOpenBtnList(e);
+          ref={ref}
+          onClick={() => {
+            handleOpenBtnList();
           }}
         >
           <MoreHoriz
@@ -214,7 +213,7 @@ function BulkUploadTable(props: BulkUploadTableProps) {
           />
         </Button>
 
-        <Menu anchorEl={anchorEl} open={open} onClose={handleClose}>
+        <Menu anchorEl={ref.current} open={isOpen} onClose={handleClose}>
           <MenuItem
             onClick={() => {
               handleRemoveCsv();

--- a/apps/storefront/src/pages/dashboard/Dashboard.tsx
+++ b/apps/storefront/src/pages/dashboard/Dashboard.tsx
@@ -1,4 +1,4 @@
-import { Dispatch, MouseEvent, SetStateAction, useContext, useEffect, useState } from 'react';
+import { Dispatch, SetStateAction, useContext, useEffect, useRef, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import { useB3Lang } from '@b3/lang';
 import MoreHorizIcon from '@mui/icons-material/MoreHoriz';
@@ -52,18 +52,14 @@ const StyledMenu = styled(Menu)(() => ({
 }));
 
 function B3Mean({ isMasquerade, handleSelect, startActing, endActing }: B3MeanProps) {
-  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+  const ref = useRef<HTMLButtonElement | null>(null);
+  const [isOpen, setIsOpen] = useState(false);
 
-  const open = Boolean(anchorEl);
   const b3Lang = useB3Lang();
 
-  const handleClose = () => {
-    setAnchorEl(null);
-  };
-
-  const handleMoreActionsClick = (event: MouseEvent<HTMLButtonElement>) => {
+  const handleOpen = () => {
     handleSelect();
-    setAnchorEl(event.currentTarget);
+    setIsOpen(true);
   };
 
   const menuItemText = isMasquerade
@@ -72,14 +68,14 @@ function B3Mean({ isMasquerade, handleSelect, startActing, endActing }: B3MeanPr
 
   return (
     <>
-      <IconButton onClick={(e) => handleMoreActionsClick(e)}>
+      <IconButton onClick={handleOpen} ref={ref}>
         <MoreHorizIcon />
       </IconButton>
       <StyledMenu
         id="basic-menu"
-        anchorEl={anchorEl}
-        open={open}
-        onClose={handleClose}
+        anchorEl={ref.current}
+        open={isOpen}
+        onClose={() => setIsOpen(false)}
         MenuListProps={{
           'aria-labelledby': 'basic-button',
         }}
@@ -100,9 +96,10 @@ function B3Mean({ isMasquerade, handleSelect, startActing, endActing }: B3MeanPr
             if (isMasquerade) {
               endActing();
             } else {
-              setAnchorEl(null);
               startActing();
             }
+
+            setIsOpen(false);
           }}
         >
           {menuItemText}

--- a/apps/storefront/src/pages/invoice/components/B3Pulldown.tsx
+++ b/apps/storefront/src/pages/invoice/components/B3Pulldown.tsx
@@ -1,4 +1,4 @@
-import { MouseEvent, useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useB3Lang } from '@b3/lang';
 import MoreHorizIcon from '@mui/icons-material/MoreHoriz';
@@ -37,29 +37,28 @@ function B3Pulldown({
   const role = useAppSelector(({ company }) => company.customer.role);
   const isAgenting = useAppSelector(({ b2bFeatures }) => b2bFeatures.masqueradeCompany.isAgenting);
   const juniorOrSenior = +role === 1 || role === 2;
-  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+  const ref = useRef<HTMLButtonElement | null>(null);
+  const [isOpen, setIsOpen] = useState(false);
   const [isCanPay, setIsCanPay] = useState<boolean>(true);
 
   const navigate = useNavigate();
 
-  const open = Boolean(anchorEl);
-
   const b3Lang = useB3Lang();
 
-  const handleClose = () => {
-    setAnchorEl(null);
+  const close = () => {
+    setIsOpen(false);
   };
 
-  const handleMoreActionsClick = (event: MouseEvent<HTMLButtonElement>) => {
+  const handleMoreActionsClick = () => {
     const { id } = row;
     setInvoiceId(id);
-    setAnchorEl(event.currentTarget);
+    setIsOpen(true);
   };
 
   const handleViewInvoice = async (isPayNow: boolean) => {
     const { id } = row;
 
-    setAnchorEl(null);
+    close();
 
     setIsRequestLoading(true);
 
@@ -82,12 +81,12 @@ function B3Pulldown({
 
   const handleViewOrder = () => {
     const { orderNumber } = row;
-    setAnchorEl(null);
+    close();
     navigate(`/orderDetail/${orderNumber}`);
   };
 
   const handlePay = async () => {
-    setAnchorEl(null);
+    close();
 
     const { openBalance, originalBalance, id } = row;
 
@@ -113,14 +112,14 @@ function B3Pulldown({
   };
 
   const viewPaymentHistory = async () => {
-    setAnchorEl(null);
+    close();
     handleOpenHistoryModal(true);
   };
 
   const handleDownloadPDF = async () => {
     const { id } = row;
 
-    setAnchorEl(null);
+    close();
     setIsRequestLoading(true);
     const url = await getInvoiceDownloadPDFUrl(id);
 
@@ -144,14 +143,14 @@ function B3Pulldown({
 
   return (
     <>
-      <IconButton onClick={(e) => handleMoreActionsClick(e)}>
+      <IconButton onClick={handleMoreActionsClick} ref={ref}>
         <MoreHorizIcon />
       </IconButton>
       <StyledMenu
         id="basic-menu"
-        anchorEl={anchorEl}
-        open={open}
-        onClose={handleClose}
+        anchorEl={ref.current}
+        open={isOpen}
+        onClose={close}
         MenuListProps={{
           'aria-labelledby': 'basic-button',
         }}

--- a/apps/storefront/src/pages/orderDetail/components/OrderAction.tsx
+++ b/apps/storefront/src/pages/orderDetail/components/OrderAction.tsx
@@ -443,6 +443,7 @@ export default function OrderAction(props: OrderActionProps) {
             role={role}
             ipStatus={ipStatus}
             invoiceId={invoiceId}
+            key={item.key}
           />
         ))}
     </OrderActionContainer>

--- a/apps/storefront/src/pages/quickorder/components/QuickOrderFooter.tsx
+++ b/apps/storefront/src/pages/quickorder/components/QuickOrderFooter.tsx
@@ -1,4 +1,4 @@
-import { Dispatch, MouseEvent, SetStateAction, useContext, useEffect, useState } from 'react';
+import { Dispatch, SetStateAction, useContext, useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useB3Lang } from '@b3/lang';
 import { ArrowDropDown } from '@mui/icons-material';
@@ -116,12 +116,12 @@ function QuickOrderFooter(props: QuickOrderFooterProps) {
 
   const isDesktopLimit = useMediaQuery('(min-width:1775px)');
   const [isMobile] = useMobile();
-  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
-  const [open, setOpen] = useState<boolean>(Boolean(anchorEl));
-  const [selectedSubTotal, setSelectedSubTotal] = useState<number>(0.0);
-  const [openShoppingList, setOpenShoppingList] = useState<boolean>(false);
-  const [isOpenCreateShopping, setIsOpenCreateShopping] = useState<boolean>(false);
-  const [isShoppingListLoading, setIisShoppingListLoading] = useState<boolean>(false);
+  const ref = useRef<HTMLButtonElement | null>(null);
+  const [isOpen, setIsOpen] = useState(false);
+  const [selectedSubTotal, setSelectedSubTotal] = useState(0.0);
+  const [openShoppingList, setOpenShoppingList] = useState(false);
+  const [isOpenCreateShopping, setIsOpenCreateShopping] = useState(false);
+  const [isShoppingListLoading, setIisShoppingListLoading] = useState(false);
 
   const customerGroupId = useAppSelector((state) => state.company.customer.customerGroupId);
 
@@ -136,18 +136,16 @@ function QuickOrderFooter(props: QuickOrderFooterProps) {
         alignItems: 'center',
       };
 
-  const handleOpenBtnList = (e: MouseEvent<HTMLButtonElement>) => {
+  const handleOpenBtnList = () => {
     if (checkedArr.length === 0) {
       snackbar.error(b3Lang('purchasedProducts.error.selectOneItem'));
     } else {
-      setAnchorEl(e.currentTarget);
-      setOpen(true);
+      setIsOpen(true);
     }
   };
 
   const handleClose = () => {
-    setAnchorEl(null);
-    setOpen(false);
+    setIsOpen(false);
   };
 
   // Add selected to cart
@@ -675,6 +673,7 @@ function QuickOrderFooter(props: QuickOrderFooterProps) {
                 >
                   <CustomButton
                     variant="contained"
+                    ref={ref}
                     onClick={handleOpenBtnList}
                     sx={{
                       marginRight: isMobile ? '1rem' : 0,
@@ -687,8 +686,8 @@ function QuickOrderFooter(props: QuickOrderFooterProps) {
 
                   <Menu
                     id="basic-menu"
-                    anchorEl={anchorEl}
-                    open={open}
+                    anchorEl={ref.current}
+                    open={isOpen}
                     onClose={handleClose}
                     MenuListProps={{
                       'aria-labelledby': 'basic-button',

--- a/apps/storefront/src/pages/shoppingListDetails/components/ShoppingDetailFooter.tsx
+++ b/apps/storefront/src/pages/shoppingListDetails/components/ShoppingDetailFooter.tsx
@@ -1,4 +1,4 @@
-import { MouseEvent, useContext, useState } from 'react';
+import { useContext, useRef, useState } from 'react';
 import { useB3Lang } from '@b3/lang';
 import { ArrowDropDown, Delete } from '@mui/icons-material';
 import { Box, Grid, Menu, MenuItem, Typography } from '@mui/material';
@@ -82,9 +82,8 @@ function ShoppingDetailFooter(props: ShoppingDetailFooterProps) {
   const isAgenting = useAppSelector(({ b2bFeatures }) => b2bFeatures.masqueradeCompany.isAgenting);
   const companyId = useAppSelector(({ company }) => company.companyInfo.id);
   const customerGroupId = useAppSelector(({ company }) => company.customer.customerGroupId);
-
-  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
-  const [open, setOpen] = useState<boolean>(Boolean(anchorEl));
+  const ref = useRef<HTMLButtonElement | null>(null);
+  const [isOpen, setIsOpen] = useState(false);
 
   const cartEntityId = Cookies.get('cartId');
 
@@ -111,18 +110,16 @@ function ShoppingDetailFooter(props: ShoppingDetailFooterProps) {
     customColor,
   } = props;
 
-  const handleOpenBtnList = (e: MouseEvent<HTMLButtonElement>) => {
+  const handleOpenBtnList = () => {
     if (checkedArr.length === 0) {
       snackbar.error(b3Lang('shoppingList.footer.selectOneItem'));
     } else {
-      setAnchorEl(e.currentTarget);
-      setOpen(true);
+      setIsOpen(true);
     }
   };
 
   const handleClose = () => {
-    setAnchorEl(null);
-    setOpen(false);
+    setIsOpen(false);
   };
 
   const verifyInventory = (inventoryInfos: ProductsProps[]) => {
@@ -629,6 +626,7 @@ function ShoppingDetailFooter(props: ShoppingDetailFooterProps) {
                       <CustomButton
                         variant="contained"
                         onClick={handleOpenBtnList}
+                        ref={ref}
                         sx={{
                           marginRight: isMobile ? '1rem' : 0,
                           width: isMobile ? '100%' : 'auto',
@@ -639,8 +637,8 @@ function ShoppingDetailFooter(props: ShoppingDetailFooterProps) {
                       </CustomButton>
                       <Menu
                         id="basic-menu"
-                        anchorEl={anchorEl}
-                        open={open}
+                        anchorEl={ref.current}
+                        open={isOpen}
                         onClose={handleClose}
                         MenuListProps={{
                           'aria-labelledby': 'basic-button',


### PR DESCRIPTION
## What?

Replace `useState` with `useRef` when defining popover/dropdown targets.

## Why?

Using useState, removes the target upon closing, which impedes animations. This is also not the best practice in terms of storing/passing elements around.

## Testing / Proof

https://github.com/bigcommerce/b2b-buyer-portal/assets/4542735/b851b071-1b31-4552-acb4-fa2b56c0c994

## How can this change be undone in case of failure?

Revert this PR

@bigcommerce/b2b-buyer-portal
