### PR TITLE
fix(catalyst): redirecting catalyst sf to checkout route

### DIFF
--- a/apps/storefront/src/pages/Invoice/utils/payment.ts
+++ b/apps/storefront/src/pages/Invoice/utils/payment.ts
@@ -37,6 +37,11 @@ export const gotoInvoiceCheckoutUrl = async (
     return;
   }
 
+  if (platform === 'catalyst') {
+    window.location.href = `/checkout?cartId=${cartId}`;
+    return;
+  }
+
   try {
     await attemptCheckoutLoginAndRedirect(cartId, checkoutUrl, isReplaceCurrentUrl);
   } catch (e) {

--- a/apps/storefront/src/pages/quote/utils/quoteCheckout.ts
+++ b/apps/storefront/src/pages/quote/utils/quoteCheckout.ts
@@ -62,6 +62,11 @@ export const handleQuoteCheckout = async ({
       return;
     }
 
+    if (platform === 'catalyst') {
+      window.location.href = `/checkout?cartId=${cartId}`;
+      return;
+    }
+
     await attemptCheckoutLoginAndRedirect(cartId, checkoutUrl as string);
   } catch (err) {
     b2bLogger.error(err);

--- a/commit-validation.json
+++ b/commit-validation.json
@@ -6,6 +6,7 @@
     "permissions",
     "account",
     "shopping-lists",
-    "orders"
+    "orders",
+    "catalyst"
   ]
 }


### PR DESCRIPTION
## What/Why?
Redirecting catalyst storefronts' B2B checkout workflows to the catalyst internal `/checkout` route passing a cart id as a search param to create the redirect url

## Rollout/Rollback
revert

## Testing

https://github.com/user-attachments/assets/25925e22-2531-4282-b076-8c369f5ddc33

