### PR TITLE
docs: update headless and stencil getting started guide into separate…

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ For assistance with activating the remote buyer portal or to inquire about multi
 - **Node:** Ensure you have Node.js version >=18.0.0.
 - **Package Manager:** This project uses Yarn v1.22.17.
 
-## ⚙ Local Development
+## ⚙ Getting Started
 
 1. Installation of Node and Yarn.
    - For Node, we recommend using [nvm](https://github.com/nvm-sh/nvm).
@@ -107,150 +107,21 @@ For assistance with activating the remote buyer portal or to inquire about multi
 2. Clone the repository.
 3. Install dependencies using `yarn`.
 4. Copy environment variables: `cp apps/storefront/.env-example apps/storefront/.env`.
-5. Update the following values in `.env`:
-
-- `VITE_ASSETS_ABSOLUTE_PATH`: For building for deployment, set this to the URL where the assets folder is hosted. **Note that this refers to the absolute URL to the `/assets` folder, NOT the root/base URL of the build. Remember to also include the trailing slash**.
-
-  For example, if you deploy the contents of the `dist` folder built by running `yarn build` and hosted it at https://my.custom.cdn/generated/b2b, the value you should put is https://my.custom.cdn/generated/b2b/assets/.
-
-Environment variables have been updated so you can run your UI directly into production storefronts.
-
+5. Update the values in `.env` with your specific values
 6. Start the development server: `yarn dev`.
 7. **Access to the store through the url i.e: https://my-store.mybigcommerce.com/ or https://my-store.com/ not http://localhost:3001**
 
+### [Developing on Stencil](./docs/stencil.md)
 
-## Running Project Locally
+Read the [Stencil Guide](./docs/stencil.md) when you are working on the BigCommerce Stencil storefront platform
 
-1. Activate store channel in the Channels Manager.
-2. Configure header and footer scripts:
+### [Developing for Headless](./docs/headless.md)
 
-- Navigate to Channels Manager -> Scripts.
-- Delete first scripts: `B2BEdition Header Script` and `B2BEdition Footer Script`, then
-- Add two scripts (e.g., B2BEdition-header, B2BEdition-footer). Ensure you set the correct port for your localhost in the script URLs. In the "Location" section make sure you check on "All pages".
-- Edit the header script:
-
-```html
-<script>
-  {{#if customer.id}}
-  {{#contains page_type "account"}}
-  var b2bHideBodyStyle = document.createElement('style');
-  b2bHideBodyStyle.id = 'b2b-account-page-hide-body';
-  b2bHideBodyStyle.innerHTML = 'body { display: none !important }';
-  document.head.appendChild(b2bHideBodyStyle);
-  {{/contains}}
-  {{/if}}
-</script>
-<script type="module">
-  import RefreshRuntime from 'http://localhost:3001/@react-refresh'
-  RefreshRuntime.injectIntoGlobalHook(window)
-  window.$RefreshReg$ = () => {}
-  window.$RefreshSig$ = () => (type) => type
-  window.__vite_plugin_react_preamble_installed__ = true
-</script>
-<script type="module" src="http://localhost:3001/@vite/client"></script>
-```
-
-- Edit the footer script:
-
-```html
-<script type="module" src="http://localhost:3001/src/main.ts"></script>
-<script>
-  window.B3 = {
-    setting: {
-      store_hash: '{{settings.store_hash}}',
-      channel_id: {{settings.channel_id}},
-      platform: 'bigcommerce', // override this depending on your store channel platform: https://developer.bigcommerce.com/docs/rest-management/channels#platform
-    },
-  }
-</script>
-```
-
-3. For local debugging, set `VITE_LOCAL_DEBUG` to `false` in .env.
-
-4. Enable `Custom (use for your self-hosted buyer portal)`, this will avoid the scripts mentioned on step 2 -> 2nd point
-- In B2B Edition App dashboard -> Settings -> Buyer Portal for global config
-![Buyer portal type global settings](public/images/buyer-portal-type-settings-global.png)
-- Or B2B Edition App dashboard -> Storefront -> Desired channel -> Buyer Portal for specific channel config
-![Buyer portal type channel settings](public/images/buyer-portal-type-settings-channel.png) [alt text](README.md)
-
-5. Visit the storefront and attempt to sign in.
-
-6. For cross-origin issues, update URL variables in .env to use the tunnel URL with HTTPS.
-
-Note: If linters aren't functional, run `yarn prepare` first.
-
-## Deploying the project
-
-Building your buyer portal application requires you to run the `yarn build:production` command. This command will generate a `dist` folder in the `apps/storefront` directory and inside an `assets` folder containing the compiled assets.
-
-**_Before building, make sure you have updated your `VITE_ASSETS_ABSOLUTE_PATH` variable pointing to where the assets folder is hosted as we'll be using this to generate the correct asset paths for the application when its mounted._**
-
-Once you have uploaded the contents of the `dist` folder to your hosting provider, you'll have to create a footer script in your BigCommerce storefront that points to the built files generated in the `dist` folder. The contents of the script are the same as the footer script B2B Edition installs in your store, but with the updated paths. It should look something like this:
-
-```html
-<script>
-  window.b3CheckoutConfig = {
-    routes: {
-      dashboard: '/account.php?action=order_status',
-    },
-  }
-  window.B3 = {
-    setting: {
-      store_hash: '<YOUR_STORE_HASH>',
-      channel_id: '<YOUR_CHANNEL_ID>',
-      platform: '<YOUR_STORE_PLATFORM>',
-      b2b_url: 'https://api-b2b.bigcommerce.com',
-      captcha_setkey: '6LdGN_sgAAAAAGYFg1lmVoakQ8QXxbhWqZ1GpYaJ',
-    },
-    'dom.checkoutRegisterParentElement': '#checkout-app',
-    'dom.registerElement':
-      '[href^="/login.php"], #checkout-customer-login, [href="/login.php"] .navUser-item-loginLabel, #checkout-customer-returning .form-legend-container [href="#"]',
-    'dom.openB3Checkout': 'checkout-customer-continue',
-    before_login_goto_page: '/account.php?action=order_status',
-    checkout_super_clear_session: 'true',
-    'dom.navUserLoginElement': '.navUser-item.navUser-item--account',
-  }
-</script>
-<script
-  type="module"
-  crossorigin=""
-  src="<YOUR_APP_URL_HERE>/index.*.js"
-></script>
-<script
-  nomodule=""
-  crossorigin=""
-  src="<YOUR_APP_URL_HERE>/polyfills-legacy.*.js"
-></script>
-<script
-  nomodule=""
-  crossorigin=""
-  src="<YOUR_APP_URL_HERE>/index-legacy.*.js"
-></script>
-```
-
-Replace `<YOUR_APP_URL_HERE>` with the URL where your build is hosted, `<YOUR_STORE_HASH>` and `<YOUR_CHANNEL_ID>` with its respective values. Replace the `*` in the file names with the generated hash from the build step.
-
-Also, you'll have to input the following header script:
-
-```html
-<script>
-  var b2bHideBodyStyle = document.createElement('style')
-  b2bHideBodyStyle.id = 'b2b-account-page-hide-body'
-  const removeCart = () => {
-    const style = document.createElement('style')
-    style.type = 'text/css'
-    style.id = 'b2bPermissions-cartElement-id'
-    style.innerHTML =
-      '[href="/cart.php"], #form-action-addToCart, [data-button-type="add-cart"], .button--cardAdd, .card-figcaption-button, [data-emthemesmodez-cart-item-add], .add-to-cart-button { display: none !important }'
-    document.getElementsByTagName('head').item(0).appendChild(style)
-  }
-  removeCart()
-</script>
-```
+Read the [Headless Guide](./docs/headless.md) when you are working on Catalyst, NextJS and other headless storefronts
 
 ### Common issues:
 
-- **Stencil CLI** We're working to bring full support to integrate buyer portal into [stencil-cli](https://developer.bigcommerce.com/docs/storefront/stencil), there are issues on logging out and cart management, if you find other problems feel free to open an issue report.
+- **Stencil CLI** We're working to bring full support to integrate buyer portal into [stencil-cli](https://developer.bigcommerce.com/docs/storefront/stencil). If you find any issues feel free to open an issue report.
 - **Cross-Origin Issues:** If you encounter cross-origin issues, ensure you have the correct URLs in your `.env` file and verify that your store's origin URL is allowed. You can use a tunnel service like [ngrok](https://ngrok.com/) to expose your local server to the internet.
 - **Environment Variables:** Ensure you have the correct environment variables set in your `.env` file. These variables are used to configure your application for different environments.
 - **Header and Footer Scripts:** Ensure you have the correct header and footer scripts set in your BigCommerce store. These scripts are used to load your application into the storefront.

--- a/docs/headless.md
+++ b/docs/headless.md
@@ -1,0 +1,108 @@
+# Headless Guide
+
+## Running Project Locally
+
+1. Activate store channel in the Channels Manager
+2. For local debugging, set `VITE_LOCAL_DEBUG` to `false` in .env.
+3. Make sure that the buyer portal is running `yarn dev`
+4. Add the buyer portal scripts to your headless storefront files running locally
+
+- Script for the `<head>` tag
+
+```html
+<script type="module">
+  import RefreshRuntime from 'http://localhost:3001/@react-refresh'
+  RefreshRuntime.injectIntoGlobalHook(window)
+  window.$RefreshReg$ = () => {}
+  window.$RefreshSig$ = () => (type) => type
+  window.__vite_plugin_react_preamble_installed__ = true
+</script>
+<script type="module" src="http://localhost:3001/@vite/client"></script>
+```
+
+- Script for the `<body>` tag and make sure to replace the `{REPLACE_WITH_YOUR_STORE_HASH}` and `{REPLACE_WITH_YOUR_CHANNEL_ID}` with the appropriate information
+
+```html
+<script type="module" src="http://localhost:3001/src/main.ts"></script>
+<script>
+  window.B3 = {
+    setting: {
+      store_hash: '{REPLACE_WITH_YOUR_STORE_HASH}',
+      channel_id: { REPLACE_WITH_YOUR_CHANNEL_ID },
+      platform: 'headless',
+      // override this depending on your store channel platform: https://developer.bigcommerce.com/docs/rest-management/channels#platform
+    },
+  }
+</script>
+```
+
+5. Enable `Custom (use for your self-hosted buyer portal)`
+
+  - In B2B Edition App dashboard -> Settings -> Buyer Portal for global config ![Buyer portal type global settings](../public/images/buyer-portal-type-settings-global.png)
+  - Or B2B Edition App dashboard -> Storefront -> Desired channel -> Buyer Portal for specific channel config ![Buyer portal type channel settings](../public/images/buyer-portal-type-settings-channel.png)
+
+6. Visit the headless storefront and attempt to sign in.
+
+**FAQs:**
+- linters are not working: run `yarn prepare` first.
+- `cross-origin` issues: update URL variables in .env to make sure api calls are using your tunnel URL with HTTPS.
+
+## Deploying the project
+
+Building your buyer portal application requires you to run the `yarn build` command. This command will generate a `dist` folder in the `apps/storefront` directory and inside an `assets` folder containing the compiled assets.
+
+Make sure that you have configured the following `.env` values correctly before building:
+
+- `VITE_ASSETS_ABSOLUTE_PATH`: Set this to the URL where the assets folder is hosted. **Note that this needs to be the absolute URL to the `/assets` folder location where the build will be served from in production.** Also please include the trailing `/`.
+
+  For example, if you deploy the contents of the `dist` folder built by running `yarn build` and hosted it at https://my.custom.cdn/generated/b2b, the value you should put is https://my.custom.cdn/generated/b2b/assets/.
+
+Environment variables have been updated so you can run your UI directly into production storefronts.
+
+Once you have uploaded the contents of the `dist` folder to your hosting provider, you will need to include a reference to the scripts in your headless site as well. It should look something like this:
+
+```html
+<script>
+  window.b3CheckoutConfig = {
+    routes: {
+      dashboard: '/account.php?action=order_status',
+    },
+  }
+  window.B3 = {
+    setting: {
+      store_hash: '<YOUR_STORE_HASH>',
+      channel_id: '<YOUR_CHANNEL_ID>',
+      platform: 'headless',
+      b2b_url: 'https://api-b2b.bigcommerce.com',
+      captcha_setkey: '6LdGN_sgAAAAAGYFg1lmVoakQ8QXxbhWqZ1GpYaJ',
+    },
+    'dom.checkoutRegisterParentElement': '#checkout-app',
+    'dom.registerElement':
+      '[href^="/login.php"], #checkout-customer-login, [href="/login.php"] .navUser-item-loginLabel, #checkout-customer-returning .form-legend-container [href="#"]',
+    'dom.openB3Checkout': 'checkout-customer-continue',
+    before_login_goto_page: '/account.php?action=order_status',
+    checkout_super_clear_session: 'true',
+    'dom.navUserLoginElement': '.navUser-item.navUser-item--account',
+  }
+</script>
+<script
+  type="module"
+  crossorigin=""
+  src="<YOUR_APP_URL_HERE>/index.*.js"
+></script>
+<script
+  nomodule=""
+  crossorigin=""
+  src="<YOUR_APP_URL_HERE>/polyfills-legacy.*.js"
+></script>
+<script
+  nomodule=""
+  crossorigin=""
+  src="<YOUR_APP_URL_HERE>/index-legacy.*.js"
+></script>
+```
+
+Replace the following values:
+- `<VITE_ASSETS_ABSOLUTE_PATH>` with the value you used for the environment variable `VITE_ASSETS_ABSOLUTE_PATH` (where your build is hosted)
+- `<YOUR_STORE_HASH>` with your store hash
+- `<YOUR_CHANNEL_ID>` with the headless channel id

--- a/docs/headless.md
+++ b/docs/headless.md
@@ -20,17 +20,22 @@
 <script type="module" src="http://localhost:3001/@vite/client"></script>
 ```
 
-- Script for the `<body>` tag and make sure to replace the `{REPLACE_WITH_YOUR_STORE_HASH}` and `{REPLACE_WITH_YOUR_CHANNEL_ID}` with the appropriate information
+- Script for the `<body>` tag and make sure to 
+
+> [!IMPORTANT]  
+> Platform is required to load buyer portal properly, select one depending on [your store channel platform](https://developer.bigcommerce.com/docs/rest-management/channels#platform)
+
+> [!WARNING]
+> Replace the `REPLACE_WITH_YOUR_STORE_HASH` and `REPLACE_WITH_YOUR_CHANNEL_ID` with the appropriate information
 
 ```html
 <script type="module" src="http://localhost:3001/src/main.ts"></script>
 <script>
   window.B3 = {
     setting: {
-      store_hash: '{REPLACE_WITH_YOUR_STORE_HASH}',
-      channel_id: { REPLACE_WITH_YOUR_CHANNEL_ID },
+      store_hash: 'REPLACE_WITH_YOUR_STORE_HASH',
+      channel_id: REPLACE_WITH_YOUR_CHANNEL_ID,
       platform: 'headless',
-      // override this depending on your store channel platform: https://developer.bigcommerce.com/docs/rest-management/channels#platform
     },
   }
 </script>
@@ -70,8 +75,8 @@ Once you have uploaded the contents of the `dist` folder to your hosting provide
   }
   window.B3 = {
     setting: {
-      store_hash: '<YOUR_STORE_HASH>',
-      channel_id: '<YOUR_CHANNEL_ID>',
+      store_hash: 'REPLACE_WITH_YOUR_STORE_HASH',  
+      channel_id: REPLACE_WITH_YOUR_CHANNEL_ID,
       platform: 'headless',
       b2b_url: 'https://api-b2b.bigcommerce.com',
       captcha_setkey: '6LdGN_sgAAAAAGYFg1lmVoakQ8QXxbhWqZ1GpYaJ',
@@ -102,7 +107,8 @@ Once you have uploaded the contents of the `dist` folder to your hosting provide
 ></script>
 ```
 
-Replace the following values:
-- `<VITE_ASSETS_ABSOLUTE_PATH>` with the value you used for the environment variable `VITE_ASSETS_ABSOLUTE_PATH` (where your build is hosted)
-- `<YOUR_STORE_HASH>` with your store hash
-- `<YOUR_CHANNEL_ID>` with the headless channel id
+> [!IMPORTANT]
+> Replace the following values:
+> - `<VITE_ASSETS_ABSOLUTE_PATH>` with the value you used for the environment variable `VITE_ASSETS_ABSOLUTE_PATH` (where your build is hosted)
+> - `REPLACE_WITH_YOUR_STORE_HASH` with your store hash
+> - `REPLACE_WITH_YOUR_CHANNEL_ID` with the headless channel id

--- a/docs/stencil.md
+++ b/docs/stencil.md
@@ -1,0 +1,142 @@
+# Stencil Guide
+
+## Running Project Locally
+
+1. Activate store channel in the Channels Manager.
+2. Configure header and footer scripts:
+  - Navigate to Channels Manager -> Scripts.
+  - Delete the scripts: with the following names:
+    - `B2BEdition Header Script`
+    - `B2BEdition Footer Script`
+  - Add a the header script with the following values
+    - Name: `B2B Edition Header Script`
+    - Location: `Header`
+    - Pages: `All Pages`
+    - Category: `Essential`
+    - Content:
+```html
+<script>
+  {{#if customer.id}}
+  {{#contains page_type "account"}}
+  var b2bHideBodyStyle = document.createElement('style');
+  b2bHideBodyStyle.id = 'b2b-account-page-hide-body';
+  b2bHideBodyStyle.innerHTML = 'body { display: none !important }';
+  document.head.appendChild(b2bHideBodyStyle);
+  {{/contains}}
+  {{/if}}
+</script>
+<script type="module">
+  import RefreshRuntime from 'http://localhost:3001/@react-refresh'
+  RefreshRuntime.injectIntoGlobalHook(window)
+  window.$RefreshReg$ = () => {}
+  window.$RefreshSig$ = () => (type) => type
+  window.__vite_plugin_react_preamble_installed__ = true
+</script>
+<script type="module" src="http://localhost:3001/@vite/client"></script>
+```
+  - Add a the footer script with the following values
+    - Name: `B2B Edition Footer Script`
+    - Location: `Footer`
+    - Pages: `All Pages`
+    - Category: `Essential`
+    - Content:
+```html
+<script type="module" src="http://localhost:3001/src/main.ts"></script>
+<script>
+  window.B3 = {
+    setting: {
+      store_hash: '{{settings.store_hash}}',
+      channel_id: {{settings.channel_id}},
+      platform: 'bigcommerce', // override this depending on your store channel platform: https://developer.bigcommerce.com/docs/rest-management/channels#platform
+    },
+  }
+</script>
+```
+
+3. Configure the following `.env` values:
+  - set `VITE_LOCAL_DEBUG` to `false`
+4. Navigate to the B2B Edition App Dashboard and set the following values:
+  - Global Config: In B2B Edition App dashboard -> Settings -> Buyer Portal for global config
+![Buyer portal type global settings](../public/images/buyer-portal-type-settings-global.png)
+  - Or B2B Edition App dashboard -> Storefront -> Desired channel -> Buyer Portal for specific channel config
+![Buyer portal type channel settings](../public/images/buyer-portal-type-settings-channel.png) [alt text](README.md)
+
+
+6. Visit the headless storefront and attempt to sign in.
+
+**FAQs:**
+- linters are not working: run `yarn prepare` first.
+- `cross-origin` issues: update URL variables in .env to make sure api calls are using your tunnel URL with HTTPS.
+
+## Deploying the project
+
+Building your buyer portal application requires you to run the `yarn build` command. This command will generate a `dist` folder in the `apps/storefront` directory and inside an `assets` folder containing the compiled assets.
+
+Make sure that you have configured the following `.env` values correctly before building:
+
+- `VITE_ASSETS_ABSOLUTE_PATH`: Set this to the URL where the assets folder is hosted. **Note that this needs to be the absolute URL to the `/assets` folder location where the build will be served from in production.** Also please include the trailing `/`.
+
+  For example, if you deploy the contents of the `dist` folder built by running `yarn build` and hosted it at https://my.custom.cdn/generated/b2b, the value you should put is https://my.custom.cdn/generated/b2b/assets/.
+
+Once you have uploaded the contents of the `dist` folder to your hosting provider, you need to update your scripts in your BigCommerce storefront that points to the newly uploaded files.
+
+- Footer Script Contents:
+```html
+<script>
+  window.b3CheckoutConfig = {
+    routes: {
+      dashboard: '/account.php?action=order_status',
+    },
+  }
+  window.B3 = {
+    setting: {
+      store_hash: '<YOUR_STORE_HASH>',
+      channel_id: '<YOUR_CHANNEL_ID>',
+      platform: 'headless',
+      b2b_url: 'https://api-b2b.bigcommerce.com',
+      captcha_setkey: '6LdGN_sgAAAAAGYFg1lmVoakQ8QXxbhWqZ1GpYaJ',
+    },
+    'dom.checkoutRegisterParentElement': '#checkout-app',
+    'dom.registerElement':
+      '[href^="/login.php"], #checkout-customer-login, [href="/login.php"] .navUser-item-loginLabel, #checkout-customer-returning .form-legend-container [href="#"]',
+    'dom.openB3Checkout': 'checkout-customer-continue',
+    before_login_goto_page: '/account.php?action=order_status',
+    checkout_super_clear_session: 'true',
+    'dom.navUserLoginElement': '.navUser-item.navUser-item--account',
+  }
+</script>
+<script
+  type="module"
+  crossorigin=""
+  src="<YOUR_APP_URL_HERE>/index.*.js"
+></script>
+<script
+  nomodule=""
+  crossorigin=""
+  src="<YOUR_APP_URL_HERE>/polyfills-legacy.*.js"
+></script>
+<script
+  nomodule=""
+  crossorigin=""
+  src="<YOUR_APP_URL_HERE>/index-legacy.*.js"
+></script>
+```
+
+Replace the following values:
+- `<VITE_ASSETS_ABSOLUTE_PATH>` with the value you used for the environment variable `VITE_ASSETS_ABSOLUTE_PATH` (where your build is hosted)
+- `<YOUR_STORE_HASH>` with your store hash
+- `<YOUR_CHANNEL_ID>` with the headless channel id
+
+- Header Script Contents:
+```html
+<script>
+  {{#if customer.id}}
+  {{#contains page_type "account"}}
+  var b2bHideBodyStyle = document.createElement('style');
+  b2bHideBodyStyle.id = 'b2b-account-page-hide-body';
+  b2bHideBodyStyle.innerHTML = 'body { display: none !important }';
+  document.head.appendChild(b2bHideBodyStyle);
+  {{/contains}}
+  {{/if}}
+</script>
+```

--- a/docs/stencil.md
+++ b/docs/stencil.md
@@ -90,8 +90,8 @@ Once you have uploaded the contents of the `dist` folder to your hosting provide
   }
   window.B3 = {
     setting: {
-      store_hash: '<YOUR_STORE_HASH>',
-      channel_id: '<YOUR_CHANNEL_ID>',
+      store_hash: '{{settings.store_hash}}',  
+      channel_id: {{settings.channel_id}}, 
       platform: 'bigcommerce',
       b2b_url: 'https://api-b2b.bigcommerce.com',
       captcha_setkey: '6LdGN_sgAAAAAGYFg1lmVoakQ8QXxbhWqZ1GpYaJ',
@@ -124,8 +124,6 @@ Once you have uploaded the contents of the `dist` folder to your hosting provide
 
 Replace the following values:
 - `<VITE_ASSETS_ABSOLUTE_PATH>` with the value you used for the environment variable `VITE_ASSETS_ABSOLUTE_PATH` (where your build is hosted)
-- `<YOUR_STORE_HASH>` with your store hash
-- `<YOUR_CHANNEL_ID>` with the headless channel id
 
 - Header Script Contents:
 ```html

--- a/docs/stencil.md
+++ b/docs/stencil.md
@@ -92,7 +92,7 @@ Once you have uploaded the contents of the `dist` folder to your hosting provide
     setting: {
       store_hash: '<YOUR_STORE_HASH>',
       channel_id: '<YOUR_CHANNEL_ID>',
-      platform: 'headless',
+      platform: 'bigcommerce',
       b2b_url: 'https://api-b2b.bigcommerce.com',
       captcha_setkey: '6LdGN_sgAAAAAGYFg1lmVoakQ8QXxbhWqZ1GpYaJ',
     },


### PR DESCRIPTION
Jira: [DEVDOCS-5858](https://bigcommercecloud.atlassian.net/browse/DEVDOCS-5858)

## What/Why?
- Separate the headless and stencil guides to make it clearer and easier to understand.

## Rollout/Rollback
Revert

## Testing
N/A - Docs


[DEVDOCS-5858]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-5858?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ