### PR TITLE
fix: use shipping display name on orders

### DIFF
--- a/apps/storefront/src/pages/OrderDetail/components/OrderShipping.tsx
+++ b/apps/storefront/src/pages/OrderDetail/components/OrderShipping.tsx
@@ -82,7 +82,7 @@ export default function OrderShipping({ isCurrentCompany }: OrderShippingProps) 
     const {
       date_created: createdDate,
       shipping_method: shippingMethod,
-      shipping_provider: shippingProvider,
+      shipping_provider_display_name: shippingProvider,
     } = shipment;
 
     const time = format(new Date(createdDate), 'LLLL, d');

--- a/apps/storefront/src/types/orderDetail.ts
+++ b/apps/storefront/src/types/orderDetail.ts
@@ -92,7 +92,7 @@ export interface OrderShipmentItem {
   order_id: number;
   shipping_address: Address;
   shipping_method: string;
-  shipping_provider: string;
+  shipping_provider_display_name: string;
   tracking_carrier: string;
   tracking_link: string;
   generated_tracking_link?: string;


### PR DESCRIPTION
Jira: [B2B-2375](https://bigcommercecloud.atlassian.net/browse/B2B-2375)

## What/Why?
<!--
  A description about what this pull request implements and its purpose.
  Try to be detailed and describe any technical details to simplify the job
  of the reviewer and the individual on production support.
-->
This PR changes orders to use `shipping_provider_display_name` from the API instead of `shipping_provider`. This results in properly formatted shipping carriers.

## Rollout/Rollback
<!--
Detail how this change will be rolled out. Include reference to any
experiments and how the success will be measured as the experiment is
ramped.

Document rollback procedures. Is rolling back the change as simple as
rolling back an experiment or does it require reverting code? Are there
database migrations that may change our decision to roll forward instead of
back?
-->
Revert.

## Testing
<!--
Provide as much information as you can about how you tested and how another
Engineer can test your change. Include screenshots, or test run output
where appropriate.
-->
Before:
<img width="826" alt="before" src="https://github.com/user-attachments/assets/4cff81a2-90a0-4d38-b41b-535824b09dc0" />


After:
<img width="817" alt="after" src="https://github.com/user-attachments/assets/2341678b-4402-44e5-97f5-489ee5610d6c" />



[B2B-2375]: https://bigcommercecloud.atlassian.net/browse/B2B-2375?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ