### PR TITLE
feat: infra-18574: Add Circle CI builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,64 @@
+aliases:
+  - &node_executor
+      executor:
+        name: node/node
+        node-version: "18.20"
+
+version: 2.1
+
+orbs:
+  ci: bigcommerce/internal@volatile
+  node: bigcommerce/internal-node@volatile
+  security: bigcommerce/internal-security@volatile
+
+jobs:
+  test:
+    <<: *node_executor
+    parallelism: 2
+    resource_class: medium+
+    steps:
+      - ci/pre-setup
+      - node/yarn-install
+      - run:
+          name: "Run unit tests for core package"
+          command: |
+            yarn test
+
+  lint:
+    <<: *node_executor
+    resource_class: medium+
+    steps:
+      - ci/pre-setup
+      - node/yarn-install
+      - run:
+          name: "Run lint"
+          command: yarn run lint
+
+  build_and_push:
+    <<: *node_executor
+    resource_class: medium+
+    steps:
+      - ci/pre-setup
+      - node/yarn-install
+      - ci/gcloud_login
+      - run:
+          name: "Build distribution files"
+          command: |
+             yarn build:production
+             mv apps/storefront/dist ${CIRCLE_SHA1}
+             tar zcf ${CIRCLE_SHA1}.tar.gz ${CIRCLE_SHA1}
+             ./google-cloud-sdk/bin/gsutil cp ${CIRCLE_SHA1}.tar.gz gs://bigcommerce-common-deployment-artifact-gcs-storage/b2b-buyer-portal/${CIRCLE_SHA1}.tar.gz
+
+workflows:
+  version: 2
+
+  default:
+    jobs:
+      - test
+      - lint
+      - build_and_push:
+          context: "GCR + Artifact Bucket Access"
+      - ci/notify-success:
+          context: "GCR + Artifact Bucket Access"
+          requires:
+            - build_and_push


### PR DESCRIPTION
Jira: [INFRA-18574](https://bigcommercecloud.atlassian.net/browse/infra-18574)

## What/Why?
Builds the application with Circle CI. This is required for a second type of deployment we're pursuing for this application.

## Rollout/Rollback
Rollout will be done by internal deployment and verifying the application exists in the expected places.

Rollback is as simple as removing the Circle CI config, and turning off builds in CCI.

## Testing
We can see the artifact uploaded to the GCS bucket here
![Screenshot 2024-10-01 at 2 31 48 PM](https://github.com/user-attachments/assets/addefab3-b643-43d9-aaff-1df01cadc7b4)



[INFRA-18574]: https://bigcommercecloud.atlassian.net/browse/INFRA-18574?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ