### PR TITLE
fix(common): removing jira ticket from pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,3 @@
-Jira: [JIRA_TOKEN](https://bigcommercecloud.atlassian.net/browse/JIRA_TOKEN)
-
 ## What/Why?
 <!--
   A description about what this pull request implements and its purpose.


### PR DESCRIPTION
## What/Why?
Removing jira ticket from pull request template to comply with BC standard of open source repos.

## Rollout/Rollback


## Testing

