### PR TITLE
fix(quote): b2b-2182 adding product list type as field type

### DIFF
--- a/apps/storefront/src/utils/b3Product/shared/config.ts
+++ b/apps/storefront/src/utils/b3Product/shared/config.ts
@@ -104,6 +104,7 @@ const fieldTypes: CustomFieldItems = {
   file: 'files',
   swatch: 'swatch',
   product_list_with_images: 'productRadio',
+  product_list: 'productRadio',
 };
 
 export const Base64 = {


### PR DESCRIPTION
Jira: [B2B-2182](https://bigcommercecloud.atlassian.net/browse/B2B-2182)

## What/Why?
When we filter the product based on the type to display the label value of the product select though the pick list we are not displaying the label for products with `Show product image on Storefront` unchecked. So I'm adding the key `product_list` to product `fieldTypes`. The ProductRadio used for pick lists currently only uses `product_list_with_images` as type for a pick list product but `product_list` is also valid type when the option `Show product image on Storefront` is unchecked.

## Rollout/Rollback
Revert PR

## Testing
Before:
<img width="584" alt="image" src="https://github.com/user-attachments/assets/c548a3d7-5dee-4710-b9d1-e29eb5a048c3" />

After:
<img width="573" alt="image" src="https://github.com/user-attachments/assets/d60faab8-620d-4b7f-8336-381bb7e15882" />


[B2B-2182]: https://bigcommercecloud.atlassian.net/browse/B2B-2182?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ