### PR TITLE
refactor(quotes): B2BCAT-16 add basic test harness to quote details page

### DIFF
--- a/apps/storefront/src/pages/QuoteDetail/index.test.tsx
+++ b/apps/storefront/src/pages/QuoteDetail/index.test.tsx
@@ -1,0 +1,440 @@
+import { useParams } from 'react-router-dom';
+import { graphql, HttpResponse } from 'msw';
+import {
+  buildCompanyStateWith,
+  builder,
+  buildStoreInfoStateWith,
+  faker,
+  getUnixTime,
+  renderWithProviders,
+  screen,
+  startMockServer,
+  within,
+} from 'tests/test-utils';
+
+import { B2BProducts } from '@/shared/service/b2b/graphql/product';
+import { B2BQuoteDetail, QuoteExtraFieldsConfig } from '@/shared/service/b2b/graphql/quote';
+import { CompanyStatus, UserTypes } from '@/types';
+
+import QuoteDetail from './index';
+
+vitest.mock('react-router-dom', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('react-router-dom')>()),
+  useParams: vitest.fn(),
+}));
+
+const { server } = startMockServer();
+
+type QuoteProduct = B2BQuoteDetail['data']['quote']['productsList'][number];
+
+const buildQuoteProductWith = builder<QuoteProduct>(() => ({
+  productId: faker.number.int().toString(),
+  sku: faker.string.uuid(),
+  basePrice: faker.commerce.price(),
+  discount: faker.commerce.price(),
+  offeredPrice: faker.commerce.price(),
+  quantity: faker.number.int(),
+  variantId: faker.number.int(),
+  imageUrl: faker.image.url(),
+  orderQuantityMaximum: faker.number.int(),
+  orderQuantityMinimum: faker.number.int(),
+  productName: faker.commerce.productName(),
+  purchaseHandled: faker.datatype.boolean(),
+  options: Array.from({ length: faker.number.int({ min: 0, max: 10 }) }, () => ({
+    type: faker.lorem.word(),
+    optionId: faker.number.int(),
+    optionName: faker.lorem.word(),
+    optionLabel: faker.commerce.productMaterial(),
+    optionValue: faker.lorem.word(),
+  })),
+  notes: faker.lorem.sentence(),
+  costPrice: faker.commerce.price(),
+  inventoryTracking: faker.lorem.word(),
+  inventoryLevel: faker.number.int(),
+}));
+
+type Address =
+  | B2BQuoteDetail['data']['quote']['billingAddress']
+  | B2BQuoteDetail['data']['quote']['shippingAddress'];
+
+const buildAddressWith = builder<Address>(() => ({
+  city: faker.location.city(),
+  label: faker.lorem.word(),
+  state: faker.location.state(),
+  address: faker.location.streetAddress(),
+  country: faker.location.country(),
+  zipCode: faker.location.zipCode(),
+  lastName: faker.person.lastName(),
+  addressId: faker.number.int().toString(),
+  apartment: faker.location.secondaryAddress(),
+  firstName: faker.person.firstName(),
+  phoneNumber: faker.phone.number(),
+  addressLabel: faker.lorem.word(),
+}));
+
+const buildQuoteWith = builder<B2BQuoteDetail>(() => ({
+  data: {
+    quote: {
+      id: faker.string.uuid(),
+      createdAt: getUnixTime(faker.date.past().getTime()),
+      updatedAt: getUnixTime(faker.date.recent().getTime()),
+      quoteNumber: faker.string.uuid(),
+      quoteTitle: faker.lorem.words(),
+      referenceNumber: faker.string.uuid(),
+      userEmail: faker.internet.email(),
+      bcCustomerId: faker.number.int(),
+      createdBy: faker.person.fullName(),
+      expiredAt: getUnixTime(faker.date.future().getTime()),
+      companyId: {
+        id: faker.string.uuid(),
+        companyName: faker.company.name(),
+        bcGroupName: faker.company.buzzPhrase(),
+        description: faker.lorem.sentence(),
+        catalogId: null,
+        companyStatus: faker.number.int(),
+        addressLine1: faker.location.streetAddress(),
+        addressLine2: faker.location.secondaryAddress(),
+        city: faker.location.city(),
+        state: faker.location.state(),
+        zipCode: faker.location.zipCode(),
+        country: faker.location.country(),
+        extraFields: [],
+      },
+      salesRepStatus: faker.number.int(),
+      customerStatus: faker.number.int(),
+      subtotal: faker.commerce.price(),
+      discount: faker.commerce.price(),
+      grandTotal: faker.commerce.price(),
+      cartId: faker.string.uuid(),
+      cartUrl: faker.internet.url(),
+      checkoutUrl: faker.internet.url(),
+      bcOrderId: faker.string.uuid(),
+      currency: {
+        token: faker.finance.currencySymbol(),
+        location: faker.location.country(),
+        currencyCode: faker.finance.currencyCode(),
+        decimalToken: '.',
+        decimalPlaces: faker.number.int({ min: 0, max: 100 }),
+        thousandsToken: ',',
+        currencyExchangeRate: faker.finance.amount(),
+      },
+      contactInfo: {
+        name: faker.person.fullName(),
+        email: faker.internet.email(),
+        companyName: faker.company.name(),
+        phoneNumber: faker.phone.number(),
+      },
+      trackingHistory: Array.from({ length: faker.number.int({ min: 0, max: 10 }) }, () => ({
+        date: getUnixTime(faker.date.recent().getTime()),
+        read: faker.datatype.boolean(),
+        role: faker.person.jobTitle(),
+        message: faker.lorem.sentence(),
+      })),
+      extraFields: [],
+      notes: faker.lorem.paragraph(),
+      legalTerms: faker.lorem.paragraph(),
+      shippingTotal: faker.commerce.price(),
+      taxTotal: faker.commerce.price(),
+      totalAmount: faker.commerce.price(),
+      shippingMethod: {
+        id: faker.number.int().toString(),
+        cost: parseFloat(faker.commerce.price()),
+        type: faker.lorem.word(),
+        imageUrl: faker.image.url(),
+        description: faker.lorem.sentence(),
+        transitTime: faker.lorem.words(),
+        additionalDescription: faker.lorem.sentence(),
+      },
+      billingAddress: buildAddressWith('WHATEVER_VALUES'),
+      oldSalesRepStatus: null,
+      oldCustomerStatus: null,
+      recipients: [],
+      discountType: faker.number.int(),
+      discountValue: faker.commerce.price(),
+      status: faker.number.int(),
+      company: faker.company.name(),
+      salesRep: faker.person.fullName(),
+      salesRepEmail: faker.internet.email(),
+      orderId: faker.number.int().toString(),
+      shippingAddress: buildAddressWith('WHATEVER_VALUES'),
+      productsList: Array.from({ length: faker.number.int({ min: 1, max: 10 }) }, () =>
+        buildQuoteProductWith('WHATEVER_VALUES'),
+      ),
+      storefrontAttachFiles: [],
+      backendAttachFiles: [],
+      storeInfo: {
+        storeName: faker.company.name(),
+        storeAddress: faker.location.streetAddress(),
+        storeCountry: faker.location.country(),
+        storeLogo: faker.image.url(),
+        storeUrl: faker.internet.url(),
+      },
+      companyInfo: {
+        companyId: faker.number.int().toString(),
+        companyName: faker.company.name(),
+        companyAddress: faker.location.streetAddress(),
+        companyCountry: faker.location.country(),
+        companyState: faker.location.state(),
+        companyCity: faker.location.city(),
+        companyZipCode: faker.location.zipCode(),
+        phoneNumber: faker.phone.number(),
+      },
+      salesRepInfo: {
+        salesRepName: faker.person.fullName(),
+        salesRepEmail: faker.internet.email(),
+        salesRepPhoneNumber: faker.phone.number(),
+      },
+      quoteLogo: faker.image.url(),
+      quoteUrl: faker.internet.url(),
+      channelId: faker.number.int(),
+      channelName: faker.company.name(),
+      allowCheckout: faker.datatype.boolean(),
+      displayDiscount: faker.datatype.boolean(),
+    },
+  },
+}));
+
+const buildProductSearchWith = builder<B2BProducts>(() => ({
+  data: {
+    productsSearch: Array.from({ length: faker.number.int({ min: 0, max: 10 }) }, () => ({
+      id: faker.number.int(),
+      name: faker.commerce.productName(),
+      sku: faker.string.uuid(),
+      costPrice: faker.commerce.price(),
+      inventoryLevel: faker.number.int(),
+      inventoryTracking: faker.helpers.arrayElement(['none', 'simple', 'complex']),
+      availability: faker.helpers.arrayElement(['available', 'unavailable']),
+      orderQuantityMinimum: faker.number.int(),
+      orderQuantityMaximum: faker.number.int(),
+      variants: Array.from({ length: faker.number.int({ min: 0, max: 10 }) }, () => ({
+        variant_id: faker.number.int(),
+        product_id: faker.number.int(),
+        sku: faker.string.uuid(),
+        option_values: Array.from({ length: faker.number.int({ min: 0, max: 10 }) }, () => ({
+          id: faker.number.int(),
+          label: faker.commerce.productAdjective(),
+          option_id: faker.number.int(),
+          option_display_name: faker.commerce.productAdjective(),
+        })),
+        calculated_price: parseFloat(faker.commerce.price()),
+        image_url: faker.image.url(),
+        has_price_list: faker.datatype.boolean(),
+        bulk_prices: [],
+        purchasing_disabled: faker.datatype.boolean(),
+        cost_price: parseFloat(faker.commerce.price()),
+        inventory_level: faker.number.int(),
+        bc_calculated_price: {
+          as_entered: parseFloat(faker.commerce.price()),
+          tax_inclusive: parseFloat(faker.commerce.price()),
+          tax_exclusive: parseFloat(faker.commerce.price()),
+          entered_inclusive: faker.datatype.boolean(),
+        },
+      })),
+      currencyCode: faker.finance.currencyCode(),
+      imageUrl: faker.image.url(),
+      modifiers: [],
+      options: Array.from({ length: faker.number.int({ min: 0, max: 10 }) }, () => ({
+        option_id: faker.number.int(),
+        display_name: faker.commerce.productAdjective(),
+        sort_order: faker.number.int(),
+        is_required: faker.datatype.boolean(),
+      })),
+      optionsV3: Array.from({ length: faker.number.int({ min: 0, max: 10 }) }, () => ({
+        id: faker.number.int(),
+        product_id: faker.number.int(),
+        name: faker.commerce.productAdjective(),
+        display_name: faker.commerce.productAdjective(),
+        type: faker.helpers.arrayElement(['rectangles', 'swatch', 'dropdown']),
+        sort_order: faker.number.int(),
+        option_values: Array.from({ length: faker.number.int({ min: 0, max: 10 }) }, () => ({
+          id: faker.number.int(),
+          label: faker.commerce.productAdjective(),
+          sort_order: faker.number.int(),
+          value_data: null,
+          is_default: faker.datatype.boolean(),
+        })),
+        config: [],
+      })),
+      channelId: [],
+      productUrl: faker.internet.url(),
+      taxClassId: faker.number.int(),
+      isPriceHidden: faker.datatype.boolean(),
+    })),
+  },
+}));
+
+const buildQuoteExtraFieldsWith = builder<QuoteExtraFieldsConfig>(() => ({
+  data: { quoteExtraFieldsConfig: [] },
+}));
+
+describe('when the user is a B2B customer', () => {
+  const approvedB2BCompany = buildCompanyStateWith({
+    companyInfo: { status: CompanyStatus.APPROVED },
+    customer: { userType: UserTypes.MULTIPLE_B2C },
+  });
+
+  const storeInfoWithDateFormat = buildStoreInfoStateWith({ timeFormat: { display: 'j F Y' } });
+
+  const preloadedState = { company: approvedB2BCompany, storeInfo: storeInfoWithDateFormat };
+
+  it('displays the quote number as the page "title"', async () => {
+    const quote = buildQuoteWith({ data: { quote: { id: '272989', quoteNumber: '911911' } } });
+
+    server.use(
+      graphql.query('GetQuoteInfoB2B', () => HttpResponse.json(quote)),
+      graphql.query('SearchProducts', () =>
+        HttpResponse.json(buildProductSearchWith('WHATEVER_VALUES')),
+      ),
+      graphql.query('getQuoteExtraFields', () =>
+        HttpResponse.json(buildQuoteExtraFieldsWith('WHATEVER_VALUES')),
+      ),
+    );
+
+    vitest.mocked(useParams).mockReturnValue({ id: '272989' });
+
+    renderWithProviders(<QuoteDetail />, { preloadedState });
+
+    expect(await screen.findByText('Quote #911911')).toBeInTheDocument();
+  });
+
+  it('displays the quote status, issue and expiration dates', async () => {
+    const quote = buildQuoteWith({
+      data: {
+        quote: {
+          id: '272989',
+          status: 4,
+          createdAt: getUnixTime(new Date('2 February 2025')),
+          expiredAt: getUnixTime(new Date('3 March 2025')),
+        },
+      },
+    });
+
+    server.use(
+      graphql.query('GetQuoteInfoB2B', () => HttpResponse.json(quote)),
+      graphql.query('SearchProducts', () =>
+        HttpResponse.json(buildProductSearchWith('WHATEVER_VALUES')),
+      ),
+      graphql.query('getQuoteExtraFields', () =>
+        HttpResponse.json(buildQuoteExtraFieldsWith('WHATEVER_VALUES')),
+      ),
+    );
+
+    vitest.mocked(useParams).mockReturnValue({ id: '272989' });
+
+    renderWithProviders(<QuoteDetail />, { preloadedState });
+
+    expect(await screen.findByText('Ordered')).toBeInTheDocument();
+
+    expect(screen.getByRole('heading', { name: 'Issued on:' })).toBeInTheDocument();
+    expect(screen.getByText('2 February 2025')).toBeInTheDocument();
+
+    expect(screen.getByRole('heading', { name: 'Expiration date:' })).toBeInTheDocument();
+    expect(screen.getByText('3 March 2025')).toBeInTheDocument();
+  });
+
+  it('displays a summary of the products within the quote', async () => {
+    const woolSock = buildQuoteProductWith({
+      productName: 'Wool Socks',
+      quantity: 10,
+      basePrice: '49.00',
+      offeredPrice: '49.00',
+    });
+
+    const denimJacket = buildQuoteProductWith({
+      productName: 'Denim Jacket',
+      quantity: 3,
+      basePrice: '133.33',
+      offeredPrice: '133.33',
+    });
+
+    const quote = buildQuoteWith({
+      data: {
+        quote: {
+          id: '272989',
+          productsList: [woolSock, denimJacket],
+          currency: { token: '$', location: 'left', decimalToken: '.', decimalPlaces: 2 },
+        },
+      },
+    });
+
+    server.use(
+      graphql.query('GetQuoteInfoB2B', () => HttpResponse.json(quote)),
+      graphql.query('SearchProducts', () =>
+        HttpResponse.json(buildProductSearchWith('WHATEVER_VALUES')),
+      ),
+      graphql.query('getQuoteExtraFields', () =>
+        HttpResponse.json(buildQuoteExtraFieldsWith('WHATEVER_VALUES')),
+      ),
+    );
+
+    vitest.mocked(useParams).mockReturnValue({ id: '272989' });
+
+    renderWithProviders(<QuoteDetail />, { preloadedState });
+
+    expect(await screen.findByText('2 products')).toBeInTheDocument();
+
+    const rowOfWoolSocks = screen.getByRole('row', { name: /Wool Socks/ });
+
+    expect(within(rowOfWoolSocks).getByRole('cell', { name: '$49.00' })).toBeInTheDocument();
+    expect(within(rowOfWoolSocks).getByRole('cell', { name: '10' })).toBeInTheDocument();
+    expect(within(rowOfWoolSocks).getByRole('cell', { name: '$490.00' })).toBeInTheDocument();
+
+    const rowOfDenimJacket = screen.getByRole('row', { name: /Denim Jacket/ });
+
+    expect(within(rowOfDenimJacket).getByRole('cell', { name: '$133.33' })).toBeInTheDocument();
+    expect(within(rowOfDenimJacket).getByRole('cell', { name: '3' })).toBeInTheDocument();
+    expect(within(rowOfDenimJacket).getByRole('cell', { name: '$399.99' })).toBeInTheDocument();
+  });
+
+  it('displays a quote summary', async () => {
+    const quote = buildQuoteWith({
+      data: {
+        quote: {
+          id: '272989',
+          productsList: [buildQuoteProductWith('WHATEVER_VALUES')],
+          currency: { token: '$', location: 'left', decimalToken: '.', decimalPlaces: 2 },
+          displayDiscount: true,
+          discount: '25.00',
+          subtotal: '1000.00',
+          shippingTotal: '50.00',
+          taxTotal: '33.00',
+          totalAmount: '1025.00',
+        },
+      },
+    });
+
+    server.use(
+      graphql.query('GetQuoteInfoB2B', () => HttpResponse.json(quote)),
+      graphql.query('SearchProducts', () =>
+        HttpResponse.json(buildProductSearchWith('WHATEVER_VALUES')),
+      ),
+      graphql.query('getQuoteExtraFields', () =>
+        HttpResponse.json(buildQuoteExtraFieldsWith('WHATEVER_VALUES')),
+      ),
+    );
+
+    vitest.mocked(useParams).mockReturnValue({ id: '272989' });
+
+    renderWithProviders(<QuoteDetail />, { preloadedState });
+
+    expect(await screen.findByRole('heading', { name: 'Quote summary' })).toBeInTheDocument();
+
+    expect(await screen.findByText('Original subtotal')).toBeInTheDocument();
+    expect(screen.getByText('$1,000.00')).toBeInTheDocument();
+
+    expect(screen.getByText('Discount amount')).toBeInTheDocument();
+    expect(screen.getByText('-$25.00')).toBeInTheDocument();
+
+    expect(screen.getByText('Quoted subtotal')).toBeInTheDocument();
+    expect(screen.getByText('$975.00')).toBeInTheDocument();
+
+    expect(screen.getByText('Shipping')).toBeInTheDocument();
+    expect(screen.getByText('$50.00')).toBeInTheDocument();
+
+    expect(screen.getByText('Tax')).toBeInTheDocument();
+    expect(screen.getByText('$33.00')).toBeInTheDocument();
+
+    expect(screen.getByText('Grand total')).toBeInTheDocument();
+    expect(screen.getByText('$1,025.00')).toBeInTheDocument();
+  });
+});

--- a/apps/storefront/src/shared/service/b2b/graphql/product.ts
+++ b/apps/storefront/src/shared/service/b2b/graphql/product.ts
@@ -68,38 +68,40 @@ const getVariantSkuByProductId = (productId: string) => `{
   }
 }`;
 
-const searchProducts = (data: CustomFieldItems) => `{
-  productsSearch (
-    search: "${data.search || ''}"
-    productIds: [${data.productIds || []}]
-    currencyCode: "${data.currencyCode || ''}"
-    companyId: "${data.companyId || ''}"
-    storeHash: "${storeHash}"
-    channelId: ${channelId}
-    customerGroupId: ${data.customerGroupId || 0}
-    ${data?.categoryFilter ? `categoryFilter: ${data?.categoryFilter}` : ''}
-  ){
-    id,
-    name,
-    sku,
-    costPrice,
-    inventoryLevel,
-    inventoryTracking,
-    availability,
-    orderQuantityMinimum,
-    orderQuantityMaximum,
-    variants,
-    currencyCode,
-    imageUrl,
-    modifiers,
-    options,
-    optionsV3,
-    channelId,
-    productUrl,
-    taxClassId,
-    isPriceHidden,
+const searchProducts = (data: CustomFieldItems) => `
+  query SearchProducts {
+    productsSearch (
+      search: "${data.search || ''}"
+      productIds: [${data.productIds || []}]
+      currencyCode: "${data.currencyCode || ''}"
+      companyId: "${data.companyId || ''}"
+      storeHash: "${storeHash}"
+      channelId: ${channelId}
+      customerGroupId: ${data.customerGroupId || 0}
+      ${data?.categoryFilter ? `categoryFilter: ${data?.categoryFilter}` : ''}
+    ){
+      id,
+      name,
+      sku,
+      costPrice,
+      inventoryLevel,
+      inventoryTracking,
+      availability,
+      orderQuantityMinimum,
+      orderQuantityMaximum,
+      variants,
+      currencyCode,
+      imageUrl,
+      modifiers,
+      options,
+      optionsV3,
+      channelId,
+      productUrl,
+      taxClassId,
+      isPriceHidden,
+    }
   }
-}`;
+`;
 
 const productsBulkUploadCSV = (data: CustomFieldItems) => `mutation {
   productUpload (
@@ -164,6 +166,75 @@ export const getB2BVariantSkuByProductId = (productId: string) =>
   B3Request.graphqlB2B({
     query: getVariantSkuByProductId(productId),
   });
+
+export interface B2BProducts {
+  data: {
+    productsSearch: {
+      id: number;
+      name: string;
+      sku: string;
+      costPrice: string;
+      inventoryLevel: number;
+      inventoryTracking: string;
+      availability: string;
+      orderQuantityMinimum: number;
+      orderQuantityMaximum: number;
+      variants: {
+        variant_id: number;
+        product_id: number;
+        sku: string;
+        option_values: {
+          id: number;
+          label: string;
+          option_id: number;
+          option_display_name: string;
+        }[];
+        calculated_price: number;
+        image_url: string;
+        has_price_list: boolean;
+        bulk_prices: unknown[];
+        purchasing_disabled: boolean;
+        cost_price: number;
+        inventory_level: number;
+        bc_calculated_price: {
+          as_entered: number;
+          tax_inclusive: number;
+          tax_exclusive: number;
+          entered_inclusive: boolean;
+        };
+      }[];
+      currencyCode: string;
+      imageUrl: string;
+      modifiers: unknown[];
+      options: {
+        option_id: number;
+        display_name: string;
+        sort_order: number;
+        is_required: boolean;
+      }[];
+      optionsV3: {
+        id: number;
+        product_id: number;
+        name: string;
+        display_name: string;
+        type: string;
+        sort_order: number;
+        option_values: {
+          id: number;
+          label: string;
+          sort_order: number;
+          value_data: unknown | null;
+          is_default: boolean;
+        }[];
+        config: unknown[];
+      }[];
+      channelId: unknown[];
+      productUrl: string;
+      taxClassId: number;
+      isPriceHidden: boolean;
+    }[];
+  };
+}
 
 export const searchB2BProducts = (data: CustomFieldItems = {}) => {
   const { currency_code: currencyCode } = getActiveCurrencyInfo();

--- a/apps/storefront/src/shared/service/b2b/graphql/quote.ts
+++ b/apps/storefront/src/shared/service/b2b/graphql/quote.ts
@@ -154,137 +154,139 @@ const quoteUpdate = (data: CustomFieldItems) => `mutation{
   }
 }`;
 
-const getQuoteInfo = (data: { id: number; date: string }) => `{
-  quote(
-    id: ${data.id},
-    storeHash: "${storeHash}",
-    date:  "${data?.date || ''}",
-  ) {
-    id,
-    createdAt,
-    updatedAt,
-    quoteNumber,
-    quoteTitle,
-    referenceNumber,
-    userEmail,
-    bcCustomerId,
-    createdBy,
-    expiredAt,
-    companyId {
+const getQuoteInfo = (data: { id: number; date: string }) => `
+  query GetQuoteInfoB2B {
+    quote(
+      id: ${data.id},
+      storeHash: "${storeHash}",
+      date:  "${data?.date || ''}",
+    ) {
       id,
-      companyName,
-      bcGroupName,
-      description,
-      catalogId,
-      companyStatus,
-      addressLine1,
-      addressLine2,
-      city,
-      state,
-      zipCode,
-      country,
+      createdAt,
+      updatedAt,
+      quoteNumber,
+      quoteTitle,
+      referenceNumber,
+      userEmail,
+      bcCustomerId,
+      createdBy,
+      expiredAt,
+      companyId {
+        id,
+        companyName,
+        bcGroupName,
+        description,
+        catalogId,
+        companyStatus,
+        addressLine1,
+        addressLine2,
+        city,
+        state,
+        zipCode,
+        country,
+        extraFields {
+          fieldName,
+          fieldValue,
+        },
+      },
+      salesRepStatus,
+      customerStatus,
+      subtotal,
+      discount,
+      grandTotal,
+      cartId,
+      cartUrl,
+      checkoutUrl,
+      bcOrderId,
+      currency,
+      contactInfo,
+      trackingHistory,
       extraFields {
         fieldName,
         fieldValue,
       },
-    },
-    salesRepStatus,
-    customerStatus,
-    subtotal,
-    discount,
-    grandTotal,
-    cartId,
-    cartUrl,
-    checkoutUrl,
-    bcOrderId,
-    currency,
-    contactInfo,
-    trackingHistory,
-    extraFields {
-      fieldName,
-      fieldValue,
-    },
-    notes,
-    legalTerms,
-    shippingTotal,
-    taxTotal,
-    totalAmount,
-    shippingMethod,
-    billingAddress,
-    oldSalesRepStatus,
-    oldCustomerStatus,
-    recipients,
-    discountType,
-    discountValue,
-    status,
-    company,
-    salesRep,
-    salesRepEmail,
-    orderId,
-    shippingAddress,
-    productsList {
-      productId,
-      sku,
-      basePrice,
-      discount,
-      offeredPrice,
-      quantity,
-      variantId,
-      imageUrl,
-      orderQuantityMaximum,
-      orderQuantityMinimum,
-      productName,
-      purchaseHandled,
-      options,
       notes,
-      costPrice,
-      inventoryTracking,
-      inventoryLevel,
-    },
-    storefrontAttachFiles {
-      id,
-      fileName,
-      fileType,
-      fileUrl,
-      createdBy,
-    },
-    backendAttachFiles {
-      id,
-      fileName,
-      fileType,
-      fileUrl,
-      createdBy,
-    },
-    storeInfo {
-      storeName,
-      storeAddress,
-      storeCountry,
-      storeLogo,
-      storeUrl,
-    },
-    companyInfo {
-      companyId,
-      companyName,
-      companyAddress,
-      companyCountry,
-      companyState,
-      companyCity,
-      companyZipCode,
-      phoneNumber,
-    },
-    salesRepInfo {
-      salesRepName,
+      legalTerms,
+      shippingTotal,
+      taxTotal,
+      totalAmount,
+      shippingMethod,
+      billingAddress,
+      oldSalesRepStatus,
+      oldCustomerStatus,
+      recipients,
+      discountType,
+      discountValue,
+      status,
+      company,
+      salesRep,
       salesRepEmail,
-      salesRepPhoneNumber,
-    },
-    quoteLogo,
-    quoteUrl,
-    channelId,
-    channelName,
-    allowCheckout,
-    displayDiscount,
+      orderId,
+      shippingAddress,
+      productsList {
+        productId,
+        sku,
+        basePrice,
+        discount,
+        offeredPrice,
+        quantity,
+        variantId,
+        imageUrl,
+        orderQuantityMaximum,
+        orderQuantityMinimum,
+        productName,
+        purchaseHandled,
+        options,
+        notes,
+        costPrice,
+        inventoryTracking,
+        inventoryLevel,
+      },
+      storefrontAttachFiles {
+        id,
+        fileName,
+        fileType,
+        fileUrl,
+        createdBy,
+      },
+      backendAttachFiles {
+        id,
+        fileName,
+        fileType,
+        fileUrl,
+        createdBy,
+      },
+      storeInfo {
+        storeName,
+        storeAddress,
+        storeCountry,
+        storeLogo,
+        storeUrl,
+      },
+      companyInfo {
+        companyId,
+        companyName,
+        companyAddress,
+        companyCountry,
+        companyState,
+        companyCity,
+        companyZipCode,
+        phoneNumber,
+      },
+      salesRepInfo {
+        salesRepName,
+        salesRepEmail,
+        salesRepPhoneNumber,
+      },
+      quoteLogo,
+      quoteUrl,
+      channelId,
+      channelName,
+      allowCheckout,
+      displayDiscount,
+    }
   }
-}`;
+`;
 
 const exportQuotePdf = (data: {
   quoteId: number;
@@ -456,6 +458,176 @@ export const updateBCQuote = (data: CustomFieldItems) =>
     query: quoteUpdate(data),
   });
 
+export interface B2BQuoteDetail {
+  data: {
+    quote: {
+      id: string;
+      createdAt: number;
+      updatedAt: number;
+      quoteNumber: string;
+      quoteTitle: string;
+      referenceNumber: string;
+      userEmail: string;
+      bcCustomerId: number;
+      createdBy: string;
+      expiredAt: number;
+      companyId: {
+        id: string;
+        companyName: string;
+        bcGroupName: string;
+        description: string;
+        catalogId: null | string;
+        companyStatus: number;
+        addressLine1: string;
+        addressLine2: string;
+        city: string;
+        state: string;
+        zipCode: string;
+        country: string;
+        extraFields: any[];
+      };
+      salesRepStatus: number;
+      customerStatus: number;
+      subtotal: string;
+      discount: string;
+      grandTotal: string;
+      cartId: string;
+      cartUrl: string;
+      checkoutUrl: string;
+      bcOrderId: string;
+      currency: {
+        token: string;
+        location: string;
+        currencyCode: string;
+        decimalToken: string;
+        decimalPlaces: number;
+        thousandsToken: string;
+        currencyExchangeRate: string;
+      };
+      contactInfo: {
+        name: string;
+        email: string;
+        companyName: string;
+        phoneNumber: string;
+      };
+      trackingHistory: {
+        date: number;
+        read: boolean;
+        role: string;
+        message: string;
+      }[];
+      extraFields: unknown[];
+      notes: string;
+      legalTerms: string;
+      shippingTotal: string;
+      taxTotal: string;
+      totalAmount: string;
+      shippingMethod: {
+        id: string;
+        cost: number;
+        type: string;
+        imageUrl: string;
+        description: string;
+        transitTime: string;
+        additionalDescription: string;
+      };
+      billingAddress: {
+        city: string;
+        label: string;
+        state: string;
+        address: string;
+        country: string;
+        zipCode: string;
+        lastName: string;
+        addressId: string;
+        apartment: string;
+        firstName: string;
+        phoneNumber: string;
+        addressLabel: string;
+      };
+      oldSalesRepStatus: null | number;
+      oldCustomerStatus: null | number;
+      recipients: unknown[];
+      discountType: number;
+      discountValue: string;
+      status: number;
+      company: string;
+      salesRep: string;
+      salesRepEmail: string;
+      orderId: string;
+      shippingAddress: {
+        city: string;
+        label: string;
+        state: string;
+        address: string;
+        country: string;
+        zipCode: string;
+        lastName: string;
+        addressId: string;
+        apartment: string;
+        firstName: string;
+        phoneNumber: string;
+        addressLabel: string;
+      };
+      productsList: {
+        productId: string;
+        sku: string;
+        basePrice: string;
+        discount: string;
+        offeredPrice: string;
+        quantity: number;
+        variantId: number;
+        imageUrl: string;
+        orderQuantityMaximum: number;
+        orderQuantityMinimum: number;
+        productName: string;
+        purchaseHandled: boolean;
+        options: {
+          type: string;
+          optionId: number;
+          optionName: string;
+          optionLabel: string;
+          optionValue: string;
+        }[];
+        notes: string;
+        costPrice: string;
+        inventoryTracking: string;
+        inventoryLevel: number;
+      }[];
+      storefrontAttachFiles: unknown[];
+      backendAttachFiles: unknown[];
+      storeInfo: {
+        storeName: string;
+        storeAddress: string;
+        storeCountry: string;
+        storeLogo: string;
+        storeUrl: string;
+      };
+      companyInfo: {
+        companyId: string;
+        companyName: string;
+        companyAddress: string;
+        companyCountry: string;
+        companyState: string;
+        companyCity: string;
+        companyZipCode: string;
+        phoneNumber: string;
+      };
+      salesRepInfo: {
+        salesRepName: null | string;
+        salesRepEmail: null | string;
+        salesRepPhoneNumber: null | string;
+      };
+      quoteLogo: string;
+      quoteUrl: string;
+      channelId: null | number;
+      channelName: string;
+      allowCheckout: boolean;
+      displayDiscount: boolean;
+    };
+  };
+}
+
 export const getB2BQuoteDetail = (data: { id: number; date: string }) =>
   B3Request.graphqlB2B({
     query: getQuoteInfo(data),
@@ -516,6 +688,12 @@ export const getBCStorefrontProductSettings = () =>
     query: getStorefrontProductSettings,
     variables: { storeHash, channelId },
   });
+
+export interface QuoteExtraFieldsConfig {
+  data: {
+    quoteExtraFieldsConfig: unknown[];
+  };
+}
 
 export const getQuoteExtraFieldsConfig = (): Promise<QuoteExtraFieldsType> =>
   B3Request.graphqlB2B({

--- a/apps/storefront/src/store/slices/company.ts
+++ b/apps/storefront/src/store/slices/company.ts
@@ -21,7 +21,7 @@ interface Tokens {
   currentCustomerJWT: string;
 }
 
-interface PermissionsCodesProps {
+export interface PermissionsCodesProps {
   code: string;
   permissionLevel: number;
 }

--- a/apps/storefront/tests/builder.ts
+++ b/apps/storefront/tests/builder.ts
@@ -1,14 +1,16 @@
 import { mergeWith, range } from 'lodash';
 
-type DeepPartial<T> = unknown extends T
+// Arrays are excluded from the DeepPartialObjects type because they are not merged
+// including can result in the accidental creation of partial objects within arrays
+type DeepPartialObjects<T> = unknown extends T
   ? T
   : T extends object
   ? {
       [P in keyof T]?: T[P] extends Array<infer U>
-        ? Array<DeepPartial<U>>
+        ? Array<U>
         : T[P] extends ReadonlyArray<infer U>
-        ? ReadonlyArray<DeepPartial<U>>
-        : DeepPartial<T[P]>;
+        ? ReadonlyArray<U>
+        : DeepPartialObjects<T[P]>;
     }
   : T;
 
@@ -20,7 +22,7 @@ type NonArray<T> = T extends unknown[] ? never : T;
 
 export const builder =
   <T extends object, O = NonArray<T>>(getDefaults: () => O) =>
-  (overrides: DeepPartial<T> | 'WHATEVER_VALUES'): O =>
+  (overrides: DeepPartialObjects<T> | 'WHATEVER_VALUES'): O =>
     overrides === 'WHATEVER_VALUES'
       ? getDefaults()
       : mergeWith({}, getDefaults(), overrides, mergeCustomizer);


### PR DESCRIPTION
Jira: [B2BCAT-16](https://bigcommercecloud.atlassian.net/browse/B2BCAT-16)

**N.B.**
- This PR should not introduce any behaviour changes, it should be purely test focussed
- Best read with "Hide whitespace"
- Some graphql queries have been given "operation names" to allow for mocking within tests, this does not change the query or the schema of the response

## What/Why?

- Add some basic, happy-path tests to the Quotes Details page
- Not meant to be exhaustive, coupled to APIs, but a reasonable start

## Rollout/Rollback
- Revert if needed

## Testing
- New tests added




[B2BCAT-16]: https://bigcommercecloud.atlassian.net/browse/B2BCAT-16?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ