### PR TITLE
fix: shopping list description bun2621

### DIFF
--- a/apps/storefront/src/pages/ShoppingListDetails/index.tsx
+++ b/apps/storefront/src/pages/ShoppingListDetails/index.tsx
@@ -230,7 +230,7 @@ function ShoppingListDetails({ setOpenPage }: ShoppingListDetailsProps) {
       const params: UpdateShoppingListParamsProps = {
         id: +id,
         name: shoppingListInfo?.name || '',
-        description: shoppingListInfo?.description || '',
+        description: shoppingListInfo?.description.split('\n').join('\\n') || '',
       };
 
       if (isB2BUser) {

--- a/apps/storefront/src/pages/ShoppingListDetails/index.tsx
+++ b/apps/storefront/src/pages/ShoppingListDetails/index.tsx
@@ -230,7 +230,7 @@ function ShoppingListDetails({ setOpenPage }: ShoppingListDetailsProps) {
       const params: UpdateShoppingListParamsProps = {
         id: +id,
         name: shoppingListInfo?.name || '',
-        description: shoppingListInfo?.description.split('\n').join('\\n') || '',
+        description: shoppingListInfo?.description || '',
       };
 
       if (isB2BUser) {

--- a/apps/storefront/src/pages/ShoppingLists/AddEditShoppingLists.tsx
+++ b/apps/storefront/src/pages/ShoppingLists/AddEditShoppingLists.tsx
@@ -72,18 +72,12 @@ function AddEditShoppingLists(
     handleSubmit(async (data) => {
       setAddUpdateLoading(true);
       try {
-        const { description } = data;
-        const submitData = data;
-        if (description.indexOf('\n') > -1) {
-          submitData.description = description.split('\n').join('\\n');
-        }
         const params: Partial<ShoppingListsItemsProps> = {
           ...data,
         };
 
         let fn = isB2BUser ? createB2BShoppingList : createBcShoppingList;
         let successTip = b3Lang('shoppingLists.addSuccess');
-
         if (type === 'edit') {
           if (isB2BUser) {
             fn = updateB2BShoppingList;

--- a/apps/storefront/src/utils/b3ShoppingList/b3ShoppingList.ts
+++ b/apps/storefront/src/utils/b3ShoppingList/b3ShoppingList.ts
@@ -14,9 +14,6 @@ const createShoppingList = ({
 }: // currentChannelId,
 CreateShoppingListParams) => {
   const createShoppingData: Record<string, string | number> = data;
-  if (data.description.indexOf('\n') > -1) {
-    createShoppingData.description = data.description.split('\n').join('\\n');
-  }
 
   const createSL = isB2BUser ? createB2BShoppingList : createBcShoppingList;
 


### PR DESCRIPTION
Jira: [BUN-2621](https://bigcommercecloud.atlassian.net/browse/BUN-2621)

## What/Why?
**Current issues:**

description is not escaped, graphql reports an error, description needs to be escaped

When we use strings in GraphQL queries or mutations, if the string contains special characters (such as newlines, double quotes, etc.), these characters may be mistaken as part of the syntax, resulting in parsing errors. For example, unescaped newlines can break the structure of the query and prevent it from parsing correctly

If we use newlines directly in the query, it will cause an error
mutation { updateDescription(description: "test\n") }
This causes parsing errors because newlines are mistaken for part of the syntax

To avoid this we need to use escape characters:
mutation { updateDescription(description: "test\\n") }
The GraphQL parser will recognize \n as an actual newline character

**Better way: use variables**

More convenient and avoids manual handling of escape characters, This allows GraphQL queries to be parsed and executed correctly

## Rollout/Rollback
undo this pr

## Testing

https://github.com/bigcommerce/b2b-buyer-portal/assets/80307788/c5560f75-a10c-43d7-be78-67a6965269b7

b2b:

https://github.com/bigcommerce/b2b-buyer-portal/assets/80307788/82cd1b67-bfff-4adf-a24a-3fdc25144dcb

bc:


https://github.com/bigcommerce/b2b-buyer-portal/assets/80307788/cbc961a3-b5c6-4ea4-8857-84438d077943





