### PR TITLE
fix(quotes): error when loading quote detail page

### DIFF
--- a/apps/storefront/src/pages/QuoteDetail/index.tsx
+++ b/apps/storefront/src/pages/QuoteDetail/index.tsx
@@ -349,9 +349,7 @@ function QuoteDetail() {
 
     try {
       const quote = await getQuote();
-      const productsWithMoreInfo = await handleGetProductsById(quote.productsList).catch((err) => {
-        snackbar.error(err);
-
+      const productsWithMoreInfo = await handleGetProductsById(quote.productsList).catch(() => {
         return undefined;
       });
       const quoteExtraFieldInfos = await getQuoteExtraFields(quote.extraFields);


### PR DESCRIPTION
Jira: [B2B-2659](https://bigcommercecloud.atlassian.net/browse/B2B-2659)

## What/Why?
I'm deleting a snackbar error call when searching for products. Currently when loading a quote detail page we are we are calling `handleGetProductsById`  and the search products in the b3request is throwing a snackbar error so we don't need to a new one to catch the result of `handleGetProductsById`. The second error it has a different format and it seems to be affecting the render of B3Tip.

![image](https://github.com/user-attachments/assets/95bdd256-d294-4c4b-8dad-0b8dba748e49)

## Rollout/Rollback
Revert PR

## Testing
Cannot test this locally since we don't know yet what configuration in a product is causing the error.


[B2B-2659]: https://bigcommercecloud.atlassian.net/browse/B2B-2659?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ