### PR TITLE
fix: infra-20041: temporarily update CDN base path to GCP microapps url

### DIFF
--- a/apps/storefront/src/main.ts
+++ b/apps/storefront/src/main.ts
@@ -5,7 +5,7 @@ const ENVIRONMENT_CDN_BASE_PATH: EnvSpecificConfig<string> = {
   local: '/',
   integration: 'https://microapps.integration.zone/b2b-buyer-portal/',
   staging: 'https://cdn.bundleb2b.net/b2b/staging/storefront/',
-  production: 'https://cdn.bundleb2b.net/b2b/production/storefront/',
+  production: 'https://microapps.bigcommerce.com/b2b-buyer-portal/',
 };
 
 window.b2b = {


### PR DESCRIPTION
Jira: [INFRA-20041](https://bigcommercecloud.atlassian.net/browse/INFRA-20041)

## What/Why?
Temporarily updates the URL to the GCP microapps URL during test of the GCP stack.

## Rollout/Rollback
We don't plan to merge this, so no rollout/rollback necessary.

## Testing
Once the PR is deployed, we can verify the buyer-portal loads on the new URL