### PR TITLE
fix(b2b-1943): improved deployment to staging

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -3,10 +3,6 @@ name: Deploy to Staging
 on:
   push:
     branches:
-      - staging
-      - main
-  pull_request:
-    branches:
       - main
   workflow_dispatch:
 


### PR DESCRIPTION
Jira: [B2B-1943](https://bigcommercecloud.atlassian.net/browse/B2B-1943)

## What/Why?
Improving deployment workflows to following state:
* Release to production just with manual trigger ( this is the current status)
* Tier 1 deployment , just with manual trigger. I want to change this for 2 reasons:
More control over Tier 1 content
API changes are not available in Tier 1 until we deploy it to production

* Staging  deployment triggered by merge operation to main and manual trigger
It will help us to have a more stable staging environment

## Rollout/Rollback
Revert PR

## Testing
NA


[B2B-1943]: https://bigcommercecloud.atlassian.net/browse/B2B-1943?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ