### PR TITLE
feat: compatible with beautify theme

### DIFF
--- a/apps/storefront/src/hooks/useB3AppOpen.ts
+++ b/apps/storefront/src/hooks/useB3AppOpen.ts
@@ -81,7 +81,7 @@ const useB3AppOpen = (initOpenState: OpenPageState) => {
           const isRegisterArrInclude = registerArr.includes(e.target as Element);
           const tagHref = (e.target as HTMLAnchorElement)?.href;
           let href = tagHref || authorizedPages;
-          if (!tagHref) {
+          if (!tagHref || typeof tagHref !== 'string') {
             let parentNode = (e.target as HTMLAnchorElement)?.parentNode;
             let parentHref = (parentNode as HTMLAnchorElement)?.href;
             let number = 0;

--- a/packages/global-b3/index.ts
+++ b/packages/global-b3/index.ts
@@ -37,6 +37,7 @@ const themeOtherElementConfig = () => {
     HaloOne:
       '[href^="/account.php"] svg, [href^="/account.php"] svg path, [href="/login.php"] svg path',
     FinchUS: '[href^="/account.php"] img',
+    Beautify: '[href^="/account.php"] .new-icon-account',
   }
 
   Object.values(themeElements).forEach((value) => {


### PR DESCRIPTION
Jira: [BUN-2601](https://bigc-b2b.atlassian.net/browse/BUN-2601)

## What/Why?
Improve Buyer Portal compatibility for Beatify Theme
* When clicking the account icon, in most cases, you cannot enter the buyer portal page, but stay on a blank page.

Reason: The theme code is not compatible with the class name or other specific identifiers corresponding to the icon; this pr adds specific identifiers in the code to be compatible with the theme.

## Rollout/Rollback
undo this pr

## Testing


https://github.com/bigcommerce/b2b-buyer-portal/assets/80307788/a769583d-d460-4173-bfdf-36cb44ef727a



