### PR TITLE
fix(b2b): b2b-2364  fix permission issue for junior buyer on shopping list creation

### DIFF
--- a/apps/storefront/src/utils/b3ShoppingList/b3ShoppingList.ts
+++ b/apps/storefront/src/utils/b3ShoppingList/b3ShoppingList.ts
@@ -20,6 +20,7 @@ CreateShoppingListParams) => {
 
   if (isB2BUser) {
     const submitShoppingListPermission = validatePermissionWithComparisonType({
+      containOrEqual: 'contain',
       code: b2bPermissionsMap.submitShoppingListPermission,
     });
     const selectCompanyHierarchyId =


### PR DESCRIPTION
Jira: [B2B-2364](https://bigcommercecloud.atlassian.net/browse/B2B-2364)

## What/Why?
Junior buyer does not have permissions to create shopping list on PDP.

The fix is to set `containOrEqual` to `contain` instead of using default `equal` 
My understanding is that Junior buyer's permission contains submit for approval permission, it also has other permissions.

## Rollout/Rollback
Revert

## Testing
Manual test with Junior Buyer, Senior Buyer and Admin role and the results are as expected
Junior Buyer Before: Cannot create shopping list

https://github.com/user-attachments/assets/e2ed7fef-a8f1-4031-960c-14a6b11edcdc


Junior Buyer After: Can create shopping list and the status is `draft`

https://github.com/user-attachments/assets/51244583-4155-4c23-a903-b9707bffda79



Senior Buyer behaviour is the same before and after: Can create shopping list and it's approved.

https://github.com/user-attachments/assets/fd85f69c-ed33-43ba-a360-4f115f47b522


Admin behaviour is the same before and after: Can create shopping list and it's approved.


https://github.com/user-attachments/assets/3f328662-97f4-4511-973d-362de130099c



[B2B-2364]: https://bigcommercecloud.atlassian.net/browse/B2B-2364?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ