### PR TITLE
feat(carts): on cart created callback

### DIFF
--- a/apps/storefront/src/utils/cartUtils.ts
+++ b/apps/storefront/src/utils/cartUtils.ts
@@ -1,3 +1,4 @@
+import { dispatchEvent } from '@b3/hooks';
 import Cookies from 'js-cookie';
 
 import { addNewLineToCart, createNewCart, getCart } from '@/shared/service/bc/graphql/cart';
@@ -100,6 +101,9 @@ export const createNewShoppingCart = async (products: any) => {
   }
   const { entityId } = res.data.cart.createCart.cart;
   Cookies.set('cartId', entityId);
+  dispatchEvent('on-cart-created', {
+    cartId: entityId,
+  });
   return res;
 };
 

--- a/commit-validation.json
+++ b/commit-validation.json
@@ -7,6 +7,8 @@
     "account",
     "shopping-lists",
     "orders",
-    "catalyst"
+    "catalyst",
+    "carts",
+    "orders"
   ]
 }

--- a/packages/hooks/useB2BCallback.ts
+++ b/packages/hooks/useB2BCallback.ts
@@ -3,6 +3,7 @@ export type EventType =
   | 'on-add-to-shopping-list'
   | 'on-click-cart-button'
   | 'on-login'
+  | 'on-cart-created'
   | 'on-registered'
   | 'on-logout';
 


### PR DESCRIPTION

## What/Why?
Creating a new event `on-cart-created` so headless storefronts can sync cart ids easier

## Rollout/Rollback
Revert

## Testing
Created a cart and listened to the event
