### PR TITLE
fix: set permissions consumed from new query

### DIFF
--- a/apps/storefront/src/App.tsx
+++ b/apps/storefront/src/App.tsx
@@ -200,7 +200,7 @@ export default function App() {
           getStoreTaxZoneRates(),
           setStorefrontConfig(dispatch),
           getTemPlateConfig(styleDispatch, dispatch),
-          getCompanyUserInfo(emailAddress, customerId),
+          getCompanyUserInfo(),
           getCompanyInfo(role, b2bId),
         ]);
       } catch (e) {

--- a/apps/storefront/src/App.tsx
+++ b/apps/storefront/src/App.tsx
@@ -22,12 +22,7 @@ import {
 import clearInvoiceCart from './utils/b3ClearCart';
 import b2bLogger from './utils/b3Logger';
 import { isUserGotoLogin } from './utils/b3logout';
-import {
-  getCompanyInfo,
-  getCompanyUserInfo,
-  getCurrentCustomerInfo,
-  loginInfo,
-} from './utils/loginInfo';
+import { getCompanyInfo, getCurrentCustomerInfo, loginInfo } from './utils/loginInfo';
 import {
   getStoreTaxZoneRates,
   getTemPlateConfig,
@@ -200,7 +195,6 @@ export default function App() {
           getStoreTaxZoneRates(),
           setStorefrontConfig(dispatch),
           getTemPlateConfig(styleDispatch, dispatch),
-          getCompanyUserInfo(),
           getCompanyInfo(role, b2bId),
         ]);
       } catch (e) {

--- a/apps/storefront/src/pages/Login/index.tsx
+++ b/apps/storefront/src/pages/Login/index.tsx
@@ -16,11 +16,10 @@ import { deleteCart, getCart } from '@/shared/service/bc/graphql/cart';
 import {
   clearMasqueradeCompany,
   isLoggedInSelector,
-  store,
   useAppDispatch,
   useAppSelector,
 } from '@/store';
-import { setB2BToken, setPermissionModules } from '@/store/slices/company';
+import { setB2BToken } from '@/store/slices/company';
 import { CustomerRole, UserTypes } from '@/types';
 import { channelId, getB3PermissionsList, loginJump, snackbar, storeHash } from '@/utils';
 import b2bLogger from '@/utils/b3Logger';
@@ -239,13 +238,12 @@ export default function Login(props: PageProps) {
         };
         const {
           login: {
-            result: { token, storefrontLoginToken, permissions },
+            result: { token, storefrontLoginToken },
             errors,
           },
         } = await b2bLogin({ loginData });
 
         storeDispatch(setB2BToken(token));
-        store.dispatch(setPermissionModules(permissions));
         customerLoginAPI(storefrontLoginToken);
 
         if (errors?.[0] || !token) {

--- a/apps/storefront/src/shared/service/b2b/graphql/register.ts
+++ b/apps/storefront/src/shared/service/b2b/graphql/register.ts
@@ -114,9 +114,13 @@ const getRegisterLogo = () => `{
   }
 }`;
 
-const getCompanyUserInfo = <T>(email: T, customerId: string | number) => `{
-  companyUserInfo(storeHash:"${storeHash}", email:"${email}", ${`customerId: ${customerId}`}) {
+const getCustomerInfo = () => `{
+  customerInfo {
     userType,
+    permissions {
+      code
+      permissionLevel
+    },
     userInfo {
       id
       phoneNumber
@@ -266,9 +270,9 @@ export const getB2BAccountFormFields = (type: number) =>
     query: getAccountFormFields(type),
   });
 
-export const getB2BCompanyUserInfo = (email: string, customerId: string | number) =>
+export const getB2BCompanyUserInfo = () =>
   B3Request.graphqlB2B({
-    query: getCompanyUserInfo(email, customerId),
+    query: getCustomerInfo(),
   });
 
 export const getB2BRegisterLogo = () =>

--- a/apps/storefront/src/utils/loginInfo.ts
+++ b/apps/storefront/src/utils/loginInfo.ts
@@ -209,22 +209,22 @@ export const agentInfo = async (customerId: number | string, role: number) => {
   }
 };
 
-export const getCompanyUserInfo = async (emailAddress: string, customerId: string | number) => {
+export const getCompanyUserInfo = async () => {
   try {
-    if (!emailAddress || !customerId) return undefined;
-
     const {
-      companyUserInfo: {
+      customerInfo: {
         userType,
         userInfo: { role = '', id, companyRoleName = '' },
+        permissions,
       },
-    } = await getB2BCompanyUserInfo(emailAddress, customerId);
+    } = await getB2BCompanyUserInfo();
 
     return {
       userType,
       role,
       id,
       companyRoleName,
+      permissions,
     };
   } catch (error) {
     b2bLogger.error(error);
@@ -290,10 +290,10 @@ export const getCurrentCustomerInfo: (b2bToken?: string) => Promise<
       customerGroupId,
     } = loginCustomer;
 
-    const companyUserInfo = await getCompanyUserInfo(emailAddress, customerId);
+    const companyUserInfo = await getCompanyUserInfo();
 
     if (companyUserInfo && customerId) {
-      const { userType, role, id, companyRoleName } = companyUserInfo;
+      const { userType, role, id, companyRoleName, permissions } = companyUserInfo;
 
       const [companyInfo] = await Promise.all([
         getCompanyInfo(role, id, userType),
@@ -328,6 +328,7 @@ export const getCurrentCustomerInfo: (b2bToken?: string) => Promise<
       store.dispatch(resetDraftQuoteList());
       store.dispatch(resetDraftQuoteInfo());
       store.dispatch(clearMasqueradeCompany());
+      store.dispatch(setPermissionModules(permissions));
       store.dispatch(setCompanyInfo(companyPayload));
       store.dispatch(setCustomerInfo(customerInfo));
       store.dispatch(setQuoteUserId(quoteUserId));


### PR DESCRIPTION
Jira: [B2B-1503](https://bigcommercecloud.atlassian.net/browse/B2B-1503)

## What/Why?

Fix for a reported bug about users are not able to use routes through `b2b.utils.openPage` function, this includes:
- Use new query `customerInfo` to retrieve customer info
- Move logic to save permissions from login form view to getCompanyUserInfo function
- Remove `getCompanyUserInfo` where is not necessary

## Rollout/Rollback

Undo this PR

## Testing

### Before

https://github.com/user-attachments/assets/c0299069-20fa-4750-8af8-cafc45f826cf


### Using login form

#### B2B

https://github.com/user-attachments/assets/e735301b-8ac6-45d6-b905-cb714e9e6917


#### B2C

https://github.com/user-attachments/assets/df16b08a-0d60-456b-b061-65c0de3b3ce4

### Using headless API

#### B2B

https://github.com/user-attachments/assets/b2d24e7c-2b88-46c0-902e-6a859c057097


#### B2C

https://github.com/user-attachments/assets/29e88284-71a1-48a3-ae74-b9b57d4d60fd



[B2B-1503]: https://bigcommercecloud.atlassian.net/browse/B2B-1503?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ