### PR TITLE
fix: resolve the problem that the buyer portal page flashes

### DIFF
--- a/apps/storefront/src/App.tsx
+++ b/apps/storefront/src/App.tsx
@@ -222,13 +222,14 @@ export default function App() {
       // background login enter judgment and refresh
       if (!href.includes('checkout') && !(customerId && !window.location.hash)) {
         await gotoAllowedAppPage(+userInfo.role, gotoPage);
+      } else {
+        showPageMask(false);
       }
 
       if (customerId) {
         clearInvoiceCart();
       }
 
-      showPageMask(false);
       storeDispatch(
         setGlabolCommonState({
           isPageComplete: true,

--- a/apps/storefront/src/pages/Login/index.tsx
+++ b/apps/storefront/src/pages/Login/index.tsx
@@ -5,6 +5,7 @@ import { Alert, Box, ImageListItem } from '@mui/material';
 
 import { B3Card } from '@/components';
 import B3Spin from '@/components/spin/B3Spin';
+import { CHECKOUT_URL } from '@/constants';
 import { useMobile } from '@/hooks';
 import { CustomStyleContext } from '@/shared/customStyleButton';
 import { defaultCreateAccountPanel } from '@/shared/customStyleButton/context/config';
@@ -223,7 +224,7 @@ export default function Login(props: PageProps) {
     if (isCheckout) {
       try {
         await loginCheckout(data);
-        window.location.reload();
+        window.location.href = CHECKOUT_URL;
       } catch (error) {
         b2bLogger.error(error);
         getForcePasswordReset(data.emailAddress);


### PR DESCRIPTION
Jira: [B2B-1061](https://bigcommercecloud.atlassian.net/browse/B2B-1061)

## What/Why?

buyer portal When the browser refreshes or logs in to the theme page (cdn cache is not available), the buyer portal page flashes

### Solution 
  **Buyer portal interface flash status**
      Solution:
      Exclude the checkout page and close redundant showPageMask(false) to solve the flash problem

  **The checkout page does not trigger the mask**
      Solution:
        Method 1: After logging in to checkout, specify the path window.location.href = CHECKOUT_URL
        Method 2: Make a separate checkout page judgment and close the mask
        Both methods are compatible.

## Rollout/Rollback
undo pr

## Testing


https://github.com/user-attachments/assets/9330cf4c-77ee-4b93-9c6a-af95bebb2d0c

https://github.com/user-attachments/assets/3b9a0f08-4b04-4597-85a1-51d270cc8f6b

@LeoChowChina  @bc-micah @bc-victor 

[B2B-1061]: https://bigcommercecloud.atlassian.net/browse/B2B-1061?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ