### PR TITLE
fix: add `tier1` mode in build commands

### DIFF
--- a/apps/storefront/package.json
+++ b/apps/storefront/package.json
@@ -8,6 +8,7 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "build:staging": "tsc && vite build --mode staging",
+    "build:tier1": "tsc && vite build --mode tier1",
     "lint": "yarn lint:eslint && yarn lint:dependencies",
     "lint:eslint": "eslint . --ext .ts,.tsx,.js --cache --cache-location ./node_modules/.cache/eslint --max-warnings 0 .",
     "lint:dependencies": "depcruise --config .dependency-cruiser.cjs . --output-type err-long",

--- a/apps/storefront/src/buyerPortal.ts
+++ b/apps/storefront/src/buyerPortal.ts
@@ -11,12 +11,14 @@ interface GraphqlOriginProps {
   development: string;
   staging: string;
   production: string;
+  tier1: string;
 }
 
 const graphqlOrigin: GraphqlOriginProps = {
   development: VITE_LOCAL_GRAPHQL_ORIGIN,
   staging: 'https://api-b2b.staging.zone',
   production: 'https://api-b2b.bigcommerce.com',
+  tier1: 'https://api-b2b.bigcommerce.com',
 };
 
 function init() {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build": "turbo run build",
     "build:production": "turbo run build",
     "build:staging": "turbo run build:staging",
-    "build:tier1": "turbo run build",
+    "build:tier1": "turbo run build:tier1",
     "dev": "turbo run dev --parallel",
     "lint": "turbo run lint --parallel --continue",
     "format": "turbo run format --parallel --continue",

--- a/turbo.json
+++ b/turbo.json
@@ -15,6 +15,10 @@
       "dependsOn": ["^build"],
       "outputs": ["dist/**"]
     },
+    "build:tier1": {
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**"]
+    },
     "test": {
       "dependsOn": ["^build"],
       "cache": false


### PR DESCRIPTION
Jira: [B2B-1585](https://bigcommercecloud.atlassian.net/browse/B2B-1585)

## What/Why?
- Add `tier1` mode in build commands

## Rollout/Rollback
Revert

## Testing
[Action running this branch](https://github.com/bigcommerce/b2b-buyer-portal/actions/runs/11584884119)


[B2B-1585]: https://bigcommercecloud.atlassian.net/browse/B2B-1585?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ