### PR TITLE
fix: headless.ts importNode to setAttribute & innerhtml

### DIFF
--- a/apps/storefront/src/shared/service/b2b/api/translation.ts
+++ b/apps/storefront/src/shared/service/b2b/api/translation.ts
@@ -1,6 +1,6 @@
 import { storeHash } from '@/utils/basicConfig';
 
-import { B2B_API_BASE_URL } from '../../request/base';
+import { getAPIBaseURL } from '../../request/base';
 
 interface GetTranslationParams {
   channelId: number;
@@ -12,7 +12,7 @@ interface GetTranslationResponse {
 
 const getTranslation = async ({ channelId, page }: GetTranslationParams) => {
   const response = await fetch(
-    `${B2B_API_BASE_URL}/storefront/translation/${storeHash}/${channelId}/${page}`,
+    `${getAPIBaseURL()}/storefront/translation/${storeHash}/${channelId}/${page}`,
   );
   return response.json() as Promise<GetTranslationResponse>;
 };

--- a/apps/storefront/src/shared/service/request/b3Fetch.ts
+++ b/apps/storefront/src/shared/service/request/b3Fetch.ts
@@ -3,21 +3,21 @@ import Cookies from 'js-cookie';
 import { store } from '@/store';
 import { BigCommerceStorefrontAPIBaseURL, channelId, snackbar, storeHash } from '@/utils';
 
-import { B2B_API_BASE_URL, queryParse, RequestType, RequestTypeKeys } from './base';
+import { getAPIBaseURL, queryParse, RequestType, RequestTypeKeys } from './base';
 import b3Fetch from './fetch';
 
 const GraphqlEndpointsFn = (type: RequestTypeKeys): string => {
   const GraphqlEndpoints: CustomFieldStringItems = {
-    B2BGraphql: `${B2B_API_BASE_URL}/graphql`,
+    B2BGraphql: `${getAPIBaseURL()}/graphql`,
     BCGraphql: `${BigCommerceStorefrontAPIBaseURL}/graphql`,
-    BCProxyGraphql: `${B2B_API_BASE_URL}/api/v3/proxy/bc-storefront/graphql`,
+    BCProxyGraphql: `${getAPIBaseURL()}/api/v3/proxy/bc-storefront/graphql`,
   };
 
   return GraphqlEndpoints[type] || '';
 };
 
 function request(path: string, config?: RequestInit, type?: RequestTypeKeys) {
-  const url = RequestType.B2BRest === type ? `${B2B_API_BASE_URL}${path}` : path;
+  const url = RequestType.B2BRest === type ? `${getAPIBaseURL()}${path}` : path;
   const { B2BToken } = store.getState().company.tokens;
   const getToken: HeadersInit =
     type === RequestType.BCRest
@@ -194,7 +194,7 @@ const B3Request = {
     formData: T,
     config?: Y,
   ): Promise<any> {
-    return request(`${B2B_API_BASE_URL}${url}`, {
+    return request(`${getAPIBaseURL()}${url}`, {
       method: 'POST',
       body: formData,
       headers: {},

--- a/apps/storefront/src/shared/service/request/base.ts
+++ b/apps/storefront/src/shared/service/request/base.ts
@@ -19,16 +19,17 @@ const ENVIRONMENT_B2B_APP_CLIENT_ID: EnvSpecificConfig<string> = {
 const DEFAULT_ENVIRONMENT =
   import.meta.env.VITE_IS_LOCAL_ENVIRONMENT === 'TRUE' ? Environment.Local : Environment.Production;
 
-export function getAPIBaseURL(environment: Environment = DEFAULT_ENVIRONMENT) {
-  return ENVIRONMENT_B2B_API_URL[environment];
+export function getAPIBaseURL(environment?: Environment) {
+  return ENVIRONMENT_B2B_API_URL[
+    environment ?? window.B3?.setting?.environment ?? DEFAULT_ENVIRONMENT
+  ];
 }
 
-export function getAppClientId(environment: Environment = DEFAULT_ENVIRONMENT) {
-  return ENVIRONMENT_B2B_APP_CLIENT_ID[environment];
+export function getAppClientId(environment?: Environment) {
+  return ENVIRONMENT_B2B_APP_CLIENT_ID[
+    environment ?? window.B3?.setting?.environment ?? DEFAULT_ENVIRONMENT
+  ];
 }
-
-const B2B_API_BASE_URL = getAPIBaseURL(window.B3?.setting?.environment);
-const B2B_APP_CLIENT_ID = getAppClientId(window.B3?.setting?.environment);
 
 enum RequestType {
   B2BGraphql = 'B2BGraphql',
@@ -50,4 +51,4 @@ const queryParse = <T>(query: T): string => {
   return queryText.slice(0, -1);
 };
 
-export { B2B_API_BASE_URL, B2B_APP_CLIENT_ID, queryParse, RequestType };
+export { queryParse, RequestType };

--- a/apps/storefront/src/utils/b2bVerifyBcLoginStatus.ts
+++ b/apps/storefront/src/utils/b2bVerifyBcLoginStatus.ts
@@ -1,5 +1,5 @@
 import { getCurrentCustomerJWT } from '@/shared/service/bc';
-import { B2B_APP_CLIENT_ID } from '@/shared/service/request/base';
+import { getAppClientId } from '@/shared/service/request/base';
 import { store } from '@/store';
 import { CustomerRole } from '@/types';
 import b2bLogger from '@/utils/b3Logger';
@@ -10,7 +10,7 @@ const b2bVerifyBcLoginStatus = async () => {
 
   try {
     if (+role !== CustomerRole.GUEST) {
-      const bcToken = await getCurrentCustomerJWT(B2B_APP_CLIENT_ID);
+      const bcToken = await getCurrentCustomerJWT(getAppClientId());
       isBcLogin = !!bcToken;
 
       return isBcLogin;

--- a/apps/storefront/src/utils/headlessInitializer.ts
+++ b/apps/storefront/src/utils/headlessInitializer.ts
@@ -2,6 +2,10 @@ import { getAPIBaseURL } from '../shared/service/request/base';
 import { Environment } from '../types';
 
 const BUYER_PORTAL_INJECTED_SCRIPT_CLASS = `buyer-portal-scripts-headless`;
+interface ScriptNodeChildren extends HTMLScriptElement {
+  dataSrc?: string;
+  crossorigin?: string;
+}
 
 export async function initHeadlessScripts() {
   const parseAndInsertStorefrontScripts = (storefrontScripts: string) => {
@@ -18,11 +22,26 @@ export async function initHeadlessScripts() {
         });
       }
 
-      b2bScriptNodes.forEach((scriptNode) => {
-        const newScriptElement = document.importNode(scriptNode, true);
-        newScriptElement.className = BUYER_PORTAL_INJECTED_SCRIPT_CLASS;
-
-        document.body.appendChild(newScriptElement);
+      b2bScriptNodes.forEach((node: ScriptNodeChildren, index: number) => {
+        const nodeInnerHTML = node?.innerHTML || '';
+        const nodeSrc = node?.src || '';
+        const dataSrc = node?.dataSrc || '';
+        const type = node?.type || '';
+        const crossorigin = node?.crossorigin || '';
+        const id = node?.id || '';
+        const scriptElement = document.createElement('script');
+        scriptElement.innerHTML = nodeInnerHTML;
+        scriptElement.className = BUYER_PORTAL_INJECTED_SCRIPT_CLASS;
+        if (nodeSrc) scriptElement.setAttribute('src', nodeSrc);
+        if (dataSrc) scriptElement.setAttribute('data-src', dataSrc);
+        if (type) {
+          scriptElement.setAttribute('type', 'module');
+        } else if (index !== 0) {
+          scriptElement.noModule = true;
+        }
+        if (id) scriptElement.setAttribute('id', id);
+        if (crossorigin) scriptElement.setAttribute('crossorigin', 'true');
+        document.body.appendChild(scriptElement);
       });
     }
   };

--- a/apps/storefront/src/utils/headlessInitializer.ts
+++ b/apps/storefront/src/utils/headlessInitializer.ts
@@ -2,9 +2,8 @@ import { getAPIBaseURL } from '../shared/service/request/base';
 import { Environment } from '../types';
 
 const BUYER_PORTAL_INJECTED_SCRIPT_CLASS = `buyer-portal-scripts-headless`;
-interface ScriptNodeChildren extends HTMLScriptElement {
+interface ScriptNode extends HTMLScriptElement {
   dataSrc?: string;
-  crossorigin?: string;
 }
 
 export async function initHeadlessScripts() {
@@ -22,12 +21,12 @@ export async function initHeadlessScripts() {
         });
       }
 
-      b2bScriptNodes.forEach((node: ScriptNodeChildren, index: number) => {
+      b2bScriptNodes.forEach((node: ScriptNode, index: number) => {
         const nodeInnerHTML = node?.innerHTML || '';
         const nodeSrc = node?.src || '';
         const dataSrc = node?.dataSrc || '';
         const type = node?.type || '';
-        const crossorigin = node?.crossorigin || '';
+        const crossOrigin = node?.crossOrigin || '';
         const id = node?.id || '';
         const scriptElement = document.createElement('script');
         scriptElement.innerHTML = nodeInnerHTML;
@@ -40,7 +39,7 @@ export async function initHeadlessScripts() {
           scriptElement.noModule = true;
         }
         if (id) scriptElement.setAttribute('id', id);
-        if (crossorigin) scriptElement.setAttribute('crossorigin', 'true');
+        if (crossOrigin) scriptElement.setAttribute('crossorigin', crossOrigin);
         document.body.appendChild(scriptElement);
       });
     }

--- a/apps/storefront/src/utils/headlessInitializer.ts
+++ b/apps/storefront/src/utils/headlessInitializer.ts
@@ -2,9 +2,6 @@ import { getAPIBaseURL } from '../shared/service/request/base';
 import { Environment } from '../types';
 
 const BUYER_PORTAL_INJECTED_SCRIPT_CLASS = `buyer-portal-scripts-headless`;
-interface ScriptNode extends HTMLScriptElement {
-  dataSrc?: string;
-}
 
 export async function initHeadlessScripts() {
   const parseAndInsertStorefrontScripts = (storefrontScripts: string) => {
@@ -21,25 +18,13 @@ export async function initHeadlessScripts() {
         });
       }
 
-      b2bScriptNodes.forEach((node: ScriptNode, index: number) => {
-        const nodeInnerHTML = node?.innerHTML || '';
-        const nodeSrc = node?.src || '';
-        const dataSrc = node?.dataSrc || '';
-        const type = node?.type || '';
-        const crossOrigin = node?.crossOrigin || '';
-        const id = node?.id || '';
+      b2bScriptNodes.forEach((node) => {
         const scriptElement = document.createElement('script');
-        scriptElement.innerHTML = nodeInnerHTML;
+        [...node.attributes].forEach((attr) => {
+          scriptElement.setAttribute(attr.nodeName, attr.nodeValue as string);
+        });
+        scriptElement.innerHTML = node.innerHTML;
         scriptElement.className = BUYER_PORTAL_INJECTED_SCRIPT_CLASS;
-        if (nodeSrc) scriptElement.setAttribute('src', nodeSrc);
-        if (dataSrc) scriptElement.setAttribute('data-src', dataSrc);
-        if (type) {
-          scriptElement.setAttribute('type', 'module');
-        } else if (index !== 0) {
-          scriptElement.noModule = true;
-        }
-        if (id) scriptElement.setAttribute('id', id);
-        if (crossOrigin) scriptElement.setAttribute('crossorigin', crossOrigin);
         document.body.appendChild(scriptElement);
       });
     }

--- a/apps/storefront/src/utils/loginInfo.ts
+++ b/apps/storefront/src/utils/loginInfo.ts
@@ -6,7 +6,7 @@ import {
   getUserCompany,
 } from '@/shared/service/b2b';
 import { getCurrentCustomerJWT, getCustomerInfo } from '@/shared/service/bc';
-import { B2B_APP_CLIENT_ID } from '@/shared/service/request/base';
+import { getAppClientId } from '@/shared/service/request/base';
 import {
   clearMasqueradeCompany,
   MasqueradeCompany,
@@ -235,7 +235,7 @@ const loginWithCurrentCustomerJWT = async () => {
   const prevCurrentCustomerJWT = store.getState().company.tokens.currentCustomerJWT;
   let currentCustomerJWT;
   try {
-    currentCustomerJWT = await getCurrentCustomerJWT(B2B_APP_CLIENT_ID);
+    currentCustomerJWT = await getCurrentCustomerJWT(getAppClientId());
   } catch (error) {
     b2bLogger.error(error);
     return undefined;

--- a/apps/storefront/tests/headless.test.ts
+++ b/apps/storefront/tests/headless.test.ts
@@ -53,7 +53,7 @@ describe('when headless.ts is run', () => {
        },
        "dom.checkoutRegisterParentElement": "#checkout-app",
        };
-      </script><script type="module" crossorigin="" src="https://cdn.bundleb2b.net/b2b/production/storefront/index.wVqliJs9.js" class="buyer-portal-scripts-headless"></script><script nomodule="" crossorigin="" src="https://cdn.bundleb2b.net/b2b/production/storefront/polyfills-legacy.DArz4FPZ.js" class="buyer-portal-scripts-headless"></script><script nomodule="" crossorigin="" src="https://cdn.bundleb2b.net/b2b/production/storefront/index-legacy.BwHISVUB.js" class="buyer-portal-scripts-headless"></script>"
+      </script><script class="buyer-portal-scripts-headless" src="https://cdn.bundleb2b.net/b2b/production/storefront/index.wVqliJs9.js" type="module"></script><script class="buyer-portal-scripts-headless" src="https://cdn.bundleb2b.net/b2b/production/storefront/polyfills-legacy.DArz4FPZ.js"></script><script class="buyer-portal-scripts-headless" src="https://cdn.bundleb2b.net/b2b/production/storefront/index-legacy.BwHISVUB.js"></script>"
     `);
 
     // calling again to make sure the old scripts get replaced properly

--- a/apps/storefront/tests/headless.test.ts
+++ b/apps/storefront/tests/headless.test.ts
@@ -53,7 +53,7 @@ describe('when headless.ts is run', () => {
        },
        "dom.checkoutRegisterParentElement": "#checkout-app",
        };
-      </script><script class="buyer-portal-scripts-headless" src="https://cdn.bundleb2b.net/b2b/production/storefront/index.wVqliJs9.js" type="module"></script><script class="buyer-portal-scripts-headless" src="https://cdn.bundleb2b.net/b2b/production/storefront/polyfills-legacy.DArz4FPZ.js"></script><script class="buyer-portal-scripts-headless" src="https://cdn.bundleb2b.net/b2b/production/storefront/index-legacy.BwHISVUB.js"></script>"
+      </script><script type="module" crossorigin="" src="https://cdn.bundleb2b.net/b2b/production/storefront/index.wVqliJs9.js" class="buyer-portal-scripts-headless"></script><script nomodule="" crossorigin="" src="https://cdn.bundleb2b.net/b2b/production/storefront/polyfills-legacy.DArz4FPZ.js" class="buyer-portal-scripts-headless"></script><script nomodule="" crossorigin="" src="https://cdn.bundleb2b.net/b2b/production/storefront/index-legacy.BwHISVUB.js" class="buyer-portal-scripts-headless"></script>"
     `);
 
     // calling again to make sure the old scripts get replaced properly


### PR DESCRIPTION
Jira: [JIRA_TOKEN](https://bigcommercecloud.atlassian.net/browse/JIRA_TOKEN)

## What/Why?
- `importNode` looked like it works, but the browser does not actually fetch the scripts or run the js.
- staging was not working properly because window.B3 value was being saved in global constant too early when using headless

## Rollout/Rollback
We need to investigate this logic more to understand (this is already a revert)

## Testing
Locally & planning to do in tier 1
