### PR TITLE
chore(common): remove bc commit validation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,14 +57,12 @@ workflows:
     jobs:
       - test
       - lint
-      - ci/validate-commits
       - build_and_push:
           context: "GCR + Artifact Bucket Access"
       - ci/notify-success:
           context: "GCR + Artifact Bucket Access"
           requires:
             - build_and_push
-            - ci/validate-commits
             - lint
             - test
       - security/scan:


### PR DESCRIPTION
## What/Why?
Removing the commit validation step from the b2b buyer portal as it is a BC open source repository and the step validates for JIRA ticket ids that ultimately fall into the category of a [corporate secret.](https://docs.dev.bigcommerce.net/process/open-source/open-sourcing-a-new-library.html#corporate-secrets)

Also do we know of other validation commit for open source repos? Enforcing domain and scope for each commit is still encouraged.

## Rollout/Rollback

## Testing

