### PR TITLE
feat: empty options and default variant support for shopping list

### DIFF
--- a/apps/storefront/src/pages/PDP/index.tsx
+++ b/apps/storefront/src/pages/PDP/index.tsx
@@ -89,9 +89,12 @@ export const addProductsToShoppingList = async ({
     const { allOptions: requiredOptions, variants } = productsInfo[index];
     const { productId, sku, variantId: vId, quantity, optionSelections } = items[index];
     // check if it's an specified product
-    const variantId = vId || variants.find((item: { sku: string }) => item.sku === sku)?.variant_id;
+    const variantId =
+      vId ||
+      variants.find((item: { sku: string }) => item.sku === sku)?.variant_id ||
+      variants[0]?.variant_id;
     // get selected options by inputed data
-    const optionList = getProductOptionList(optionSelections);
+    const optionList = !optionSelections ? [] : getProductOptionList(optionSelections);
     // verify inputed data includes required data
     const { isValid, message } = isAllRequiredOptionFilled(requiredOptions, optionList);
 


### PR DESCRIPTION
Jira: [B2B-1447](https://bigcommercecloud.atlassian.net/browse/B2B-1447)

## What/Why?
Fixing a bug where empty options would break the add product to shopping list callback. Adding support to choose a default variant id if no sku is supplied

## Rollout/Rollback
Rolled out via ci/ revert

## Testing

![shlistfix](https://github.com/user-attachments/assets/37f3d4d6-d64a-44ae-a3e6-d38c83b4b1b8)


[B2B-1447]: https://bigcommercecloud.atlassian.net/browse/B2B-1447?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ