### PR TITLE
fix: validate platform before request graphql token

### DIFF
--- a/apps/storefront/src/shared/service/b2b/graphql/login.ts
+++ b/apps/storefront/src/shared/service/b2b/graphql/login.ts
@@ -1,4 +1,4 @@
-import { convertObjectOrArrayKeysToCamel } from '@/utils';
+import { convertObjectOrArrayKeysToCamel, platform } from '@/utils';
 
 import B3Request from '../../request/b3Fetch';
 
@@ -15,9 +15,12 @@ const storeFrontToken = `mutation storeFrontToken($storeFrontTokenData: Customer
   }
 }
 `;
-
-export const getBCGraphqlToken = (data: Partial<ApiTokenConfig>) =>
-  B3Request.graphqlB2B({
+export const getBCGraphqlToken = (data: Partial<ApiTokenConfig>): Promise<string> | undefined => {
+  if (platform !== 'bigcommerce') {
+    return undefined;
+  }
+  return B3Request.graphqlB2B({
     query: storeFrontToken,
     variables: { storeFrontTokenData: convertObjectOrArrayKeysToCamel(data) },
-  });
+  }).then((res) => res.storeFrontToken.token);
+};

--- a/apps/storefront/src/utils/loginInfo.ts
+++ b/apps/storefront/src/utils/loginInfo.ts
@@ -112,11 +112,10 @@ export const getloginTokenInfo = () => {
 export const loginInfo = async () => {
   const loginTokenInfo = getloginTokenInfo();
 
-  const {
-    storeFrontToken: { token },
-  } = await getBCGraphqlToken(loginTokenInfo);
-
-  store.dispatch(setbcGraphqlToken(token));
+  const token = await getBCGraphqlToken(loginTokenInfo);
+  if (token) {
+    store.dispatch(setbcGraphqlToken(token));
+  }
 };
 
 export const clearCurrentCustomerInfo = async () => {


### PR DESCRIPTION
Jira: [NA](https://bigcommercecloud.atlassian.net/browse/NA)

## What/Why?

Add validation to request only `bcGraphqlToken` in `bigcommerce` platforms

## Rollout/Rollback

Revert

## Testing

### Before the fix
<img width="1240" alt="image" src="https://github.com/user-attachments/assets/1bb6e9fc-e98c-4495-baf5-824ef4a94f31">

### After the fix
<img width="976" alt="image" src="https://github.com/user-attachments/assets/dbd53534-c95d-4b71-b738-8a92a31f46db">
