### PR TITLE
fix: refresh the flicker that appears in the load

### DIFF
--- a/apps/storefront/src/App.tsx
+++ b/apps/storefront/src/App.tsx
@@ -228,7 +228,6 @@ export default function App() {
         clearInvoiceCart();
       }
 
-      showPageMask(false);
       storeDispatch(
         setGlabolCommonState({
           isPageComplete: true,


### PR DESCRIPTION
Jira: [B2B-1061](https://bigcommercecloud.atlassian.net/browse/B2B-1061)

## What/Why?

refresh the flicker that appears in the load,

Because when the page is not loaded, the load mask is closed, and only the code needs to be deleted.

## Rollout/Rollback

undo pr

## Testing


https://github.com/user-attachments/assets/12df00b1-408a-4fb1-a8cf-4034417afa21



[B2B-1061]: https://bigcommercecloud.atlassian.net/browse/B2B-1061?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ