### PR TITLE
fix: disabling expired session redirect

### DIFF
--- a/apps/storefront/src/shared/service/request/b3Fetch.ts
+++ b/apps/storefront/src/shared/service/request/b3Fetch.ts
@@ -85,7 +85,9 @@ const B3Request = {
       const extensions = error?.extensions;
 
       if (extensions?.code === 40101) {
-        window.location.href = '#/login?loginFlag=3&showTip=false';
+        if (window.location.hash.startsWith('#/')) {
+          window.location.href = '#/login?loginFlag=3&showTip=false';
+        }
 
         if (message) {
           snackbar.error(message);


### PR DESCRIPTION
Jira: [B2B-1581](https://bigcommercecloud.atlassian.net/browse/B2B-1581)

## What/Why?
fix: disabling expired session redirect if the buyer portal is not open

## Rollout/Rollback
Revert

## Testing



[B2B-1581]: https://bigcommercecloud.atlassian.net/browse/B2B-1581?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ