### PR TITLE
B2B-2150 add Type definitions to B3PaginationTable

### DIFF
--- a/apps/storefront/src/components/table/B3Table.tsx
+++ b/apps/storefront/src/components/table/B3Table.tsx
@@ -58,7 +58,7 @@ interface TableProps<T> {
     index?: number,
     checkBox?: (disable?: boolean) => ReactElement,
   ) => ReactElement;
-  CollapseComponent?: (row: T) => ReactElement;
+  CollapseComponent?: (row: { row: T }) => ReactElement;
   isCustomRender?: boolean;
   isInfiniteScroll?: boolean;
   isLoading?: boolean;

--- a/apps/storefront/src/pages/Address/index.tsx
+++ b/apps/storefront/src/pages/Address/index.tsx
@@ -105,7 +105,8 @@ function Address() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const getAddressList = async (params = {}) => {
+  const defaultParams: FilterSearchProps = {};
+  const getAddressList = async (params = defaultParams) => {
     let list = [];
     let count = 0;
 

--- a/apps/storefront/src/pages/Invoice/components/PrintTemplate.tsx
+++ b/apps/storefront/src/pages/Invoice/components/PrintTemplate.tsx
@@ -1,6 +1,7 @@
 import { SyntheticEvent, useEffect, useRef, useState } from 'react';
 import { Resizable } from 'react-resizable';
 import { Box } from '@mui/material';
+// cspell:disable-next-line
 import PDFObject from 'pdfobject';
 
 import B3Spin from '@/components/spin/B3Spin';
@@ -9,7 +10,6 @@ import { snackbar } from '@/utils';
 import { handlePrintPDF } from '../utils/pdf';
 
 interface RowList {
-  [key: string]: CustomFieldItems | string | number;
   id: string;
   createdAt: number;
   updatedAt: number;

--- a/apps/storefront/src/pages/Invoice/index.tsx
+++ b/apps/storefront/src/pages/Invoice/index.tsx
@@ -1,4 +1,4 @@
-import { ReactElement, useContext, useEffect, useRef, useState } from 'react';
+import { useContext, useEffect, useRef, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useB3Lang } from '@b3/lang';
 import { Box, Button, InputAdornment, TextField, Typography } from '@mui/material';
@@ -132,7 +132,7 @@ function Invoice() {
   const [selectedPay, setSelectedPay] = useState<CustomFieldItems | InvoiceListNode[]>([]);
   const [list, setList] = useState<InvoiceListNode[]>([]);
 
-  const [filterData, setFilterData] = useState<Partial<FilterSearchProps> | null>();
+  const [filterData, setFilterData] = useState<Partial<FilterSearchProps>>({});
 
   const [exportCsvText, setExportCsvText] = useState<string>(b3Lang('invoice.exportCsvText'));
 
@@ -959,11 +959,7 @@ function Invoice() {
           isSelectOtherPageCheckbox
           hover
           isAutoRefresh={false}
-          renderItem={(
-            row: InvoiceList,
-            index?: number,
-            checkBox?: (disable?: boolean) => ReactElement,
-          ) => (
+          renderItem={(row, index, checkBox) => (
             <InvoiceItemCard
               item={row}
               checkBox={checkBox}

--- a/apps/storefront/src/pages/QuickOrder/components/QuickOrderB2BTable.tsx
+++ b/apps/storefront/src/pages/QuickOrder/components/QuickOrderB2BTable.tsx
@@ -1,4 +1,4 @@
-import { Dispatch, ReactElement, SetStateAction, useRef, useState } from 'react';
+import { Dispatch, SetStateAction, useRef, useState } from 'react';
 import { useB3Lang } from '@b3/lang';
 import { Box, styled, TextField, Typography } from '@mui/material';
 
@@ -32,10 +32,6 @@ import B3FilterSearch from '../../../components/filter/B3FilterSearch';
 import { CheckedProduct } from '../utils';
 
 import QuickOrderCard from './QuickOrderCard';
-
-interface ListItem {
-  [key: string]: string;
-}
 
 interface ProductInfoProps {
   basePrice: number | string;
@@ -319,7 +315,7 @@ function QuickOrderTable({
     return qty;
   };
 
-  const columnItems: TableColumnItem<ListItem>[] = [
+  const columnItems: TableColumnItem<ProductInfoProps>[] = [
     {
       key: 'product',
       title: b3Lang('purchasedProducts.product'),
@@ -563,7 +559,7 @@ function QuickOrderTable({
           sortDirection={order}
           orderBy={orderBy}
           sortByFn={handleSetOrderBy}
-          renderItem={(row: ProductInfoProps, _?: number, checkBox?: () => ReactElement) => (
+          renderItem={(row, _, checkBox) => (
             <QuickOrderCard
               item={row}
               checkBox={checkBox}

--- a/apps/storefront/src/pages/ShoppingListDetails/components/ShoppingDetailTable.tsx
+++ b/apps/storefront/src/pages/ShoppingListDetails/components/ShoppingDetailTable.tsx
@@ -1,7 +1,6 @@
 import {
   Dispatch,
   forwardRef,
-  ReactElement,
   Ref,
   SetStateAction,
   useEffect,
@@ -14,7 +13,7 @@ import { Delete, Edit, StickyNote2 } from '@mui/icons-material';
 import { Box, Grid, styled, TextField, Typography } from '@mui/material';
 import cloneDeep from 'lodash-es/cloneDeep';
 
-import { B3PaginationTable } from '@/components/table/B3PaginationTable';
+import { B3PaginationTable, GetRequestList } from '@/components/table/B3PaginationTable';
 import { TableColumnItem } from '@/components/table/B3Table';
 import { PRODUCT_DEFAULT_IMAGE } from '@/constants';
 import { useMobile, useSort } from '@/hooks';
@@ -67,7 +66,7 @@ interface ShoppingDetailTableProps {
   isRequestLoading: boolean;
   setIsRequestLoading: Dispatch<SetStateAction<boolean>>;
   shoppingListId: number | string;
-  getShoppingListDetails: CustomFieldItems;
+  getShoppingListDetails: GetRequestList<SearchProps, CustomFieldItems>;
   setCheckedArr: (values: CustomFieldItems) => void;
   isReadForApprove: boolean;
   isJuniorApprove: boolean;
@@ -81,7 +80,7 @@ interface ShoppingDetailTableProps {
 }
 
 interface SearchProps {
-  search: string;
+  search?: string;
   first?: number;
   offset?: number;
   orderBy: string;
@@ -179,7 +178,7 @@ function ShoppingDetailTable(props: ShoppingDetailTableProps, ref: Ref<unknown>)
   const [chooseOptionsOpen, setSelectedOptionsOpen] = useState(false);
   const [optionsProduct, setOptionsProduct] = useState<any>(null);
   const [editProductItemId, setEditProductItemId] = useState<number | string | null>(null);
-  const [search, setSearch] = useState<SearchProps | {}>({
+  const [search, setSearch] = useState<SearchProps>({
     orderBy: `-${sortKeys[defaultSortKey]}`,
   });
   const [qtyNotChangeFlag, setQtyNotChangeFlag] = useState<boolean>(true);
@@ -763,7 +762,7 @@ function ShoppingDetailTable(props: ShoppingDetailTableProps, ref: Ref<unknown>)
         orderBy={orderBy}
         sortByFn={handleSetOrderBy}
         pageType="shoppingListDetailsTable"
-        renderItem={(row: ProductInfoProps, index?: number, checkBox?: () => ReactElement) => (
+        renderItem={(row, index, checkBox) => (
           <ShoppingDetailCard
             len={shoppingListInfo?.products?.edges.length || 0}
             item={row}

--- a/apps/storefront/src/pages/ShoppingLists/index.tsx
+++ b/apps/storefront/src/pages/ShoppingLists/index.tsx
@@ -5,7 +5,7 @@ import { Box } from '@mui/material';
 import B3Dialog from '@/components/B3Dialog';
 import B3Filter from '@/components/filter/B3Filter';
 import B3Spin from '@/components/spin/B3Spin';
-import { B3PaginationTable } from '@/components/table/B3PaginationTable';
+import { B3PaginationTable, GetRequestList } from '@/components/table/B3PaginationTable';
 import { useCardListColumn, useMobile, useTableRef } from '@/hooks';
 import { GlobalContext } from '@/shared/global';
 import {
@@ -165,7 +165,7 @@ function ShoppingLists() {
     setFilterSearch(search);
   };
 
-  const fetchList = async (params: ShoppingListSearch) => {
+  const fetchList: GetRequestList<ShoppingListSearch, ShoppingListsItemsProps> = async (params) => {
     const { edges, totalCount } = isB2BUser
       ? await getB2BShoppingList(params)
       : await getBcShoppingList({
@@ -248,7 +248,7 @@ function ShoppingLists() {
           isCustomRender
           itemXs={isExtraLarge ? 3 : 4}
           requestLoading={setIsRequestLoading}
-          renderItem={(row: ShoppingListsItemsProps) => (
+          renderItem={(row) => (
             <ShoppingListsCard
               key={row.id || ''}
               item={row}

--- a/apps/storefront/src/pages/quote/components/QuoteDetailTable.tsx
+++ b/apps/storefront/src/pages/quote/components/QuoteDetailTable.tsx
@@ -2,7 +2,7 @@ import { forwardRef, Ref, useImperativeHandle, useRef, useState } from 'react';
 import { useB3Lang } from '@b3/lang';
 import { Box, styled, Typography } from '@mui/material';
 
-import { B3PaginationTable } from '@/components/table/B3PaginationTable';
+import { B3PaginationTable, GetRequestList } from '@/components/table/B3PaginationTable';
 import { TableColumnItem } from '@/components/table/B3Table';
 import { PRODUCT_DEFAULT_IMAGE } from '@/constants';
 import { useAppSelector } from '@/store';
@@ -10,10 +10,6 @@ import { currencyFormatConvert } from '@/utils';
 import { getBCPrice, getDisplayPrice } from '@/utils/b3Product/b3Product';
 
 import QuoteDetailTableCard from './QuoteDetailTableCard';
-
-interface ListItem {
-  [key: string]: string;
-}
 
 interface ProductInfoProps {
   basePrice: number | string;
@@ -43,10 +39,7 @@ interface ListItemProps {
 
 interface ShoppingDetailTableProps {
   total: number;
-  getQuoteTableDetails: (params: any) => Promise<{
-    edges: any[];
-    totalCount: number;
-  }>;
+  getQuoteTableDetails: GetRequestList<SearchProps, ProductInfoProps>;
   isHandleApprove: boolean;
   getTaxRate: (taxClassId: number, variants: any) => number;
   displayDiscount: boolean;
@@ -142,7 +135,7 @@ function QuoteDetailTable(props: ShoppingDetailTableProps, ref: Ref<unknown>) {
     }
     return price;
   };
-  const columnItems: TableColumnItem<ListItem>[] = [
+  const columnItems: TableColumnItem<ProductInfoProps>[] = [
     {
       key: 'Product',
       title: b3Lang('quoteDetail.table.product'),
@@ -405,7 +398,7 @@ function QuoteDetailTable(props: ShoppingDetailTableProps, ref: Ref<unknown>) {
         itemIsMobileSpacing={0}
         noDataText={b3Lang('quoteDetail.table.noProducts')}
         tableKey="productId"
-        renderItem={(row: ProductInfoProps, index?: number) => (
+        renderItem={(row, index) => (
           <QuoteDetailTableCard
             len={total || 0}
             item={row}

--- a/apps/storefront/src/utils/b3Product/shared/config.ts
+++ b/apps/storefront/src/utils/b3Product/shared/config.ts
@@ -78,7 +78,7 @@ export interface CurrencyProps {
 }
 
 export interface SearchProps {
-  search: string;
+  search?: string;
   first?: number;
   offset?: number;
 }

--- a/apps/storefront/src/utils/forwardRefWithGenerics.ts
+++ b/apps/storefront/src/utils/forwardRefWithGenerics.ts
@@ -1,0 +1,10 @@
+import { forwardRef } from 'react';
+
+// does not modify the behavior of forwardRef in any way
+// simply adds type information to the function signature
+// preserving any generics passed to the original forwardRef function
+export const forwardRefWithGenerics = forwardRef as <T, P = NonNullable<unknown>>(
+  render: (props: P, ref: React.ForwardedRef<T>) => ReturnType<React.FunctionComponent>,
+) => (
+  props: React.PropsWithoutRef<P> & React.RefAttributes<T>,
+) => ReturnType<React.FunctionComponent>;

--- a/apps/storefront/src/utils/index.ts
+++ b/apps/storefront/src/utils/index.ts
@@ -22,12 +22,14 @@ import {
   getDefaultCurrencyInfo,
   handleGetCorrespondingCurrencyToken,
 } from './currencyUtils';
+import { forwardRefWithGenerics } from './forwardRefWithGenerics';
 import {
   convertArrayToGraphql,
   convertObjectOrArrayKeysToCamel,
   convertObjectOrArrayKeysToSnake,
   convertObjectToGraphql,
 } from './graphqlDataConvert';
+import { memoWithGenerics } from './memoWithGenerics';
 import { validatorRules } from './validatorRules';
 
 export * from './basicConfig';
@@ -76,4 +78,6 @@ export {
   snackbar,
   validatorRules,
   handleGetCorrespondingCurrencyToken,
+  forwardRefWithGenerics,
+  memoWithGenerics,
 };

--- a/apps/storefront/src/utils/memoWithGenerics.ts
+++ b/apps/storefront/src/utils/memoWithGenerics.ts
@@ -1,0 +1,9 @@
+import { memo } from 'react';
+
+// does not modify the behavior of memo in any way
+// simply adds type information to the function signature
+// preserving any generics passed to the original memo function
+export const memoWithGenerics = memo as <P extends object>(
+  Component: (props: P) => ReturnType<React.FunctionComponent>,
+  propsAreEqual?: (prevProps: Readonly<P>, nextProps: Readonly<P>) => boolean,
+) => (props: P) => ReturnType<React.FunctionComponent>;


### PR DESCRIPTION
Jira: [B2B-2150](https://bigcommercecloud.atlassian.net/browse/B2B-2150)

## What/Why?

- `B3PaginationTable` was full of `any` types, making it impossible to trace how fetched data was (or wasn't) being used
- The PR attempts to add true, descriptive types without changing the true signature of behaviour
- Small fixes have been made in components which use `B3PaginationTable` where there types were wrong (these mistakes were enabled by `B3PaginationTable` many `any`s)

## Rollout/Rollback

- Revert this PR

## Testing

- 99% just type definition fixes
- Remaining code changes were manually tested


[B2B-2150]: https://bigcommercecloud.atlassian.net/browse/B2B-2150?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ