### PR TITLE
fix: forgot password redirect issue

### DIFF
--- a/apps/storefront/src/utils/b3logout.ts
+++ b/apps/storefront/src/utils/b3logout.ts
@@ -9,7 +9,7 @@ export const logoutSession = () => {
 };
 
 export const isB2bTokenPage = (gotoUrl?: string) => {
-  const noB2bTokenPages = ['quoteDraft', 'quoteDetail', 'register', 'login'];
+  const noB2bTokenPages = ['quoteDraft', 'quoteDetail', 'register', 'login', 'forgotpassword'];
 
   if (gotoUrl) {
     return !noB2bTokenPages.some((item: string) => gotoUrl.includes(item));


### PR DESCRIPTION
Jira: [BUN-2129](https://bigc-b2b.atlassian.net/browse/BUN-2129)

## What/Why?
Right now the password reset url we get from emails if failing due to a redirect when user needs to set up a new password. I added forgotPassword url to isB2bTokenPage array to avoid the validation of required login for this page.

## Rollout/Rollback
Revert PR

## Testing
Create a new company via the dashboard app and when you get the email to reset the password it redirects the user to the login page instead of letting them set up the password.

Before: 

https://github.com/bigcommerce/b2b-buyer-portal/assets/4503787/4a0bcbaa-c88d-4bf3-88aa-3f14e9f88836

After:

https://github.com/bigcommerce/b2b-buyer-portal/assets/4503787/bde240d8-04f5-4cc4-86ed-9a7d918ccd9c
