### PR TITLE
fix(common): B2B-2619 Remove invalid center% value in CSS

### DIFF
--- a/apps/storefront/src/pages/Address/components/SetDefaultDialog.tsx
+++ b/apps/storefront/src/pages/Address/components/SetDefaultDialog.tsx
@@ -84,7 +84,6 @@ export default function SetDefaultDialog(props: SetDefaultDialogProps) {
         sx={{
           display: 'flex',
           alignItems: isMobile ? 'start' : 'center',
-          justifyContent: isMobile ? 'center%' : 'start',
           width: isMobile ? '100%' : '450px',
           height: '100%',
         }}
@@ -92,7 +91,7 @@ export default function SetDefaultDialog(props: SetDefaultDialogProps) {
         {address && (
           <Box
             sx={{
-              padding: !isMobile ? '10px 0' : '0',
+              padding: isMobile ? '0' : '10px 0',
             }}
           >
             <FormGroup>

--- a/apps/storefront/src/pages/QuickOrder/components/QuickOrderFooter.tsx
+++ b/apps/storefront/src/pages/QuickOrder/components/QuickOrderFooter.tsx
@@ -723,7 +723,7 @@ function QuickOrderFooter(props: QuickOrderFooterProps) {
               <Box
                 sx={{
                   width: '33.3333%',
-                  display: !isMobile ? 'block' : 'none',
+                  display: isMobile ? 'none' : 'block',
                 }}
               />
             </Box>

--- a/apps/storefront/src/pages/QuickOrder/index.tsx
+++ b/apps/storefront/src/pages/QuickOrder/index.tsx
@@ -63,7 +63,7 @@ function QuickOrder() {
             item
             xs={isMobile ? 12 : 4}
             sx={{
-              pt: !isMobile ? '0px !important' : '16px',
+              pt: isMobile ? '16px' : '0px !important',
               pl: isMobile ? '0px !important' : '16px',
             }}
           >

--- a/apps/storefront/src/pages/QuoteDetail/index.tsx
+++ b/apps/storefront/src/pages/QuoteDetail/index.tsx
@@ -681,7 +681,7 @@ function QuoteDetail() {
             flexWrap: isMobile ? 'wrap' : 'nowrap',
             paddingBottom: '20px',
             marginBottom: isMobile ? '6rem' : 0,
-            marginTop: !isMobile ? '1rem' : 0,
+            marginTop: isMobile ? 0 : '1rem',
             '@media print': {
               overflow: 'hidden',
             },

--- a/apps/storefront/src/pages/QuoteDraft/index.tsx
+++ b/apps/storefront/src/pages/QuoteDraft/index.tsx
@@ -785,20 +785,7 @@ function QuoteDraft({ setOpenPage }: PageProps) {
           </Box>
           {quotesActionsPermission && (
             <Box>
-              {!isMobile ? (
-                <CustomButton
-                  variant="contained"
-                  size="small"
-                  sx={{
-                    padding: '8px 22px',
-                    alignSelf: 'center',
-                    marginBottom: '24px',
-                  }}
-                  onClick={handleSubmit}
-                >
-                  {b3Lang('quoteDraft.button.submit')}
-                </CustomButton>
-              ) : (
+              {isMobile ? (
                 <Box
                   sx={{
                     position: 'fixed',
@@ -824,6 +811,19 @@ function QuoteDraft({ setOpenPage }: PageProps) {
                     {b3Lang('quoteDraft.button.submit')}
                   </CustomButton>
                 </Box>
+              ) : (
+                <CustomButton
+                  variant="contained"
+                  size="small"
+                  sx={{
+                    padding: '8px 22px',
+                    alignSelf: 'center',
+                    marginBottom: '24px',
+                  }}
+                  onClick={handleSubmit}
+                >
+                  {b3Lang('quoteDraft.button.submit')}
+                </CustomButton>
               )}
             </Box>
           )}
@@ -976,7 +976,6 @@ function QuoteDraft({ setOpenPage }: PageProps) {
           </Container>
         </Box>
       </Box>
-
       <QuoteSubmissionResponse
         isOpen={quoteSubmissionResponseOpen}
         onClose={handleCloseQuoteSubmissionResponse}

--- a/apps/storefront/src/pages/ShoppingListDetails/components/ShoppingDetailAddNotes.tsx
+++ b/apps/storefront/src/pages/ShoppingListDetails/components/ShoppingDetailAddNotes.tsx
@@ -31,7 +31,6 @@ function ShoppingDetailAddNotes(props: ShoppingDetailAddNotesProps) {
       <Box
         sx={{
           display: 'flex',
-          justifyContent: isMobile ? 'center%' : 'start',
           width: isMobile ? '100%' : '450px',
           height: '100%',
         }}

--- a/apps/storefront/src/pages/ShoppingListDetails/components/ShoppingDetailDeleteItems.tsx
+++ b/apps/storefront/src/pages/ShoppingListDetails/components/ShoppingDetailDeleteItems.tsx
@@ -30,7 +30,6 @@ function ShoppingDetailDeleteItems(props: ShoppingDetailDeleteItemsProps) {
       <Box
         sx={{
           display: 'flex',
-          justifyContent: isMobile ? 'center%' : 'start',
           width: isMobile ? '100%' : '450px',
           height: '100%',
         }}

--- a/apps/storefront/src/pages/ShoppingLists/index.tsx
+++ b/apps/storefront/src/pages/ShoppingLists/index.tsx
@@ -263,7 +263,6 @@ function ShoppingLists() {
           <Box
             sx={{
               display: 'flex',
-              justifyContent: isMobile ? 'center%' : 'start',
               width: isMobile ? '100%' : '450px',
               height: '100%',
             }}

--- a/apps/storefront/src/pages/UserManagement/index.tsx
+++ b/apps/storefront/src/pages/UserManagement/index.tsx
@@ -249,7 +249,6 @@ function UserManagement() {
           <Box
             sx={{
               display: 'flex',
-              justifyContent: isMobile ? 'center%' : 'start',
               width: isMobile ? '100%' : '450px',
               height: '100%',
             }}


### PR DESCRIPTION
Jira: [B2B-2619](https://bigcommercecloud.atlassian.net/browse/B2B-2619)

## What/Why?
As part of a previous pr, we noticed this css value for justifyContent is invalid.
Took the opportunity to flip `!isMobile` with `isMobile` across the repo.

This value makes the `justifyContent` default to start. Removing all of it so we keep the current behaviour intact.

## Rollout/Rollback
Revert

## Testing
Manual

[B2B-2619]: https://bigcommercecloud.atlassian.net/browse/B2B-2619?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ