### PR TITLE
fix: infra-19970 change to microapps url

### DIFF
--- a/apps/storefront/src/main.ts
+++ b/apps/storefront/src/main.ts
@@ -3,7 +3,7 @@ import { Environment, EnvSpecificConfig } from '@/types';
 // TODO: update the following to BC cdn when migration is completed
 const ENVIRONMENT_CDN_BASE_PATH: EnvSpecificConfig<string> = {
   local: '/',
-  integration: 'https://microapp-cdn.gcp.integration.zone/b2b-buyer-portal/',
+  integration: 'https://microapps.integration.zone/b2b-buyer-portal/',
   staging: 'https://cdn.bundleb2b.net/b2b/staging/storefront/',
   production: 'https://cdn.bundleb2b.net/b2b/production/storefront/',
 };

--- a/config/deploy/after.sh
+++ b/config/deploy/after.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
 if [[ $ENVIRONMENT =~ "integration" ]]; then
-  CDN_BASE_URL="https://microapp-cdn.gcp.integration.zone"
+  CDN_BASE_URL="https://microapps.integration.zone"
 elif [[ $ENVIRONMENT =~ "staging" ]]; then
-  CDN_BASE_URL="https://microapp-cdn.gcp.staging.zone"
+  CDN_BASE_URL="https://microapps.staging.zone"
 elif [[ $ENVIRONMENT =~ "production-tier1" ]]; then
   CDN_BASE_URL="https://microapps.bigcommerce.com"
 elif [[ $ENVIRONMENT =~ "production" ]]; then


### PR DESCRIPTION
Jira: [INFRA-19970](https://bigcommercecloud.atlassian.net/browse/INFRA-19970)

## What/Why?
The microapp-cdn URLs were the incorrect URLs to use, they're actually CNAMEd by `microapps.integration/staging` which is what we should be using. This also means the certs would have worked from the get go.

So we can just swap to those URLs and move on with our lives.

## Rollout/Rollback
The usual rollout process.

## Testing
Can see the apps exist on those urls
<img width="1280" alt="Screenshot 2025-02-07 at 10 09 12 AM" src="https://github.com/user-attachments/assets/bdb44709-1727-4fce-a61f-506254b71a38" />

I've also deployed this and verified that buyer portal loads in integration

<img width="1468" alt="Screenshot 2025-02-07 at 10 36 11 AM" src="https://github.com/user-attachments/assets/e98f7e70-5a21-4d6b-8c7f-91cd20aaba9f" />


[INFRA-19970]: https://bigcommercecloud.atlassian.net/browse/INFRA-19970?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ