### PR TITLE
refactor(addresses): B2B-2154 Use a single useState for all dialog controls

### DIFF
--- a/apps/storefront/src/pages/Address/components/DeleteAddressDialog.tsx
+++ b/apps/storefront/src/pages/Address/components/DeleteAddressDialog.tsx
@@ -11,7 +11,7 @@ import { AddressItemType } from '../../../types/address';
 
 interface DeleteAddressDialogProps {
   isOpen: boolean;
-  setIsOpen: Dispatch<SetStateAction<boolean>>;
+  closeDialog: () => void;
   setIsLoading: Dispatch<SetStateAction<boolean>>;
   addressData?: AddressItemType;
   updateAddressList: (isFirst?: boolean) => void;
@@ -22,7 +22,7 @@ interface DeleteAddressDialogProps {
 export default function DeleteAddressDialog(props: DeleteAddressDialogProps) {
   const {
     isOpen,
-    setIsOpen,
+    closeDialog,
     addressData,
     updateAddressList,
     setIsLoading,
@@ -40,7 +40,7 @@ export default function DeleteAddressDialog(props: DeleteAddressDialogProps) {
 
     try {
       setIsLoading(true);
-      setIsOpen(false);
+      closeDialog();
 
       const { id = '', bcAddressId = '' } = addressData;
 
@@ -69,9 +69,7 @@ export default function DeleteAddressDialog(props: DeleteAddressDialogProps) {
       title={b3Lang('addresses.deleteAddressDialog.deleteAddress')}
       leftSizeBtn={b3Lang('addresses.deleteAddressDialog.cancel')}
       rightSizeBtn={b3Lang('addresses.deleteAddressDialog.delete')}
-      handleLeftClick={() => {
-        setIsOpen(false);
-      }}
+      handleLeftClick={closeDialog}
       handRightClick={handleDelete}
       rightStyleBtn={{
         color: '#D32F2F',

--- a/apps/storefront/src/pages/Address/components/SetDefaultDialog.tsx
+++ b/apps/storefront/src/pages/Address/components/SetDefaultDialog.tsx
@@ -11,7 +11,7 @@ import { AddressItemType } from '../../../types/address';
 
 interface SetDefaultDialogProps {
   isOpen: boolean;
-  setIsOpen: Dispatch<SetStateAction<boolean>>;
+  closeDialog: () => void;
   setIsLoading: Dispatch<SetStateAction<boolean>>;
   addressData?: AddressItemType;
   updateAddressList: (isFirst?: boolean) => void;
@@ -19,7 +19,7 @@ interface SetDefaultDialogProps {
 }
 
 export default function SetDefaultDialog(props: SetDefaultDialogProps) {
-  const { isOpen, setIsOpen, setIsLoading, addressData, updateAddressList, companyId } = props;
+  const { isOpen, closeDialog, setIsLoading, addressData, updateAddressList, companyId } = props;
 
   const [isMobile] = useMobile();
 
@@ -54,7 +54,7 @@ export default function SetDefaultDialog(props: SetDefaultDialogProps) {
   const handleSetDefault = async () => {
     try {
       setIsLoading(true);
-      setIsOpen(false);
+      closeDialog();
 
       await updateB2BAddress({
         ...address,
@@ -75,9 +75,7 @@ export default function SetDefaultDialog(props: SetDefaultDialogProps) {
       title={b3Lang('addresses.setDefaultDialog.setDefaultAddress')}
       leftSizeBtn={b3Lang('addresses.setDefaultDialog.cancel')}
       rightSizeBtn="set"
-      handleLeftClick={() => {
-        setIsOpen(false);
-      }}
+      handleLeftClick={closeDialog}
       handRightClick={handleSetDefault}
     >
       <Box

--- a/apps/storefront/src/shared/service/b2b/graphql/address.ts
+++ b/apps/storefront/src/shared/service/b2b/graphql/address.ts
@@ -263,7 +263,7 @@ const deleteCustomerAddress = (data: CustomFieldItems) => `mutation{
 export const getB2BAddress = (data: CustomFieldItems = {}) =>
   B3Request.graphqlB2B({
     query: getAddress(data),
-  });
+  }).then((res) => res.addresses);
 
 export const getB2BAddressConfig = () =>
   B3Request.graphqlB2B({
@@ -273,7 +273,7 @@ export const getB2BAddressConfig = () =>
 export const getBCCustomerAddress = (data: CustomFieldItems = {}) =>
   B3Request.graphqlB2B({
     query: getCustomerAddress(data),
-  });
+  }).then((res) => res.customerAddresses);
 
 export const deleteB2BAddress = (data: CustomFieldItems = {}) =>
   B3Request.graphqlB2B({

--- a/commit-validation.json
+++ b/commit-validation.json
@@ -9,6 +9,7 @@
     "orders",
     "catalyst",
     "carts",
-    "orders"
+    "orders",
+    "addresses"
   ]
 }


### PR DESCRIPTION
Jira: [B2B-2154](https://bigcommercecloud.atlassian.net/browse/B2B-2154)

## What/Why?
- use a single useState to control which dialog is open
- reduce api shared with children components, `closeDialog` instead of `setIsOpen`
- helper to check config
- add missing dependencies to react hooks

## Rollout/Rollback
Revert

## Testing

https://github.com/user-attachments/assets/af7ed7ad-9b70-4287-bc12-0bb7eafc0a4d



[B2B-2154]: https://bigcommercecloud.atlassian.net/browse/B2B-2154?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ