### PR TITLE
feat: enable open page routes

### DIFF
--- a/apps/storefront/src/components/HeadlessController.tsx
+++ b/apps/storefront/src/components/HeadlessController.tsx
@@ -251,6 +251,8 @@ export default function HeadlessController({ setOpenPage }: HeadlessControllerPr
         },
       },
     };
+    // disabling because we don't want to run this effect on every render
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [productList, B2BToken, globalState]);
 
   return null;

--- a/apps/storefront/src/components/HeadlessController.tsx
+++ b/apps/storefront/src/components/HeadlessController.tsx
@@ -251,9 +251,7 @@ export default function HeadlessController({ setOpenPage }: HeadlessControllerPr
         },
       },
     };
-    // disabling because we don't want to run this effect on every render
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [productList, B2BToken]);
+  }, [productList, B2BToken, globalState]);
 
   return null;
 }

--- a/apps/storefront/src/components/HeadlessController.tsx
+++ b/apps/storefront/src/components/HeadlessController.tsx
@@ -138,7 +138,8 @@ export default function HeadlessController({ setOpenPage }: HeadlessControllerPr
               setOpenPage({ isOpen: false });
               return;
             }
-            setOpenPage({ isOpen: true, openUrl: HeadlessRoutes[page] });
+            const openUrl = page.startsWith('/') ? page : HeadlessRoutes[page];
+            setOpenPage({ isOpen: true, openUrl });
           }, 0),
         quote: {
           addProductFromPage: (item) => addProductsToDraftQuote([item], setOpenPage),


### PR DESCRIPTION
Jira: [B2B-1933](https://bigcommercecloud.atlassian.net/browse/B2B-1933)

## What/Why?
Enabling usage of routes directly in the `openPage` function instead of only HeadlessRoutes keys.

## Rollout/Rollback
Revert

## Testing
Tested on Catalyst sf

[B2B-1933]: https://bigcommercecloud.atlassian.net/browse/B2B-1933?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ