### PR TITLE
fix: set guest customerGroupId is 0

### DIFF
--- a/apps/storefront/src/store/slices/company.ts
+++ b/apps/storefront/src/store/slices/company.ts
@@ -35,7 +35,8 @@ const initialState: CompanyState = {
     firstName: '',
     lastName: '',
     emailAddress: '',
-    customerGroupId: 1,
+    /** the customerGroupId for the guest user is 0 */
+    customerGroupId: 0,
     role: CustomerRole.GUEST,
     userType: UserTypes.DOESNT_EXIST,
     loginType: LoginTypes.WAITING_LOGIN,


### PR DESCRIPTION
Jira: [BUN-2637](https://bigc-b2b.atlassian.net/browse/BUN-2637)

## What/Why?

When the user is guest, customerGroupId should be 0, not 1,
causing calculated_price to obtain an incorrect price

## Rollout/Rollback

undo pr

## Testing


https://github.com/bigcommerce/b2b-buyer-portal/assets/80307788/b797a4b4-e27f-4e3c-aa75-db2b9c785623

