### PR TITLE
refactor: remove unnecessary query to string and type

### DIFF
--- a/apps/storefront/src/shared/service/request/b3Fetch.ts
+++ b/apps/storefront/src/shared/service/request/b3Fetch.ts
@@ -3,10 +3,10 @@ import Cookies from 'js-cookie';
 import { store } from '@/store';
 import { BigCommerceStorefrontAPIBaseURL, channelId, snackbar, storeHash } from '@/utils';
 
-import { B2B_API_BASE_URL, queryParse, RequestType, RequestTypeKeys } from './base';
+import { B2B_API_BASE_URL, RequestType } from './base';
 import b3Fetch from './fetch';
 
-const GraphqlEndpointsFn = (type: RequestTypeKeys): string => {
+const GraphqlEndpointsFn = (type: RequestType): string => {
   const GraphqlEndpoints: CustomFieldStringItems = {
     B2BGraphql: `${B2B_API_BASE_URL}/graphql`,
     BCGraphql: `${BigCommerceStorefrontAPIBaseURL}/graphql`,
@@ -16,7 +16,7 @@ const GraphqlEndpointsFn = (type: RequestTypeKeys): string => {
   return GraphqlEndpoints[type] || '';
 };
 
-function request(path: string, config?: RequestInit, type?: RequestTypeKeys) {
+function request(path: string, config?: RequestInit, type?: RequestType) {
   const url = RequestType.B2BRest === type ? `${B2B_API_BASE_URL}${path}` : path;
   const { B2BToken } = store.getState().company.tokens;
   const getToken: HeadersInit =
@@ -44,7 +44,7 @@ function request(path: string, config?: RequestInit, type?: RequestTypeKeys) {
   return b3Fetch(url, init);
 }
 
-function graphqlRequest<T, Y>(type: RequestTypeKeys, data: T, config?: Y) {
+function graphqlRequest<T, Y>(type: RequestType, data: T, config?: Y) {
   const init = {
     method: 'POST',
     headers: {
@@ -138,10 +138,10 @@ const B3Request = {
 
     return graphqlRequest(RequestType.BCProxyGraphql, data, config);
   },
-  get: function get<T, Y>(url: string, type: RequestTypeKeys, data?: T, config?: Y): Promise<any> {
+  get: function get<T, Y>(url: string, type: RequestType, data?: T, config?: Y): Promise<any> {
     if (data) {
-      const params = queryParse(data);
-      return request(`${url}?${params}`, {
+      const params = new URLSearchParams(data);
+      return request(`${url}?${params.toString()}`, {
         method: 'GET',
         ...config,
       });
@@ -154,7 +154,7 @@ const B3Request = {
       type,
     );
   },
-  post: function post<T>(url: string, type: RequestTypeKeys, data: T): Promise<any> {
+  post: function post<T>(url: string, type: RequestType, data: T): Promise<any> {
     return request(
       url,
       {
@@ -167,7 +167,7 @@ const B3Request = {
       type,
     );
   },
-  put: function put<T>(url: string, type: RequestTypeKeys, data: T): Promise<any> {
+  put: function put<T>(url: string, type: RequestType, data: T): Promise<any> {
     return request(
       url,
       {
@@ -180,7 +180,7 @@ const B3Request = {
       type,
     );
   },
-  delete: function deleteFn(url: string, type: RequestTypeKeys): Promise<any> {
+  delete: function deleteFn(url: string, type: RequestType): Promise<any> {
     return request(
       url,
       {

--- a/apps/storefront/src/shared/service/request/base.ts
+++ b/apps/storefront/src/shared/service/request/base.ts
@@ -38,15 +38,4 @@ enum RequestType {
   TranslationService = 'TranslationService',
 }
 
-export type RequestTypeKeys = keyof typeof RequestType;
-
-const queryParse = <T>(query: T): string => {
-  let queryText = '';
-
-  Object.keys(query || {}).forEach((key: string) => {
-    queryText += `${key}=${(query as any)[key]}&`;
-  });
-  return queryText.slice(0, -1);
-};
-
-export { B2B_API_BASE_URL, B2B_APP_CLIENT_ID, queryParse, RequestType };
+export { B2B_API_BASE_URL, B2B_APP_CLIENT_ID, RequestType };

--- a/apps/storefront/tests/shared/request.test.ts
+++ b/apps/storefront/tests/shared/request.test.ts
@@ -1,0 +1,54 @@
+import { RequestType } from '@/shared/service/request/base';
+
+// TODO: Old logic - remove
+const queryParse = <T>(query: T): string => {
+  let queryText = '';
+
+  Object.keys(query || {}).forEach((key: string) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    queryText += `${key}=${(query as any)[key]}&`;
+  });
+  return queryText.slice(0, -1);
+};
+
+describe('queryParse', () => {
+  it('should stringify objects', () => {
+    const params = {
+      foo: 'bar',
+      hello: 'world',
+    };
+    const output = queryParse(params);
+
+    expect(output).toMatchInlineSnapshot(`"foo=bar&hello=world"`);
+
+    const newLogic = new URLSearchParams(params);
+
+    expect(newLogic.toString()).toMatchInlineSnapshot(`"foo=bar&hello=world"`);
+
+    expect(output).toMatch(newLogic.toString());
+  });
+});
+
+describe('enum should use typeof keyof for function argument type', () => {
+  it('should accept enum so that types are checked properly', () => {
+    const validFunction = (type: RequestType) => {
+      if (type === RequestType.B2BGraphql) {
+        return true;
+      }
+      return false;
+    };
+
+    const alsoValidFunction = (type: keyof typeof RequestType) => {
+      if (type === RequestType.B2BGraphql) {
+        return true;
+      }
+      return false;
+    };
+
+    expect(validFunction(RequestType.B2BGraphql)).toBe(true);
+    expect(alsoValidFunction(RequestType.B2BGraphql)).toBe(true);
+    // @ts-expect-error typescript should complain but javascript output should still work
+    expect(validFunction('B2BGraphql')).toBe(true);
+    expect(alsoValidFunction('B2BGraphql')).toBe(true);
+  });
+});


### PR DESCRIPTION
Jira: [B2B-1714](https://bigcommercecloud.atlassian.net/browse/B2B-1714)

## What/Why?
- remove unnecessary `queryParse` function
- remove unnecessary enum type

## Rollout/Rollback
Revert

## Testing
TBD

[B2B-1714]: https://bigcommercecloud.atlassian.net/browse/B2B-1714?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ