### PR TITLE
fix: return to window origin locally

### DIFF
--- a/apps/storefront/src/pages/ForgotPassword/index.test.tsx
+++ b/apps/storefront/src/pages/ForgotPassword/index.test.tsx
@@ -243,7 +243,7 @@ describe('when captcha is disabled', () => {
     const serverMock = vi.fn();
 
     server.use(
-      http.post('/bigcommerce/login.php', async ({ request }) => {
+      http.post('/login.php', async ({ request }) => {
         assertQueryParams(request, {
           action: 'send_password_email',
         });
@@ -276,7 +276,7 @@ describe('when captcha is disabled', () => {
 
   it('logs an error when the request to reset password fails', async () => {
     server.use(
-      http.post('/bigcommerce/login.php', async ({ request }) => {
+      http.post('/login.php', async ({ request }) => {
         assertQueryParams(request, {
           action: 'send_password_email',
         });

--- a/apps/storefront/src/utils/basicConfig.ts
+++ b/apps/storefront/src/utils/basicConfig.ts
@@ -5,10 +5,7 @@ export const {
   platform = 'custom',
 } = window.B3.setting;
 
-const { VITE_IS_LOCAL_ENVIRONMENT } = import.meta.env;
-
 const generateBcStorefrontAPIBaseUrl = () => {
-  if (VITE_IS_LOCAL_ENVIRONMENT === 'TRUE') return window.origin;
   if (platform === 'bigcommerce') return window.origin;
   if (channelId === 1) return `https://store-${storeHash}.mybigcommerce.com`;
 

--- a/apps/storefront/src/utils/basicConfig.ts
+++ b/apps/storefront/src/utils/basicConfig.ts
@@ -8,7 +8,7 @@ export const {
 const { VITE_IS_LOCAL_ENVIRONMENT } = import.meta.env;
 
 const generateBcStorefrontAPIBaseUrl = () => {
-  if (VITE_IS_LOCAL_ENVIRONMENT === 'TRUE') return '/bigcommerce';
+  if (VITE_IS_LOCAL_ENVIRONMENT === 'TRUE') return window.origin;
   if (platform === 'bigcommerce') return window.origin;
   if (channelId === 1) return `https://store-${storeHash}.mybigcommerce.com`;
 


### PR DESCRIPTION
Jira: [B2B-2203](https://bigcommercecloud.atlassian.net/browse/B2B-2203)

## What/Why?
Using window origin url while login in local env. Right now is creating an incorrect url for the login graphql api call. `/bigcommerce/graphql`

## Rollout/Rollback
Revert 

## Testing
login to buyer portal locally



[B2B-2203]: https://bigcommercecloud.atlassian.net/browse/B2B-2203?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ