### PR TITLE
fix: handling password reset error on login

### DIFF
--- a/apps/storefront/src/pages/Login/config.ts
+++ b/apps/storefront/src/pages/Login/config.ts
@@ -90,9 +90,9 @@ export const loginCheckout = (data: LoginConfig) => {
     }),
   };
 
-  return fetch(`${baseUrl}/internalapi/v1/checkout/customer`, requestOptions)
-    .then((response) => response.text())
-    .catch((error) => b2bLogger.error('error', error));
+  return fetch(`${baseUrl}/internalapi/v1/checkout/customer`, requestOptions).then((response) =>
+    response.json(),
+  );
 };
 
 export const sendEmail = (emailAddress: string) => {

--- a/apps/storefront/src/pages/Login/index.tsx
+++ b/apps/storefront/src/pages/Login/index.tsx
@@ -222,11 +222,19 @@ export default function Login(props: PageProps) {
 
     if (isCheckout) {
       try {
-        await loginCheckout(data);
-        window.location.href = CHECKOUT_URL;
+        const response = await loginCheckout(data);
+
+        if (response.status === 400 && response.type === 'reset_password_before_login') {
+          b2bLogger.error(response);
+          await getForcePasswordReset(data.emailAddress);
+        } else {
+          window.location.href = CHECKOUT_URL;
+        }
       } catch (error) {
         b2bLogger.error(error);
-        getForcePasswordReset(data.emailAddress);
+        await getForcePasswordReset(data.emailAddress);
+      } finally {
+        setLoading(false);
       }
     } else {
       try {


### PR DESCRIPTION
Jira: [B2B-1559](https://bigcommercecloud.atlassian.net/browse/B2B-1559)

## What/Why?
Headless checkout login api call needs to show error message properly to the user when the request to login /internalapi/checkout/* fails.

## Rollout/Rollback
revert

## Testing
<img width="1624" alt="Screenshot 2024-10-31 at 9 36 00 p m" src="https://github.com/user-attachments/assets/bc3093be-c9de-4dc7-a55f-7711a9a4e286">



[B2B-1559]: https://bigcommercecloud.atlassian.net/browse/B2B-1559?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ