### PR TITLE
feat: b2b-2135: add team customers to codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @bigcommerce/team-b2b @icatalina @LeoChowChina
+* @bigcommerce/team-b2b @icatalina @LeoChowChina @bigcommerce/team-customers


### PR DESCRIPTION
Jira: [B2B-2135](https://bigcommercecloud.atlassian.net/browse/B2B-2135)

## What/Why?
Add team customers to codeowners

## Rollout/Rollback
Rollback

## Testing
No testing needed


[B2B-2135]: https://bigcommercecloud.atlassian.net/browse/B2B-2135?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ