### PR TITLE
refactor: simplify login page (Step 1)

### DIFF
--- a/apps/storefront/src/pages/Login/LoginForm.tsx
+++ b/apps/storefront/src/pages/Login/LoginForm.tsx
@@ -6,22 +6,20 @@ import { B3CustomForm } from '@/components';
 import CustomButton from '@/components/button/CustomButton';
 import { getContrastColor } from '@/components/outSideComponents/utils/b3CustomStyles';
 
-import { getLoginFields, LoginConfig, LoginInfoInit } from './config';
+import { getLoginFields, LoginConfig } from './config';
 
 interface LoginFormProps {
-  loginInfo: Partial<LoginInfoInit>;
+  loginBtn: string;
   handleLoginSubmit: (data: LoginConfig) => void;
   gotoForgotPassword: () => void;
   backgroundColor: string;
 }
 
 function LoginForm(props: LoginFormProps) {
-  const { loginInfo, handleLoginSubmit, gotoForgotPassword, backgroundColor } = props;
+  const { loginBtn, handleLoginSubmit, gotoForgotPassword, backgroundColor } = props;
 
   const b3Lang = useB3Lang();
   const theme = useTheme();
-
-  const { loginBtn } = loginInfo;
 
   const {
     control,

--- a/apps/storefront/src/pages/Login/LoginPanel.tsx
+++ b/apps/storefront/src/pages/Login/LoginPanel.tsx
@@ -4,20 +4,18 @@ import CustomButton from '@/components/button/CustomButton';
 import { useMobile } from '@/hooks';
 
 import LoginWidget from './component/LoginWidget';
-import { LoginInfoInit } from './config';
 
 interface LoginPanelProps {
-  loginInfo: Partial<LoginInfoInit>;
+  widgetBodyText: string;
+  createAccountButtonText: string;
   handleSubmit?: () => void;
 }
 
 function LoginPanel(props: LoginPanelProps) {
-  const { loginInfo, handleSubmit } = props;
+  const { handleSubmit, widgetBodyText, createAccountButtonText } = props;
 
   const theme = useTheme();
   const [isMobile] = useMobile();
-
-  const { widgetBodyText = '', CreateAccountButtonText } = loginInfo;
 
   return (
     <Box
@@ -57,7 +55,7 @@ function LoginPanel(props: LoginPanelProps) {
             backgroundColor: theme.palette.primary.main,
           }}
         >
-          {CreateAccountButtonText}
+          {createAccountButtonText}
         </CustomButton>
       </Box>
     </Box>

--- a/apps/storefront/src/shared/service/b2b/graphql/register.ts
+++ b/apps/storefront/src/shared/service/b2b/graphql/register.ts
@@ -218,7 +218,7 @@ export const getB2BLoginPageConfig = () =>
 export const getBCForcePasswordReset = (email: string) =>
   B3Request.graphqlB2B({
     query: getForcePasswordReset(email),
-  });
+  }).then((res) => res.companyUserInfo.userInfo.forcePasswordReset);
 
 export const getBCStoreChannelId = () =>
   B3Request.graphqlB2B({


### PR DESCRIPTION
## What/Why?
This commit extracts some of the logic in the login outside of it and simplifies the syntax a bit.

Also simplifies the creation and use of `loginInfo`, ensuring it is always defined.

## Rollout/Rollback
Revert

## Testing
Most of the refactor here is automated.

Page still loads fine:
<img width="947" alt="image" src="https://github.com/bigcommerce/b2b-buyer-portal/assets/4542735/578113b4-9d93-4085-9e79-a9ecbfd1a228">
