### PR TITLE
fix: update translation variable

### DIFF
--- a/packages/lang/locales/en.json
+++ b/packages/lang/locales/en.json
@@ -265,7 +265,7 @@
   "purchasedProducts.quickOrderCard.lastOrdered": "Last ordered: {lastOrderedAt}",
   "purchasedProducts.quickOrderPad.productsAdded": "Products were added to cart",
   "purchasedProducts.quickOrderPad.viewCart": "VIEW CART",
-  "purchasedProducts.quickOrderPad.insufficientStockSku": "{SKU} does not have enough stock, please change the quantity  ",
+  "purchasedProducts.quickOrderPad.insufficientStockSku": "{sku} does not have enough stock, please change the quantity  ",
   "purchasedProducts.quickOrderPad.notEnoughStock": "{variantSku} does not have enough stock",
   "purchasedProducts.quickOrderPad.availableAmount": "Available amount - {availableAmount}",
   "purchasedProducts.quickOrderPad.outOfStockSku": "{outOfStock} are out of stock",


### PR DESCRIPTION
Issue - 
purchasedProducts.quickOrderPad.insufficientStockSku showing as msg when item not in stock

Result 
- It should be display translate msg

![image](https://github.com/user-attachments/assets/b7b2520a-ed19-4708-8e69-8c7883950b0a)

