### PR TITLE
fix: sourcemap generation on build

### DIFF
--- a/apps/storefront/vite.config.ts
+++ b/apps/storefront/vite.config.ts
@@ -93,6 +93,7 @@ export default defineConfig(({ mode }) => {
     },
     build: {
       minify: true,
+      sourcemap: true,
       rollupOptions: {
         input: {
           index: 'src/main.ts',


### PR DESCRIPTION
Jira: [B2B-1534](https://bigcommercecloud.atlassian.net/browse/B2B-1534)

## What/Why?
Added config to generate sourcemaps on build

## Rollout/Rollback
Undo this PR

## Testing
### Before

![prev dist output](https://github.com/user-attachments/assets/8f05a76a-8fcd-49aa-886d-83ade03a5b73)

### After

![updated dist output](https://github.com/user-attachments/assets/66b7ca78-0c26-4473-a2b2-75c4404b4976)

[B2B-1534]: https://bigcommercecloud.atlassian.net/browse/B2B-1534?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ