### PR TITLE
fix: saving order path previous order detail

### DIFF
--- a/apps/storefront/src/components/layout/B3Nav.tsx
+++ b/apps/storefront/src/components/layout/B3Nav.tsx
@@ -8,6 +8,7 @@ import { DynamicallyVariableedContext } from '@/shared/dynamicallyVariable';
 import { GlobaledContext } from '@/shared/global';
 import { getAllowedRoutes } from '@/shared/routes';
 import { useAppSelector } from '@/store';
+import { B3SStorage } from '@/utils';
 
 import { b3HexToRgb, getContrastColor } from '../outSideComponents/utils/b3CustomStyles';
 
@@ -79,10 +80,14 @@ export default function B3Nav({ closeSidebar }: B3NavProps) {
   };
   const newRoutes = menuItems();
   const activePath = (path: string) => {
-    if (location.pathname === path) return true;
+    if (location.pathname === path) {
+      B3SStorage.set('prevPath', path);
+      return true;
+    }
 
     if (location.pathname.includes('orderDetail')) {
-      const gotoOrderPath = path === '/company-orders' ? '/company-orders' : '/orders';
+      const gotoOrderPath =
+        B3SStorage.get('prevPath') === '/company-orders' ? '/company-orders' : '/orders';
       if (path === gotoOrderPath) return true;
     }
 

--- a/apps/storefront/src/utils/b3Storage.ts
+++ b/apps/storefront/src/utils/b3Storage.ts
@@ -5,6 +5,7 @@ interface StorageStore {
   blockPendingAccountOrderCreation: boolean;
   blockPendingAccountViewPrice: boolean;
   cartToQuoteId: string;
+  prevPath: string;
   isAgenting: boolean;
   isB2BUser: boolean;
   isShowBlockPendingAccountOrderCreationTip: {


### PR DESCRIPTION
Jira: [BUN-2749](https://bigc-b2b.atlassian.net/browse/BUN-2749)

## What/Why?
I added back a variable to the session storage to keep the value of the route in the nav clicked before seeing the orderDetail. In the routes we have "My Orders" and "Company orders" and both re routes to page orderDetail when users clicks for a specific order, so they are both displayed as selected when in orderDetail page. By having saved the value from the path we clicked we can add styles only to one of those routes.

![image](https://github.com/user-attachments/assets/fd2c2b0d-37af-463d-972c-7cba5c6366dc)


## Rollout/Rollback
Revert

## Testing
![image](https://github.com/user-attachments/assets/c039aef0-807b-460e-a963-2a71f08febb1)

![image](https://github.com/user-attachments/assets/72dc7a70-d797-4afd-ba66-a06eae803013)

