### PR TITLE
chore(common): B2B-2710 Require testing and linting to pass before allowing to merge

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,6 +65,8 @@ workflows:
           requires:
             - build_and_push
             - ci/validate-commits
+            - lint
+            - test
       - security/scan:
           name: "Gitleaks secrets scan"
           context: org-global


### PR DESCRIPTION
Jira: [B2B-2710](https://bigcommercecloud.atlassian.net/browse/B2B-2710)

## What/Why?
Before this, even if linting and/or unit tests failed, we are still able to merge the PR

## Rollout/Rollback
Revert

## Testing
Passing CI

When linting failed:
<img width="758" alt="Screenshot 2025-04-09 at 3 30 45 pm" src="https://github.com/user-attachments/assets/fdc91ced-d39d-42fb-bfbb-8f1d8da3bfd4" />

When unit tests failed:
<img width="757" alt="Screenshot 2025-04-09 at 3 17 51 pm" src="https://github.com/user-attachments/assets/6d79d69e-b597-4828-92a5-20424c11dd23" />


[B2B-2710]: https://bigcommercecloud.atlassian.net/browse/B2B-2710?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ