### PR TITLE
refactor(account-settings): refactor formValidation, updateAccountSettings & dataProcessing

### DIFF
--- a/apps/storefront/src/pages/AccountSetting/config.ts
+++ b/apps/storefront/src/pages/AccountSetting/config.ts
@@ -18,47 +18,15 @@ export interface GetFilterMoreListProps {
   size: string;
 }
 
-interface GetAccountSettingFilesReturnProps {
-  accountB2BFormFields: GetFilterMoreListProps[];
-  passwordModified: GetFilterMoreListProps[];
-}
-
-interface PasswordKeysProps {
-  name: string;
-  label: string;
-  idLang: string;
-}
-
-export const getPasswordKeys = (): PasswordKeysProps[] => [
-  {
-    name: 'currentPassword',
-    label: 'Current Password',
-    idLang: 'accountSettings.form.currentPassword',
-  },
-  {
-    name: 'password',
-    label: 'Password',
-    idLang: 'accountSettings.form.password',
-  },
-  {
-    name: 'confirmPassword',
-    label: 'Confirm Password',
-    idLang: 'accountSettings.form.confirmPassword',
-  },
-];
-
-export const getAccountSettingFiles = (
-  xs: number,
-  b3Lang: LangFormatFunction,
-): GetAccountSettingFilesReturnProps => {
-  const accountB2BFormFields = [
+export const getAccountSettingsFields = (b3Lang: LangFormatFunction): GetFilterMoreListProps[] => {
+  return [
     {
       name: 'company',
       label: b3Lang('accountSettings.form.company'),
       required: false,
       default: '',
       fieldType: 'text',
-      xs,
+      xs: 12,
       variant: 'filled',
       size: 'small',
     },
@@ -86,26 +54,44 @@ export const getAccountSettingFiles = (
           value: 3,
         },
       ],
-      xs,
+      xs: 12,
       variant: 'filled',
       size: 'small',
     },
   ];
+};
 
-  const passwordModified = getPasswordKeys().map((item: PasswordKeysProps) => ({
-    name: item.name,
-    label: item.label,
-    required: false,
-    default: '',
-    fieldType: 'password',
-    xs,
-    variant: 'filled',
-    size: 'small',
-    idLang: item.idLang,
-  }));
-
-  return {
-    accountB2BFormFields,
-    passwordModified,
-  };
+export const getPasswordModifiedFields = (b3Lang: LangFormatFunction): GetFilterMoreListProps[] => {
+  return [
+    {
+      name: 'currentPassword',
+      label: b3Lang('accountSettings.form.currentPassword'),
+      required: false,
+      default: '',
+      fieldType: 'password',
+      xs: 12,
+      variant: 'filled',
+      size: 'small',
+    },
+    {
+      name: 'password',
+      label: b3Lang('accountSettings.form.password'),
+      required: false,
+      default: '',
+      fieldType: 'password',
+      xs: 12,
+      variant: 'filled',
+      size: 'small',
+    },
+    {
+      name: 'confirmPassword',
+      label: b3Lang('accountSettings.form.confirmPassword'),
+      required: false,
+      default: '',
+      fieldType: 'password',
+      xs: 12,
+      variant: 'filled',
+      size: 'small',
+    },
+  ];
 };

--- a/apps/storefront/src/pages/AccountSetting/index.tsx
+++ b/apps/storefront/src/pages/AccountSetting/index.tsx
@@ -257,14 +257,9 @@ function AccountSetting() {
         const dataProcessingFn = !isBCUser ? b2bSubmitDataProcessing : bcSubmitDataProcessing;
 
         if (isValid && emailFlag && passwordFlag) {
-          const { isEdit, param } = dataProcessingFn(
-            data,
-            accountSettings,
-            decryptionFields,
-            extraFields,
-          );
+          const param = dataProcessingFn(data, accountSettings, decryptionFields, extraFields);
 
-          if (isEdit) {
+          if (param) {
             if (!isBCUser) {
               param.companyId = companyId;
               param.extraFields = userExtraFields;

--- a/apps/storefront/src/pages/AccountSetting/utils.ts
+++ b/apps/storefront/src/pages/AccountSetting/utils.ts
@@ -201,7 +201,7 @@ export const b2bSubmitDataProcessing = (
 
   const param: Partial<ParamProps> = {};
   param.formFields = [];
-  let isEdit = true;
+  let pristine = true;
   let flag = true;
   let useExtraFieldsFlag = false;
 
@@ -210,19 +210,19 @@ export const b2bSubmitDataProcessing = (
       if (key === item.name) {
         flag = false;
         if (deCodeField(item.name) === 'first_name') {
-          if (accountSettings.firstName !== data[item.name]) isEdit = false;
+          if (accountSettings.firstName !== data[item.name]) pristine = false;
           param.firstName = data[item.name];
         }
         if (deCodeField(item.name) === 'last_name') {
-          if (accountSettings.lastName !== data[item.name]) isEdit = false;
+          if (accountSettings.lastName !== data[item.name]) pristine = false;
           param.lastName = data[item.name];
         }
         if (deCodeField(item.name) === 'phone') {
-          if (accountSettings.phoneNumber !== data[item.name]) isEdit = false;
+          if (accountSettings.phoneNumber !== data[item.name]) pristine = false;
           param.phoneNumber = data[item.name];
         }
         if (deCodeField(item.name) === 'email') {
-          if (accountSettings.email !== data[item.name]) isEdit = false;
+          if (accountSettings.email !== data[item.name]) pristine = false;
           param.email = data[item.name];
         }
         if (item.custom) {
@@ -234,7 +234,7 @@ export const b2bSubmitDataProcessing = (
       }
     });
     if (useExtraFieldsFlag) {
-      isEdit = false;
+      pristine = false;
     }
 
     if (flag) {
@@ -250,11 +250,11 @@ export const b2bSubmitDataProcessing = (
             (formField: Partial<Fields>) => formField.name === field.bcLabel,
           );
           if (account && JSON.stringify(account.value) !== JSON.stringify(data[key])) {
-            isEdit = false;
+            pristine = false;
           }
 
           if (!accountSettings?.formFields?.length && name && !!data[name]) {
-            isEdit = false;
+            pristine = false;
           }
         }
       });
@@ -262,7 +262,7 @@ export const b2bSubmitDataProcessing = (
     if (flag) {
       if (key === 'password') {
         param.newPassword = data[key];
-        if (data[key]) isEdit = false;
+        if (data[key]) pristine = false;
       } else {
         param[key] = data[key];
       }
@@ -274,10 +274,11 @@ export const b2bSubmitDataProcessing = (
 
   delete param.role;
 
-  return {
-    isEdit: !isEdit,
-    param,
-  };
+  if (pristine) {
+    return undefined;
+  }
+
+  return param;
 };
 
 export const bcSubmitDataProcessing = (
@@ -288,30 +289,30 @@ export const bcSubmitDataProcessing = (
 ) => {
   const param: Partial<ParamProps> = {};
   param.formFields = [];
-  let isEdit = true;
+  let pristine = true;
   let flag = true;
   Object.keys(data).forEach((key: string) => {
     decryptionFields.forEach((item: Partial<Fields>) => {
       if (key === item.name) {
         flag = false;
         if (deCodeField(item.name) === 'first_name') {
-          if (accountSettings.firstName !== data[item.name]) isEdit = false;
+          if (accountSettings.firstName !== data[item.name]) pristine = false;
           param.firstName = data[item.name];
         }
         if (deCodeField(item.name) === 'last_name') {
-          if (accountSettings.lastName !== data[item.name]) isEdit = false;
+          if (accountSettings.lastName !== data[item.name]) pristine = false;
           param.lastName = data[item.name];
         }
         if (deCodeField(item.name) === 'phone') {
-          if (accountSettings.phoneNumber !== data[item.name]) isEdit = false;
+          if (accountSettings.phoneNumber !== data[item.name]) pristine = false;
           param.phoneNumber = data[item.name];
         }
         if (deCodeField(item.name) === 'email') {
-          if (accountSettings.email !== data[item.name]) isEdit = false;
+          if (accountSettings.email !== data[item.name]) pristine = false;
           param.email = data[item.name];
         }
         if (deCodeField(item.name) === 'company') {
-          if (accountSettings.company !== data[item.name]) isEdit = false;
+          if (accountSettings.company !== data[item.name]) pristine = false;
           param.company = data[item.name];
         }
       }
@@ -329,7 +330,7 @@ export const bcSubmitDataProcessing = (
             (formField: Partial<Fields>) => formField.name === field.bcLabel,
           );
           if (account && JSON.stringify(account.value) !== JSON.stringify(data[key]))
-            isEdit = false;
+            pristine = false;
         }
       });
     }
@@ -337,7 +338,7 @@ export const bcSubmitDataProcessing = (
     if (flag) {
       if (key === 'password') {
         param.newPassword = data[key];
-        if (data[key]) isEdit = false;
+        if (data[key]) pristine = false;
       } else {
         param[key] = data[key];
       }
@@ -345,10 +346,11 @@ export const bcSubmitDataProcessing = (
     flag = true;
   });
 
-  return {
-    isEdit: !isEdit,
-    param,
-  };
+  if (pristine) {
+    return undefined;
+  }
+
+  return param;
 };
 
 export default sendEmail;


### PR DESCRIPTION
Jira: [B2B-2158](https://bigcommercecloud.atlassian.net/browse/B2B-2158)

## What/Why?
#### refactor(account-settings): reorganise account settings update

Separate payload preparation from the update process.
Purify and simplify handleGetUserExtraFields.

#### refactor(account-settings): separate formValidation from error notifications

The current logic conflates form validation with form error
display/translations.

We should probably include some form library, but for now we'll just
separate the methods doing the validation from the methods displaying
the errors/alerts.

#### refactor(account-settings): separate getAccountSettingsFields & getPasswordModifiedFields

These two methods are used at different stages of the process and for
different reasons. Separating them allows us to only execute them when
they are needed and more importantly _when_ they are needed.

eg. the `getAccountSettingFiles` is not required for bc users.

Remove the configuration for the `xs` prop, the only use of it is `12`.

Translate the passwordFields directly upon receiving them, as opposed to
doing it in the component.

Hard code the list of fields directly in the method, we had a method for
indirection that wasn't needed.

Bonus: flip all the `!isBcUser` ternaries

#### refactor(account-settings): rename isEdit to pristine in the dataProcessing methods

Current code uses `isEdit`, but then exposes it as `!isEdit`, this is
ultimately confusing. Change the flag name to `pristine`, and change the
method to either return the payload, if we need to save it, or undefined
if not modified.

## Rollout/Rollback
Revert

## Testing
Manual

[B2B-2158]: https://bigcommercecloud.atlassian.net/browse/B2B-2158?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ