### PR TITLE
fix: fixing superAdminCompany query in getMasquerade util

### DIFF
--- a/apps/storefront/src/components/HeadlessController.tsx
+++ b/apps/storefront/src/components/HeadlessController.tsx
@@ -159,7 +159,7 @@ export default function HeadlessController({ setOpenPage }: HeadlessControllerPr
             } = await superAdminCompanies(customerRef.current.b2bId, {
               first: 50,
               offset: 0,
-              orderBy: 'companyId',
+              orderBy: 'companyName',
             });
 
             return {


### PR DESCRIPTION
Jira: [B2B-1447](https://bigcommercecloud.atlassian.net/browse/B2B-1447)

## What/Why?
Fixing a bug where the superAdminCompanies query would fail as the sortBy parameter is incorrect.

## Rollout/Rollback
Rolled out via ci/ revert

## Testing
<img width="1624" alt="Screenshot 2024-10-02 at 4 50 12 p m" src="https://github.com/user-attachments/assets/ef36053d-0357-439d-a211-2233dc0b7b6d">


[B2B-1447]: https://bigcommercecloud.atlassian.net/browse/B2B-1447?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ