### PR TITLE
DO NOT MERGE: fix: infra-18901 set cdn to point to microapps

### DIFF
--- a/apps/storefront/src/main.ts
+++ b/apps/storefront/src/main.ts
@@ -4,7 +4,7 @@ import { Environment, EnvSpecificConfig } from '@/types';
 const ENVIRONMENT_CDN_BASE_PATH: EnvSpecificConfig<string> = {
   local: '/',
   integration: 'https://microapp-cdn.gcp.integration.zone/b2b-buyer-portal/',
-  staging: 'https://cdn.bundleb2b.net/b2b/staging/storefront/',
+  staging: 'https://microapp-cdn.gcp.staging.zone/b2b-buyer-portal/',
   production: 'https://cdn.bundleb2b.net/b2b/production/storefront/',
 };
 

--- a/apps/storefront/src/shared/service/request/base.ts
+++ b/apps/storefront/src/shared/service/request/base.ts
@@ -3,7 +3,7 @@ import { Environment, EnvSpecificConfig } from '@/types';
 const ENVIRONMENT_B2B_API_URL: EnvSpecificConfig<string> = {
   local: import.meta.env.VITE_B2B_URL ?? 'http://localhost:9000',
   integration: 'https://api-b2b.integration.zone',
-  staging: 'https://api-b2b.staging.zone',
+  staging: 'https://api-b2b-gcp.staging.zone',
   production: 'https://api-b2b.bigcommerce.com',
 };
 


### PR DESCRIPTION
Jira: [INFRA-18901](https://bigcommercecloud.atlassian.net/browse/INFRA-18901)

## What/Why?
Adds the microapps cdn to the map instead of the original cdn. This is used for testing in staging.

## Rollout/Rollback
Do not merge

## Testing
Not for merging

[INFRA-18901]: https://bigcommercecloud.atlassian.net/browse/INFRA-18901?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ