### PR TITLE
feat: add cart sync util functions

### DIFF
--- a/apps/storefront/src/components/HeadlessController.tsx
+++ b/apps/storefront/src/components/HeadlessController.tsx
@@ -1,5 +1,6 @@
 import { useContext, useEffect, useRef } from 'react';
 import { useB3Lang } from '@b3/lang';
+import Cookies from 'js-cookie';
 
 import { HeadlessRoutes } from '@/constants';
 import { addProductFromPage as addProductFromPageToShoppingList } from '@/hooks/dom/useOpenPDP';
@@ -221,6 +222,12 @@ export default function HeadlessController({ setOpenPage }: HeadlessControllerPr
             ...shoppingListBtnRef.current,
             enabled: shoppingListEnabledRef.current,
           }),
+        },
+        cart: {
+          setEntityId: (entityId) => {
+            Cookies.set('cartId', entityId);
+          },
+          getEntityId: () => Cookies.get('cartId'),
         },
       },
     };

--- a/apps/storefront/src/index.d.ts
+++ b/apps/storefront/src/index.d.ts
@@ -73,6 +73,10 @@ declare interface Window {
         ) => Promise<{ id: number; name: string; description: string }>;
         getButtonInfo: () => import('@/shared/customStyleButton/context/config').BtnProperties;
       };
+      cart: {
+        setEntityId: (entityId: string) => void;
+        getEntityId: () => undefined | string;
+      };
     };
   };
 }


### PR DESCRIPTION
Jira: [B2B-1255](https://bigcommercecloud.atlassian.net/browse/B2B-1255)

## What/Why?

Add cart util functions in order to help sync process in headless channels, this way they can have cart id in both sides

## Rollout/Rollback

Undo this PR

## Testing

https://github.com/user-attachments/assets/d522032a-6bab-4d74-bcdd-4a1396d7387a




[B2B-1255]: https://bigcommercecloud.atlassian.net/browse/B2B-1255?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ