### PR TITLE
fix: allowed_cors_origins Type definition

### DIFF
--- a/apps/storefront/src/shared/service/b2b/graphql/login.ts
+++ b/apps/storefront/src/shared/service/b2b/graphql/login.ts
@@ -6,7 +6,7 @@ interface ApiTokenConfig {
   storeHash: string;
   channel_id: number;
   expires_at: number;
-  allowed_cors_origins: string[];
+  allowed_cors_origins: string[] | Location[];
 }
 
 const storeFrontToken = `mutation storeFrontToken($storeFrontTokenData: CustomerStoreFrontTokenInputType!) {


### PR DESCRIPTION
Jira: [B2B-1684](https://bigcommercecloud.atlassian.net/browse/B2B-1684)

## What/Why?

Compatible with type inconsistencies that occur in server deployments

> `src/utils/loginInfo.ts(117,31): error TS2345: Argument of type '{ storeHash: string; channel_id: number; expires_at: number; allowed_cors_origins: Location[]; }' is not assignable to parameter of type 'Partial<ApiTokenConfig>'.
> 10:44:52 AM: storefront:build:   Types of property 'allowed_cors_origins' are incompatible.
> 10:44:52 AM: storefront:build:     Type 'Location[]' is not assignable to type 'string[]'.
> 10:44:52 AM: storefront:build:       Type 'Location' is not assignable to type 'string'.`

## Rollout/Rollback
undo pr

## Testing

node: 18.18.0
![image](https://github.com/user-attachments/assets/d027db58-05b8-4e8c-9dd1-f6942562feee)


node: 20.17.0
![image](https://github.com/user-attachments/assets/00871c56-c989-43f8-9e24-bac8bf6f454c)



[B2B-1684]: https://bigcommercecloud.atlassian.net/browse/B2B-1684?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

cc: @bc-victor @bc-micah @LeoChowChina @bc-marco 