### PR TITLE
fix(b2b-1585): support for build command in deployment workflow

### DIFF
--- a/.github/workflows/deploy-production-tier1-only.yml
+++ b/.github/workflows/deploy-production-tier1-only.yml
@@ -12,4 +12,5 @@ jobs:
     with:
       environment: production
       store_list: ./deployment/production-tier1.json
+      build_command: build:tier1
     secrets: inherit

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -8,4 +8,5 @@ jobs:
     uses: ./.github/workflows/deploy.yml
     with:
       environment: production
+      build_command: build:production
     secrets: inherit

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -14,4 +14,5 @@ jobs:
     uses: ./.github/workflows/deploy.yml
     with:
       environment: staging
+      build_command: build:staging
     secrets: inherit

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,9 @@ on:
       store_list:
         required: false
         type: string
+      build_command:
+        required: true
+        type: string
     secrets:
       ENV:
         required: true
@@ -42,7 +45,7 @@ jobs:
         run: base64 -d <<<${{ secrets.ENV }} > apps/storefront/.env.${{ inputs.environment }}
 
       - name: Build
-        run: yarn build:${{ inputs.environment }}
+        run: yarn ${{ inputs.build_command }}
 
       - name: Calculate revision
         run: echo "REVISION_TITLE=$(git rev-parse --short HEAD)-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}" >> $GITHUB_ENV


### PR DESCRIPTION
Jira: [B2B-1585](https://bigcommercecloud.atlassian.net/browse/B2B-1585)

## What/Why?
Add support for build command independent from environment in deployment workflow

## Rollout/Rollback
Revert this PR 

## Testing
NA

[B2B-1585]: https://bigcommercecloud.atlassian.net/browse/B2B-1585?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ