### PR TITLE
fix: migrate from `companyUserInfo` to `userLoginState` graphql query

### DIFF
--- a/apps/storefront/src/shared/service/b2b/graphql/register.ts
+++ b/apps/storefront/src/shared/service/b2b/graphql/register.ts
@@ -203,11 +203,8 @@ const getLoginPageConfig = () => `{
 }`;
 
 const getForcePasswordReset = (email: string) => `{
-  companyUserInfo(storeHash: "${storeHash}", email: "${email}"){
-    userType
-    userInfo {
-        forcePasswordReset
-    }
+  userLoginState(storeHash: "${storeHash}", email: "${email}"){
+    forcePasswordReset
   }
 }`;
 
@@ -308,7 +305,7 @@ export const getB2BLoginPageConfig = () =>
 export const getBCForcePasswordReset = (email: string) =>
   B3Request.graphqlB2B({
     query: getForcePasswordReset(email),
-  }).then((res) => res.companyUserInfo.userInfo.forcePasswordReset);
+  }).then((res) => res.userLoginState.forcePasswordReset);
 
 export const getBCStoreChannelId = () =>
   B3Request.graphqlB2B({


### PR DESCRIPTION
Jira: [B2B-1632](https://bigcommercecloud.atlassian.net/browse/B2B-1632)

## What/Why?
Change `companyUserInfo` to `userLoginState` graphql query in order to improve security

## Rollout/Rollback

Revert PR

## Testing
<img width="1795" alt="image" src="https://github.com/user-attachments/assets/48365be5-4730-4133-8335-d72a7e89c1c1">



[B2B-1632]: https://bigcommercecloud.atlassian.net/browse/B2B-1632?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ