### PR TITLE
B2B-2160 Refactor B3Table and B3TablePaginationTable towards type safety

### DIFF
--- a/apps/storefront/src/components/table/PaginationTable.tsx
+++ b/apps/storefront/src/components/table/PaginationTable.tsx
@@ -1,23 +1,24 @@
-import { ReactElement, useCallback, useEffect, useState } from 'react';
+import { FC, ReactElement, useCallback, useEffect, useState } from 'react';
 
 import { useMobile } from '@/hooks';
 
-import { B3Table, TableColumnItem } from './B3Table';
+import { B3Table, isNodeWrapper, PossibleNodeWrapper, TableColumnItem } from './B3Table';
 
 export interface TablePagination {
   offset: number;
   first: number;
 }
-interface PaginationTableProps {
+
+interface PaginationTableProps<Row extends object> {
   tableFixed?: boolean;
   tableHeaderHide?: boolean;
-  columnItems: TableColumnItem<any>[];
+  columnItems: TableColumnItem<Row>[];
   itemSpacing?: number;
   itemXs?: number;
   rowsPerPageOptions?: number[];
   showPagination?: boolean;
-  renderItem?: (row: any, index?: number, checkBox?: () => ReactElement) => ReactElement;
-  CollapseComponent?: (row: any) => ReactElement;
+  renderItem?: (row: Row, index?: number, checkBox?: () => ReactElement) => ReactElement;
+  CollapseComponent?: FC<{ row: Row }>;
   isCustomRender?: boolean;
   noDataText?: string;
   tableKey?: string;
@@ -32,16 +33,16 @@ interface PaginationTableProps {
   itemIsMobileSpacing?: number;
   disableCheckbox?: boolean;
   applyAllDisableCheckbox?: boolean;
-  onClickRow?: (item: any, index?: number) => void;
+  onClickRow?: (item: Row, index?: number) => void;
   showRowsPerPageOptions?: boolean;
   sortDirection?: 'asc' | 'desc';
   sortByFn?: (e: { key: string }) => void;
   orderBy?: string;
   pageType?: string;
-  items: any[];
+  items: PossibleNodeWrapper<Row>[];
 }
 
-function PaginationTable({
+function PaginationTable<Row extends object>({
   columnItems,
   isCustomRender = false,
   tableKey,
@@ -72,7 +73,7 @@ function PaginationTable({
   orderBy = '',
   pageType = '',
   items,
-}: PaginationTableProps) {
+}: PaginationTableProps<Row>) {
   const initPagination = {
     offset: 0,
     first: rowsPerPageOptions[0],
@@ -104,8 +105,9 @@ function PaginationTable({
   const getCurrentAllItemsSelect = useCallback(() => {
     if (!selectCheckbox.length) return false;
     return items.every((item) => {
-      const option = item?.node || item;
+      const option = isNodeWrapper(item) ? item.node : item;
 
+      // @ts-expect-error typed previously as an any
       return selectCheckbox.includes(option[selectedSymbol]);
     });
   }, [items, selectCheckbox, selectedSymbol]);
@@ -124,13 +126,15 @@ function PaginationTable({
       } else {
         const selects: Array<string | number> = [];
         items.forEach((item) => {
-          const option = item?.node || item;
+          const option = isNodeWrapper(item) ? item.node : item;
           if (option) {
             if (pageType === 'shoppingListDetailsTable') {
               selects.push(
+                // @ts-expect-error typed previously as an any
                 option.quantity > 0 || !option.disableCurrentCheckbox ? option[selectedSymbol] : '',
               );
             } else {
+              // @ts-expect-error typed previously as an any
               selects.push(option[selectedSymbol]);
             }
           }
@@ -144,15 +148,18 @@ function PaginationTable({
 
       const newSelectCheckbox = [...selectCheckbox];
       if (flag) {
-        items.forEach((item: CustomFieldItems) => {
-          const option = item?.node || item;
-          const index = newSelectCheckbox.findIndex((item: any) => item === option[selectedSymbol]);
+        items.forEach((item) => {
+          const option = isNodeWrapper(item) ? item.node : item;
+          // @ts-expect-error typed previously as an any
+          const index = newSelectCheckbox.findIndex((item) => item === option[selectedSymbol]);
           newSelectCheckbox.splice(index, 1);
         });
       } else {
-        items.forEach((item: CustomFieldItems) => {
-          const option = item?.node || item;
+        items.forEach((item) => {
+          const option = isNodeWrapper(item) ? item.node : item;
+          // @ts-expect-error typed previously as an any
           if (!selectCheckbox.includes(option[selectedSymbol])) {
+            // @ts-expect-error typed previously as an any
             newSelectCheckbox.push(option[selectedSymbol]);
           }
         });

--- a/apps/storefront/src/components/upload/BulkUploadTable.tsx
+++ b/apps/storefront/src/components/upload/BulkUploadTable.tsx
@@ -4,7 +4,7 @@ import { InsertDriveFile, MoreHoriz } from '@mui/icons-material';
 import { Box, Button, Link, Menu, MenuItem, Tab, Tabs, Typography } from '@mui/material';
 import { styled } from '@mui/material/styles';
 
-import { B3PaginationTable } from '@/components/table/B3PaginationTable';
+import { B3PaginationTable, GetRequestList } from '@/components/table/B3PaginationTable';
 import { TableColumnItem } from '@/components/table/B3Table';
 import { useMobile } from '@/hooks';
 
@@ -152,7 +152,7 @@ function BulkUploadTable(props: BulkUploadTableProps) {
     setActiveTab(selectedTabValue);
   };
 
-  const getProductInfo = (params: CustomFieldItems) => {
+  const getProductInfo: GetRequestList<CustomFieldItems, CustomFieldItems> = (params) => {
     const products = activeTab === 'error' ? errorProduct : validProduct;
 
     const { first, offset } = params;
@@ -269,9 +269,7 @@ function BulkUploadTable(props: BulkUploadTableProps) {
             searchParams={{
               activeTab,
             }}
-            renderItem={(row: CustomFieldItems) => (
-              <BulkUploadTableCard products={row} activeTab={activeTab} />
-            )}
+            renderItem={(row) => <BulkUploadTableCard products={row} activeTab={activeTab} />}
           />
         </StyledTableContainer>
 

--- a/apps/storefront/src/pages/Address/index.tsx
+++ b/apps/storefront/src/pages/Address/index.tsx
@@ -4,7 +4,7 @@ import { Box } from '@mui/material';
 
 import B3Filter from '@/components/filter/B3Filter';
 import B3Spin from '@/components/spin/B3Spin';
-import { B3PaginationTable } from '@/components/table/B3PaginationTable';
+import { B3PaginationTable, GetRequestList } from '@/components/table/B3PaginationTable';
 import { useCardListColumn, useTableRef, useVerifyCreatePermission } from '@/hooks';
 import { GlobalContext } from '@/shared/global';
 import {
@@ -106,7 +106,9 @@ function Address() {
   }, []);
 
   const defaultParams: FilterSearchProps = {};
-  const getAddressList = async (params = defaultParams) => {
+  const getAddressList: GetRequestList<FilterSearchProps, AddressItemType> = async (
+    params = defaultParams,
+  ) => {
     let list = [];
     let count = 0;
 
@@ -290,7 +292,7 @@ function Address() {
           itemXs={isExtraLarge ? 3 : 4}
           requestLoading={setIsRequestLoading}
           tableKey="id"
-          renderItem={(row: AddressItemType) => (
+          renderItem={(row) => (
             <AddressItemCard
               key={row.id}
               item={row}

--- a/apps/storefront/src/pages/Dashboard/index.tsx
+++ b/apps/storefront/src/pages/Dashboard/index.tsx
@@ -6,7 +6,7 @@ import { Box } from '@mui/material';
 import { usePageMask } from '@/components';
 import B3FilterSearch from '@/components/filter/B3FilterSearch';
 import B3Spin from '@/components/spin/B3Spin';
-import { B3PaginationTable } from '@/components/table/B3PaginationTable';
+import { B3PaginationTable, GetRequestList } from '@/components/table/B3PaginationTable';
 import { TableColumnItem } from '@/components/table/B3Table';
 import { useSort } from '@/hooks';
 import { PageProps } from '@/pages/PageProps';
@@ -67,7 +67,7 @@ function Dashboard(props: PageProps) {
 
   const location = useLocation();
 
-  const getSuperAdminCompaniesList = async (params: ListItem) => {
+  const getSuperAdminCompaniesList: GetRequestList<ListItem, ListItem> = async (params) => {
     let list = { edges: [], totalCount: 0 };
     if (typeof b2bId === 'number') {
       list = (await superAdminCompanies(b2bId, params)).superAdminCompanies;
@@ -196,7 +196,7 @@ function Dashboard(props: PageProps) {
           sortDirection={order}
           orderBy={orderBy}
           sortByFn={handleSetOrderBy}
-          renderItem={({ companyName, companyEmail, companyId }: ListItem) => {
+          renderItem={({ companyName, companyEmail, companyId }) => {
             const isSelected = Number(companyId) === Number(salesRepCompanyId);
             const action = isSelected
               ? {

--- a/apps/storefront/src/pages/Invoice/index.tsx
+++ b/apps/storefront/src/pages/Invoice/index.tsx
@@ -6,7 +6,7 @@ import cloneDeep from 'lodash-es/cloneDeep';
 
 import { B2BAutoCompleteCheckbox } from '@/components';
 import B3Spin from '@/components/spin/B3Spin';
-import { B3PaginationTable } from '@/components/table/B3PaginationTable';
+import { B3PaginationTable, GetRequestList } from '@/components/table/B3PaginationTable';
 import { TableColumnItem } from '@/components/table/B3Table';
 import { permissionLevels } from '@/constants';
 import { useMobile, useSort } from '@/hooks';
@@ -478,7 +478,7 @@ function Invoice() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [checkedArr]);
 
-  const fetchList = async (params: Partial<FilterSearchProps>) => {
+  const fetchList: GetRequestList<Partial<FilterSearchProps>, InvoiceList> = async (params) => {
     const {
       invoices: { edges, totalCount },
     } = await getInvoiceList(params);

--- a/apps/storefront/src/pages/QuickOrder/components/QuickOrderB2BTable.tsx
+++ b/apps/storefront/src/pages/QuickOrder/components/QuickOrderB2BTable.tsx
@@ -3,7 +3,7 @@ import { useB3Lang } from '@b3/lang';
 import { Box, styled, TextField, Typography } from '@mui/material';
 
 import B3Spin from '@/components/spin/B3Spin';
-import { B3PaginationTable } from '@/components/table/B3PaginationTable';
+import { B3PaginationTable, GetRequestList } from '@/components/table/B3PaginationTable';
 import { TableColumnItem } from '@/components/table/B3Table';
 import { PRODUCT_DEFAULT_IMAGE } from '@/constants';
 import { useMobile, useSort } from '@/hooks';
@@ -189,7 +189,7 @@ function QuickOrderTable({
     return [];
   };
 
-  const getList = async (params: SearchProps) => {
+  const getList: GetRequestList<SearchProps, ProductInfoProps> = async (params) => {
     const {
       orderedProducts: { edges, totalCount },
     } = isB2BUser ? await getOrderedProducts(params) : await getBcOrderedProducts(params);

--- a/apps/storefront/src/pages/QuotesList/index.tsx
+++ b/apps/storefront/src/pages/QuotesList/index.tsx
@@ -5,7 +5,7 @@ import { Box } from '@mui/material';
 
 import B3Filter from '@/components/filter/B3Filter';
 import B3Spin from '@/components/spin/B3Spin';
-import { B3PaginationTable } from '@/components/table/B3PaginationTable';
+import { B3PaginationTable, GetRequestList } from '@/components/table/B3PaginationTable';
 import { TableColumnItem } from '@/components/table/B3Table';
 import { useMobile, useSort } from '@/hooks';
 import { GlobalContext } from '@/shared/global';
@@ -313,8 +313,8 @@ function QuotesList() {
     }
   };
 
-  const fetchList = useCallback(
-    async (params: Partial<FilterSearchProps>) => {
+  const fetchList: GetRequestList<Partial<FilterSearchProps>, ListItem> = useCallback(
+    async (params) => {
       const { edges = [], totalCount } = await getQuotesList(params);
 
       if (params.offset === 0 && draftQuoteListLength) {
@@ -421,8 +421,8 @@ function QuotesList() {
           labelRowsPerPage={`${
             isMobile ? b3Lang('quotes.cardsPerPage') : b3Lang('quotes.quotesPerPage')
           }`}
-          renderItem={(row: ListItem) => <QuoteItemCard item={row} goToDetail={goToDetail} />}
-          onClickRow={(row: ListItem) => {
+          renderItem={(row) => <QuoteItemCard item={row} goToDetail={goToDetail} />}
+          onClickRow={(row) => {
             goToDetail(row, Number(row.status));
           }}
           hover

--- a/apps/storefront/src/pages/UserManagement/index.tsx
+++ b/apps/storefront/src/pages/UserManagement/index.tsx
@@ -5,7 +5,7 @@ import { Box } from '@mui/material';
 import B3Dialog from '@/components/B3Dialog';
 import B3Filter from '@/components/filter/B3Filter';
 import B3Spin from '@/components/spin/B3Spin';
-import { B3PaginationTable } from '@/components/table/B3PaginationTable';
+import { B3PaginationTable, GetRequestList } from '@/components/table/B3PaginationTable';
 import { useCardListColumn, useMobile, useTableRef } from '@/hooks';
 import { deleteUsers, getUsers } from '@/shared/service/b2b';
 import { rolePermissionSelector, useAppSelector } from '@/store';
@@ -98,7 +98,7 @@ function UserManagement() {
     useState<CustomFieldItems[]>(filterMoreInfo);
   const [valueName, setValueName] = useState<string>('');
 
-  const fetchList = async (params: Partial<FilterProps>) => {
+  const fetchList: GetRequestList<Partial<FilterProps>, UsersList> = async (params) => {
     const data = await getUsers(params);
 
     const {
@@ -219,7 +219,7 @@ function UserManagement() {
           isCustomRender
           itemXs={isExtraLarge ? 3 : 4}
           requestLoading={setIsRequestLoading}
-          renderItem={(row: UsersList) => (
+          renderItem={(row) => (
             <UserItemCard
               key={row.id || ''}
               item={row}

--- a/apps/storefront/src/pages/order/Order.tsx
+++ b/apps/storefront/src/pages/order/Order.tsx
@@ -6,7 +6,7 @@ import { Box } from '@mui/material';
 import { B2BAutoCompleteCheckbox } from '@/components';
 import B3Filter from '@/components/filter/B3Filter';
 import B3Spin from '@/components/spin/B3Spin';
-import { B3PaginationTable } from '@/components/table/B3PaginationTable';
+import { B3PaginationTable, GetRequestList } from '@/components/table/B3PaginationTable';
 import { TableColumnItem } from '@/components/table/B3Table';
 import { useMobile, useSort } from '@/hooks';
 import {
@@ -185,7 +185,7 @@ function Order({ isCompanyOrder = false }: OrderProps) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectCompanyHierarchyId]);
 
-  const fetchList = async (params: Partial<FilterSearchProps>) => {
+  const fetchList: GetRequestList<Partial<FilterSearchProps>, ListItem> = async (params) => {
     const { edges = [], totalCount } = isB2BUser
       ? await getB2BAllOrders(params)
       : await getBCAllOrders(params);
@@ -400,7 +400,7 @@ function Order({ isCompanyOrder = false }: OrderProps) {
           sortDirection={order}
           orderBy={orderBy}
           sortByFn={handleSetOrderBy}
-          renderItem={(row: ListItem, index?: number) => (
+          renderItem={(row, index) => (
             <OrderItemCard
               key={row.orderId}
               item={row}
@@ -410,7 +410,7 @@ function Order({ isCompanyOrder = false }: OrderProps) {
               isCompanyOrder={isCompanyOrder}
             />
           )}
-          onClickRow={(item: ListItem, index?: number) => {
+          onClickRow={(item, index) => {
             if (index !== undefined) {
               goToDetail(item, index);
             }

--- a/apps/storefront/src/pages/quote/components/QuoteTable.tsx
+++ b/apps/storefront/src/pages/quote/components/QuoteTable.tsx
@@ -473,7 +473,7 @@ function QuoteTable(props: ShoppingDetailTableProps) {
         showBorder={false}
         itemIsMobileSpacing={0}
         noDataText={b3Lang('quoteDraft.quoteTable.noProducts')}
-        renderItem={(row: QuoteItem, index?: number) => (
+        renderItem={(row, index?) => (
           <QuoteTableCard
             len={total || 0}
             item={row}

--- a/apps/storefront/tests/components/b3table/B3Table.test.tsx
+++ b/apps/storefront/tests/components/b3table/B3Table.test.tsx
@@ -4,7 +4,7 @@ import { renderWithProviders } from 'tests/test-utils';
 import { B3Table } from '@/components';
 import { TableColumnItem } from '@/components/table/B3Table';
 
-const columnItems: TableColumnItem<1> = {
+const columnItems: TableColumnItem<{ id: number }> = {
   key: 'key test1',
   title: 'title test',
 };


### PR DESCRIPTION
Jira: [B2B-2160](https://bigcommercecloud.atlassian.net/browse/B2B-2160)

## What/Why?

- `B3Table` and `B3TablePaginationTable` made prolific use of `any`, losing type safety and a clear view of values
- This PR moves away from the use of `any` by adding more accurate types
- 99% just type definition changes, except for a new `isNodeWrapper` type-guard

**N.B.**

Due to the 'quirky' implementation of these components, some states cannot be legally represented by Typescript.
E.g. if a `selectedSymbol` prop is defined, then it must be a populated key on the `Row` value object

Typescript _could_ represent this if the prop was mandatory, but this is not the case. As such `B3Table` and `B3TablePaginationTable` have numerous type suppressions such as:

```tsx
<Checkbox
  // @ts-expect-error typed previously as an any
  checked={selectCheckbox.includes(node[selectedSymbol])}
  // etc etc
/>
```

The idea is to make these bits of code redundant through future refactoring. 

## Rollout/Rollback

- Revert this PR

## Testing

- Manual tests


[B2B-2160]: https://bigcommercecloud.atlassian.net/browse/B2B-2160?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ