### PR TITLE
refactor: add a PageProps interface to simplify the definition of the standard props for a page

### DIFF
--- a/apps/storefront/src/components/B3Card.tsx
+++ b/apps/storefront/src/components/B3Card.tsx
@@ -1,16 +1,11 @@
-import { Dispatch, ReactNode, SetStateAction } from 'react';
+import { PropsWithChildren } from 'react';
 
-import { OpenPageState } from '@/types/hooks';
+import { type SetOpenPage } from '@/pages/SetOpenPage';
 
 import RegisteredCloseButton from './RegisteredCloseButton';
 import { CardContainer } from './styled';
 
-interface B3CardProps {
-  setOpenPage?: Dispatch<SetStateAction<OpenPageState>>;
-  children: ReactNode;
-}
-
-export default function B3Card(props: B3CardProps) {
+export default function B3Card(props: PropsWithChildren<{ setOpenPage?: SetOpenPage }>) {
   const { setOpenPage, children } = props;
 
   return (

--- a/apps/storefront/src/components/HeadlessController.tsx
+++ b/apps/storefront/src/components/HeadlessController.tsx
@@ -1,10 +1,11 @@
-import { Dispatch, SetStateAction, useContext, useEffect, useRef } from 'react';
+import { useContext, useEffect, useRef } from 'react';
 import { useB3Lang } from '@b3/lang';
 
 import { HeadlessRoutes } from '@/constants';
 import { addProductFromPage as addProductFromPageToShoppingList } from '@/hooks/dom/useOpenPDP';
 import { addProductsFromCartToQuote, addProductsToDraftQuote } from '@/hooks/dom/utils';
 import { addProductsToShoppingList } from '@/pages/PDP';
+import { type SetOpenPage } from '@/pages/SetOpenPage';
 import { CustomStyleContext } from '@/shared/customStyleButton';
 import { GlobaledContext } from '@/shared/global';
 import { superAdminCompanies } from '@/shared/service/b2b';
@@ -16,7 +17,6 @@ import {
   useAppSelector,
 } from '@/store';
 import { setB2BToken } from '@/store/slices/company';
-import { OpenPageState } from '@/types/hooks';
 import { QuoteItem } from '@/types/quotes';
 import CallbackManager from '@/utils/b3Callbacks';
 import { LineItems } from '@/utils/b3Product/b3Product';
@@ -33,7 +33,7 @@ export interface FormattedQuoteItem
 }
 
 interface HeadlessControllerProps {
-  setOpenPage: Dispatch<SetStateAction<OpenPageState>>;
+  setOpenPage: SetOpenPage;
 }
 
 const transformOptionSelectionsToAttributes = (items: LineItems[]) =>

--- a/apps/storefront/src/components/RegisteredCloseButton.tsx
+++ b/apps/storefront/src/components/RegisteredCloseButton.tsx
@@ -1,14 +1,14 @@
-import { Dispatch, SetStateAction, useContext } from 'react';
+import { useContext } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Box } from '@mui/material';
 
+import { type SetOpenPage } from '@/pages/SetOpenPage';
 import { GlobaledContext } from '@/shared/global';
-import { OpenPageState } from '@/types/hooks';
 
 import { CloseButton } from './styled';
 
 interface CloseButtonProps {
-  setOpenPage: Dispatch<SetStateAction<OpenPageState>>;
+  setOpenPage: SetOpenPage;
 }
 
 export default function RegisteredCloseButton(props: CloseButtonProps) {

--- a/apps/storefront/src/components/extraTip/CheckoutTip.tsx
+++ b/apps/storefront/src/components/extraTip/CheckoutTip.tsx
@@ -1,15 +1,15 @@
-import { Dispatch, SetStateAction, useState } from 'react';
+import { useState } from 'react';
 import { Dialog, DialogActions, DialogContent } from '@mui/material';
 
 import { CHECKOUT_URL } from '@/constants';
 import useMobile from '@/hooks/useMobile';
+import { type SetOpenPage } from '@/pages/SetOpenPage';
 import { useAppSelector } from '@/store';
-import { OpenPageState } from '@/types/hooks';
 
 import CustomButton from '../button/CustomButton';
 
 interface CheckoutTipProps {
-  setOpenPage: Dispatch<SetStateAction<OpenPageState>>;
+  setOpenPage: SetOpenPage;
 }
 
 function CheckoutTip(props: CheckoutTipProps) {

--- a/apps/storefront/src/components/layout/B3RenderRouter.tsx
+++ b/apps/storefront/src/components/layout/B3RenderRouter.tsx
@@ -1,7 +1,8 @@
-import { Dispatch, lazy, SetStateAction, Suspense, useContext, useEffect } from 'react';
+import { lazy, Suspense, useContext, useEffect } from 'react';
 import { Outlet, Route, Routes, useLocation, useNavigate } from 'react-router-dom';
 
 import { RegisteredProvider } from '@/pages/Registered/context/RegisteredContext';
+import { type SetOpenPage } from '@/pages/SetOpenPage';
 import { GlobaledContext } from '@/shared/global';
 import {
   firstLevelRouting,
@@ -10,7 +11,6 @@ import {
   RouteItem,
 } from '@/shared/routes';
 import { getPageTranslations, useAppDispatch } from '@/store';
-import { OpenPageState } from '@/types/hooks';
 import { channelId } from '@/utils';
 
 import Loading from '../loading/Loading';
@@ -20,7 +20,7 @@ const B3Layout = lazy(() => import('@/components/layout/B3Layout'));
 const B3LayoutTip = lazy(() => import('@/components/layout/B3LayoutTip'));
 
 interface B3RenderRouterProps {
-  setOpenPage: Dispatch<SetStateAction<OpenPageState>>;
+  setOpenPage: SetOpenPage;
   openUrl?: string;
   isOpen: boolean;
 }

--- a/apps/storefront/src/components/outSideComponents/B3HoverButton.tsx
+++ b/apps/storefront/src/components/outSideComponents/B3HoverButton.tsx
@@ -1,4 +1,4 @@
-import { Dispatch, SetStateAction, useContext, useEffect, useState } from 'react';
+import { useContext, useEffect, useState } from 'react';
 import { Box, Button, Snackbar, SnackbarOrigin, SxProps } from '@mui/material';
 
 import {
@@ -8,9 +8,9 @@ import {
 } from '@/constants';
 import { useGetButtonText } from '@/hooks';
 import useMobile from '@/hooks/useMobile';
+import { type SetOpenPage } from '@/pages/SetOpenPage';
 import { CustomStyleContext } from '@/shared/customStyleButton';
 import { useAppSelector } from '@/store';
-import { OpenPageState } from '@/types/hooks';
 
 import {
   getHoverColor,
@@ -24,7 +24,7 @@ import {
 interface B3HoverButtonProps {
   isOpen: boolean;
   productQuoteEnabled: boolean;
-  setOpenPage: Dispatch<SetStateAction<OpenPageState>>;
+  setOpenPage: SetOpenPage;
 }
 
 export default function B3HoverButton(props: B3HoverButtonProps) {

--- a/apps/storefront/src/components/outSideComponents/B3MasquradeGobalTip.tsx
+++ b/apps/storefront/src/components/outSideComponents/B3MasquradeGobalTip.tsx
@@ -1,4 +1,4 @@
-import { Dispatch, SetStateAction, useContext } from 'react';
+import { useContext } from 'react';
 import { useB3Lang } from '@b3/lang';
 import GroupIcon from '@mui/icons-material/Group';
 import KeyboardArrowLeftIcon from '@mui/icons-material/KeyboardArrowLeft';
@@ -14,10 +14,10 @@ import {
 import { useGetButtonText } from '@/hooks';
 import useMobile from '@/hooks/useMobile';
 import useStorageState from '@/hooks/useStorageState';
+import { type SetOpenPage } from '@/pages/SetOpenPage';
 import { CustomStyleContext } from '@/shared/customStyleButton';
 import { superAdminEndMasquerade } from '@/shared/service/b2b';
 import { clearMasqueradeCompany, useAppDispatch, useAppSelector } from '@/store';
-import { OpenPageState } from '@/types/hooks';
 
 import {
   getContrastColor,
@@ -30,7 +30,7 @@ import {
 
 interface B3MasquradeGobalTipProps {
   isOpen: boolean;
-  setOpenPage: Dispatch<SetStateAction<OpenPageState>>;
+  setOpenPage: SetOpenPage;
 }
 
 const bottomHeightPage = ['shoppingList/', 'purchased-products'];

--- a/apps/storefront/src/hooks/dom/useOpenPDP.ts
+++ b/apps/storefront/src/hooks/dom/useOpenPDP.ts
@@ -1,4 +1,4 @@
-import { Dispatch, SetStateAction, useCallback, useContext, useEffect, useRef } from 'react';
+import { useCallback, useContext, useEffect, useRef } from 'react';
 import globalB3 from '@b3/global-b3';
 import { AnyAction, Dispatch as DispatchRedux } from '@reduxjs/toolkit';
 import cloneDeep from 'lodash-es/cloneDeep';
@@ -13,10 +13,10 @@ import {
   ADD_TO_SHOPPING_LIST_DEFUALT_VALUE,
   TRANSLATION_SHOPPING_LIST_BTN_VARAIBLE,
 } from '@/constants';
+import { type SetOpenPage } from '@/pages/SetOpenPage';
 import { CustomStyleContext } from '@/shared/customStyleButton';
 import { GlobaledContext } from '@/shared/global';
 import { isB2BUserSelector, setGlabolCommonState, useAppDispatch, useAppSelector } from '@/store';
-import { OpenPageState } from '@/types/hooks';
 
 import useGetButtonText from '../useGetButtonText';
 import useRole from '../useRole';
@@ -25,14 +25,14 @@ import useDomVariation from './useDomVariation';
 import { removeElement } from './utils';
 
 interface MutationObserverProps {
-  setOpenPage: Dispatch<SetStateAction<OpenPageState>>;
+  setOpenPage: SetOpenPage;
   role: number | string;
 }
 interface AddProductFromPageParams {
   role: number;
   storeDispatch: DispatchRedux<AnyAction>;
   saveFn: () => void;
-  setOpenPage: (value: SetStateAction<OpenPageState>) => void;
+  setOpenPage: SetOpenPage;
   registerEnabled: boolean;
 }
 

--- a/apps/storefront/src/hooks/dom/utils.ts
+++ b/apps/storefront/src/hooks/dom/utils.ts
@@ -1,11 +1,10 @@
-import { Dispatch, SetStateAction } from 'react';
 import globalB3 from '@b3/global-b3';
 
 import B3AddToQuoteTip from '@/components/B3AddToQuoteTip';
+import { type SetOpenPage } from '@/pages/SetOpenPage';
 import { searchB2BProducts, searchBcProducts } from '@/shared/service/b2b';
 import { getCart } from '@/shared/service/bc/graphql/cart';
 import { store } from '@/store';
-import { OpenPageState } from '@/types/hooks';
 import { B3LStorage, B3SStorage, getActiveCurrencyInfo, globalSnackbar, serialize } from '@/utils';
 import { getProductOptionList, isAllRequiredOptionFilled } from '@/utils/b3AddToShoppingList';
 import b2bLogger from '@/utils/b3Logger';
@@ -19,8 +18,6 @@ import {
 } from '@/utils/b3Product/b3Product';
 
 import { conversionProductsList } from '../../utils/b3Product/shared/config';
-
-type DispatchProps = Dispatch<SetStateAction<OpenPageState>>;
 
 interface DiscountsProps {
   discountedAmount: number;
@@ -131,7 +128,7 @@ const removeLoadding = () => {
   if (b2bLoading) removeElement(b2bLoading);
 };
 
-const gotoQuoteDraft = (setOpenPage: DispatchProps) => {
+const gotoQuoteDraft = (setOpenPage: SetOpenPage) => {
   setOpenPage({
     isOpen: true,
     openUrl: '/quoteDraft',
@@ -167,7 +164,7 @@ const getCartProducts = (lineItems: LineItemsProps) =>
 
 const addProductsToDraftQuote = async (
   products: LineItems[],
-  setOpenPage: DispatchProps,
+  setOpenPage: SetOpenPage,
   cartId?: string,
 ) => {
   // filter products with SKU
@@ -226,7 +223,7 @@ const addProductsToDraftQuote = async (
   });
 };
 
-const addProductsFromCartToQuote = (setOpenPage: DispatchProps) => {
+const addProductsFromCartToQuote = (setOpenPage: SetOpenPage) => {
   const addToQuote = async () => {
     try {
       const cartInfoWithOptions: CartInfoProps | any = await getCart();
@@ -269,7 +266,7 @@ const addProductsFromCartToQuote = (setOpenPage: DispatchProps) => {
   };
 };
 
-const addProductFromProductPageToQuote = (setOpenPage: DispatchProps) => {
+const addProductFromProductPageToQuote = (setOpenPage: SetOpenPage) => {
   const addToQuote = async (role: string | number, node?: HTMLElement) => {
     try {
       const productView = node ? node.closest(globalB3['dom.productView']) : document;

--- a/apps/storefront/src/pages/Dashboard/index.tsx
+++ b/apps/storefront/src/pages/Dashboard/index.tsx
@@ -1,4 +1,4 @@
-import { Dispatch, SetStateAction, useContext, useEffect, useRef, useState } from 'react';
+import { useContext, useEffect, useRef, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import { useB3Lang } from '@b3/lang';
 import MoreHorizIcon from '@mui/icons-material/MoreHoriz';
@@ -14,8 +14,9 @@ import { useSort } from '@/hooks';
 import { GlobaledContext } from '@/shared/global';
 import { superAdminCompanies } from '@/shared/service/b2b';
 import { useAppSelector } from '@/store';
-import { OpenPageState } from '@/types/hooks';
 import { endMasquerade, startMasquerade } from '@/utils/masquerade';
+
+import { type PageProps } from '../PageProps';
 
 import DashboardCard from './components/DashboardCard';
 
@@ -28,10 +29,6 @@ interface B3MeanProps {
   handleSelect: () => void;
   startActing: () => void;
   endActing: () => void;
-}
-
-interface DashboardProps {
-  setOpenPage: Dispatch<SetStateAction<OpenPageState>>;
 }
 
 export const defaultSortKey = 'companyName';
@@ -108,7 +105,7 @@ function B3Mean({ isMasquerade, handleSelect, startActing, endActing }: B3MeanPr
   );
 }
 
-function Dashboard(props: DashboardProps) {
+function Dashboard(props: PageProps) {
   const { dispatch } = useContext(GlobaledContext);
   const customerId = useAppSelector(({ company }) => company.customer.id);
   const b2bId = useAppSelector(({ company }) => company.customer.b2bId);

--- a/apps/storefront/src/pages/ForgotPassword/index.tsx
+++ b/apps/storefront/src/pages/ForgotPassword/index.tsx
@@ -1,4 +1,4 @@
-import { Dispatch, SetStateAction, useContext, useEffect, useState } from 'react';
+import { useContext, useEffect, useState } from 'react';
 import { SubmitHandler, useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
 import { useB3Lang } from '@b3/lang';
@@ -12,17 +12,13 @@ import { useMobile } from '@/hooks';
 import { CustomStyleContext } from '@/shared/customStyleButton/context';
 import { GlobaledContext } from '@/shared/global';
 import { getStorefrontToken, requestResetPassword } from '@/shared/service/b2b/graphql/recaptcha';
-import { OpenPageState } from '@/types/hooks';
 import b2bLogger from '@/utils/b3Logger';
 
 import { getForgotPasswordFields, LoginConfig, sendEmail } from '../Login/config';
 import { B3ResetPassWordButton, LoginImage } from '../Login/styled';
+import { type PageProps } from '../PageProps';
 
-interface ForgotPasswordProps {
-  setOpenPage: Dispatch<SetStateAction<OpenPageState>>;
-}
-
-function ForgotPassword(props: ForgotPasswordProps) {
+function ForgotPassword(props: PageProps) {
   const {
     state: { logo },
   } = useContext(GlobaledContext);

--- a/apps/storefront/src/pages/Login/index.tsx
+++ b/apps/storefront/src/pages/Login/index.tsx
@@ -1,4 +1,4 @@
-import { Dispatch, SetStateAction, useContext, useEffect, useState } from 'react';
+import { useContext, useEffect, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useB3Lang } from '@b3/lang';
 import { Alert, Box, ImageListItem } from '@mui/material';
@@ -21,12 +21,13 @@ import {
 } from '@/store';
 import { setB2BToken, setPermissionModules } from '@/store/slices/company';
 import { CustomerRole, UserTypes } from '@/types';
-import { OpenPageState } from '@/types/hooks';
 import { channelId, getB3PermissionsList, loginJump, snackbar, storeHash } from '@/utils';
 import b2bLogger from '@/utils/b3Logger';
 import { logoutSession } from '@/utils/b3logout';
 import { deleteCartData } from '@/utils/cartUtils';
 import { getCurrentCustomerInfo } from '@/utils/loginInfo';
+
+import { type PageProps } from '../PageProps';
 
 import LoginWidget from './component/LoginWidget';
 import { loginCheckout, LoginConfig, LoginInfoInit } from './config';
@@ -44,13 +45,9 @@ const initialLoginInfo = {
   displayStoreLogo: false,
 };
 
-interface RegisteredProps {
-  setOpenPage: Dispatch<SetStateAction<OpenPageState>>;
-}
-
 type AlertColor = 'success' | 'info' | 'warning' | 'error';
 
-export default function Login(props: RegisteredProps) {
+export default function Login(props: PageProps) {
   const { setOpenPage } = props;
   const storeDispatch = useAppDispatch();
 

--- a/apps/storefront/src/pages/PDP/index.tsx
+++ b/apps/storefront/src/pages/PDP/index.tsx
@@ -1,4 +1,4 @@
-import { Dispatch, lazy, SetStateAction, useContext, useEffect, useState } from 'react';
+import { lazy, useContext, useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import globalB3 from '@b3/global-b3';
 import { LangFormatFunction, useB3Lang } from '@b3/lang';
@@ -12,19 +12,16 @@ import {
   searchBcProducts,
 } from '@/shared/service/b2b';
 import { isB2BUserSelector, store, useAppSelector } from '@/store';
-import { OpenPageState } from '@/types/hooks';
 import { getActiveCurrencyInfo, globalSnackbar, serialize } from '@/utils';
 import { getProductOptionList, isAllRequiredOptionFilled } from '@/utils/b3AddToShoppingList';
 import { getValidOptionsList } from '@/utils/b3Product/b3Product';
 
 import { conversionProductsList } from '../../utils/b3Product/shared/config';
+import { type PageProps } from '../PageProps';
 
 const CreateShoppingList = lazy(() => import('../OrderDetail/components/CreateShoppingList'));
 const OrderShoppingList = lazy(() => import('../OrderDetail/components/OrderShoppingList'));
 
-interface PDPProps {
-  setOpenPage: Dispatch<SetStateAction<OpenPageState>>;
-}
 interface AddProductsToShoppingListParams {
   isB2BUser: boolean;
   items: CustomFieldItems[];
@@ -129,7 +126,7 @@ export const addProductsToShoppingList = async ({
   });
 };
 
-function PDP({ setOpenPage }: PDPProps) {
+function PDP({ setOpenPage }: PageProps) {
   const isPromission = true;
   const {
     state: { shoppingListClickNode },

--- a/apps/storefront/src/pages/PageProps.ts
+++ b/apps/storefront/src/pages/PageProps.ts
@@ -1,0 +1,5 @@
+import { type SetOpenPage } from '@/pages/SetOpenPage';
+
+export interface PageProps {
+  setOpenPage: SetOpenPage;
+}

--- a/apps/storefront/src/pages/QuoteDraft/index.tsx
+++ b/apps/storefront/src/pages/QuoteDraft/index.tsx
@@ -1,4 +1,4 @@
-import { Dispatch, SetStateAction, useContext, useEffect, useRef, useState } from 'react';
+import { useContext, useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { CallbackKey, useCallbacks } from '@b3/hooks';
 import { useB3Lang } from '@b3/lang';
@@ -39,6 +39,7 @@ import validateObject from '@/utils/quoteUtils';
 
 import { getProductOptionsFields } from '../../utils/b3Product/shared/config';
 import { convertBCToB2BAddress } from '../Address/shared/config';
+import { type PageProps } from '../PageProps';
 import AddToQuote from '../quote/components/AddToQuote';
 import ContactInfo from '../quote/components/ContactInfo';
 import QuoteAddress from '../quote/components/QuoteAddress';
@@ -74,15 +75,6 @@ interface QuoteSummaryRef extends HTMLInputElement {
   refreshSummary: () => void;
 }
 
-interface OpenPageState {
-  isOpen: boolean;
-  openUrl?: string;
-}
-
-interface QuoteDraftProps {
-  setOpenPage: Dispatch<SetStateAction<OpenPageState>>;
-}
-
 const shippingAddress = {
   address: '',
   addressId: 0,
@@ -113,7 +105,7 @@ const billingAddress = {
   companyName: '',
 };
 
-function QuoteDraft({ setOpenPage }: QuoteDraftProps) {
+function QuoteDraft({ setOpenPage }: PageProps) {
   const {
     state: { countriesList, openAPPParams },
   } = useContext(GlobaledContext);

--- a/apps/storefront/src/pages/Registered/index.tsx
+++ b/apps/storefront/src/pages/Registered/index.tsx
@@ -1,4 +1,4 @@
-import { Dispatch, SetStateAction, useContext, useEffect, useState } from 'react';
+import { useContext, useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useB3Lang } from '@b3/lang';
 import { Box, ImageListItem } from '@mui/material';
@@ -11,12 +11,12 @@ import { GlobaledContext } from '@/shared/global';
 import { getB2BAccountFormFields, getB2BCountries } from '@/shared/service/b2b';
 import { bcLogin } from '@/shared/service/bc';
 import { themeFrameSelector, useAppSelector } from '@/store';
-import { OpenPageState } from '@/types/hooks';
 import { B3SStorage, loginJump } from '@/utils';
 import b2bLogger from '@/utils/b3Logger';
 import { getCurrentCustomerInfo } from '@/utils/loginInfo';
 
 import { loginCheckout, LoginConfig } from '../Login/config';
+import { type PageProps } from '../PageProps';
 
 import { RegisteredContext } from './context/RegisteredContext';
 import {
@@ -34,11 +34,7 @@ import { RegisterFields } from './types';
 // 1 bc 2 b2b
 const formType: Array<number> = [1, 2];
 
-interface RegisteredProps {
-  setOpenPage: Dispatch<SetStateAction<OpenPageState>>;
-}
-
-function Registered(props: RegisteredProps) {
+function Registered(props: PageProps) {
   const { setOpenPage } = props;
 
   const [activeStep, setActiveStep] = useState(0);

--- a/apps/storefront/src/pages/RegisteredBCToB2B/index.tsx
+++ b/apps/storefront/src/pages/RegisteredBCToB2B/index.tsx
@@ -1,4 +1,4 @@
-import { Dispatch, MouseEvent, SetStateAction, useContext, useEffect, useState } from 'react';
+import { MouseEvent, useContext, useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
 import { useB3Lang } from '@b3/lang';
@@ -14,7 +14,6 @@ import { useMobile } from '@/hooks';
 import { CustomStyleContext } from '@/shared/customStyleButton';
 import { GlobaledContext } from '@/shared/global';
 import { useAppSelector } from '@/store';
-import { OpenPageState } from '@/types/hooks';
 import { channelId, loginJump, storeHash } from '@/utils';
 import b2bLogger from '@/utils/b3Logger';
 import { getCurrentCustomerInfo } from '@/utils/loginInfo';
@@ -27,6 +26,7 @@ import {
   validateBCCompanyExtraFields,
   validateBCCompanyUserExtraFields,
 } from '../../shared/service/b2b';
+import { type PageProps } from '../PageProps';
 import {
   AccountFormFieldsItems,
   b2bAddressRequiredFields,
@@ -54,10 +54,6 @@ interface CustomerInfo {
   [k: string]: string;
 }
 
-interface RegisteredProps {
-  setOpenPage: Dispatch<SetStateAction<OpenPageState>>;
-}
-
 export const StyledRegisterContent = styled(Box)({
   '& #b3-customForm-id-name': {
     '& label[data-shrink="true"]': {
@@ -72,7 +68,7 @@ export const StyledRegisterContent = styled(Box)({
   },
 });
 
-export default function RegisteredBCToB2B(props: RegisteredProps) {
+export default function RegisteredBCToB2B(props: PageProps) {
   const [errorMessage, setErrorMessage] = useState('');
   const [showFinishPage, setShowFinishPage] = useState<boolean>(false);
 

--- a/apps/storefront/src/pages/SetOpenPage.tsx
+++ b/apps/storefront/src/pages/SetOpenPage.tsx
@@ -1,0 +1,5 @@
+export type SetOpenPage = (value: {
+  isOpen: boolean;
+  openUrl?: string;
+  params?: Record<string, string>;
+}) => void;

--- a/apps/storefront/src/pages/ShoppingListDetails/components/ShoppingDetailHeader.tsx
+++ b/apps/storefront/src/pages/ShoppingListDetails/components/ShoppingDetailHeader.tsx
@@ -1,4 +1,4 @@
-import { Dispatch, SetStateAction, useContext } from 'react';
+import { useContext } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useB3Lang } from '@b3/lang';
 import { ArrowBackIosNew } from '@mui/icons-material';
@@ -7,6 +7,7 @@ import { Box, Grid, styled, Typography } from '@mui/material';
 import CustomButton from '@/components/button/CustomButton';
 import { getContrastColor } from '@/components/outSideComponents/utils/b3CustomStyles';
 import { useMobile } from '@/hooks';
+import { type SetOpenPage } from '@/pages/SetOpenPage';
 import { CustomStyleContext } from '@/shared/customStyleButton';
 import { rolePermissionSelector, useAppSelector } from '@/store';
 
@@ -17,10 +18,6 @@ const StyledCreateName = styled('div')(() => ({
   alignItems: 'center',
 }));
 
-interface OpenPageState {
-  isOpen: boolean;
-  openUrl?: string;
-}
 interface ShoppingDetailHeaderProps {
   shoppingListInfo: any;
   role: string | number;
@@ -28,7 +25,7 @@ interface ShoppingDetailHeaderProps {
   goToShoppingLists: () => void;
   handleUpdateShoppingList: (status: number) => void;
   isB2BUser: boolean;
-  setOpenPage: Dispatch<SetStateAction<OpenPageState>>;
+  setOpenPage: SetOpenPage;
   isAgenting: boolean;
   openAPPParams: {
     shoppingListBtn: string;

--- a/apps/storefront/src/pages/ShoppingListDetails/index.tsx
+++ b/apps/storefront/src/pages/ShoppingListDetails/index.tsx
@@ -1,4 +1,4 @@
-import { Dispatch, SetStateAction, useContext, useEffect, useRef, useState } from 'react';
+import { useContext, useEffect, useRef, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useB3Lang } from '@b3/lang';
 import { Box, Grid, useTheme } from '@mui/material';
@@ -35,6 +35,8 @@ import {
   ShoppingListInfoProps,
 } from '@/utils/b3Product/shared/config';
 
+import { type PageProps } from '../PageProps';
+
 import AddToShoppingList from './components/AddToShoppingList';
 import ReAddToCart from './components/ReAddToCart';
 import ShoppingDetailDeleteItems from './components/ShoppingDetailDeleteItems';
@@ -50,24 +52,12 @@ interface TableRefProps extends HTMLInputElement {
   initSearch: () => void;
 }
 
-interface OpenPageState {
-  isOpen: boolean;
-  openUrl?: string;
-}
-
 interface UpdateShoppingListParamsProps {
   id: number;
   name: string;
   description: string;
   status?: number;
   channelId?: number;
-}
-
-interface ShoppingListDetailsProps {
-  setOpenPage: Dispatch<SetStateAction<OpenPageState>>;
-}
-interface ShoppingListDetailsContentProps {
-  setOpenPage: Dispatch<SetStateAction<OpenPageState>>;
 }
 
 interface PermissionLevelInfoProps {
@@ -78,7 +68,7 @@ interface PermissionLevelInfoProps {
 // shoppingList status: 0 -- Approved; 20 -- Rejected; 30 -- Draft; 40 -- Ready for approval
 // 0: Admin, 1: Senior buyer, 2: Junior buyer, 3: Super admin
 
-function ShoppingListDetails({ setOpenPage }: ShoppingListDetailsProps) {
+function ShoppingListDetails({ setOpenPage }: PageProps) {
   const { id = '' } = useParams();
   const {
     state: { openAPPParams, productQuoteEnabled = false },
@@ -506,7 +496,7 @@ function ShoppingListDetails({ setOpenPage }: ShoppingListDetailsProps) {
   );
 }
 
-function ShoppingListDetailsContent({ setOpenPage }: ShoppingListDetailsContentProps) {
+function ShoppingListDetailsContent({ setOpenPage }: PageProps) {
   return (
     <ShoppingListDetailsProvider>
       <ShoppingListDetails setOpenPage={setOpenPage} />

--- a/apps/storefront/src/shared/routes/index.tsx
+++ b/apps/storefront/src/shared/routes/index.tsx
@@ -1,6 +1,7 @@
-import { lazy } from 'react';
+import { FC, lazy } from 'react';
 import { matchPath } from 'react-router-dom';
 
+import { type PageProps } from '@/pages/PageProps';
 import { GlobalState, QuoteConfigProps } from '@/shared/global/context/config';
 import { getCustomerInfo } from '@/shared/service/bc';
 import { store } from '@/store';
@@ -32,16 +33,14 @@ const ShippingLists = lazy(() => import('@/pages/ShoppingLists'));
 const ShoppingListDetails = lazy(() => import('@/pages/ShoppingListDetails'));
 const UserManagement = lazy(() => import('@/pages/UserManagement'));
 
-type RegisteredItem = typeof Registered | typeof HomePage;
-
 interface RouteItemBasic {
+  component: FC<PageProps>;
   path: string;
   name: string;
   permissions: number[]; // 0: admin, 1: senior buyer, 2: junior buyer, 3: salesRep, 4: salesRep-【Not represented】, 99: bc user, 100: guest
 }
 
 export interface RouteItem extends RouteItemBasic {
-  component: RegisteredItem;
   isMenuItem: boolean;
   wsKey: string;
   configKey?: string;
@@ -53,7 +52,6 @@ export interface RouteItem extends RouteItemBasic {
 
 export interface RouteFirstLevelItem extends RouteItemBasic {
   isProvider: boolean;
-  component: RegisteredItem;
 }
 
 const routes: RouteItem[] = [


### PR DESCRIPTION
## What/Why?
We are currently repeating the same definition on each page, and type checking the list of routes is a bit more complex than it needs to be.

This introduces a type for `PageProps` that all pages can conform to and can be used to type the RouteItem.

## Rollout/Rollback
Revert

## Testing
typescript