### PR TITLE
feat(catalyst): B2B-2648 fix pay by invoice redirect in catalyst

### DIFF
--- a/apps/storefront/src/pages/Invoice/components/B3Pulldown.tsx
+++ b/apps/storefront/src/pages/Invoice/components/B3Pulldown.tsx
@@ -37,7 +37,6 @@ function B3Pulldown({
   isCurrentCompany,
   invoicePay,
 }: B3PulldownProps) {
-  const platform = useAppSelector(({ global }) => global.storeInfo.platform);
   const ref = useRef<HTMLButtonElement | null>(null);
   const [isOpen, setIsOpen] = useState(false);
   const [isPay, setIsPay] = useState<boolean>(true);
@@ -114,7 +113,7 @@ function B3Pulldown({
       return;
     }
 
-    await gotoInvoiceCheckoutUrl(params, platform, false);
+    await gotoInvoiceCheckoutUrl(params, false);
   };
 
   const viewPaymentHistory = async () => {

--- a/apps/storefront/src/pages/Invoice/components/InvoiceFooter.tsx
+++ b/apps/storefront/src/pages/Invoice/components/InvoiceFooter.tsx
@@ -73,7 +73,7 @@ function InvoiceFooter(props: InvoiceFooterProps) {
         currency,
       };
 
-      await gotoInvoiceCheckoutUrl(params, platform, false);
+      await gotoInvoiceCheckoutUrl(params, false)
     }
   };
 

--- a/apps/storefront/src/pages/Invoice/utils/payment.ts
+++ b/apps/storefront/src/pages/Invoice/utils/payment.ts
@@ -2,7 +2,7 @@ import round from 'lodash-es/round';
 
 import { getInvoiceCheckoutUrl } from '@/shared/service/b2b';
 import { BcCartData } from '@/types/invoice';
-import { attemptCheckoutLoginAndRedirect } from '@/utils/b3checkout';
+import { attemptCheckoutLoginAndRedirect, redirect } from '@/utils/b3checkout';
 import b2bLogger from '@/utils/b3Logger';
 
 export const getCheckoutUrlAndCart = async (params: BcCartData) => {
@@ -18,30 +18,20 @@ export const getCheckoutUrlAndCart = async (params: BcCartData) => {
   };
 };
 
-export const gotoInvoiceCheckoutUrl = async (
-  params: BcCartData,
-  platform: string,
-  isReplaceCurrentUrl?: boolean,
-) => {
-  const { checkoutUrl, cartId } = await getCheckoutUrlAndCart(params);
-  const handleStencil = () => {
-    if (isReplaceCurrentUrl) {
-      window.location.replace(checkoutUrl);
-    } else {
-      window.location.href = checkoutUrl;
-    }
-  };
-
-  if (platform === 'bigcommerce') {
-    handleStencil();
+export const gotoInvoiceCheckoutUrl = async (params: BcCartData, isReplaceCurrentUrl?: boolean) => {
+  let checkoutUrl;
+  let cartId;
+  try {
+    ({ checkoutUrl, cartId } = await getCheckoutUrlAndCart(params));
+  } catch (e) {
+    b2bLogger.error(e);
     return;
   }
 
   try {
     await attemptCheckoutLoginAndRedirect(cartId, checkoutUrl, isReplaceCurrentUrl);
   } catch (e) {
-    b2bLogger.error(e);
-    handleStencil();
+    redirect(checkoutUrl, isReplaceCurrentUrl);
   }
 };
 

--- a/apps/storefront/src/pages/InvoicePayment/index.tsx
+++ b/apps/storefront/src/pages/InvoicePayment/index.tsx
@@ -61,7 +61,7 @@ function Payment() {
             currency: code,
           };
 
-          await gotoInvoiceCheckoutUrl(data, platform, true);
+          await gotoInvoiceCheckoutUrl(data, true);
         } catch (error: unknown) {
           snackbar.error(
             (error as CustomFieldItems)?.message || b3Lang('payment.invoiceDoesNotExist'),

--- a/apps/storefront/src/utils/b3checkout.ts
+++ b/apps/storefront/src/utils/b3checkout.ts
@@ -1,6 +1,7 @@
 import { b2bCheckoutLogin } from '@/shared/service/b2b/graphql/checkout';
+import { platform } from './basicConfig';
 
-const redirect = (url: string, isReplaceCurrentUrl?: boolean) => {
+export const redirect = (url: string, isReplaceCurrentUrl?: boolean) => {
   if (isReplaceCurrentUrl) {
     window.location.replace(url);
   } else {
@@ -13,6 +14,10 @@ export const attemptCheckoutLoginAndRedirect = async (
   defaultCheckoutUrl: string,
   isReplaceCurrentUrl?: boolean,
 ) => {
+  if (['bigcommerce', 'catalyst'].includes(platform)) {
+    throw new Error('unsupported platform for checkout login');
+  }
+
   try {
     const resLogin = await b2bCheckoutLogin({
       cartData: { cartId },


### PR DESCRIPTION
Jira: [B2B-2648](https://bigcommercecloud.atlassian.net/browse/B2B-2648)

## What/Why?
MoM customers can't pay an invoice in checkout in catalyst platforms. This is due to the `checkoutLogin` graphql query returning a checkout url for a `canonical` site url instead of a `checkout` site url. This conflicts with buyer portal authentication as it does not allow checkout login in a non checkout site url.

## Rollout/Rollback
Revert this PR

## Testing



[B2B-2648]: https://bigcommercecloud.atlassian.net/browse/B2B-2648?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ