### PR TITLE
fix: if a B2BToken is already set up, skip verification

### DIFF
--- a/apps/storefront/src/utils/b2bVerifyBcLoginStatus.ts
+++ b/apps/storefront/src/utils/b2bVerifyBcLoginStatus.ts
@@ -7,6 +7,9 @@ import b2bLogger from '@/utils/b3Logger';
 const b2bVerifyBcLoginStatus = async () => {
   let isBcLogin = false;
   const { role } = store.getState().company.customer;
+  const { B2BToken } = store.getState().company.tokens;
+
+  if (B2BToken) return true;
 
   try {
     if (+role !== CustomerRole.GUEST) {

--- a/apps/storefront/src/utils/b2bVerifyBcLoginStatus.ts
+++ b/apps/storefront/src/utils/b2bVerifyBcLoginStatus.ts
@@ -4,12 +4,14 @@ import { store } from '@/store';
 import { CustomerRole } from '@/types';
 import b2bLogger from '@/utils/b3Logger';
 
+import { platform } from './basicConfig';
+
 const b2bVerifyBcLoginStatus = async () => {
   let isBcLogin = false;
   const { role } = store.getState().company.customer;
   const { B2BToken } = store.getState().company.tokens;
 
-  if (B2BToken) return true;
+  if (B2BToken && platform !== 'bigcommerce') return true;
 
   try {
     if (+role !== CustomerRole.GUEST) {


### PR DESCRIPTION
Jira: [B2B-2090](https://bigcommercecloud.atlassian.net/browse/B2B-2090)

## What/Why?
#200 Introduced a new feature that verifies if a user is already authenticated in a different browser and broke catalyst login.

## Rollout/Rollback
Revert

## Testing
Buyer portal doesn't log you out automatically anymore

https://github.com/user-attachments/assets/e943f20a-69f7-4b03-aae9-fabaee9e2b93




[B2B-2090]: https://bigcommercecloud.atlassian.net/browse/B2B-2090?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ