### PR TITLE
fix: checkout link open register page instead of sending mail

### DIFF
--- a/apps/storefront/src/hooks/useB3AppOpen.ts
+++ b/apps/storefront/src/hooks/useB3AppOpen.ts
@@ -64,6 +64,16 @@ const useB3AppOpen = (initOpenState: OpenPageState) => {
     return isSearchNode;
   };
 
+  const handleJudgeCheckoutNormalHref = (element: MouseEvent) => {
+    if (window?.location?.pathname !== CHECKOUT_URL) return false;
+
+    const target = element.target as HTMLAnchorElement;
+
+    if (target.getAttribute('href') && target.getAttribute('href') === '#') return true;
+
+    return false;
+  };
+
   useLayoutEffect(() => {
     const registerArr = Array.from(document.querySelectorAll(globalB3['dom.registerElement']));
     const allOtherArr = Array.from(document.querySelectorAll(globalB3['dom.allOtherElement']));
@@ -75,7 +85,9 @@ const useB3AppOpen = (initOpenState: OpenPageState) => {
           allOtherArr.includes(e.target as Element)
         ) {
           const isSearchNode = handleJudgeSearchNode(e);
-          if (isSearchNode) return false;
+          const isCheckoutNormalHref = handleJudgeCheckoutNormalHref(e);
+
+          if (isSearchNode || isCheckoutNormalHref) return false;
           e.preventDefault();
           e.stopPropagation();
           const isRegisterArrInclude = registerArr.includes(e.target as Element);
@@ -114,13 +126,6 @@ const useB3AppOpen = (initOpenState: OpenPageState) => {
           const hrefArr = href.split('/#');
           if (hrefArr[1] === '') {
             href = isLogin ? authorizedPages : '/login';
-          }
-
-          if (
-            window?.location?.pathname === CHECKOUT_URL &&
-            (e.target as HTMLAnchorElement)?.getAttribute('href') === '#'
-          ) {
-            href = '/register';
           }
 
           if (


### PR DESCRIPTION
Jira: [BUN-2841](https://bigc-b2b.atlassian.net/browse/BUN-2841)

## What/Why

The passwordless login link email is not being sent correctly. Instead, it redirects the user to the Buyer Portal account registration.  Because the Buyer Portal has changed the link to jump to other

The solution:
Buyer Portal only needs to change the login and registration links

## Rollout/Rollback
undo pr

## Testing

https://github.com/user-attachments/assets/8a6bed75-029e-430b-8f46-06b2d3f64c91



