### PR TITLE
fix: validate errors inside getCurrentCustomerJWT

### DIFF
--- a/apps/storefront/src/shared/service/bc/api/login.ts
+++ b/apps/storefront/src/shared/service/bc/api/login.ts
@@ -19,10 +19,14 @@ export const getCurrentCustomerJWT = async (app_client_id: string) => {
   const response = await fetch(
     `${BigCommerceStorefrontAPIBaseURL}/customer/current.jwt?app_client_id=${app_client_id}`,
   );
+  const bcToken = await response.text();
   if (!response.ok) {
+    if (bcToken.includes('errors')) {
+      return undefined;
+    }
     throw new Error(response.statusText);
   }
-  return response.text() as Promise<string>;
+  return bcToken;
 };
 
 /**

--- a/apps/storefront/src/utils/loginInfo.ts
+++ b/apps/storefront/src/utils/loginInfo.ts
@@ -241,12 +241,7 @@ const loginWithCurrentCustomerJWT = async () => {
     return undefined;
   }
 
-  if (
-    !currentCustomerJWT ||
-    currentCustomerJWT?.includes('errors') ||
-    prevCurrentCustomerJWT === currentCustomerJWT
-  )
-    return undefined;
+  if (!currentCustomerJWT || prevCurrentCustomerJWT === currentCustomerJWT) return undefined;
 
   const data = await getB2BToken(currentCustomerJWT, channelId);
   const B2BToken = data.authorization.result.token as string;


### PR DESCRIPTION
Jira: [NA](https://bigcommercecloud.atlassian.net/browse/NA)

## What/Why?

Move currentCustomerJWT?.includes('errors') inside `getCurrentCustomerJWT` function, that way we avoid `console.error` an expected message

## Rollout/Rollback

Revert this PR

## Testing
### Before
<img width="1254" alt="image" src="https://github.com/user-attachments/assets/e74d30be-8847-4207-ae4b-00ae97e009f2">

### After
<img width="1237" alt="image" src="https://github.com/user-attachments/assets/3bf93afd-6426-48ab-8781-a8abcbb2fca3">
