### PR TITLE
fix: cart Clearing After Navigating Away from Invoice Checkout

### DIFF
--- a/apps/storefront/src/utils/b3ClearCart.ts
+++ b/apps/storefront/src/utils/b3ClearCart.ts
@@ -14,9 +14,9 @@ const clearInvoiceCart = async () => {
     const isInvoicePay = localStorage.getItem('invoicePay');
 
     if (url !== CHECKOUT_URL && isInvoicePay === '1') {
-      const cartEntityId = Cookies.get('cartId');
+      const cartInfo = await getCart();
 
-      const cartInfo = cartEntityId ? await getCart() : null;
+      const cartEntityId = Cookies.get('cartId');
 
       if (cartInfo) {
         let newCartId = cartEntityId;


### PR DESCRIPTION
Jira: [B2B-1909](https://bigcommercecloud.atlassian.net/browse/B2B-1909)

## What/Why?

1. Cart Not Clearing After Navigating Away from Invoice Checkout
2. The special request based on "If the user quickly goes to invocie checkout and then immediately returns to the theme page" resulted in the cart not being deleted.

    associated pr:  https://github.com/b3bc-external/b2b-checkout-app/pull/345
    
    **The following logic is determined on the checkout screen**
    
    - Determine whether other products have been added by judging the total amount.
    
          total amount is returned via /api/v2/carts/{cartId} ==> cartType = 2
    
    - Check whether a coupon is added to the current cart

## Rollout/Rollback
Revert

## Testing


https://github.com/user-attachments/assets/afaceeb8-4165-4ccb-bc7b-9bec1e9dff1b





[B2B-1909]: https://bigcommercecloud.atlassian.net/browse/B2B-1909?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ