### PR TITLE
fix: adding variables for translation of notifications

### DIFF
--- a/apps/storefront/src/components/layout/B3StatusNotification.tsx
+++ b/apps/storefront/src/components/layout/B3StatusNotification.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { useB3Lang } from '@b3/lang';
 import styled from '@emotion/styled';
 import { Alert, Box } from '@mui/material';
 
@@ -23,9 +24,10 @@ const B3StatusNotificationContainer = styled(Box)(() => ({
 
 export default function B3StatusNotification(props: B3StatusNotificationProps) {
   const { title } = props;
+  const dispatch = useAppDispatch();
+  const b3Lang = useB3Lang();
 
   const loginType = useAppSelector(({ company }) => company.customer.loginType);
-  const dispatch = useAppDispatch();
   const role = useAppSelector(({ company }) => company.customer.role);
   const companyStatus = useAppSelector(({ company }) => company.companyInfo.status);
   const blockPendingAccountOrderCreation = B3SStorage.get('blockPendingAccountOrderCreation');
@@ -53,19 +55,19 @@ export default function B3StatusNotification(props: B3StatusNotificationProps) {
     if (showTip) {
       if (+companyStatus === 0) {
         if (blockPendingAccountOrderCreation && blockPendingAccountViewPrice) {
-          setTip(StatusNotifications.pendingOrderingAndViewPriceBlocked);
+          setTip(b3Lang(StatusNotifications.pendingOrderingAndViewPriceBlocked));
         }
 
         if (blockPendingAccountOrderCreation && !blockPendingAccountViewPrice) {
-          setTip(StatusNotifications.pendingOrderingBlocked);
+          setTip(b3Lang(StatusNotifications.pendingOrderingBlocked));
         }
 
         if (!blockPendingAccountOrderCreation && blockPendingAccountViewPrice) {
-          setTip(StatusNotifications.pendingViewPriceBlocked);
+          setTip(b3Lang(StatusNotifications.pendingViewPriceBlocked));
         }
 
         if (!blockPendingAccountOrderCreation && !blockPendingAccountViewPrice) {
-          setTip(StatusNotifications.pendingOrderingNotBlocked);
+          setTip(b3Lang(StatusNotifications.pendingOrderingNotBlocked));
         }
         setType('info');
         setBcColor('#0288D1');
@@ -89,6 +91,7 @@ export default function B3StatusNotification(props: B3StatusNotificationProps) {
     companyStatus,
     loginType,
     role,
+    b3Lang,
   ]);
 
   return isShow ? (

--- a/apps/storefront/src/constants/index.ts
+++ b/apps/storefront/src/constants/index.ts
@@ -45,18 +45,14 @@ export enum HeadlessRoutes {
 export type HeadlessRoute = keyof typeof HeadlessRoutes;
 
 export const StatusNotifications = {
-  pendingOrderingBlocked:
-    'Your business account is pending approval. Ordering will be enabled after account approval.',
-  pendingOrderingNotBlocked:
-    'Your business account is pending approval. You will gain access to business account features after account approval.',
+  pendingOrderingBlocked: 'global.statusNotifications.orderingWillBeEnabledAfterAccountApproval',
+  pendingOrderingNotBlocked: 'global.statusNotifications.willGainAccessToBusinessFeatAfterApproval',
   pendingViewPriceBlocked:
-    'Your business account is pending approval. You will gain access to business account features, products, and pricing after account approval.',
+    'global.statusNotifications.willGainAccessToBusinessFeatProductsAndPricingAfterApproval',
   pendingOrderingAndViewPriceBlocked:
-    'Your business account is pending approval. Products, pricing, and ordering will be enabled after account approval',
-  approvedTip:
-    'Your business account has been approved. Check your email inbox, we sent you a letter with all details.',
-  rejectedTip:
-    'Your business account has been rejected. Check your email inbox, we sent you a letter with all details. You can resubmit your application.',
+    'global.statusNotifications.productsPricingAndOrderingWillBeEnabledAfterApproval',
+  approvedTip: 'global.statusNotifications.checkEmailLetterWithDetails',
+  rejectedTip: 'global.statusNotifications.checkEmailLetterWithDetailsResubmitApplication',
 };
 
 export const ADD_TO_QUOTE_DEFAULT_VALUE = 'Add to quote';

--- a/packages/lang/locales/en.json
+++ b/packages/lang/locales/en.json
@@ -116,6 +116,12 @@
   "global.addtoCart.purchasableAbdoosTip": "Products are out of stock or there are products that cannot be purchased.",
   "global.companyCredit.alert": "Your account does not currently allow purchasing due to a credit hold. Please contact us to reconcile.",
   "global.B3Upload.downloadErrorResults": "Download error results",
+  "global.statusNotifications.orderingWillBeEnabledAfterAccountApproval": "Your business account is pending approval. Ordering will be enabled after account approval.",
+  "global.statusNotifications.productsPricingAndOrderingWillBeEnabledAfterApproval": "Your business account is pending approval. Products, pricing, and ordering will be enabled after account approval",
+  "global.statusNotifications.willGainAccessToBusinessFeatAfterApproval": "Your business account is pending approval. You will gain access to business account features after account approval.",
+  "global.statusNotifications.willGainAccessToBusinessFeatProductsAndPricingAfterApproval": "Your business account is pending approval. You will gain access to business account features, products, and pricing after account approval.",
+  "global.statusNotifications.checkEmailLetterWithDetails": "Your business account has been approved. Check your email inbox, we sent you a letter with all details.",
+  "global.statusNotifications.checkEmailLetterWithDetailsResubmitApplication": "Your business account has been rejected. Check your email inbox, we sent you a letter with all details. You can resubmit your application.",
 
   "dashboard.company": "Company",
   "dashboard.admin": "Admin",


### PR DESCRIPTION
Jira: [BUN-2764](https://bigc-b2b.atlassian.net/browse/BUN-2764)

## What/Why?
I'm adding variables to translate notifications related to the status of new accounts. Right now there's no way to translate those notifications.

## Rollout/Rollback
Revert 

## Testing
<img width="979" alt="image" src="https://github.com/user-attachments/assets/b17f4be6-3b23-4683-943e-f5c86af4194a">

