### PR TITLE
fix: remove invalid email from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ For developers wishing to contribute, ensure all PRs meet the linting and commit
 
 ## 📞 Contact & Support
 
-For queries, issues, or support, reach out to us at b2b@bigcommerce.com or open an issue in this repository.
+For queries, issues, or support please open an issue in this repository.
 
 ## License
 


### PR DESCRIPTION
Jira: [BUN-2802](https://bigc-b2b.atlassian.net/browse/BUN-2802)

## What/Why?
Remove email from README as it is not a valid monitored email.

## Rollout/Rollback
Revert

## Testing
Not applicable
