### PR TITLE
feat(common): adding dynamic staging url to support integration domain

### DIFF
--- a/apps/storefront/src/index.d.ts
+++ b/apps/storefront/src/index.d.ts
@@ -31,6 +31,7 @@ declare interface Window {
       environment: import('@/types/global').Environment;
       disable_logout_button?: boolean;
       cart_url?: string;
+      staging_url?: string;
     };
   };
   b2b: {

--- a/apps/storefront/src/shared/service/request/base.ts
+++ b/apps/storefront/src/shared/service/request/base.ts
@@ -1,10 +1,11 @@
 import { Environment, EnvSpecificConfig } from '@/types';
+import { stagingUrl } from '@/utils';
 
 const ENVIRONMENT_B2B_API_URL: EnvSpecificConfig<string> = {
   local: import.meta.env.VITE_B2B_URL ?? 'http://localhost:9000',
   integration: 'https://api-b2b.integration.zone',
   staging: 'https://api-b2b.staging.zone',
-  production: 'https://api-b2b.bigcommerce.com',
+  production: stagingUrl ?? 'https://api-b2b.bigcommerce.com',
 };
 
 // cspell:disable

--- a/apps/storefront/src/utils/basicConfig.ts
+++ b/apps/storefront/src/utils/basicConfig.ts
@@ -3,6 +3,7 @@ export const {
   channel_id: channelId,
   disable_logout_button: disableLogoutButton,
   platform = 'custom',
+  staging_url: stagingUrl,
 } = window.B3.setting;
 
 const generateBcStorefrontAPIBaseUrl = () => {


### PR DESCRIPTION
## What/Why?
While deploying a Catalyst in an integration store we realized the default staging domain will not work as it is different. Adding a dynamic variable to override this url while we migrate all staging stores to integration.

## Rollout/Rollback
Revert

## Testing
NA
