### PR TITLE
refactor(quotes): add basic test harness to quotes listing page

### DIFF
--- a/apps/storefront/.dependency-cruiser.cjs
+++ b/apps/storefront/.dependency-cruiser.cjs
@@ -36,7 +36,12 @@ module.exports = {
       },
       module: {
         path: ['^tests/'],
-        pathNot: [testFilesRegex, '\\.d\\.ts$', '^tests/setup-test-environment.ts'],
+        pathNot: [
+          testFilesRegex,
+          '\\.d\\.ts$',
+          '^tests/setup-test-environment.ts',
+          '^tests/global-setup.ts',
+        ],
         numberOfDependentsLessThan: 1,
       },
     },

--- a/apps/storefront/package.json
+++ b/apps/storefront/package.json
@@ -59,6 +59,7 @@
   },
   "devDependencies": {
     "@b3/tsconfig": "*",
+    "@faker-js/faker": "^9.7.0",
     "@graphql-codegen/cli": "^5.0.2",
     "@graphql-codegen/client-preset": "^4.2.5",
     "@testing-library/dom": "^10.1.0",

--- a/apps/storefront/src/pages/QuotesList/index.test.tsx
+++ b/apps/storefront/src/pages/QuotesList/index.test.tsx
@@ -19,13 +19,6 @@ import { CompanyStatus, UserTypes } from '@/types';
 
 import QuotesList from './index';
 
-// Required to stop the view using the mobile layout
-// which often switches to different, non-semantic elements
-vitest.mock('@/hooks', async (importOriginal) => ({
-  ...(await importOriginal<typeof import('@/hooks')>()),
-  useMobile: () => [false],
-}));
-
 const buildShoppingListsCreatedByUserWith = builder<ShoppingListsCreatedByUser>(() => ({
   data: { createdByUser: { results: { createdBy: [], salesRep: [] } } },
 }));

--- a/apps/storefront/src/pages/QuotesList/index.test.tsx
+++ b/apps/storefront/src/pages/QuotesList/index.test.tsx
@@ -1,0 +1,299 @@
+import { graphql, HttpResponse } from 'msw';
+import {
+  buildCompanyStateWith,
+  builder,
+  buildStoreInfoStateWith,
+  bulk,
+  faker,
+  getUnixTime,
+  renderWithProviders,
+  screen,
+  startMockServer,
+  userEvent,
+  within,
+} from 'tests/test-utils';
+
+import { QuoteEdge, QuotesListB2B } from '@/shared/service/b2b/graphql/quote';
+import { ShoppingListsCreatedByUser } from '@/shared/service/b2b/graphql/shoppingList';
+import { CompanyStatus, UserTypes } from '@/types';
+
+import QuotesList from './index';
+
+// Required to stop the view using the mobile layout
+// which often switches to different, non-semantic elements
+vitest.mock('@/hooks', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/hooks')>()),
+  useMobile: () => [false],
+}));
+
+const buildShoppingListsCreatedByUserWith = builder<ShoppingListsCreatedByUser>(() => ({
+  data: { createdByUser: { results: { createdBy: [], salesRep: [] } } },
+}));
+
+const buildQuoteEdgeWith = builder<QuoteEdge>(() => ({
+  node: {
+    id: faker.string.uuid(),
+    createdAt: getUnixTime(faker.date.past()),
+    updatedAt: getUnixTime(faker.date.recent()),
+    quoteNumber: faker.string.numeric(),
+    quoteTitle: faker.commerce.productName(),
+    referenceNumber: faker.string.numeric(),
+    createdBy: faker.person.fullName(),
+    expiredAt: getUnixTime(faker.date.future()),
+    discount: faker.commerce.price(),
+    grandTotal: faker.commerce.price(),
+    currency: {
+      token: faker.finance.currencySymbol(),
+      location: faker.location.country(),
+      currencyCode: faker.finance.currencyCode(),
+      decimalToken: faker.string.symbol(),
+      decimalPlaces: faker.number.int({ min: 0, max: 100 }),
+      thousandsToken: faker.string.symbol(),
+      currencyExchangeRate: faker.finance.amount(),
+    },
+    status: faker.helpers.arrayElement([0, 1, 4, 5]),
+    salesRep: faker.person.fullName(),
+    salesRepEmail: faker.internet.email(),
+    orderId: faker.string.uuid(),
+    subtotal: faker.commerce.price(),
+    totalAmount: faker.commerce.price(),
+    taxTotal: faker.commerce.price(),
+  },
+}));
+
+const buildQuotesListB2BWith = builder<QuotesListB2B>(() => {
+  const totalCount = faker.number.int({ min: 0, max: 10 });
+  const edges = bulk(buildQuoteEdgeWith, 'WHATEVER_VALUES').times(totalCount);
+
+  return { data: { quotes: { totalCount, edges } } };
+});
+
+const { server } = startMockServer();
+
+describe('when the user is a B2B customer', () => {
+  const approvedB2BCompany = buildCompanyStateWith({
+    companyInfo: { status: CompanyStatus.APPROVED },
+    customer: { userType: UserTypes.MULTIPLE_B2C },
+  });
+
+  const storeInfoWithDateFormat = buildStoreInfoStateWith({ timeFormat: { display: 'j F Y' } });
+
+  const preloadedState = { company: approvedB2BCompany, storeInfo: storeInfoWithDateFormat };
+
+  it('displays a table with headings for each key attribute of a quote', async () => {
+    const quotesListB2B = buildQuotesListB2BWith({
+      data: { quotes: { totalCount: 1, edges: [buildQuoteEdgeWith('WHATEVER_VALUES')] } },
+    });
+
+    server.use(
+      graphql.query('GetQuotesList', () => HttpResponse.json(quotesListB2B)),
+      graphql.query('GetShoppingListsCreatedByUser', () =>
+        HttpResponse.json(buildShoppingListsCreatedByUserWith('WHATEVER_VALUES')),
+      ),
+    );
+
+    renderWithProviders(<QuotesList />, { preloadedState });
+
+    const table = await screen.findByRole('table');
+
+    expect(within(table).getByRole('columnheader', { name: 'Quote #' })).toBeInTheDocument();
+    expect(within(table).getByRole('columnheader', { name: 'Title' })).toBeInTheDocument();
+    expect(within(table).getByRole('columnheader', { name: 'Sales rep' })).toBeInTheDocument();
+    expect(within(table).getByRole('columnheader', { name: 'Created by' })).toBeInTheDocument();
+    expect(within(table).getByRole('columnheader', { name: 'Date created' })).toBeInTheDocument();
+    expect(within(table).getByRole('columnheader', { name: 'Last update' })).toBeInTheDocument();
+    expect(
+      within(table).getByRole('columnheader', { name: 'Expiration date' }),
+    ).toBeInTheDocument();
+    expect(within(table).getByRole('columnheader', { name: 'Subtotal' })).toBeInTheDocument();
+    expect(within(table).getByRole('columnheader', { name: 'Status' })).toBeInTheDocument();
+  });
+
+  it('displays a table with values for each key attribute of a quote', async () => {
+    const manySocks = buildQuoteEdgeWith({
+      node: {
+        quoteNumber: '123456789',
+        quoteTitle: 'Many Socks',
+        salesRep: 'Fred Salesman',
+        createdBy: 'Sam Shopper',
+        createdAt: getUnixTime(new Date('1 January 2025')),
+        updatedAt: getUnixTime(new Date('2 February 2025')),
+        expiredAt: getUnixTime(new Date('3 March 2025')),
+        totalAmount: '101.99',
+        currency: { token: '$', location: 'left', decimalToken: '.', decimalPlaces: 2 },
+        status: 1,
+      },
+    });
+
+    const quotesListB2B = buildQuotesListB2BWith({
+      data: { quotes: { totalCount: 1, edges: [manySocks] } },
+    });
+
+    server.use(
+      graphql.query('GetQuotesList', () => HttpResponse.json(quotesListB2B)),
+      graphql.query('GetShoppingListsCreatedByUser', () =>
+        HttpResponse.json(buildShoppingListsCreatedByUserWith('WHATEVER_VALUES')),
+      ),
+    );
+
+    renderWithProviders(<QuotesList />, { preloadedState });
+
+    const table = await screen.findByRole('table');
+    const row = within(table).getByRole('row', { name: /Many Socks/ });
+
+    expect(within(row).getByRole('cell', { name: '123456789' })).toBeInTheDocument();
+    expect(within(row).getByRole('cell', { name: 'Many Socks' })).toBeInTheDocument();
+    expect(within(row).getByRole('cell', { name: 'Fred Salesman' })).toBeInTheDocument();
+    expect(within(row).getByRole('cell', { name: 'Sam Shopper' })).toBeInTheDocument();
+    expect(within(row).getByRole('cell', { name: '1 January 2025' })).toBeInTheDocument();
+    expect(within(row).getByRole('cell', { name: '2 February 2025' })).toBeInTheDocument();
+    expect(within(row).getByRole('cell', { name: '3 March 2025' })).toBeInTheDocument();
+    expect(within(row).getByRole('cell', { name: '$101.99' })).toBeInTheDocument();
+    expect(within(row).getByRole('cell', { name: 'Open' })).toBeInTheDocument();
+  });
+
+  it('displays a quote per row', async () => {
+    const manySocks = buildQuoteEdgeWith({ node: { quoteTitle: 'Many Socks' } });
+    const someTrousers = buildQuoteEdgeWith({ node: { quoteTitle: 'Some Trouser' } });
+    const oneShirt = buildQuoteEdgeWith({ node: { quoteTitle: 'One Shirt' } });
+
+    const quotesListB2B = buildQuotesListB2BWith({
+      data: { quotes: { totalCount: 3, edges: [manySocks, someTrousers, oneShirt] } },
+    });
+
+    server.use(
+      graphql.query('GetQuotesList', () => HttpResponse.json(quotesListB2B)),
+      graphql.query('GetShoppingListsCreatedByUser', () =>
+        HttpResponse.json(buildShoppingListsCreatedByUserWith('WHATEVER_VALUES')),
+      ),
+    );
+
+    renderWithProviders(<QuotesList />, { preloadedState });
+
+    const table = await screen.findByRole('table');
+
+    expect(within(table).getByRole('row', { name: /Many Socks/ })).toBeInTheDocument();
+    expect(within(table).getByRole('row', { name: /Some Trouser/ })).toBeInTheDocument();
+    expect(within(table).getByRole('row', { name: /One Shirt/ })).toBeInTheDocument();
+  });
+
+  describe('when clicking on the row of a non-draft quote', () => {
+    it('navigates to the respective quote details page, with the created date', async () => {
+      const manySocks = buildQuoteEdgeWith({
+        node: {
+          quoteTitle: 'Many Socks',
+          id: '939232',
+          createdAt: getUnixTime(new Date('1 January 2025')),
+          status: 1,
+        },
+      });
+      const someQuote = buildQuoteEdgeWith('WHATEVER_VALUES');
+      const anotherQuote = buildQuoteEdgeWith('WHATEVER_VALUES');
+
+      const quotesListB2B = buildQuotesListB2BWith({
+        data: { quotes: { totalCount: 3, edges: [someQuote, manySocks, anotherQuote] } },
+      });
+
+      server.use(
+        graphql.query('GetQuotesList', () => HttpResponse.json(quotesListB2B)),
+        graphql.query('GetShoppingListsCreatedByUser', () =>
+          HttpResponse.json(buildShoppingListsCreatedByUserWith('WHATEVER_VALUES')),
+        ),
+      );
+
+      const { navigation } = renderWithProviders(<QuotesList />, { preloadedState });
+
+      const table = await screen.findByRole('table');
+
+      await userEvent.click(within(table).getByRole('row', { name: /Many Socks/ }));
+
+      expect(navigation).toHaveBeenCalledWith(
+        `/quoteDetail/939232?date=${getUnixTime(new Date('1 January 2025'))}`,
+      );
+    });
+  });
+
+  describe('when clicking on the row of the draft quote', () => {
+    // A user can only ever have one draft quote at a time
+    it('navigates to the quote draft page', async () => {
+      const workInProgress = buildQuoteEdgeWith({
+        node: { quoteTitle: 'Work in Progress', status: 0 },
+      });
+      const someQuote = buildQuoteEdgeWith('WHATEVER_VALUES');
+      const anotherQuote = buildQuoteEdgeWith('WHATEVER_VALUES');
+
+      const quotesListB2B = buildQuotesListB2BWith({
+        data: { quotes: { totalCount: 3, edges: [someQuote, workInProgress, anotherQuote] } },
+      });
+
+      server.use(
+        graphql.query('GetQuotesList', () => HttpResponse.json(quotesListB2B)),
+        graphql.query('GetShoppingListsCreatedByUser', () =>
+          HttpResponse.json(buildShoppingListsCreatedByUserWith('WHATEVER_VALUES')),
+        ),
+      );
+
+      const { navigation } = renderWithProviders(<QuotesList />, { preloadedState });
+
+      const table = await screen.findByRole('table');
+
+      await userEvent.click(within(table).getByRole('row', { name: /Work in Progress/ }));
+
+      expect(navigation).toHaveBeenCalledWith('/quoteDraft');
+    });
+  });
+
+  it('displays the current status of each quote', async () => {
+    const manySocks = buildQuoteEdgeWith({ node: { quoteTitle: 'Many Socks', status: 0 } });
+    const someTrousers = buildQuoteEdgeWith({ node: { quoteTitle: 'Some Trouser', status: 1 } });
+    const oneShirt = buildQuoteEdgeWith({ node: { quoteTitle: 'One Shirt', status: 4 } });
+    const everyHat = buildQuoteEdgeWith({ node: { quoteTitle: 'Every Hat', status: 5 } });
+
+    const quotesListB2B = buildQuotesListB2BWith({
+      data: { quotes: { totalCount: 4, edges: [manySocks, someTrousers, oneShirt, everyHat] } },
+    });
+
+    server.use(
+      graphql.query('GetQuotesList', () => HttpResponse.json(quotesListB2B)),
+      graphql.query('GetShoppingListsCreatedByUser', () =>
+        HttpResponse.json(buildShoppingListsCreatedByUserWith('WHATEVER_VALUES')),
+      ),
+    );
+
+    renderWithProviders(<QuotesList />, { preloadedState });
+
+    const table = await screen.findByRole('table');
+
+    const rowOfManySocks = within(table).getByRole('row', { name: /Many Socks/ });
+    expect(within(rowOfManySocks).getByText('Draft')).toBeInTheDocument();
+
+    const rowOfSomeTrouser = within(table).getByRole('row', { name: /Some Trouser/ });
+    expect(within(rowOfSomeTrouser).getByText('Open')).toBeInTheDocument();
+
+    const rowOfOneShirt = within(table).getByRole('row', { name: /One Shirt/ });
+    expect(within(rowOfOneShirt).getByText('Ordered')).toBeInTheDocument();
+
+    const rowOfEveryHat = within(table).getByRole('row', { name: /Every Hat/ });
+    expect(within(rowOfEveryHat).getByText('Expired')).toBeInTheDocument();
+  });
+
+  describe('when the user has no quotes', () => {
+    it('displays a message of "No data" and does not display the quotes table', async () => {
+      const quotesListB2B = buildQuotesListB2BWith({
+        data: { quotes: { totalCount: 0, edges: [] } },
+      });
+
+      server.use(
+        graphql.query('GetQuotesList', () => HttpResponse.json(quotesListB2B)),
+        graphql.query('GetShoppingListsCreatedByUser', () =>
+          HttpResponse.json(buildShoppingListsCreatedByUserWith('WHATEVER_VALUES')),
+        ),
+      );
+
+      renderWithProviders(<QuotesList />, { preloadedState });
+
+      expect(await screen.findByText('No data')).toBeInTheDocument();
+      expect(screen.queryByRole('table')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/apps/storefront/src/shared/service/b2b/graphql/orders.ts
+++ b/apps/storefront/src/shared/service/b2b/graphql/orders.ts
@@ -181,14 +181,16 @@ const getOrderStatusTypeQl = (fn: string) => `{
   }
 }`;
 
-const getCreatedByUser = (companyId: number, module: number, fn: string) => `{
-  ${fn}(
-    companyId: ${companyId},
-    module: ${module},
-  ){
-    results,
+const getCreatedByUser = (companyId: number, module: number, fn: string) => `
+  query GetOrdersCreatedByUser {
+    ${fn}(
+      companyId: ${companyId},
+      module: ${module},
+    ){
+      results,
+    }
   }
-}`;
+`;
 
 export const getB2BAllOrders = (data: CustomFieldItems) =>
   B3Request.graphqlB2B({

--- a/apps/storefront/src/shared/service/b2b/graphql/quote.ts
+++ b/apps/storefront/src/shared/service/b2b/graphql/quote.ts
@@ -3,46 +3,48 @@ import { channelId, convertArrayToGraphql, convertObjectToGraphql, storeHash } f
 
 import B3Request from '../../request/b3Fetch';
 
-const getQuotesList = (data: CustomFieldItems, type: string) => `{
-  ${type === 'b2b' ? 'quotes' : 'customerQuotes'}(
-    first: ${data.first}
-    offset: ${data.offset}
-    search: "${data.q || ''}"
-    orderBy: "${data?.orderBy || ''}"
-    createdBy: "${data?.createdBy || ''}"
-    email: "${data?.email || ''}"
-    salesRep: "${data?.salesRep || ''}"
-    ${data?.status ? `status: "${data.status}"` : ''}
-    ${data?.dateCreatedBeginAt ? `dateCreatedBeginAt: "${data.dateCreatedBeginAt}"` : ''}
-    ${data?.dateCreatedEndAt ? `dateCreatedEndAt: "${data.dateCreatedEndAt}"` : ''}
-    ${type === 'bc' ? `channelId: ${data?.channelId || 1}` : ''}
-  ) {
-    totalCount,
-    edges {
-      node {
-        id,
-        createdAt,
-        updatedAt,
-        quoteNumber,
-        quoteTitle,
-        referenceNumber,
-        createdBy,
-        expiredAt,
-        expiredAt,
-        discount,
-        grandTotal,
-        currency,
-        status,
-        salesRep,
-        salesRepEmail,
-        orderId,
-        subtotal,
-        totalAmount,
-        taxTotal,
+const getQuotesList = (data: CustomFieldItems, type: string) => `
+  query GetQuotesList {
+    ${type === 'b2b' ? 'quotes' : 'customerQuotes'}(
+      first: ${data.first}
+      offset: ${data.offset}
+      search: "${data.q || ''}"
+      orderBy: "${data?.orderBy || ''}"
+      createdBy: "${data?.createdBy || ''}"
+      email: "${data?.email || ''}"
+      salesRep: "${data?.salesRep || ''}"
+      ${data?.status ? `status: "${data.status}"` : ''}
+      ${data?.dateCreatedBeginAt ? `dateCreatedBeginAt: "${data.dateCreatedBeginAt}"` : ''}
+      ${data?.dateCreatedEndAt ? `dateCreatedEndAt: "${data.dateCreatedEndAt}"` : ''}
+      ${type === 'bc' ? `channelId: ${data?.channelId || 1}` : ''}
+    ) {
+      totalCount,
+      edges {
+        node {
+          id,
+          createdAt,
+          updatedAt,
+          quoteNumber,
+          quoteTitle,
+          referenceNumber,
+          createdBy,
+          expiredAt,
+          expiredAt,
+          discount,
+          grandTotal,
+          currency,
+          status,
+          salesRep,
+          salesRepEmail,
+          orderId,
+          subtotal,
+          totalAmount,
+          taxTotal,
+        }
       }
     }
   }
-}`;
+`;
 
 const getCustomerAddresses = () => `{
   customerAddresses (
@@ -337,14 +339,16 @@ const quoteAttachFileDelete = (data: CustomFieldItems) => `mutation{
   }
 }`;
 
-const getCreatedByUser = (companyId: number, module: number, fn: string) => `{
-  ${fn}(
-    companyId: ${companyId},
-    module: ${module},
-  ){
-    results,
+const getCreatedByUser = (companyId: number, module: number, fn: string) => `
+  query GetQuotesCreatedByUser {
+    ${fn}(
+      companyId: ${companyId},
+      module: ${module},
+    ){
+      results,
+    }
   }
-}`;
+`;
 
 const getStorefrontProductSettings = `
 query getStorefrontProductSettings($storeHash: String!, $channelId: Int) {
@@ -383,10 +387,49 @@ export const getB2BCustomerAddresses = (companyId: number) =>
     query: getAddresses(companyId),
   });
 
+export interface QuoteEdge {
+  node: {
+    id: string;
+    createdAt: number;
+    updatedAt: number;
+    quoteNumber: string;
+    quoteTitle: string;
+    referenceNumber: string;
+    createdBy: string;
+    expiredAt: number;
+    discount: string;
+    grandTotal: string;
+    currency: {
+      token: string;
+      location: string;
+      currencyCode: string;
+      decimalToken: string;
+      decimalPlaces: number;
+      thousandsToken: string;
+      currencyExchangeRate: string;
+    };
+    status: number;
+    salesRep: string;
+    salesRepEmail: string;
+    orderId: string;
+    subtotal: string;
+    totalAmount: string;
+    taxTotal: string;
+  };
+}
+
+export interface QuotesListB2B {
+  data: { quotes: { totalCount: number; edges: QuoteEdge[] } };
+}
+
 export const getB2BQuotesList = (data: CustomFieldItems) =>
   B3Request.graphqlB2B({
     query: getQuotesList(data, 'b2b'),
   }).then((res) => res.quotes);
+
+export interface QuotesListBC {
+  data: { customerQuotes: { totalCount: number; edges: QuoteEdge[] } };
+}
 
 export const getBCQuotesList = (data: CustomFieldItems) =>
   B3Request.graphqlB2B({

--- a/apps/storefront/src/shared/service/b2b/graphql/shoppingList.ts
+++ b/apps/storefront/src/shared/service/b2b/graphql/shoppingList.ts
@@ -485,14 +485,16 @@ const getJuniorPlaceOrder = () => `{
   }
 }`;
 
-const getCreatedByUser = (companyId: number, module: number, fn: string) => `{
-  ${fn}(
-    companyId: ${companyId},
-    module: ${module},
-  ){
-    results,
+const getCreatedByUser = (companyId: number, module: number, fn: string) => `
+  query GetShoppingListsCreatedByUser {
+    ${fn}(
+      companyId: ${companyId},
+      module: ${module},
+    ){
+      results,
+    }
   }
-}`;
+`;
 
 export const getB2BShoppingList = (data: CustomFieldItems = {}) =>
   B3Request.graphqlB2B({
@@ -634,6 +636,20 @@ export const getB2BJuniorPlaceOrder = () =>
   B3Request.graphqlB2B({
     query: getJuniorPlaceOrder(),
   });
+
+export interface ShoppingListsCreatedByUser {
+  data: {
+    createdByUser: {
+      results: {
+        createdBy: {
+          name: string;
+          email: string;
+        }[];
+        salesRep: unknown[];
+      };
+    };
+  };
+}
 
 export const getShoppingListsCreatedByUser = (companyId: number, module: number) =>
   B3Request.graphqlB2B({

--- a/apps/storefront/tests/builder.ts
+++ b/apps/storefront/tests/builder.ts
@@ -1,4 +1,4 @@
-import { merge, range } from 'lodash';
+import { mergeWith, range } from 'lodash';
 
 type DeepPartial<T> = unknown extends T
   ? T
@@ -12,12 +12,18 @@ type DeepPartial<T> = unknown extends T
     }
   : T;
 
+const mergeCustomizer = <T>(objValue: T, srcValue: T) =>
+  // Replace, rather than merge, arrays for more predictable results
+  Array.isArray(objValue) ? srcValue : undefined;
+
 type NonArray<T> = T extends unknown[] ? never : T;
 
 export const builder =
   <T extends object, O = NonArray<T>>(getDefaults: () => O) =>
   (overrides: DeepPartial<T> | 'WHATEVER_VALUES'): O =>
-    overrides === 'WHATEVER_VALUES' ? getDefaults() : merge({}, getDefaults(), overrides);
+    overrides === 'WHATEVER_VALUES'
+      ? getDefaults()
+      : mergeWith({}, getDefaults(), overrides, mergeCustomizer);
 
 export const bulk = <T extends object>(
   someBuilder: ReturnType<typeof builder<T>>,

--- a/apps/storefront/tests/global-setup.ts
+++ b/apps/storefront/tests/global-setup.ts
@@ -1,0 +1,4 @@
+export const setup = () => {
+  // Set the timezone to GMT for consistent date handling and no offsets in tests
+  process.env.TZ = 'GMT';
+};

--- a/apps/storefront/tests/setup-test-environment.ts
+++ b/apps/storefront/tests/setup-test-environment.ts
@@ -12,6 +12,7 @@ window.B3 = {
     environment: Environment.Local,
   },
 };
+
 beforeEach(() => {
   window.B3 = {
     setting: {
@@ -21,7 +22,11 @@ beforeEach(() => {
       environment: Environment.Local,
     },
   };
+
+  // Required to stop `useMobile` from triggering the mobile layouts in tests
+  vi.spyOn(document.body, 'clientWidth', 'get').mockReturnValue(1000);
 });
+
 afterEach(() => {
   cleanup();
 });

--- a/apps/storefront/tests/storeStateBuilders/index.ts
+++ b/apps/storefront/tests/storeStateBuilders/index.ts
@@ -1,1 +1,2 @@
-export { buildCompanyStateWith } from 'tests/storeStateBuilders/companyStateBuilder';
+export { buildCompanyStateWith } from './companyStateBuilder';
+export { buildStoreInfoStateWith } from './storeInfoStateBuilder';

--- a/apps/storefront/tests/storeStateBuilders/storeInfoStateBuilder.ts
+++ b/apps/storefront/tests/storeStateBuilders/storeInfoStateBuilder.ts
@@ -1,0 +1,12 @@
+import { builder } from 'tests/builder';
+
+import { StoreInfo } from '@/store/slices/storeInfo';
+
+export const buildStoreInfoStateWith = builder<StoreInfo>(() => ({
+  timeFormat: {
+    display: 'M jS Y',
+    export: 'M j Y',
+    extendedDisplay: 'M j Y @ g:i A',
+    offset: 0,
+  },
+}));

--- a/apps/storefront/tests/test-utils.tsx
+++ b/apps/storefront/tests/test-utils.tsx
@@ -6,7 +6,7 @@ import { render, RenderOptions } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import { Mock } from 'vitest';
 
-import { AppStore, RootState, setupStore } from '@/store';
+import { AppStore, RootState, setTimeFormat, setupStore, store as storeSingleton } from '@/store';
 
 interface ExtendedRenderOptions extends Omit<RenderOptions, 'queries'> {
   preloadedState?: Partial<RootState>;
@@ -31,6 +31,13 @@ export const renderWithProviders = (
     store = setupStore(preloadedState),
     ...renderOptions
   } = extendedRenderOptions;
+
+  // `formatCreator` reaches to the store singleton to get the time format
+  // and NOT to the store passed in to the Provider context below
+  // until this is fixed, we need manually sync the time format to the store singleton
+  if (preloadedState.storeInfo?.timeFormat) {
+    storeSingleton.dispatch(setTimeFormat(preloadedState.storeInfo.timeFormat));
+  }
 
   const navigation = vi.fn<[string]>();
 
@@ -63,4 +70,6 @@ export * from '@testing-library/react';
 export { default as userEvent } from '@testing-library/user-event';
 
 export { builder, bulk } from 'tests/builder';
-export { buildCompanyStateWith } from 'tests/storeStateBuilders';
+export * from 'tests/storeStateBuilders';
+export { faker } from '@faker-js/faker';
+export { getUnixTime } from 'date-fns';

--- a/apps/storefront/vite.config.ts
+++ b/apps/storefront/vite.config.ts
@@ -49,6 +49,7 @@ export default defineConfig(({ mode }) => {
       restoreMocks: true,
       globals: true,
       environment: 'jsdom',
+      globalSetup: './tests/global-setup.ts',
       setupFiles: './tests/setup-test-environment.ts',
       coverage: {
         provider: 'istanbul',

--- a/packages/eslint-config-b2b/.eslintrc.js
+++ b/packages/eslint-config-b2b/.eslintrc.js
@@ -83,7 +83,14 @@ module.exports = {
     'react/require-default-props': 0,
     'import/no-extraneous-dependencies': [
       'error',
-      { devDependencies: ['**/tests/**/*.ts', '**/tests/**/*.tsx'] },
+      {
+        devDependencies: [
+          '**/tests/**/*.ts',
+          '**/tests/**/*.tsx',
+          '**/*.test.ts',
+          '**/*.test.tsx',
+        ],
+      },
     ],
     'react/jsx-no-useless-fragment': ['warn', { allowExpressions: true }],
     'import/prefer-default-export': 'off',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1395,12 +1395,17 @@
   resolved "https://registry.yarnpkg.com/@babel/regjsgen/-/regjsgen-0.8.0.tgz#f0ba69b075e1f05fb2825b7fad991e7adbb18310"
   integrity sha512-x/rqGMdzj+fWZvCOYForTghzbtqPDZ5gPwaoNGHdgDfF2QA/XZbCBp4Moo5scrkAMPhB7z26XM/AaHuIJdgauA==
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.5", "@babel/runtime@^7.18.3", "@babel/runtime@^7.18.9", "@babel/runtime@^7.21.0", "@babel/runtime@^7.23.2", "@babel/runtime@^7.23.9", "@babel/runtime@^7.3.1", "@babel/runtime@^7.4.4", "@babel/runtime@^7.5.5", "@babel/runtime@^7.8.3", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.5", "@babel/runtime@^7.18.3", "@babel/runtime@^7.18.9", "@babel/runtime@^7.23.2", "@babel/runtime@^7.23.9", "@babel/runtime@^7.3.1", "@babel/runtime@^7.4.4", "@babel/runtime@^7.5.5", "@babel/runtime@^7.8.3", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
   version "7.26.10"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.26.10.tgz#a07b4d8fa27af131a633d7b3524db803eb4764c2"
   integrity sha512-2WJMeRQPHKSPemqk/awGrAiuFfzBmOIPXKizAsVhWH9YJqLZ0H+HS4c8loHGgW6utJ3E/ejXQUsiGaQy2NZ9Fw==
   dependencies:
     regenerator-runtime "^0.14.0"
+
+"@babel/runtime@^7.21.0":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.27.1.tgz#9fce313d12c9a77507f264de74626e87fd0dc541"
+  integrity sha512-1x3D2xEk2fRo3PAhwQwu5UubzgiVWSXTBfWpVd2Mx2AzRqJuDJCsgaDVZ7HB5iGzDW1Hl1sWN2mFyKjmR9uAog==
 
 "@babel/template@^7.18.10", "@babel/template@^7.20.7", "@babel/template@^7.22.15", "@babel/template@^7.24.0":
   version "7.24.0"
@@ -2000,6 +2005,11 @@
   version "8.57.0"
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.57.0.tgz#a5417ae8427873f1dd08b70b3574b453e67b5f7f"
   integrity sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==
+
+"@faker-js/faker@^9.7.0":
+  version "9.7.0"
+  resolved "https://registry.yarnpkg.com/@faker-js/faker/-/faker-9.7.0.tgz#1cf1fecfcad5e2da2332140bf3b5f23cc1c2a7f4"
+  integrity sha512-aozo5vqjCmDoXLNUJarFZx2IN/GgGaogY4TMJ6so/WLZOWpSV7fvj2dmrV6sEAnUm1O7aCrhTibjpzeDFgNqbg==
 
 "@floating-ui/core@^1.0.0":
   version "1.6.1"


### PR DESCRIPTION
Jira: [B2B-2149](https://bigcommercecloud.atlassian.net/browse/B2B-2149)

**N.B.**
- This PR should not introduce any behaviour changes, it should be purely test focussed
- Best read with "Hide whitespace"
- Some graphql queries have been given "operation names" to allow for mocking within tests, this does not change the query or the schema of the response

## What/Why?

- Add some basic, happy-path tests to the Quotes Listing page
- Not meant to be exhaustive, coupled to APIs, but a reasonable start

## Rollout/Rollback
- Revert if needed

## Testing
- New tests added


[B2B-2149]: https://bigcommercecloud.atlassian.net/browse/B2B-2149?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ