### PR TITLE
fix: deploy headless.js file for tier1 environment

### DIFF
--- a/apps/storefront/package.json
+++ b/apps/storefront/package.json
@@ -8,6 +8,7 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "build:staging": "tsc && vite build --mode staging",
+    "build:tier1": "tsc && vite build --mode tier1",
     "lint": "yarn lint:eslint && yarn lint:dependencies",
     "lint:eslint": "eslint . --ext .ts,.tsx,.js --cache --cache-location ./node_modules/.cache/eslint --max-warnings 0 .",
     "lint:dependencies": "depcruise --config .dependency-cruiser.cjs . --output-type err-long",

--- a/apps/storefront/vite.config.ts
+++ b/apps/storefront/vite.config.ts
@@ -10,13 +10,20 @@ interface AssetsAbsolutePathProps {
   [key: string]: string;
 }
 
+const PRODUCTION_ENV = 'production';
+const TIER1_ENV = 'tier1';
+
 const assetsAbsolutePath: AssetsAbsolutePathProps = {
   staging: 'https://cdn.bundleb2b.net/b2b/staging/storefront/assets/',
   production: 'https://cdn.bundleb2b.net/b2b/production/storefront/assets/',
 };
 
 export default defineConfig(({ mode }) => {
-  const env = loadEnv(mode, process.cwd());
+  let modeVariable = mode;
+  if (mode === TIER1_ENV) {
+    modeVariable = PRODUCTION_ENV;
+  }
+  const env = loadEnv(modeVariable, process.cwd());
   return {
     plugins: [
       legacy({
@@ -39,7 +46,7 @@ export default defineConfig(({ mode }) => {
           const name = filename.split('assets/')[1];
           return isCustom
             ? `${env.VITE_ASSETS_ABSOLUTE_PATH}${name}`
-            : `${assetsAbsolutePath[mode]}${name}`;
+            : `${assetsAbsolutePath[modeVariable]}${name}`;
         }
 
         return undefined;
@@ -100,8 +107,12 @@ export default defineConfig(({ mode }) => {
         },
         output: {
           entryFileNames(info) {
+            let baseNameFile = '[name].js';
+            if (mode === TIER1_ENV) {
+              baseNameFile = '[name]-tier1.js';
+            }
             const { name } = info;
-            return name.includes('headless') ? '[name].js' : '[name].[hash].js';
+            return name.includes('headless') ? baseNameFile : '[name].[hash].js';
           },
           manualChunks: {
             reactVendor: ['react', 'react-dom'],

--- a/apps/storefront/vite.config.ts
+++ b/apps/storefront/vite.config.ts
@@ -19,10 +19,7 @@ const assetsAbsolutePath: AssetsAbsolutePathProps = {
 };
 
 export default defineConfig(({ mode }) => {
-  let modeVariable = mode;
-  if (mode === TIER1_ENV) {
-    modeVariable = PRODUCTION_ENV;
-  }
+  const modeVariable = mode === TIER1_ENV ? PRODUCTION_ENV : mode;
   const env = loadEnv(modeVariable, process.cwd());
   return {
     plugins: [
@@ -106,13 +103,12 @@ export default defineConfig(({ mode }) => {
           headless: 'src/buyerPortal.ts',
         },
         output: {
-          entryFileNames(info) {
-            let baseNameFile = '[name].js';
-            if (mode === TIER1_ENV) {
-              baseNameFile = '[name]-tier1.js';
+          entryFileNames({ name }) {
+            if (name.includes('headless')) {
+              return mode === TIER1_ENV ? '[name]-tier1.js' : '[name].js';
             }
-            const { name } = info;
-            return name.includes('headless') ? baseNameFile : '[name].[hash].js';
+
+            return '[name].[hash].js';
           },
           manualChunks: {
             reactVendor: ['react', 'react-dom'],

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "build": "turbo run build",
     "build:production": "turbo run build",
     "build:staging": "turbo run build:staging",
+    "build:tier1": "turbo run build:tier1",
     "dev": "turbo run dev --parallel",
     "lint": "turbo run lint --parallel --continue",
     "format": "turbo run format --parallel --continue",

--- a/turbo.json
+++ b/turbo.json
@@ -15,6 +15,10 @@
       "dependsOn": ["^build"],
       "outputs": ["dist/**"]
     },
+    "build:tier1": {
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**"]
+    },
     "test": {
       "dependsOn": ["^build"],
       "cache": false


### PR DESCRIPTION
Jira: [B2B-1009](https://bigcommercecloud.atlassian.net/browse/B2B-1009)

## What/Why?

Fix for deployment process to tier1

## Rollout/Rollback

Undo this PR

## Testing
![image](https://github.com/user-attachments/assets/9a9182c5-48ca-4a7a-afd6-e890e3dafa46)

[B2B-1009]: https://bigcommercecloud.atlassian.net/browse/B2B-1009?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ