### PR TITLE
refactor: remove unnecessary isVisible from the LoginWidget component

### DIFF
--- a/apps/storefront/src/pages/Login/LoginPanel.tsx
+++ b/apps/storefront/src/pages/Login/LoginPanel.tsx
@@ -41,7 +41,6 @@ function LoginPanel(props: LoginPanelProps) {
             },
           },
         }}
-        isVisible
         html={widgetBodyText}
       />
       <Box

--- a/apps/storefront/src/pages/Login/component/LoginWidget.tsx
+++ b/apps/storefront/src/pages/Login/component/LoginWidget.tsx
@@ -1,15 +1,14 @@
 import { Box, SxProps } from '@mui/material';
 
 interface LoginWidgetProps {
-  isVisible: boolean;
   sx: SxProps;
   html: string;
 }
 
 function LoginWidget(props: LoginWidgetProps) {
-  const { isVisible, html, sx } = props;
+  const { html, sx } = props;
 
-  return isVisible ? (
+  return (
     <Box
       sx={{
         ...sx,
@@ -18,7 +17,7 @@ function LoginWidget(props: LoginWidgetProps) {
         __html: html,
       }}
     />
-  ) : null;
+  );
 }
 
 export default LoginWidget;

--- a/apps/storefront/src/pages/Login/config.ts
+++ b/apps/storefront/src/pages/Login/config.ts
@@ -13,17 +13,14 @@ export type LoginConfig = {
 };
 
 export interface LoginInfoInit {
-  isShowWidgetHead: boolean;
-  isShowWidgetBody?: boolean;
-  isShowWidgetFooter: boolean;
   loginTitle: string;
   loginBtn?: string;
   createAccountPanelTittle?: string;
   CreateAccountButtonText: string;
   btnColor: string;
-  widgetHeadText: string;
+  widgetHeadText?: string;
   widgetBodyText: string;
-  widgetFooterText: string;
+  widgetFooterText?: string;
   displayStoreLogo: boolean;
 }
 

--- a/apps/storefront/src/pages/Login/index.tsx
+++ b/apps/storefront/src/pages/Login/index.tsx
@@ -36,18 +36,14 @@ import { LoginContainer, LoginImage } from './styled';
 
 const initialLoginInfo = {
   loginTitle: 'Sign In',
-  isShowWidgetHead: false,
-  isShowWidgetBody: false,
-  isShowWidgetFooter: false,
   loginBtn: 'Sign in',
   createAccountPanelTittle: 'Create Account Panel Title',
   CreateAccountButtonText: 'Create Account',
   btnColor: 'red',
-  widgetHeadText: '',
   widgetBodyText: '',
-  widgetFooterText: '',
   displayStoreLogo: false,
 };
+
 interface RegisteredProps {
   setOpenPage: Dispatch<SetStateAction<OpenPageState>>;
 }
@@ -113,11 +109,9 @@ export default function Login(props: RegisteredProps) {
           loginBtn: signInButtonText || b3Lang('login.button.signInUppercase'),
           CreateAccountButtonText: createAccountButtonText || b3Lang('login.button.createAccount'),
           btnColor: primaryButtonColor || '',
-          isShowWidgetHead: topHtmlRegionEnabled || false,
-          widgetHeadText: topHtmlRegionHtml || '',
+          widgetHeadText: topHtmlRegionEnabled ? topHtmlRegionHtml : undefined,
           widgetBodyText: createAccountPanelHtml || defaultCreateAccountPanel,
-          isShowWidgetFooter: bottomHtmlRegionEnabled || false,
-          widgetFooterText: bottomHtmlRegionHtml || '',
+          widgetFooterText: bottomHtmlRegionEnabled ? bottomHtmlRegionHtml : undefined,
           displayStoreLogo: displayStoreLogo || false,
         };
 
@@ -396,7 +390,6 @@ export default function Login(props: RegisteredProps) {
                       minHeight: '48px',
                       width: registerEnabled || isMobile ? '100%' : '50%',
                     }}
-                    isVisible={loginInfo.isShowWidgetHead}
                     html={loginInfo.widgetHeadText}
                   />
                 )}
@@ -467,7 +460,6 @@ export default function Login(props: RegisteredProps) {
                       minHeight: '48px',
                       width: registerEnabled || isMobile ? '100%' : '50%',
                     }}
-                    isVisible={loginInfo.isShowWidgetFooter}
                     html={loginInfo.widgetFooterText}
                   />
                 )}


### PR DESCRIPTION
## What/Why?
Remove unnecessary prop, if we don't want to show the component, we should just not render it.

## Rollout/Rollback
Revert

## Testing
TS + Manual checks