### PR TITLE
feat(common): optionally remove hashes from entry filenames

### DIFF
--- a/apps/storefront/vite.config.ts
+++ b/apps/storefront/vite.config.ts
@@ -84,7 +84,7 @@ export default defineConfig(({ mode }) => {
         },
         output: {
           entryFileNames({ name }) {
-            if (name.includes('headless')) {
+            if (name.includes('headless') || env.VITE_DISABLE_BUILD_HASH) {
               return '[name].js';
             }
 

--- a/docs/headless.md
+++ b/docs/headless.md
@@ -58,6 +58,7 @@ Make sure that you have configured the following `.env` values correctly before 
 
 - `VITE_IS_LOCAL_ENVIRONMENT`: Set this to `FALSE`
 - `VITE_ASSETS_ABSOLUTE_PATH`: Set this to the URL where the assets folder is hosted. **Note that this needs to be the absolute URL to the `/assets` folder location where the build will be served from in production.** Also please include the trailing `/`.
+- `VITE_DISABLE_BUILD_HASH`: Set this to `TRUE` if you want to disable the hash in the build files. This is useful if you want to avoid updating the file names in your headless app everytime you deploy or if you are using a CDN that does not support cache busting with hashes.
 
   For example, if you deploy the contents of the `dist` folder built by running `yarn build` and hosted it at https://my.custom.cdn/generated/b2b, the value you should put is https://my.custom.cdn/generated/b2b/assets/.
 


### PR DESCRIPTION
## What/Why?
Adding environment variable `VITE_DISABLE_BUILD_HASH` to remove hashes from entry files for custom buyer portal users.

## Rollout/Rollback
revert

## Testing
build without hashes in names:
<img width="245" alt="Screenshot 2025-04-22 at 1 51 42 p m" src="https://github.com/user-attachments/assets/c98f866b-cbe2-4706-a5f4-7e28640f3717" />


before:
<img width="334" alt="Screenshot 2025-04-22 at 1 52 53 p m" src="https://github.com/user-attachments/assets/18d0a1ca-e83a-4f5d-bb75-516cbeeadeb0" />

