### PR TITLE
refactor(shopping-lists): B2B-2131 introduce enum for shopping list status and updated all hardcoded number to use the enum

### DIFF
--- a/apps/storefront/src/pages/OrderDetail/components/OrderShoppingList.tsx
+++ b/apps/storefront/src/pages/OrderDetail/components/OrderShoppingList.tsx
@@ -13,6 +13,7 @@ import { isB2BUserSelector, rolePermissionSelector, useAppSelector } from '@/sto
 import { channelId } from '@/utils';
 
 import { ShoppingListItem } from '../../../types';
+import { ShoppingListStatus } from '@/pages/ShoppingLists';
 
 interface OrderShoppingListProps {
   isOpen: boolean;
@@ -73,7 +74,12 @@ export default function OrderShoppingList(props: OrderShoppingListProps) {
 
           const newList = list.filter(
             (item: CustomFieldItems) =>
-              item.node.status === Number(submitShoppingListPermission ? 30 : 0),
+              item.node.status ===
+              Number(
+                submitShoppingListPermission
+                  ? ShoppingListStatus.Draft
+                  : ShoppingListStatus.Approved,
+              ),
           );
           setList(newList);
         }

--- a/apps/storefront/src/pages/ShoppingListDetails/components/ReAddToCart.tsx
+++ b/apps/storefront/src/pages/ShoppingListDetails/components/ReAddToCart.tsx
@@ -20,6 +20,7 @@ import {
 } from '@/utils/b3Product/shared/config';
 import b3TriggerCartNumber from '@/utils/b3TriggerCartNumber';
 import { callCart } from '@/utils/cartUtils';
+import { ShoppingListStatus } from '@/pages/ShoppingLists';
 
 interface ShoppingProductsProps {
   shoppingListInfo: any;
@@ -229,7 +230,7 @@ export default function ReAddToCart(props: ShoppingProductsProps) {
         if (
           allowJuniorPlaceOrder &&
           submitShoppingListPermission &&
-          shoppingListInfo?.status === 0
+          shoppingListInfo?.status === ShoppingListStatus.Approved
         ) {
           window.location.href = CHECKOUT_URL;
         } else {

--- a/apps/storefront/src/pages/ShoppingListDetails/components/ShoppingDetailFooter.tsx
+++ b/apps/storefront/src/pages/ShoppingListDetails/components/ShoppingDetailFooter.tsx
@@ -32,6 +32,7 @@ import {
 } from '@/utils/b3Product/shared/config';
 import b3TriggerCartNumber from '@/utils/b3TriggerCartNumber';
 import { callCart, deleteCartData, updateCart } from '@/utils/cartUtils';
+import { ShoppingListStatus } from '@/pages/ShoppingLists';
 
 interface ShoppingDetailFooterProps {
   shoppingListInfo: any;
@@ -268,7 +269,7 @@ function ShoppingDetailFooter(props: ShoppingDetailFooterProps) {
           if (
             allowJuniorPlaceOrder &&
             b2bSubmitShoppingListPermission &&
-            shoppingListInfo?.status === 0
+            shoppingListInfo?.status === ShoppingListStatus.Approved
           ) {
             window.location.href = CHECKOUT_URL;
           } else {
@@ -487,7 +488,7 @@ function ShoppingDetailFooter(props: ShoppingDetailFooterProps) {
   };
 
   const allowButtonList = () => {
-    if (!(shoppingListInfo?.status === 0 || !isB2BUser)) return [];
+    if (!(shoppingListInfo?.status === ShoppingListStatus.Approved || !isB2BUser)) return [];
 
     if (!isCanAddToCart && isB2BUser)
       return productQuoteEnabled ? [buttons.addSelectedToQuote] : [];
@@ -608,7 +609,7 @@ function ShoppingDetailFooter(props: ShoppingDetailFooterProps) {
                       margin: isMobile ? '0 1rem 0 0' : '0 1rem',
                       minWidth: 'auto',
                     }}
-                    disabled={shoppingListInfo?.status === 40}
+                    disabled={shoppingListInfo?.status === ShoppingListStatus.ReadyForApproval}
                   >
                     <Delete
                       color="primary"

--- a/apps/storefront/src/pages/ShoppingListDetails/components/ShoppingDetailHeader.tsx
+++ b/apps/storefront/src/pages/ShoppingListDetails/components/ShoppingDetailHeader.tsx
@@ -14,6 +14,7 @@ import { verifyLevelPermission, verifySubmitShoppingListSubsidiariesPermission }
 import { b2bPermissionsMap } from '@/utils/b3CheckPermissions/config';
 
 import { ShoppingStatus } from '../../ShoppingLists/ShoppingStatus';
+import { ShoppingListStatus } from '@/pages/ShoppingLists';
 
 const StyledCreateName = styled('div')(() => ({
   display: 'flex',
@@ -240,42 +241,44 @@ function ShoppingDetailHeader(props: ShoppingDetailHeaderProps) {
           }}
           {...gridOptions(4)}
         >
-          {submitShoppingListPermission && shoppingListInfo?.status === 30 && (
-            <CustomButton
-              variant="outlined"
-              disabled={isDisabledBtn}
-              onClick={() => {
-                handleUpdateShoppingList(40);
-              }}
-            >
-              {b3Lang('shoppingList.header.submitForApproval')}
-            </CustomButton>
-          )}
-          {approveShoppingListPermission && shoppingListInfo?.status === 40 && (
-            <Box>
+          {submitShoppingListPermission &&
+            shoppingListInfo?.status === ShoppingListStatus.Draft && (
               <CustomButton
                 variant="outlined"
-                sx={{
-                  marginRight: '1rem',
-                }}
+                disabled={isDisabledBtn}
                 onClick={() => {
-                  handleUpdateShoppingList(20);
+                  handleUpdateShoppingList(ShoppingListStatus.ReadyForApproval);
                 }}
               >
-                {b3Lang('shoppingList.header.reject')}
+                {b3Lang('shoppingList.header.submitForApproval')}
               </CustomButton>
-              {approveShoppingListPermission && (
+            )}
+          {approveShoppingListPermission &&
+            shoppingListInfo?.status === ShoppingListStatus.ReadyForApproval && (
+              <Box>
                 <CustomButton
                   variant="outlined"
+                  sx={{
+                    marginRight: '1rem',
+                  }}
                   onClick={() => {
-                    handleUpdateShoppingList(0);
+                    handleUpdateShoppingList(ShoppingListStatus.Deleted);
                   }}
                 >
-                  {b3Lang('shoppingList.header.approve')}
+                  {b3Lang('shoppingList.header.reject')}
                 </CustomButton>
-              )}
-            </Box>
-          )}
+                {approveShoppingListPermission && (
+                  <CustomButton
+                    variant="outlined"
+                    onClick={() => {
+                      handleUpdateShoppingList(ShoppingListStatus.Approved);
+                    }}
+                  >
+                    {b3Lang('shoppingList.header.approve')}
+                  </CustomButton>
+                )}
+              </Box>
+            )}
         </Grid>
       </Grid>
     </>

--- a/apps/storefront/src/pages/ShoppingListDetails/index.tsx
+++ b/apps/storefront/src/pages/ShoppingListDetails/index.tsx
@@ -48,6 +48,7 @@ import {
   ShoppingListDetailsContext,
   ShoppingListDetailsProvider,
 } from './context/ShoppingListDetailsContext';
+import { ShoppingListStatus } from '../ShoppingLists';
 
 interface TableRefProps extends HTMLInputElement {
   initSearch: () => void;
@@ -142,7 +143,6 @@ function useData() {
   };
 }
 
-// shoppingList status: 0 -- Approved; 20 -- Rejected; 30 -- Draft; 40 -- Ready for approval
 // 0: Admin, 1: Senior buyer, 2: Junior buyer, 3: Super admin
 
 function ShoppingListDetails({ setOpenPage }: PageProps) {
@@ -206,9 +206,12 @@ function ShoppingListDetails({ setOpenPage }: PageProps) {
     ? submitShoppingList
     : role === CustomerRole.JUNIOR_BUYER;
 
-  const isJuniorApprove = shoppingListInfo?.status === 0 && b2bSubmitShoppingListPermission;
+  const isJuniorApprove =
+    shoppingListInfo?.status === ShoppingListStatus.Approved && b2bSubmitShoppingListPermission;
 
-  const isReadForApprove = shoppingListInfo?.status === 40 || shoppingListInfo?.status === 20;
+  const isReadForApprove =
+    shoppingListInfo?.status === ShoppingListStatus.ReadyForApproval ||
+    shoppingListInfo?.status === ShoppingListStatus.Deleted;
 
   const goToShoppingLists = () => {
     navigate('/shoppingLists');

--- a/apps/storefront/src/pages/ShoppingLists/AddEditShoppingLists.tsx
+++ b/apps/storefront/src/pages/ShoppingLists/AddEditShoppingLists.tsx
@@ -19,6 +19,7 @@ import {
   getCreatedShoppingListFiles,
   GetFilterMoreListProps,
   ShoppingListsItemsProps,
+  ShoppingListStatus,
 } from './config';
 
 interface AddEditUserProps {
@@ -102,7 +103,9 @@ function AddEditShoppingLists(
             if (selectCompanyHierarchyId) {
               params.companyId = Number(selectCompanyHierarchyId);
             }
-            params.status = submitShoppingListPermission ? 30 : 0;
+            params.status = submitShoppingListPermission
+              ? ShoppingListStatus.Draft
+              : ShoppingListStatus.Approved;
           } else {
             params.channelId = channelId;
           }

--- a/apps/storefront/src/pages/ShoppingLists/ShoppingListsCard.tsx
+++ b/apps/storefront/src/pages/ShoppingLists/ShoppingListsCard.tsx
@@ -16,7 +16,7 @@ import { rolePermissionSelector, useAppSelector } from '@/store';
 import { displayFormat, verifyLevelPermission } from '@/utils';
 import { b2bPermissionsMap } from '@/utils/b3CheckPermissions/config';
 
-import { ShoppingListsItemsProps } from './config';
+import { ShoppingListsItemsProps, ShoppingListStatus } from './config';
 import { ShoppingStatus } from './ShoppingStatus';
 
 export interface OrderItemCardProps {
@@ -56,18 +56,20 @@ function ShoppingListsCard(props: OrderItemCardProps) {
 
   const getEditPermissions = (status: number) => {
     if (submitShoppingListPermission) {
-      if (status === 30 || status === 0) return false;
+      if (status === ShoppingListStatus.Draft || status === ShoppingListStatus.Approved)
+        return false;
       return true;
     }
 
-    if (status === 40) return true;
+    if (status === ShoppingListStatus.ReadyForApproval) return true;
 
     return false;
   };
 
   const getDeletePermissions = (status: number) => {
     if (submitShoppingListPermission) {
-      if (status === 20 || status === 30) return false;
+      if (status === ShoppingListStatus.Deleted || status === ShoppingListStatus.Draft)
+        return false;
       return true;
     }
 

--- a/apps/storefront/src/pages/ShoppingLists/ShoppingStatus.tsx
+++ b/apps/storefront/src/pages/ShoppingLists/ShoppingStatus.tsx
@@ -1,7 +1,7 @@
 import { B3Tag } from '@/components';
 import { rolePermissionSelector, useAppSelector } from '@/store';
 
-import { useGetFilterShoppingListStatus } from './config';
+import { ShoppingListStatus, useGetFilterShoppingListStatus } from './config';
 
 export const useGetStatus = () => {
   const getFilterShoppingListStatus = useGetFilterShoppingListStatus();
@@ -10,7 +10,7 @@ export const useGetStatus = () => {
     const statusArr = getFilterShoppingListStatus(submitShoppingListPermission);
 
     const newStatus = statusArr.map((item) => {
-      if (Number(item.value) === 0) {
+      if (Number(item.value) === ShoppingListStatus.Approved) {
         return {
           color: '#C4DD6C',
           textColor: 'black',
@@ -18,7 +18,7 @@ export const useGetStatus = () => {
         };
       }
 
-      if (Number(item.value) === 40) {
+      if (Number(item.value) === ShoppingListStatus.ReadyForApproval) {
         return {
           color: '#F4CC46',
           textColor: 'black',
@@ -26,7 +26,7 @@ export const useGetStatus = () => {
         };
       }
 
-      if (Number(item.value) === 30) {
+      if (Number(item.value) === ShoppingListStatus.Draft) {
         return {
           color: '#899193',
           textColor: '#FFFFFF',

--- a/apps/storefront/src/pages/ShoppingLists/config.ts
+++ b/apps/storefront/src/pages/ShoppingLists/config.ts
@@ -57,18 +57,36 @@ export interface GetFilterMoreListProps {
   idLang?: string;
 }
 
+export enum ShoppingListStatus {
+  Approved = 0,
+  Deleted = 20,
+  Draft = 30,
+  ReadyForApproval = 40,
+  Rejected = 50,
+}
+
 export const useGetFilterShoppingListStatus = () => {
   const b3Lang = useB3Lang();
 
   return (submitShoppingListPermission: boolean) => {
-    const draftStatus = { value: 30, label: b3Lang('global.shoppingLists.status.draft') };
-    const rejectedStatus = { value: 20, label: b3Lang('global.shoppingLists.status.rejected') };
+    const draftStatus = {
+      value: ShoppingListStatus.Draft,
+      label: b3Lang('global.shoppingLists.status.draft'),
+    };
+    const rejectedStatus = {
+      value: ShoppingListStatus.Deleted,
+      label: b3Lang('global.shoppingLists.status.rejected'),
+    };
 
+    // TODO: fix 99 which is used for selecting all
     return [
       { value: 99, label: b3Lang('global.shoppingLists.status.all') },
-      { value: 0, label: b3Lang('global.shoppingLists.status.approved') },
+      { value: ShoppingListStatus.Approved, label: b3Lang('global.shoppingLists.status.approved') },
       ...(submitShoppingListPermission ? [draftStatus] : []),
-      { value: 40, label: b3Lang('global.shoppingLists.status.readyForApproval') },
+      {
+        value: ShoppingListStatus.ReadyForApproval,
+        label: b3Lang('global.shoppingLists.status.readyForApproval'),
+      },
       ...(submitShoppingListPermission ? [rejectedStatus] : []),
     ];
   };

--- a/apps/storefront/src/pages/ShoppingLists/index.tsx
+++ b/apps/storefront/src/pages/ShoppingLists/index.tsx
@@ -19,8 +19,15 @@ import { isB2BUserSelector, rolePermissionSelector, useAppSelector } from '@/sto
 import { channelId, snackbar } from '@/utils';
 
 import AddEditShoppingLists from './AddEditShoppingLists';
-import { ShoppingListSearch, ShoppingListsItemsProps, useGetFilterMoreList } from './config';
+import {
+  ShoppingListSearch,
+  ShoppingListsItemsProps,
+  ShoppingListStatus,
+  useGetFilterMoreList,
+} from './config';
 import ShoppingListsCard from './ShoppingListsCard';
+
+export { ShoppingListStatus } from './config';
 
 interface RefCurrentProps extends HTMLInputElement {
   handleOpenAddEditShoppingListsClick: (type: string, data?: ShoppingListsItemsProps) => void;
@@ -110,7 +117,9 @@ function ShoppingLists() {
       padding: '0',
     },
   };
-  const statusPermissions = !submitShoppingListPermission ? [0, 40] : '';
+  const statusPermissions = !submitShoppingListPermission
+    ? [ShoppingListStatus.Approved, ShoppingListStatus.ReadyForApproval]
+    : '';
 
   const initSearch = {
     search: '',

--- a/apps/storefront/src/utils/b3ShoppingList/b3ShoppingList.ts
+++ b/apps/storefront/src/utils/b3ShoppingList/b3ShoppingList.ts
@@ -3,6 +3,7 @@ import { store } from '@/store';
 
 import { b2bPermissionsMap, validatePermissionWithComparisonType } from '../b3CheckPermissions';
 import { channelId } from '../basicConfig';
+import { ShoppingListStatus } from '@/pages/ShoppingLists';
 
 interface CreateShoppingListParams {
   data: { name: string; description: string };
@@ -25,7 +26,9 @@ CreateShoppingListParams) => {
     });
     const selectCompanyHierarchyId =
       store.getState()?.company?.companyHierarchyInfo?.selectCompanyHierarchyId || 0;
-    createShoppingData.status = submitShoppingListPermission ? 30 : 0;
+    createShoppingData.status = submitShoppingListPermission
+      ? ShoppingListStatus.Draft
+      : ShoppingListStatus.Approved;
     if (selectCompanyHierarchyId) {
       createShoppingData.companyId = selectCompanyHierarchyId;
     }

--- a/commit-validation.json
+++ b/commit-validation.json
@@ -1,3 +1,10 @@
 {
-  "scopes": ["common", "companies", "quotes", "permissions", "account"]
+  "scopes": [
+    "common",
+    "companies",
+    "quotes",
+    "permissions",
+    "account",
+    "shopping-lists"
+  ]
 }


### PR DESCRIPTION
Jira: [B2B-2131](https://bigcommercecloud.atlassian.net/browse/B2B-2131)

## What/Why?
It's not ideal to use hardcoded numbers for the status, which could also cause status got misused. In fact, `20` is supposed to be for `deleted` for shopping lists but it somehow got misused as `rejected`. This PR is to introduce enum for shopping list status and updated all hardcoded number to use the enum.

## Rollout/Rollback
merge/revert

## Testing
Replacing hardcoded with enum only so passing ci would be sufficient