### PR TITLE
fix: accountSetting save requires that the companyId be a number

### DIFF
--- a/apps/storefront/src/pages/AccountSetting/index.tsx
+++ b/apps/storefront/src/pages/AccountSetting/index.tsx
@@ -78,7 +78,7 @@ function AccountSetting() {
 
   const [isVisible, setIsVisible] = useState<boolean>(false);
 
-  const companyId = role === 3 && isAgenting ? salesRepCompanyId : +companyInfoId;
+  const companyId = role === 3 && isAgenting ? +salesRepCompanyId : +companyInfoId;
 
   const isBCUser = !isB2BUser || (role === 3 && !isAgenting);
 


### PR DESCRIPTION
Jira: [B2B-1663](https://bigcommercecloud.atlassian.net/browse/B2B-1663)


## What/Why?

accountSetting save requires that the companyId be a number

## Rollout/Rollback
undo pr

## Testing

https://github.com/user-attachments/assets/c987679b-3a6c-4327-879e-0a2854451d6f




[B2B-1663]: https://bigcommercecloud.atlassian.net/browse/B2B-1663?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ