### PR TITLE
B2B-2150 fix types and simplify getFilterMoreList within ShippingLists

### DIFF
--- a/apps/storefront/src/pages/ShoppingLists/ShoppingStatus.tsx
+++ b/apps/storefront/src/pages/ShoppingLists/ShoppingStatus.tsx
@@ -3,7 +3,7 @@ import { useB3Lang } from '@b3/lang';
 import { B3Tag } from '@/components';
 import { rolePermissionSelector, useAppSelector } from '@/store';
 
-import { getFilterShoppingListStatus } from './config';
+import { useGetFilterShoppingListStatus } from './config';
 
 interface NewStatusProps {
   label: string;
@@ -13,41 +13,45 @@ interface NewStatusProps {
   idLang: string;
 }
 
-export const getStatus = (submitShoppingListPermission: boolean) => {
-  const statusArr = getFilterShoppingListStatus(submitShoppingListPermission);
+export const useGetStatus = () => {
+  const getFilterShoppingListStatus = useGetFilterShoppingListStatus();
 
-  const newStatus: Array<NewStatusProps> = statusArr.map((item) => {
-    if (Number(item.value) === 0) {
-      return {
-        color: '#C4DD6C',
-        textColor: 'black',
-        ...item,
-      };
-    }
+  return (submitShoppingListPermission: boolean) => {
+    const statusArr = getFilterShoppingListStatus(submitShoppingListPermission);
 
-    if (Number(item.value) === 40) {
-      return {
-        color: '#F4CC46',
-        textColor: 'black',
-        ...item,
-      };
-    }
+    const newStatus: Array<NewStatusProps> = statusArr.map((item) => {
+      if (Number(item.value) === 0) {
+        return {
+          color: '#C4DD6C',
+          textColor: 'black',
+          ...item,
+        };
+      }
 
-    if (Number(item.value) === 30) {
+      if (Number(item.value) === 40) {
+        return {
+          color: '#F4CC46',
+          textColor: 'black',
+          ...item,
+        };
+      }
+
+      if (Number(item.value) === 30) {
+        return {
+          color: '#899193',
+          textColor: '#FFFFFF',
+          ...item,
+        };
+      }
       return {
-        color: '#899193',
+        color: '#7A6041',
         textColor: '#FFFFFF',
         ...item,
       };
-    }
-    return {
-      color: '#7A6041',
-      textColor: '#FFFFFF',
-      ...item,
-    };
-  });
+    });
 
-  return newStatus;
+    return newStatus;
+  };
 };
 
 interface ShoppingStatusProps {
@@ -56,6 +60,7 @@ interface ShoppingStatusProps {
 
 export function ShoppingStatus({ status }: ShoppingStatusProps) {
   const { submitShoppingListPermission } = useAppSelector(rolePermissionSelector);
+  const getStatus = useGetStatus();
 
   const b3Lang = useB3Lang();
   const statusList = getStatus(submitShoppingListPermission);

--- a/apps/storefront/src/pages/ShoppingLists/ShoppingStatus.tsx
+++ b/apps/storefront/src/pages/ShoppingLists/ShoppingStatus.tsx
@@ -1,17 +1,7 @@
-import { useB3Lang } from '@b3/lang';
-
 import { B3Tag } from '@/components';
 import { rolePermissionSelector, useAppSelector } from '@/store';
 
 import { useGetFilterShoppingListStatus } from './config';
-
-interface NewStatusProps {
-  label: string;
-  value: string | number;
-  color: string;
-  textColor: string;
-  idLang: string;
-}
 
 export const useGetStatus = () => {
   const getFilterShoppingListStatus = useGetFilterShoppingListStatus();
@@ -19,7 +9,7 @@ export const useGetStatus = () => {
   return (submitShoppingListPermission: boolean) => {
     const statusArr = getFilterShoppingListStatus(submitShoppingListPermission);
 
-    const newStatus: Array<NewStatusProps> = statusArr.map((item) => {
+    const newStatus = statusArr.map((item) => {
       if (Number(item.value) === 0) {
         return {
           color: '#C4DD6C',
@@ -62,16 +52,13 @@ export function ShoppingStatus({ status }: ShoppingStatusProps) {
   const { submitShoppingListPermission } = useAppSelector(rolePermissionSelector);
   const getStatus = useGetStatus();
 
-  const b3Lang = useB3Lang();
   const statusList = getStatus(submitShoppingListPermission);
-  const statusItem = statusList.find(
-    (item: NewStatusProps) => Number(item.value) === Number(status),
-  );
+  const statusItem = statusList.find((item) => Number(item.value) === Number(status));
 
   if (statusItem) {
     return (
       <B3Tag color={statusItem.color} textColor={statusItem.textColor}>
-        {b3Lang(statusItem.idLang)}
+        {statusItem.label}
       </B3Tag>
     );
   }

--- a/apps/storefront/src/pages/ShoppingLists/config.ts
+++ b/apps/storefront/src/pages/ShoppingLists/config.ts
@@ -57,10 +57,8 @@ export interface GetFilterMoreListProps {
   idLang?: string;
 }
 
-export const getFilterShoppingListStatus = (
-  submitShoppingListPermission: boolean,
-): Array<ShoppingListStatusProps> => {
-  const shoppingListStatus: Array<ShoppingListStatusProps> = [
+export const getFilterShoppingListStatus = (submitShoppingListPermission: boolean) => {
+  const shoppingListStatus = [
     {
       label: 'All',
       value: 99,
@@ -97,17 +95,45 @@ export const getFilterShoppingListStatus = (
   return getShoppingListStatus;
 };
 
+interface CreatedByUsers {
+  createdByUser?: {
+    results: Array<{ firstName: string; lastName: string; email: string }>;
+  };
+}
+
+interface BaseFilter {
+  label: string;
+  required: boolean;
+  default: string;
+  fieldType: string;
+  xs: number;
+  variant: string;
+  size: string;
+  idLang: string;
+}
+
+interface CreatedByFilter extends BaseFilter {
+  name: 'createdBy';
+  options: Array<{ createdBy: string }>;
+  replaceOptions: { label: string; value: string };
+}
+
+interface StatusFilter extends BaseFilter {
+  name: 'status';
+  options: Array<{ label: string; value: number; idLang: string }>;
+}
+
 export const getFilterMoreList = (
   submitShoppingListPermission: boolean,
-  createdByUsers: any,
-): GetFilterMoreListProps[] => {
+  createdByUsers: CreatedByUsers,
+): Array<CreatedByFilter | StatusFilter> => {
   const newCreatedByUsers =
-    createdByUsers?.createdByUser?.results.map((item: any) => ({
+    createdByUsers?.createdByUser?.results.map((item) => ({
       createdBy: `${item.firstName} ${item.lastName} (${item.email})`,
     })) || [];
   const filterMoreList = [
     {
-      name: 'createdBy',
+      name: 'createdBy' as const,
       label: 'Created by',
       required: false,
       default: '',
@@ -123,7 +149,7 @@ export const getFilterMoreList = (
       idLang: 'global.shoppingLists.filter.createdBy',
     },
     {
-      name: 'status',
+      name: 'status' as const,
       label: 'Status',
       required: false,
       default: '',

--- a/apps/storefront/src/pages/ShoppingLists/config.ts
+++ b/apps/storefront/src/pages/ShoppingLists/config.ts
@@ -98,8 +98,8 @@ export const getFilterShoppingListStatus = (
 };
 
 export const getFilterMoreList = (
-  createdByUsers: any,
   submitShoppingListPermission: boolean,
+  createdByUsers: any,
 ): GetFilterMoreListProps[] => {
   const newCreatedByUsers =
     createdByUsers?.createdByUser?.results.map((item: any) => ({

--- a/apps/storefront/src/pages/ShoppingLists/config.ts
+++ b/apps/storefront/src/pages/ShoppingLists/config.ts
@@ -62,26 +62,11 @@ export const useGetFilterShoppingListStatus = () => {
 
   return (submitShoppingListPermission: boolean) => {
     const shoppingListStatus = [
-      {
-        value: 99,
-        label: b3Lang('global.shoppingLists.status.all'),
-      },
-      {
-        value: 0,
-        label: b3Lang('global.shoppingLists.status.approved'),
-      },
-      {
-        value: 30,
-        label: b3Lang('global.shoppingLists.status.draft'),
-      },
-      {
-        value: 40,
-        label: b3Lang('global.shoppingLists.status.readyForApproval'),
-      },
-      {
-        value: 20,
-        label: b3Lang('global.shoppingLists.status.rejected'),
-      },
+      { value: 99, label: b3Lang('global.shoppingLists.status.all') },
+      { value: 0, label: b3Lang('global.shoppingLists.status.approved') },
+      { value: 30, label: b3Lang('global.shoppingLists.status.draft') },
+      { value: 40, label: b3Lang('global.shoppingLists.status.readyForApproval') },
+      { value: 20, label: b3Lang('global.shoppingLists.status.rejected') },
     ];
 
     const getShoppingListStatus = !submitShoppingListPermission

--- a/apps/storefront/src/pages/ShoppingLists/config.ts
+++ b/apps/storefront/src/pages/ShoppingLists/config.ts
@@ -64,15 +64,13 @@ export const useGetFilterShoppingListStatus = () => {
     const draftStatus = { value: 30, label: b3Lang('global.shoppingLists.status.draft') };
     const rejectedStatus = { value: 20, label: b3Lang('global.shoppingLists.status.rejected') };
 
-    const shoppingListStatus = [
+    return [
       { value: 99, label: b3Lang('global.shoppingLists.status.all') },
       { value: 0, label: b3Lang('global.shoppingLists.status.approved') },
       ...(submitShoppingListPermission ? [draftStatus] : []),
       { value: 40, label: b3Lang('global.shoppingLists.status.readyForApproval') },
       ...(submitShoppingListPermission ? [rejectedStatus] : []),
     ];
-
-    return shoppingListStatus;
   };
 };
 

--- a/apps/storefront/src/pages/ShoppingLists/config.ts
+++ b/apps/storefront/src/pages/ShoppingLists/config.ts
@@ -1,4 +1,4 @@
-import { LangFormatFunction } from '@b3/lang';
+import { LangFormatFunction, useB3Lang } from '@b3/lang';
 
 import { CompanyInfoTypes } from '@/types';
 
@@ -58,39 +58,34 @@ export interface GetFilterMoreListProps {
 }
 
 export const useGetFilterShoppingListStatus = () => {
+  const b3Lang = useB3Lang();
+
   return (submitShoppingListPermission: boolean) => {
     const shoppingListStatus = [
       {
-        label: 'All',
         value: 99,
-        idLang: 'global.shoppingLists.status.all',
+        label: b3Lang('global.shoppingLists.status.all'),
       },
       {
-        label: 'Approved',
         value: 0,
-        idLang: 'global.shoppingLists.status.approved',
+        label: b3Lang('global.shoppingLists.status.approved'),
       },
       {
-        label: 'Draft',
         value: 30,
-        idLang: 'global.shoppingLists.status.draft',
+        label: b3Lang('global.shoppingLists.status.draft'),
       },
       {
-        label: 'Ready for approval',
         value: 40,
-        idLang: 'global.shoppingLists.status.readyForApproval',
+        label: b3Lang('global.shoppingLists.status.readyForApproval'),
       },
       {
-        label: 'Rejected',
         value: 20,
-        idLang: 'global.shoppingLists.status.rejected',
+        label: b3Lang('global.shoppingLists.status.rejected'),
       },
     ];
 
     const getShoppingListStatus = !submitShoppingListPermission
-      ? shoppingListStatus.filter(
-          (item: ShoppingListStatusProps) => item.value !== 30 && item.value !== 20,
-        )
+      ? shoppingListStatus.filter((item) => item.value !== 30 && item.value !== 20)
       : shoppingListStatus;
 
     return getShoppingListStatus;
@@ -122,7 +117,7 @@ interface CreatedByFilter extends BaseFilter {
 
 interface StatusFilter extends BaseFilter {
   name: 'status';
-  options: Array<{ label: string; value: number; idLang: string }>;
+  options: Array<{ label: string; value: number }>;
 }
 
 export const useGetFilterMoreList = () => {

--- a/apps/storefront/src/pages/ShoppingLists/config.ts
+++ b/apps/storefront/src/pages/ShoppingLists/config.ts
@@ -57,42 +57,44 @@ export interface GetFilterMoreListProps {
   idLang?: string;
 }
 
-export const getFilterShoppingListStatus = (submitShoppingListPermission: boolean) => {
-  const shoppingListStatus = [
-    {
-      label: 'All',
-      value: 99,
-      idLang: 'global.shoppingLists.status.all',
-    },
-    {
-      label: 'Approved',
-      value: 0,
-      idLang: 'global.shoppingLists.status.approved',
-    },
-    {
-      label: 'Draft',
-      value: 30,
-      idLang: 'global.shoppingLists.status.draft',
-    },
-    {
-      label: 'Ready for approval',
-      value: 40,
-      idLang: 'global.shoppingLists.status.readyForApproval',
-    },
-    {
-      label: 'Rejected',
-      value: 20,
-      idLang: 'global.shoppingLists.status.rejected',
-    },
-  ];
+export const useGetFilterShoppingListStatus = () => {
+  return (submitShoppingListPermission: boolean) => {
+    const shoppingListStatus = [
+      {
+        label: 'All',
+        value: 99,
+        idLang: 'global.shoppingLists.status.all',
+      },
+      {
+        label: 'Approved',
+        value: 0,
+        idLang: 'global.shoppingLists.status.approved',
+      },
+      {
+        label: 'Draft',
+        value: 30,
+        idLang: 'global.shoppingLists.status.draft',
+      },
+      {
+        label: 'Ready for approval',
+        value: 40,
+        idLang: 'global.shoppingLists.status.readyForApproval',
+      },
+      {
+        label: 'Rejected',
+        value: 20,
+        idLang: 'global.shoppingLists.status.rejected',
+      },
+    ];
 
-  const getShoppingListStatus = !submitShoppingListPermission
-    ? shoppingListStatus.filter(
-        (item: ShoppingListStatusProps) => item.value !== 30 && item.value !== 20,
-      )
-    : shoppingListStatus;
+    const getShoppingListStatus = !submitShoppingListPermission
+      ? shoppingListStatus.filter(
+          (item: ShoppingListStatusProps) => item.value !== 30 && item.value !== 20,
+        )
+      : shoppingListStatus;
 
-  return getShoppingListStatus;
+    return getShoppingListStatus;
+  };
 };
 
 interface CreatedByUsers {
@@ -124,6 +126,8 @@ interface StatusFilter extends BaseFilter {
 }
 
 export const useGetFilterMoreList = () => {
+  const getFilterShoppingListStatus = useGetFilterShoppingListStatus();
+
   return (
     submitShoppingListPermission: boolean,
     createdByUsers: CreatedByUsers,

--- a/apps/storefront/src/pages/ShoppingLists/config.ts
+++ b/apps/storefront/src/pages/ShoppingLists/config.ts
@@ -123,46 +123,48 @@ interface StatusFilter extends BaseFilter {
   options: Array<{ label: string; value: number; idLang: string }>;
 }
 
-export const getFilterMoreList = (
-  submitShoppingListPermission: boolean,
-  createdByUsers: CreatedByUsers,
-): Array<CreatedByFilter | StatusFilter> => {
-  const newCreatedByUsers =
-    createdByUsers?.createdByUser?.results.map((item) => ({
-      createdBy: `${item.firstName} ${item.lastName} (${item.email})`,
-    })) || [];
-  const filterMoreList = [
-    {
-      name: 'createdBy' as const,
-      label: 'Created by',
-      required: false,
-      default: '',
-      fieldType: 'dropdown',
-      options: newCreatedByUsers,
-      replaceOptions: {
-        label: 'createdBy',
-        value: 'createdBy',
+export const useGetFilterMoreList = () => {
+  return (
+    submitShoppingListPermission: boolean,
+    createdByUsers: CreatedByUsers,
+  ): Array<CreatedByFilter | StatusFilter> => {
+    const newCreatedByUsers =
+      createdByUsers?.createdByUser?.results.map((item) => ({
+        createdBy: `${item.firstName} ${item.lastName} (${item.email})`,
+      })) || [];
+    const filterMoreList = [
+      {
+        name: 'createdBy' as const,
+        label: 'Created by',
+        required: false,
+        default: '',
+        fieldType: 'dropdown',
+        options: newCreatedByUsers,
+        replaceOptions: {
+          label: 'createdBy',
+          value: 'createdBy',
+        },
+        xs: 12,
+        variant: 'filled',
+        size: 'small',
+        idLang: 'global.shoppingLists.filter.createdBy',
       },
-      xs: 12,
-      variant: 'filled',
-      size: 'small',
-      idLang: 'global.shoppingLists.filter.createdBy',
-    },
-    {
-      name: 'status' as const,
-      label: 'Status',
-      required: false,
-      default: '',
-      fieldType: 'dropdown',
-      options: getFilterShoppingListStatus(submitShoppingListPermission),
-      xs: 12,
-      variant: 'filled',
-      size: 'small',
-      idLang: 'global.shoppingLists.filter.status',
-    },
-  ];
+      {
+        name: 'status' as const,
+        label: 'Status',
+        required: false,
+        default: '',
+        fieldType: 'dropdown',
+        options: getFilterShoppingListStatus(submitShoppingListPermission),
+        xs: 12,
+        variant: 'filled',
+        size: 'small',
+        idLang: 'global.shoppingLists.filter.status',
+      },
+    ];
 
-  return filterMoreList;
+    return filterMoreList;
+  };
 };
 
 export const getCreatedShoppingListFiles = (

--- a/apps/storefront/src/pages/ShoppingLists/config.ts
+++ b/apps/storefront/src/pages/ShoppingLists/config.ts
@@ -88,7 +88,6 @@ interface BaseFilter {
   xs: number;
   variant: string;
   size: string;
-  idLang: string;
 }
 
 interface CreatedByFilter extends BaseFilter {
@@ -103,6 +102,7 @@ interface StatusFilter extends BaseFilter {
 }
 
 export const useGetFilterMoreList = () => {
+  const b3Lang = useB3Lang();
   const getFilterShoppingListStatus = useGetFilterShoppingListStatus();
 
   return (
@@ -116,7 +116,6 @@ export const useGetFilterMoreList = () => {
     const filterMoreList = [
       {
         name: 'createdBy' as const,
-        label: 'Created by',
         required: false,
         default: '',
         fieldType: 'dropdown',
@@ -128,11 +127,10 @@ export const useGetFilterMoreList = () => {
         xs: 12,
         variant: 'filled',
         size: 'small',
-        idLang: 'global.shoppingLists.filter.createdBy',
+        label: b3Lang('global.shoppingLists.filter.createdBy'),
       },
       {
         name: 'status' as const,
-        label: 'Status',
         required: false,
         default: '',
         fieldType: 'dropdown',
@@ -140,7 +138,7 @@ export const useGetFilterMoreList = () => {
         xs: 12,
         variant: 'filled',
         size: 'small',
-        idLang: 'global.shoppingLists.filter.status',
+        label: b3Lang('global.shoppingLists.filter.status'),
       },
     ];
 

--- a/apps/storefront/src/pages/ShoppingLists/config.ts
+++ b/apps/storefront/src/pages/ShoppingLists/config.ts
@@ -61,12 +61,15 @@ export const useGetFilterShoppingListStatus = () => {
   const b3Lang = useB3Lang();
 
   return (submitShoppingListPermission: boolean) => {
+    const draftStatus = { value: 30, label: b3Lang('global.shoppingLists.status.draft') };
+    const rejectedStatus = { value: 20, label: b3Lang('global.shoppingLists.status.rejected') };
+
     const shoppingListStatus = [
       { value: 99, label: b3Lang('global.shoppingLists.status.all') },
       { value: 0, label: b3Lang('global.shoppingLists.status.approved') },
-      { value: 30, label: b3Lang('global.shoppingLists.status.draft') },
+      draftStatus,
       { value: 40, label: b3Lang('global.shoppingLists.status.readyForApproval') },
-      { value: 20, label: b3Lang('global.shoppingLists.status.rejected') },
+      rejectedStatus,
     ];
 
     const getShoppingListStatus = !submitShoppingListPermission

--- a/apps/storefront/src/pages/ShoppingLists/config.ts
+++ b/apps/storefront/src/pages/ShoppingLists/config.ts
@@ -80,35 +80,11 @@ interface CreatedByUsers {
   };
 }
 
-interface BaseFilter {
-  label: string;
-  required: boolean;
-  default: string;
-  fieldType: string;
-  xs: number;
-  variant: string;
-  size: string;
-}
-
-interface CreatedByFilter extends BaseFilter {
-  name: 'createdBy';
-  options: Array<{ createdBy: string }>;
-  replaceOptions: { label: string; value: string };
-}
-
-interface StatusFilter extends BaseFilter {
-  name: 'status';
-  options: Array<{ label: string; value: number }>;
-}
-
 export const useGetFilterMoreList = () => {
   const b3Lang = useB3Lang();
   const getFilterShoppingListStatus = useGetFilterShoppingListStatus();
 
-  return (
-    submitShoppingListPermission: boolean,
-    createdByUsers: CreatedByUsers,
-  ): Array<CreatedByFilter | StatusFilter> => {
+  return (submitShoppingListPermission: boolean, createdByUsers: CreatedByUsers) => {
     const newCreatedByUsers =
       createdByUsers?.createdByUser?.results.map((item) => ({
         createdBy: `${item.firstName} ${item.lastName} (${item.email})`,
@@ -116,7 +92,7 @@ export const useGetFilterMoreList = () => {
 
     return [
       {
-        name: 'createdBy' as const,
+        name: 'createdBy',
         required: false,
         default: '',
         fieldType: 'dropdown',
@@ -131,7 +107,7 @@ export const useGetFilterMoreList = () => {
         label: b3Lang('global.shoppingLists.filter.createdBy'),
       },
       {
-        name: 'status' as const,
+        name: 'status',
         required: false,
         default: '',
         fieldType: 'dropdown',

--- a/apps/storefront/src/pages/ShoppingLists/config.ts
+++ b/apps/storefront/src/pages/ShoppingLists/config.ts
@@ -67,16 +67,12 @@ export const useGetFilterShoppingListStatus = () => {
     const shoppingListStatus = [
       { value: 99, label: b3Lang('global.shoppingLists.status.all') },
       { value: 0, label: b3Lang('global.shoppingLists.status.approved') },
-      draftStatus,
+      ...(submitShoppingListPermission ? [draftStatus] : []),
       { value: 40, label: b3Lang('global.shoppingLists.status.readyForApproval') },
-      rejectedStatus,
+      ...(submitShoppingListPermission ? [rejectedStatus] : []),
     ];
 
-    const getShoppingListStatus = !submitShoppingListPermission
-      ? shoppingListStatus.filter((item) => item.value !== 30 && item.value !== 20)
-      : shoppingListStatus;
-
-    return getShoppingListStatus;
+    return shoppingListStatus;
   };
 };
 

--- a/apps/storefront/src/pages/ShoppingLists/config.ts
+++ b/apps/storefront/src/pages/ShoppingLists/config.ts
@@ -113,7 +113,8 @@ export const useGetFilterMoreList = () => {
       createdByUsers?.createdByUser?.results.map((item) => ({
         createdBy: `${item.firstName} ${item.lastName} (${item.email})`,
       })) || [];
-    const filterMoreList = [
+
+    return [
       {
         name: 'createdBy' as const,
         required: false,
@@ -141,8 +142,6 @@ export const useGetFilterMoreList = () => {
         label: b3Lang('global.shoppingLists.filter.status'),
       },
     ];
-
-    return filterMoreList;
   };
 };
 

--- a/apps/storefront/src/pages/ShoppingLists/index.tsx
+++ b/apps/storefront/src/pages/ShoppingLists/index.tsx
@@ -76,13 +76,9 @@ function ShoppingLists() {
 
   useEffect(() => {
     const initFilter = async () => {
-      const createdByUsers = await getUserShoppingLists();
-
-      const filterInfo = getFilterMoreList(submitShoppingListPermission, createdByUsers);
-
-      const translatedFilterInfo: typeof filterInfo = JSON.parse(JSON.stringify(filterInfo));
-
-      setFilterMoreInfo(translatedFilterInfo);
+      setFilterMoreInfo(
+        getFilterMoreList(submitShoppingListPermission, await getUserShoppingLists()),
+      );
     };
 
     initFilter();

--- a/apps/storefront/src/pages/ShoppingLists/index.tsx
+++ b/apps/storefront/src/pages/ShoppingLists/index.tsx
@@ -82,13 +82,6 @@ function ShoppingLists() {
 
       const translatedFilterInfo: typeof filterInfo = JSON.parse(JSON.stringify(filterInfo));
 
-      translatedFilterInfo.forEach((element) => {
-        const translatedInfo = element;
-        translatedInfo.label = b3Lang(element.idLang);
-
-        return element;
-      });
-
       setFilterMoreInfo(translatedFilterInfo);
     };
 

--- a/apps/storefront/src/pages/ShoppingLists/index.tsx
+++ b/apps/storefront/src/pages/ShoppingLists/index.tsx
@@ -83,9 +83,9 @@ function ShoppingLists() {
 
       translatedFilterInfo.forEach((element) => {
         const translatedInfo = element;
-        translatedInfo.label = element.idLang ? b3Lang(element.idLang) : '';
+        translatedInfo.label = b3Lang(element.idLang);
         if (element.name === 'status') {
-          element.options?.map((option) => {
+          element.options.map((option) => {
             const elementOption = option;
             elementOption.label = b3Lang(option.idLang);
             return option;

--- a/apps/storefront/src/pages/ShoppingLists/index.tsx
+++ b/apps/storefront/src/pages/ShoppingLists/index.tsx
@@ -85,13 +85,6 @@ function ShoppingLists() {
       translatedFilterInfo.forEach((element) => {
         const translatedInfo = element;
         translatedInfo.label = b3Lang(element.idLang);
-        if (element.name === 'status') {
-          element.options.map((option) => {
-            const elementOption = option;
-            elementOption.label = b3Lang(option.idLang);
-            return option;
-          });
-        }
 
         return element;
       });

--- a/apps/storefront/src/pages/ShoppingLists/index.tsx
+++ b/apps/storefront/src/pages/ShoppingLists/index.tsx
@@ -77,7 +77,7 @@ function ShoppingLists() {
     const initFilter = async () => {
       const createdByUsers = await getUserShoppingLists();
 
-      const filterInfo = getFilterMoreList(createdByUsers, submitShoppingListPermission);
+      const filterInfo = getFilterMoreList(submitShoppingListPermission, createdByUsers);
 
       const translatedFilterInfo: typeof filterInfo = JSON.parse(JSON.stringify(filterInfo));
 

--- a/apps/storefront/src/pages/ShoppingLists/index.tsx
+++ b/apps/storefront/src/pages/ShoppingLists/index.tsx
@@ -19,7 +19,7 @@ import { isB2BUserSelector, rolePermissionSelector, useAppSelector } from '@/sto
 import { channelId, snackbar } from '@/utils';
 
 import AddEditShoppingLists from './AddEditShoppingLists';
-import { getFilterMoreList, ShoppingListSearch, ShoppingListsItemsProps } from './config';
+import { ShoppingListSearch, ShoppingListsItemsProps, useGetFilterMoreList } from './config';
 import ShoppingListsCard from './ShoppingListsCard';
 
 interface RefCurrentProps extends HTMLInputElement {
@@ -54,6 +54,7 @@ function ShoppingLists() {
   const [deleteOpen, setDeleteOpen] = useState<boolean>(false);
   const [deleteItem, setDeleteItem] = useState<null | ShoppingListsItemsProps>(null);
   const [filterMoreInfo, setFilterMoreInfo] = useState<Array<any>>([]);
+  const getFilterMoreList = useGetFilterMoreList();
 
   const [isMobile] = useMobile();
   const b3Lang = useB3Lang();

--- a/apps/storefront/src/pages/ShoppingLists/index.tsx
+++ b/apps/storefront/src/pages/ShoppingLists/index.tsx
@@ -79,23 +79,21 @@ function ShoppingLists() {
 
       const filterInfo = getFilterMoreList(createdByUsers, submitShoppingListPermission);
 
-      const translatedFilterInfo = JSON.parse(JSON.stringify(filterInfo));
+      const translatedFilterInfo: typeof filterInfo = JSON.parse(JSON.stringify(filterInfo));
 
-      translatedFilterInfo.forEach(
-        (element: { label: string; idLang: any; name: string; options: any[] }) => {
-          const translatedInfo = element;
-          translatedInfo.label = b3Lang(element.idLang);
-          if (element.name === 'status') {
-            element.options?.map((option) => {
-              const elementOption = option;
-              elementOption.label = b3Lang(option.idLang);
-              return option;
-            });
-          }
+      translatedFilterInfo.forEach((element) => {
+        const translatedInfo = element;
+        translatedInfo.label = element.idLang ? b3Lang(element.idLang) : '';
+        if (element.name === 'status') {
+          element.options?.map((option) => {
+            const elementOption = option;
+            elementOption.label = b3Lang(option.idLang);
+            return option;
+          });
+        }
 
-          return element;
-        },
-      );
+        return element;
+      });
 
       setFilterMoreInfo(translatedFilterInfo);
     };


### PR DESCRIPTION
Jira: [B2B-2150](https://bigcommercecloud.atlassian.net/browse/B2B-2150)

**N.B.** - this might be easy enough to read as one change, rather than 1 commit at a time

## What/Why?

- `getFilterMoreList` created a list of filters that was transformed within the view
- this PR moves all transformations into the `getFilterMoreList` (now the return function of a hook)
- this simplifies the view and takes a step towards more typesafety to help find our IO boundary
- Further work needed within `B3Filter` to workout if or not `getFilterMoreList`'s interface can be further simplified

## Rollout/Rollback

- Revert this PR

## Testing

- Manual Testing 


[B2B-2150]: https://bigcommercecloud.atlassian.net/browse/B2B-2150?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ