### PR TITLE
fix(catalyst): fixing product object for shopping list add operation

### DIFF
--- a/apps/storefront/src/components/HeadlessController.tsx
+++ b/apps/storefront/src/components/HeadlessController.tsx
@@ -41,22 +41,23 @@ interface HeadlessControllerProps {
 
 const transformOptionSelectionsToAttributes = (items: LineItems[]) =>
   items.map((product) => {
-    const selectedOptions =  product.selectedOptions?.reduce(
-      (accumulator: Record<string, number>, { optionEntityId, optionValueEntityId }) => {
-        accumulator[`attribute[${optionEntityId}]`] = optionValueEntityId;
+    const selectedOptions =
+      product.selectedOptions?.reduce(
+        (accumulator: Record<string, number>, { optionEntityId, optionValueEntityId }) => {
+          accumulator[`attribute[${optionEntityId}]`] = optionValueEntityId;
 
-        return accumulator;
-      },
-      {},
-    ) ?? {};
+          return accumulator;
+        },
+        {},
+      ) ?? {};
 
-  return {
-    ...product,
-    productId: product.productEntityId,
-    selectedOptions,
-    optionSelections: selectedOptions,
-  };
-});
+    return {
+      ...product,
+      productId: product.productEntityId,
+      selectedOptions,
+      optionSelections: selectedOptions,
+    };
+  });
 
 export type ProductMappedAttributes = ReturnType<typeof transformOptionSelectionsToAttributes>;
 

--- a/apps/storefront/src/components/HeadlessController.tsx
+++ b/apps/storefront/src/components/HeadlessController.tsx
@@ -45,6 +45,7 @@ const transformOptionSelectionsToAttributes = (items: LineItems[]) =>
 
     return {
       ...product,
+      productId: product.productEntityId,
       selectedOptions: selectedOptions?.reduce(
         (accumulator: Record<string, number>, { optionEntityId, optionValueEntityId }) => {
           accumulator[`attribute[${optionEntityId}]`] = optionValueEntityId;
@@ -206,7 +207,7 @@ export default function HeadlessController({ setOpenPage }: HeadlessControllerPr
           },
         },
         shoppingList: {
-          itemFromCurrentPage: [],
+          itemFromCurrentPage: window.b2b?.utils?.shoppingList?.itemFromCurrentPage ?? [],
           addProductFromPage: (item) => {
             window.b2b.utils.shoppingList.itemFromCurrentPage =
               transformOptionSelectionsToAttributes([item]);

--- a/apps/storefront/src/components/HeadlessController.tsx
+++ b/apps/storefront/src/components/HeadlessController.tsx
@@ -41,21 +41,22 @@ interface HeadlessControllerProps {
 
 const transformOptionSelectionsToAttributes = (items: LineItems[]) =>
   items.map((product) => {
-    const { selectedOptions } = product;
+    const selectedOptions =  product.selectedOptions?.reduce(
+      (accumulator: Record<string, number>, { optionEntityId, optionValueEntityId }) => {
+        accumulator[`attribute[${optionEntityId}]`] = optionValueEntityId;
 
-    return {
-      ...product,
-      productId: product.productEntityId,
-      selectedOptions: selectedOptions?.reduce(
-        (accumulator: Record<string, number>, { optionEntityId, optionValueEntityId }) => {
-          accumulator[`attribute[${optionEntityId}]`] = optionValueEntityId;
+        return accumulator;
+      },
+      {},
+    ) ?? {};
 
-          return accumulator;
-        },
-        {},
-      ),
-    };
-  });
+  return {
+    ...product,
+    productId: product.productEntityId,
+    selectedOptions,
+    optionSelections: selectedOptions,
+  };
+});
 
 export type ProductMappedAttributes = ReturnType<typeof transformOptionSelectionsToAttributes>;
 

--- a/commit-validation.json
+++ b/commit-validation.json
@@ -6,6 +6,7 @@
     "permissions",
     "account",
     "shopping-lists",
-    "orders"
+    "orders",
+    "catalyst"
   ]
 }


### PR DESCRIPTION
## What/Why?
Passing `productId` to the created item for the add to shopping list feature to work. Also reading the item from the window object since we were losing the reference after a new render

## Rollout/Rollback
revert

## Testing

https://github.com/user-attachments/assets/dfb352ee-af4d-42ab-ab1a-46d5da78fb1a

