### PR TITLE
feat: send channel id when validate company extrafields

### DIFF
--- a/apps/storefront/src/shared/service/b2b/api/register.ts
+++ b/apps/storefront/src/shared/service/b2b/api/register.ts
@@ -1,4 +1,4 @@
-import { storeHash } from '@/utils';
+import { channelId, storeHash } from '@/utils';
 
 import B3Request from '../../request/b3Fetch';
 import { RequestType } from '../../request/base';
@@ -71,6 +71,7 @@ export const validateBCCompanyExtraFields = (data: CustomFieldItems) =>
   B3Request.post('/api/v2/extra-fields/company/validate', RequestType.B2BRest, {
     ...data,
     storeHash,
+    bcChannelId: channelId,
   });
 
 export const validateBCCompanyUserExtraFields = (data: CustomFieldItems) =>


### PR DESCRIPTION
Jira: [B2B-1391](https://bigcommercecloud.atlassian.net/browse/B2B-1391)

## What/Why?

Add channel id to payload to validate company extra fields to support translations

## Rollout/Rollback

Undo this PR

## Testing

### Use storefront translate 
![image](https://github.com/user-attachments/assets/2f526b6f-8ff2-4bcc-a991-eb41fc040ccf)


### Use global translate
![image](https://github.com/user-attachments/assets/37c1166b-b021-4a8f-9a71-0d663efb89dd)



[B2B-1391]: https://bigcommercecloud.atlassian.net/browse/B2B-1391?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ