### PR TITLE
refactor(account): B2B-2146 Use local instead of global state for login after registration

### DIFF
--- a/apps/storefront/src/pages/ForgotPassword/index.test.tsx
+++ b/apps/storefront/src/pages/ForgotPassword/index.test.tsx
@@ -172,7 +172,7 @@ describe('when captcha is enabled', () => {
     captchaResponse(
       {
         payload: 'foo-bar',
-        type: 'captcha-success',
+        type: 'CAPTCHA_SUCCESS',
       },
       'https://www.google.com',
       iframe,
@@ -220,7 +220,7 @@ describe('when captcha is enabled', () => {
     captchaResponse(
       {
         payload: 'foo-bar',
-        type: 'captcha-success',
+        type: 'CAPTCHA_SUCCESS',
       },
       'https://www.google.com',
       iframe,

--- a/apps/storefront/src/pages/ForgotPassword/index.tsx
+++ b/apps/storefront/src/pages/ForgotPassword/index.tsx
@@ -49,14 +49,14 @@ export function ForgotPassword({
   });
 
   const navigate = useNavigate();
-  const emailAddressReset = watch('emailAddress');
+  const emailReset = watch('email');
 
   useEffect(() => {
     if (captchaKey || !isEnabledOnStorefront) setIsCaptchaMissing(false);
   }, [captchaKey, isEnabledOnStorefront]);
 
   const handleLoginClick: SubmitHandler<LoginConfig> = async (data) => {
-    const { emailAddress } = data;
+    const { email } = data;
 
     if (isEnabledOnStorefront && !captchaKey) {
       setIsCaptchaMissing(true);
@@ -67,7 +67,7 @@ export function ForgotPassword({
       setLoading(true);
       if (isEnabledOnStorefront && captchaKey) {
         try {
-          await requestResetPassword(captchaKey, emailAddressReset);
+          await requestResetPassword(captchaKey, emailReset);
           navigate('/login?loginFlag=receivePassword');
           setLoading(false);
         } catch (e) {
@@ -76,7 +76,7 @@ export function ForgotPassword({
       }
 
       if (!isEnabledOnStorefront) {
-        await sendEmail(emailAddress);
+        await sendEmail(email);
         setLoading(false);
         navigate('/login?loginFlag=receivePassword');
       }
@@ -169,7 +169,7 @@ export function ForgotPassword({
               <Captcha
                 siteKey={storefrontSiteKey}
                 size="normal"
-                email={emailAddressReset}
+                email={emailReset}
                 handleGetKey={setCaptchaKey}
               />
             </Box>

--- a/apps/storefront/src/pages/Login/config.ts
+++ b/apps/storefront/src/pages/Login/config.ts
@@ -5,7 +5,7 @@ import { BigCommerceStorefrontAPIBaseURL, validatorRules } from '@/utils';
 import b2bLogger from '@/utils/b3Logger';
 
 export type LoginConfig = {
-  emailAddress: string;
+  email: string;
   password: string;
 };
 
@@ -16,7 +16,7 @@ interface ChannelIdProps {
 
 export const getForgotPasswordFields = (b3Lang: LangFormatFunction) => [
   {
-    name: 'emailAddress',
+    name: 'email',
     label: b3Lang('global.loginText.emailAddress'),
     required: true,
     default: '',
@@ -60,10 +60,7 @@ export const loginCheckout = (data: LoginConfig) => {
     headers: {
       'content-type': 'application/json',
     },
-    body: JSON.stringify({
-      email: data.emailAddress,
-      password: data.password,
-    }),
+    body: JSON.stringify(data),
   };
 
   return fetch(
@@ -73,9 +70,9 @@ export const loginCheckout = (data: LoginConfig) => {
   ).then((response) => response.json());
 };
 
-export const sendEmail = (emailAddress: string) => {
+export const sendEmail = (email: string) => {
   const urlencoded = new URLSearchParams();
-  urlencoded.append('email', emailAddress);
+  urlencoded.append('email', email);
 
   const requestOptions: RequestInit = {
     method: 'POST',

--- a/apps/storefront/src/pages/Login/config.ts
+++ b/apps/storefront/src/pages/Login/config.ts
@@ -30,7 +30,7 @@ export const getForgotPasswordFields = (b3Lang: LangFormatFunction) => [
 
 export const getLoginFields = (b3Lang: LangFormatFunction, submitLoginFn: () => void) => [
   {
-    name: 'emailAddress',
+    name: 'email',
     label: b3Lang('global.loginText.emailAddress'),
     required: true,
     default: '',
@@ -70,7 +70,7 @@ export const loginCheckout = (data: LoginConfig) => {
   ).then((response) => response.json());
 };
 
-export const sendEmail = (email: string) => {
+export const sendForgotPasswordEmailFor = (email: string) => {
   const urlencoded = new URLSearchParams();
   urlencoded.append('email', email);
 

--- a/apps/storefront/src/pages/Login/index.tsx
+++ b/apps/storefront/src/pages/Login/index.tsx
@@ -137,10 +137,7 @@ export default function Login(props: PageProps) {
   };
 
   const forcePasswordReset = async (email: string, password: string) => {
-    const { errors: bcErrors } = await bcLogin({
-      email,
-      pass: password,
-    });
+    const { errors: bcErrors } = await bcLogin({ email, password });
 
     if (bcErrors?.[0]) {
       const { message } = bcErrors[0];

--- a/apps/storefront/src/pages/Login/index.tsx
+++ b/apps/storefront/src/pages/Login/index.tsx
@@ -47,7 +47,7 @@ export default function Login(props: PageProps) {
   const [showTipInfo, setShowTipInfo] = useState<boolean>(true);
   const [flag, setLoginFlag] = useState<LoginFlagType>();
   const [loginAccount, setLoginAccount] = useState<LoginConfig>({
-    emailAddress: '',
+    email: '',
     password: '',
   });
   const navigate = useNavigate();
@@ -175,20 +175,20 @@ export default function Login(props: PageProps) {
         }
       } catch (error) {
         b2bLogger.error(error);
-        await getForcePasswordReset(data.emailAddress);
+        await getForcePasswordReset(data.email);
       } finally {
         setLoading(false);
       }
     } else {
       try {
         const loginData = {
-          email: data.emailAddress,
+          email: data.email,
           password: data.password,
           storeHash,
           channelId,
         };
 
-        const isForcePasswordReset = await forcePasswordReset(data.emailAddress, data.password);
+        const isForcePasswordReset = await forcePasswordReset(data.email, data.password);
         if (isForcePasswordReset) return;
 
         const {
@@ -212,7 +212,7 @@ export default function Login(props: PageProps) {
               return;
             }
           }
-          getForcePasswordReset(data.emailAddress);
+          getForcePasswordReset(data.email);
         } else {
           const info = await getCurrentCustomerInfo(token);
 
@@ -251,7 +251,7 @@ export default function Login(props: PageProps) {
   const loginAndRegisterContainerWidth = registerEnabled ? '100%' : '50%';
   const loginContainerWidth = registerEnabled ? '50%' : 'auto';
 
-  const tip = flag && tipInfo(flag, loginAccount?.emailAddress);
+  const tip = flag && tipInfo(flag, loginAccount?.email);
 
   return (
     <B3Card setOpenPage={setOpenPage}>

--- a/apps/storefront/src/pages/Registered/RegisterComplete.tsx
+++ b/apps/storefront/src/pages/Registered/RegisterComplete.tsx
@@ -26,7 +26,7 @@ import { RegisterFields } from './types';
 
 interface RegisterCompleteProps {
   handleBack: () => void;
-  handleNext: () => void;
+  handleNext: (password: string) => void;
 }
 
 type RegisterCompleteList = Array<RegisterFields> | undefined;
@@ -395,8 +395,8 @@ export default function RegisterComplete(props: RegisterCompleteProps) {
   };
 
   const handleCompleted = (event: MouseEvent) => {
-    handleSubmit(async (completeData: CustomFieldItems) => {
-      if (completeData.password !== completeData.confirmPassword) {
+    handleSubmit(async ({ password, confirmPassword }: CustomFieldItems) => {
+      if (password !== confirmPassword) {
         setError('confirmPassword', {
           type: 'manual',
           message: b3Lang('global.registerComplete.passwordMatchPrompt'),
@@ -424,15 +424,19 @@ export default function RegisterComplete(props: RegisterCompleteProps) {
 
           let isAuto = true;
           if (accountType === '2') {
-            await getBCFieldsValue(completeData);
+            await getBCFieldsValue({ password, confirmPassword });
           } else {
             const attachmentsList = companyInformation.filter((list) => list.fieldType === 'files');
             const fileList = await getFileUrl(attachmentsList || []);
-            const res = await getBCFieldsValue(completeData);
+            const res = await getBCFieldsValue({ password, confirmPassword });
             const {
               customerCreate: { customer: data },
             } = res;
-            const accountInfo = await getB2BFieldsValue(completeData, data.id, fileList);
+            const accountInfo = await getB2BFieldsValue(
+              { password, confirmPassword },
+              data.id,
+              fileList,
+            );
 
             const companyStatus = accountInfo?.companyCreate?.company?.companyStatus || '';
             isAuto = Number(companyStatus) === 1;
@@ -445,9 +449,9 @@ export default function RegisterComplete(props: RegisterCompleteProps) {
               blockPendingAccountOrderCreation,
             },
           });
-          saveRegisterPassword(completeData);
+          saveRegisterPassword({ password, confirmPassword });
           await handleSendSubscribersState();
-          handleNext();
+          handleNext(password);
         } catch (err: any) {
           setErrorMessage(err?.message || err);
         } finally {

--- a/apps/storefront/src/pages/Registered/RegisterContent.tsx
+++ b/apps/storefront/src/pages/Registered/RegisterContent.tsx
@@ -1,18 +1,13 @@
-import { ReactNode } from 'react';
+import { ReactNode, useState } from 'react';
 import styled from '@emotion/styled';
 import { Box } from '@mui/material';
+
+import { LoginConfig } from '../Login/config';
 
 import RegisterComplete from './RegisterComplete';
 import RegisteredAccount from './RegisteredAccount';
 import RegisteredDetail from './RegisteredDetail';
 import RegisteredFinish from './RegisteredFinish';
-
-interface RegisterContentProps {
-  activeStep: number;
-  handleBack: () => void;
-  handleNext: () => void;
-  handleFinish: () => void;
-}
 
 export const StyledRegisterContent = styled(Box)({
   '& #b3-customForm-id-name': {
@@ -28,25 +23,50 @@ export const StyledRegisterContent = styled(Box)({
   },
 });
 
+interface RegisterContentProps {
+  activeStep: number;
+  handleBack: () => void;
+  handleNext: () => void;
+  handleFinish: ({ email, password }: LoginConfig) => void;
+}
+
 export default function RegisterContent({
   activeStep,
   handleBack,
   handleNext,
   handleFinish,
 }: RegisterContentProps) {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+
   const renderStep = (step: number): ReactNode => {
     switch (step) {
       case 0:
-        return <RegisteredAccount handleNext={handleNext} />;
+        return (
+          <RegisteredAccount
+            handleNext={(email) => {
+              setEmail(email);
+              handleNext();
+            }}
+          />
+        );
 
       case 1:
         return <RegisteredDetail handleBack={handleBack} handleNext={handleNext} />;
 
       case 2:
-        return <RegisterComplete handleBack={handleBack} handleNext={handleNext} />;
+        return (
+          <RegisterComplete
+            handleBack={handleBack}
+            handleNext={(password) => {
+              setPassword(password);
+              handleNext();
+            }}
+          />
+        );
 
       case 3:
-        return <RegisteredFinish handleFinish={handleFinish} />;
+        return <RegisteredFinish handleFinish={() => handleFinish({ email, password })} />;
 
       default:
         return null;

--- a/apps/storefront/src/pages/Registered/RegisteredAccount.tsx
+++ b/apps/storefront/src/pages/Registered/RegisteredAccount.tsx
@@ -22,7 +22,7 @@ import { InformationFourLabels, TipContent } from './styled';
 import { RegisterFields } from './types';
 
 interface RegisteredAccountProps {
-  handleNext: () => void;
+  handleNext: (email: string) => void;
 }
 
 export default function RegisteredAccount({ handleNext }: RegisteredAccountProps) {
@@ -220,7 +220,7 @@ export default function RegisteredAccount({ handleNext }: RegisteredAccountProps
           [contactName]: [...newContactInfo],
         },
       });
-      handleNext();
+      handleNext(data[emailName]);
     })(event);
   };
 

--- a/apps/storefront/src/pages/Registered/RegisteredFinish.tsx
+++ b/apps/storefront/src/pages/Registered/RegisteredFinish.tsx
@@ -5,6 +5,7 @@ import { Alert, Box } from '@mui/material';
 import { getContrastColor } from '@/components/outSideComponents/utils/b3CustomStyles';
 import { useMobile } from '@/hooks';
 import { CustomStyleContext } from '@/shared/customStyleButton';
+import { GlobalContext } from '@/shared/global';
 import { B3SStorage } from '@/utils';
 
 import { RegisteredContext } from './context/RegisteredContext';
@@ -29,7 +30,9 @@ export default function RegisteredFinish({ handleFinish, isBCToB2B = false }: Pr
 
   const customColor = getContrastColor(backgroundColor);
 
-  const { accountType, submitSuccess, isAutoApproval, storeName } = state;
+  const { storeName } = useContext(GlobalContext).state;
+
+  const { accountType, submitSuccess, isAutoApproval } = state;
 
   const blockPendingAccountOrderCreation =
     B3SStorage.get('blockPendingAccountOrderCreation') && !isAutoApproval;
@@ -38,9 +41,7 @@ export default function RegisteredFinish({ handleFinish, isBCToB2B = false }: Pr
     if (accountType === '1') {
       return isAutoApproval ? (
         <StyleTipContainer>
-          {b3Lang('global.registerFinish.autoApproved.tip', {
-            storeName: storeName ?? '',
-          })}
+          {b3Lang('global.registerFinish.autoApproved.tip', { storeName })}
         </StyleTipContainer>
       ) : (
         <>
@@ -70,9 +71,7 @@ export default function RegisteredFinish({ handleFinish, isBCToB2B = false }: Pr
     if (accountType === '2') {
       return (
         <StyleTipContainer>
-          {b3Lang('global.registerFinish.bcSuccess.tip', {
-            storeName: storeName ?? '',
-          })}
+          {b3Lang('global.registerFinish.bcSuccess.tip', { storeName })}
         </StyleTipContainer>
       );
     }

--- a/apps/storefront/src/pages/Registered/context/RegisteredContext.tsx
+++ b/apps/storefront/src/pages/Registered/context/RegisteredContext.tsx
@@ -24,7 +24,6 @@ interface RegisterState {
   isLoading?: boolean;
   submitSuccess?: boolean;
   isAutoApproval?: boolean;
-  storeName?: string;
   blockPendingAccountOrderCreation?: boolean;
   bcTob2bContactInformation?: Array<RegisterFields>;
   bcTob2bCompanyExtraFields?: Array<RegisterFields>;
@@ -63,7 +62,6 @@ const initState = {
   countryList: [],
   stateList: [],
   isLoading: false,
-  storeName: '',
   submitSuccess: false,
   isAutoApproval: true,
   blockPendingAccountOrderCreation: true,

--- a/apps/storefront/src/pages/Registered/index.tsx
+++ b/apps/storefront/src/pages/Registered/index.tsx
@@ -29,7 +29,6 @@ import {
 import RegisterContent from './RegisterContent';
 import RegisteredStep from './RegisteredStep';
 import { RegisteredContainer, RegisteredImage } from './styled';
-import { RegisterFields } from './types';
 
 // 1 bc 2 b2b
 const formType: Array<number> = [1, 2];
@@ -51,14 +50,7 @@ function Registered(props: PageProps) {
   } = useContext(GlobalContext);
 
   const {
-    state: {
-      isLoading,
-      accountType,
-      contactInformation = [],
-      passwordInformation = [],
-      bcPasswordInformation = [],
-      bcContactInformation = [],
-    },
+    state: { isLoading },
     dispatch,
   } = useContext(RegisteredContext);
 
@@ -184,22 +176,6 @@ function Registered(props: PageProps) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const getLoginData = () => {
-    const emailAddress =
-      ((accountType === '1' ? contactInformation : bcContactInformation).find(
-        (field: RegisterFields) => field.name === 'email',
-      )?.default as string) || '';
-
-    const password =
-      ((accountType === '1' ? passwordInformation : bcPasswordInformation).find(
-        (field: RegisterFields) => field.name === 'password',
-      )?.default as string) || '';
-
-    return {
-      emailAddress,
-      password,
-    };
-  };
   const handleNext = async () => {
     setActiveStep((prevActiveStep: number) => prevActiveStep + 1);
   };
@@ -231,7 +207,7 @@ function Registered(props: PageProps) {
     }
   };
 
-  const handleFinish = async () => {
+  const handleFinish = async ({ email, password }: LoginConfig) => {
     dispatch({
       type: 'loading',
       payload: {
@@ -239,29 +215,25 @@ function Registered(props: PageProps) {
       },
     });
 
-    const data: LoginConfig = getLoginData();
-
     if (isCheckout) {
       try {
-        await loginCheckout(data);
+        await loginCheckout({ email, password });
         window.location.reload();
       } catch (error) {
         b2bLogger.error(error);
       }
     } else {
       try {
-        const getBCFieldsValue = {
-          email: data.emailAddress,
-          pass: data.password,
-        };
+        const customer = await bcLogin({
+          email,
+          pass: password,
+        }).then((res) => res?.data?.login?.customer);
 
-        const { data: bcData } = await bcLogin(getBCFieldsValue);
-
-        if (bcData?.login?.customer) {
+        if (customer) {
           B3SStorage.set('loginCustomer', {
-            emailAddress: bcData.login.customer.email,
-            phoneNumber: bcData.login.customer.phone,
-            ...bcData.login.customer,
+            emailAddress: customer.email,
+            phoneNumber: customer.phone,
+            ...customer,
           });
         }
 

--- a/apps/storefront/src/pages/Registered/index.tsx
+++ b/apps/storefront/src/pages/Registered/index.tsx
@@ -45,9 +45,7 @@ function Registered(props: PageProps) {
 
   const IframeDocument = useAppSelector(themeFrameSelector);
 
-  const {
-    state: { isCheckout, isCloseGotoBCHome, logo, storeName, registerEnabled },
-  } = useContext(GlobalContext);
+  const { isCheckout, isCloseGotoBCHome, logo, registerEnabled } = useContext(GlobalContext).state;
 
   const {
     state: { isLoading },
@@ -55,11 +53,9 @@ function Registered(props: PageProps) {
   } = useContext(RegisteredContext);
 
   const {
-    state: {
-      accountLoginRegistration,
-      portalStyle: { backgroundColor = '#FEF9F5' },
-    },
-  } = useContext(CustomStyleContext);
+    accountLoginRegistration,
+    portalStyle: { backgroundColor = '#FEF9F5' },
+  } = useContext(CustomStyleContext).state;
 
   useEffect(() => {
     if (!registerEnabled) {
@@ -147,7 +143,6 @@ function Registered(props: PageProps) {
             payload: {
               accountType: accountB2cEnabledInfo ? '2' : '1',
               isLoading: false,
-              storeName,
               // account
               contactInformation: [...(b2bAccountFormFields.contactInformation || [])],
               bcContactInformation: [...(bcAccountFormFields.contactInformation || [])],
@@ -191,7 +186,6 @@ function Registered(props: PageProps) {
         payload: {
           accountType: '',
           isLoading: false,
-          storeName: '',
           submitSuccess: false,
           contactInformation: [],
           additionalInformation: [],
@@ -224,10 +218,9 @@ function Registered(props: PageProps) {
       }
     } else {
       try {
-        const customer = await bcLogin({
-          email,
-          pass: password,
-        }).then((res) => res?.data?.login?.customer);
+        const customer = await bcLogin({ email, password }).then(
+          (res) => res?.data?.login?.customer,
+        );
 
         if (customer) {
           B3SStorage.set('loginCustomer', {

--- a/apps/storefront/src/pages/RegisteredBCToB2B/index.tsx
+++ b/apps/storefront/src/pages/RegisteredBCToB2B/index.tsx
@@ -89,7 +89,7 @@ export default function RegisteredBCToB2B(props: PageProps) {
   });
 
   const {
-    state: { storeName, logo, blockPendingAccountOrderCreation, registerEnabled },
+    state: { logo, blockPendingAccountOrderCreation, registerEnabled },
   } = useContext(GlobalContext);
 
   const navigate = useNavigate();
@@ -198,7 +198,6 @@ export default function RegisteredBCToB2B(props: PageProps) {
             type: 'all',
             payload: {
               isLoading: false,
-              storeName,
               bcTob2bContactInformation: [...newContactInformation],
               bcTob2bCompanyExtraFields: [],
               bcTob2bCompanyInformation: [...bcToB2BAccountFormFields.businessDetails],

--- a/apps/storefront/src/shared/service/bc/graphql/login.ts
+++ b/apps/storefront/src/shared/service/bc/graphql/login.ts
@@ -27,8 +27,8 @@ interface UserLoginResult {
   };
 }
 
-const getbcLogin = () => `mutation Login($email: String!, $pass: String!) {
-  login(email: $email, password: $pass) {
+const getBcLogin = () => `mutation Login($email: String!, $password: String!) {
+  login(email: $email, password: $password) {
     result,
     customer {
       entityId,
@@ -69,16 +69,18 @@ export const b2bLogin = (variables: LoginData, customMessage = true): Promise<Us
     customMessage,
   );
 
-export const bcLogin = (data: CustomFieldItems) =>
-  platform === 'bigcommerce'
-    ? B3Request.graphqlBC({
-        query: getbcLogin(),
-        variables: data,
-      })
-    : B3Request.graphqlBCProxy({
-        query: getbcLogin(),
-        variables: data,
-      });
+interface LoginVariables {
+  email: string;
+  password: string;
+}
+
+export const bcLogin = (variables: LoginVariables) => {
+  const query = getBcLogin();
+
+  return platform === 'bigcommerce'
+    ? B3Request.graphqlBC({ query, variables })
+    : B3Request.graphqlBCProxy({ query, variables });
+};
 
 export const bcLogoutLogin = () =>
   platform === 'bigcommerce'


### PR DESCRIPTION
Jira: [B2B-2146](https://bigcommercecloud.atlassian.net/browse/B2B-2146)

## What/Why?
### refactor(account): B2B-2146 Use local instead of global state for login after registration

The login after registration functionality was trying to find email &
password on the global "registration" state. Since the state is quite
big and convoluted it meant looping through all the fields to find the
customer's email and password.

By explicitly exposing it we remove the dependency on global state and
make the code simpler.

### refactor(account): B2B-2146 Rename emailAddress to email and remove storeName from RegisteredContext

Rename for consistency:

- `emailAddress` -> `email`
- `pass` -> `password`

Remove `storeName` from the RegisteredContext, all we are doing is
reading it from global and saving it in local context.

## Rollout/Rollback
Revert

## Testing
Manual

[B2B-2146]: https://bigcommercecloud.atlassian.net/browse/B2B-2146?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ