### PR TITLE
refactor(quotes): B2BCAT-22 add basic test harness to user management page

### DIFF
--- a/apps/storefront/src/pages/UserManagement/index.test.tsx
+++ b/apps/storefront/src/pages/UserManagement/index.test.tsx
@@ -1,0 +1,324 @@
+import { graphql, HttpResponse } from 'msw';
+import {
+  buildCompanyStateWith,
+  builder,
+  faker,
+  renderWithProviders,
+  screen,
+  startMockServer,
+  userEvent,
+  waitFor,
+  within,
+} from 'tests/test-utils';
+
+import { UserExtraFieldsInfoResponse, UsersResponse } from '@/shared/service/b2b/graphql/users';
+
+import UserManagement from './index';
+
+const { server } = startMockServer();
+
+type UserExtraField = UserExtraFieldsInfoResponse['data']['userExtraFields'][number];
+
+const buildUserExtraFieldWith = builder<UserExtraField>(() => ({
+  fieldName: faker.lorem.words(3),
+  fieldType: faker.number.int(),
+  isRequired: faker.datatype.boolean(),
+  defaultValue: faker.word.sample(),
+  maximumLength: faker.number.int({ min: 1, max: 100 }).toString(),
+  numberOfRows: faker.number.int({ min: 1, max: 10 }),
+  maximumValue: faker.number.int({ min: 1, max: 100 }).toString(),
+  listOfValue: Array.from({ length: faker.number.int({ min: 1, max: 10 }) }, () =>
+    faker.word.sample(),
+  ),
+  visibleToEnduser: faker.datatype.boolean(),
+  labelName: faker.lorem.words(),
+}));
+
+const buildUserExtraFieldsResponseWith = builder<UserExtraFieldsInfoResponse>(() => ({
+  data: {
+    userExtraFields: Array.from({ length: faker.number.int({ min: 1, max: 10 }) }, () =>
+      buildUserExtraFieldWith('WHATEVER_VALUES'),
+    ),
+  },
+}));
+
+type UserEdge = UsersResponse['data']['users']['edges'][number];
+
+const buildUserEdgeWith = builder<UserEdge>(() => ({
+  node: {
+    id: faker.string.uuid(),
+    createdAt: faker.date.past().getTime(),
+    updatedAt: faker.date.recent().getTime(),
+    firstName: faker.person.firstName(),
+    lastName: faker.person.lastName(),
+    email: faker.internet.email(),
+    phone: faker.phone.number(),
+    bcId: faker.number.int(),
+    role: faker.number.int({ min: 0, max: 2 }),
+    uuid: faker.datatype.boolean() ? faker.string.uuid() : null,
+    extraFields: Array.from({ length: faker.number.int({ min: 1, max: 5 }) }, () => ({
+      fieldName: faker.lorem.words(3),
+      fieldValue: faker.word.sample(),
+    })),
+    companyRoleId: faker.number.int(),
+    companyRoleName: faker.lorem.words(2),
+    masqueradingCompanyId: faker.datatype.boolean() ? faker.string.uuid() : null,
+    companyInfo: {
+      companyId: faker.string.uuid(),
+      companyName: faker.company.name(),
+      companyAddress: faker.location.streetAddress(),
+      companyCountry: faker.location.country(),
+      companyState: faker.location.state(),
+      companyCity: faker.location.city(),
+      companyZipCode: faker.location.zipCode(),
+      phoneNumber: faker.phone.number(),
+      bcId: faker.string.numeric(),
+    },
+  },
+}));
+
+const buildUsersResponseWith = builder<UsersResponse>(() => {
+  const edges = Array.from({ length: faker.number.int({ min: 1, max: 10 }) }, () =>
+    buildUserEdgeWith('WHATEVER_VALUES'),
+  );
+
+  return {
+    data: {
+      users: {
+        totalCount: edges.length,
+        pageInfo: { hasNextPage: false, hasPreviousPage: false },
+        edges,
+      },
+    },
+  };
+});
+
+const companyWithAllUserPermissions = buildCompanyStateWith({
+  companyInfo: { id: '82828' },
+  permissions: [
+    { code: 'create_user', permissionLevel: 3 },
+    { code: 'update_user', permissionLevel: 3 },
+    { code: 'delete_user', permissionLevel: 3 },
+  ],
+  companyHierarchyInfo: { selectCompanyHierarchyId: '123' },
+});
+
+const preloadedState = { company: companyWithAllUserPermissions };
+
+it('displays the "Add new user" button', async () => {
+  server.use(
+    graphql.query('GetUserExtraFields', () =>
+      HttpResponse.json(buildUserExtraFieldsResponseWith('WHATEVER_VALUES')),
+    ),
+    graphql.query('GetUsers', () => HttpResponse.json(buildUsersResponseWith('WHATEVER_VALUES'))),
+  );
+
+  renderWithProviders(<UserManagement />, { preloadedState });
+
+  expect(await screen.findByRole('button', { name: 'Add new user' })).toBeInTheDocument();
+});
+
+it('displays the basic details of each user', async () => {
+  const fredSmith = buildUserEdgeWith({
+    node: {
+      firstName: 'Fred',
+      lastName: 'Smith',
+      email: 'fred.smith@acme.org',
+      companyRoleName: 'Admin',
+    },
+  });
+  const sallyCinnamon = buildUserEdgeWith({
+    node: {
+      firstName: 'Sally',
+      lastName: 'Cinnamon',
+      email: 'sally.cinnamon@acme.org',
+      companyRoleName: 'Senior Buyer',
+    },
+  });
+  const troyMcClure = buildUserEdgeWith({
+    node: {
+      firstName: 'Troy',
+      lastName: 'McClure',
+      email: 'troy.mcclure@acme.org',
+      companyRoleName: 'Junior Buyer',
+    },
+  });
+
+  server.use(
+    graphql.query('GetUserExtraFields', () =>
+      HttpResponse.json(buildUserExtraFieldsResponseWith('WHATEVER_VALUES')),
+    ),
+    graphql.query('GetUsers', () =>
+      HttpResponse.json(
+        buildUsersResponseWith({
+          data: { users: { edges: [fredSmith, sallyCinnamon, troyMcClure] } },
+        }),
+      ),
+    ),
+  );
+
+  renderWithProviders(<UserManagement />, { preloadedState });
+
+  expect(await screen.findByRole('heading', { name: 'Fred Smith' })).toBeInTheDocument();
+  expect(screen.getByText('fred.smith@acme.org')).toBeInTheDocument();
+  expect(screen.getByText('Admin')).toBeInTheDocument();
+
+  expect(screen.getByRole('heading', { name: 'Sally Cinnamon' })).toBeInTheDocument();
+  expect(screen.getByText('sally.cinnamon@acme.org')).toBeInTheDocument();
+  expect(screen.getByText('Senior buyer')).toBeInTheDocument();
+
+  expect(screen.getByRole('heading', { name: 'Troy McClure' })).toBeInTheDocument();
+  expect(screen.getByText('troy.mcclure@acme.org')).toBeInTheDocument();
+  expect(screen.getByText('Junior buyer')).toBeInTheDocument();
+});
+
+it('displays users with custom roles', async () => {
+  const joeSwanson = buildUserEdgeWith({
+    node: {
+      firstName: 'Joe',
+      lastName: 'Swanson',
+      companyRoleName: 'Junior Assistant to the Regional Manager',
+    },
+  });
+
+  server.use(
+    graphql.query('GetUserExtraFields', () =>
+      HttpResponse.json(buildUserExtraFieldsResponseWith('WHATEVER_VALUES')),
+    ),
+    graphql.query('GetUsers', () =>
+      HttpResponse.json(buildUsersResponseWith({ data: { users: { edges: [joeSwanson] } } })),
+    ),
+  );
+
+  renderWithProviders(<UserManagement />, { preloadedState });
+
+  expect(await screen.findByRole('heading', { name: 'Joe Swanson' })).toBeInTheDocument();
+  expect(screen.getByText('Junior Assistant to the Regional Manager')).toBeInTheDocument();
+});
+
+describe('when the user clicks on the "edit" button for a user', () => {
+  it('opens the "Edit User" modal', async () => {
+    const troyMcClure = buildUserEdgeWith({
+      node: {
+        firstName: 'Troy',
+        lastName: 'McClure',
+        email: 'troy.mcclure@acme.org',
+        companyRoleName: 'Junior Buyer',
+        phone: '04747665241',
+      },
+    });
+
+    server.use(
+      graphql.query('GetUserExtraFields', () =>
+        HttpResponse.json(buildUserExtraFieldsResponseWith('WHATEVER_VALUES')),
+      ),
+      graphql.query('GetUsers', () =>
+        HttpResponse.json(buildUsersResponseWith({ data: { users: { edges: [troyMcClure] } } })),
+      ),
+    );
+
+    renderWithProviders(<UserManagement />, { preloadedState });
+
+    expect(await screen.findByRole('heading', { name: 'Troy McClure' })).toBeInTheDocument();
+
+    // the 0th edit button is the search filter button
+    await userEvent.click(screen.getAllByRole('button', { name: 'edit' })[1]);
+
+    const modal = await screen.findByRole('dialog');
+
+    expect(within(modal).getByRole('heading', { name: 'Edit user' })).toBeInTheDocument();
+
+    expect(within(modal).getByRole('combobox', { name: 'User role' })).toHaveValue('Junior Buyer');
+
+    const emailField = within(modal).getByRole('textbox', { name: 'Email' });
+    expect(emailField).toHaveValue('troy.mcclure@acme.org');
+    expect(emailField).toBeDisabled();
+
+    expect(within(modal).getByRole('textbox', { name: 'First name' })).toHaveValue('Troy');
+    expect(within(modal).getByRole('textbox', { name: 'Last name' })).toHaveValue('McClure');
+    expect(within(modal).getByRole('textbox', { name: 'Phone number' })).toHaveValue('04747665241');
+  });
+});
+
+describe('when the "Edit User" modal is open and the user clicks "cancel"', () => {
+  it('closes the "Edit User" modal', async () => {
+    const troyMcClure = buildUserEdgeWith({ node: { firstName: 'Troy', lastName: 'McClure' } });
+
+    server.use(
+      graphql.query('GetUserExtraFields', () =>
+        HttpResponse.json(buildUserExtraFieldsResponseWith('WHATEVER_VALUES')),
+      ),
+      graphql.query('GetUsers', () =>
+        HttpResponse.json(buildUsersResponseWith({ data: { users: { edges: [troyMcClure] } } })),
+      ),
+    );
+
+    renderWithProviders(<UserManagement />, { preloadedState });
+
+    expect(await screen.findByRole('heading', { name: 'Troy McClure' })).toBeInTheDocument();
+
+    // the 0th edit button is the search filter button
+    await userEvent.click(screen.getAllByRole('button', { name: 'edit' })[1]);
+
+    const modal = await screen.findByRole('dialog');
+
+    await userEvent.click(within(modal).getByRole('button', { name: 'cancel' }));
+
+    await waitFor(() => expect(modal).not.toBeInTheDocument());
+  });
+});
+
+describe('when the user clicks on the "delete" button for a user', () => {
+  it('opens the "Delete User" modal', async () => {
+    const troyMcClure = buildUserEdgeWith({ node: { firstName: 'Troy', lastName: 'McClure' } });
+
+    server.use(
+      graphql.query('GetUserExtraFields', () =>
+        HttpResponse.json(buildUserExtraFieldsResponseWith('WHATEVER_VALUES')),
+      ),
+      graphql.query('GetUsers', () =>
+        HttpResponse.json(buildUsersResponseWith({ data: { users: { edges: [troyMcClure] } } })),
+      ),
+    );
+
+    renderWithProviders(<UserManagement />, { preloadedState });
+
+    expect(await screen.findByRole('heading', { name: 'Troy McClure' })).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: 'delete' }));
+
+    const modal = await screen.findByRole('dialog');
+
+    expect(within(modal).getByRole('heading', { name: 'Delete user' })).toBeInTheDocument();
+    expect(
+      within(modal).getByText('Are you sure you want to delete this user?'),
+    ).toBeInTheDocument();
+  });
+});
+
+describe('when the "Delete User" modal is open and the user clicks "cancel"', () => {
+  it('closes the "Delete User" modal', async () => {
+    const troyMcClure = buildUserEdgeWith({ node: { firstName: 'Troy', lastName: 'McClure' } });
+
+    server.use(
+      graphql.query('GetUserExtraFields', () =>
+        HttpResponse.json(buildUserExtraFieldsResponseWith('WHATEVER_VALUES')),
+      ),
+      graphql.query('GetUsers', () =>
+        HttpResponse.json(buildUsersResponseWith({ data: { users: { edges: [troyMcClure] } } })),
+      ),
+    );
+
+    renderWithProviders(<UserManagement />, { preloadedState });
+
+    expect(await screen.findByRole('heading', { name: 'Troy McClure' })).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: 'delete' }));
+
+    const modal = await screen.findByRole('dialog');
+
+    await userEvent.click(within(modal).getByRole('button', { name: 'cancel' }));
+
+    await waitFor(() => expect(modal).not.toBeInTheDocument());
+  });
+});

--- a/apps/storefront/src/shared/service/b2b/graphql/users.ts
+++ b/apps/storefront/src/shared/service/b2b/graphql/users.ts
@@ -3,53 +3,55 @@ import { UserTypes } from '@/types';
 import { convertArrayToGraphql, storeHash } from '../../../../utils';
 import B3Request from '../../request/b3Fetch';
 
-const getUsersQl = (data: CustomFieldItems) => `{
-  users (
-    first: ${data.first}
-    search: "${data.q || ''}"
-    offset: ${data.offset}
-    companyId: ${data.companyId}
-    ${data.companyRoleId === '' ? '' : `companyRoleId: ${data.companyRoleId}`}
-  ){
-    totalCount,
-    pageInfo{
-      hasNextPage,
-      hasPreviousPage,
-    },
-    edges{
-      node{
-        id,
-        createdAt,
-        updatedAt,
-        firstName,
-        lastName,
-        email,
-        phone,
-        bcId,
-        role,
-        uuid,
-        extraFields{
-          fieldName
-          fieldValue
-        }
-        companyRoleId,
-        companyRoleName,
-        masqueradingCompanyId,
-        companyInfo {
-          companyId,
-          companyName,
-          companyAddress,
-          companyCountry,
-          companyState,
-          companyCity,
-          companyZipCode,
-          phoneNumber,
+const getUsersQl = (data: CustomFieldItems) => `
+  query GetUsers {
+    users (
+      first: ${data.first}
+      search: "${data.q || ''}"
+      offset: ${data.offset}
+      companyId: ${data.companyId}
+      ${data.companyRoleId === '' ? '' : `companyRoleId: ${data.companyRoleId}`}
+    ){
+      totalCount,
+      pageInfo{
+        hasNextPage,
+        hasPreviousPage,
+      },
+      edges{
+        node{
+          id,
+          createdAt,
+          updatedAt,
+          firstName,
+          lastName,
+          email,
+          phone,
           bcId,
-        },
+          role,
+          uuid,
+          extraFields{
+            fieldName
+            fieldValue
+          }
+          companyRoleId,
+          companyRoleName,
+          masqueradingCompanyId,
+          companyInfo {
+            companyId,
+            companyName,
+            companyAddress,
+            companyCountry,
+            companyState,
+            companyCity,
+            companyZipCode,
+            phoneNumber,
+            bcId,
+          },
+        }
       }
     }
   }
-}`;
+`;
 
 const addOrUpdateUsersQl = (data: CustomFieldItems) => `mutation{
   ${data?.userId ? 'userUpdate' : 'userCreate'} (
@@ -114,25 +116,82 @@ const checkCustomerBCEmail = (data: CustomFieldItems) => `{
   }
 }`;
 
-const getUserExtraFields = () => `{
-  userExtraFields {
-    fieldName
-    fieldType
-    isRequired
-    defaultValue
-    maximumLength
-    numberOfRows
-    maximumValue
-    listOfValue
-    visibleToEnduser
-    labelName
+const getUserExtraFields = () => `
+  query GetUserExtraFields {
+    userExtraFields {
+      fieldName
+      fieldType
+      isRequired
+      defaultValue
+      maximumLength
+      numberOfRows
+      maximumValue
+      listOfValue
+      visibleToEnduser
+      labelName
+    }
   }
-}`;
+`;
+
+export interface UsersResponse {
+  data: {
+    users: {
+      totalCount: number;
+      pageInfo: { hasNextPage: boolean; hasPreviousPage: boolean };
+      edges: Array<{
+        node: {
+          id: string;
+          createdAt: number;
+          updatedAt: number;
+          firstName: string;
+          lastName: string;
+          email: string;
+          phone: string;
+          bcId: number;
+          role: number;
+          uuid: string | null;
+          extraFields: { fieldName: string; fieldValue: string }[];
+          companyRoleId: number;
+          companyRoleName: string;
+          masqueradingCompanyId: string | null;
+          companyInfo: {
+            companyId: string;
+            companyName: string;
+            companyAddress: string;
+            companyCountry: string;
+            companyState: string;
+            companyCity: string;
+            companyZipCode: string;
+            phoneNumber: string;
+            bcId: string;
+          };
+        };
+      }>;
+    };
+  };
+}
 
 export const getUsers = (data: CustomFieldItems) =>
   B3Request.graphqlB2B({
     query: getUsersQl(data),
   });
+
+export interface UserExtraFieldsInfoResponse {
+  data: {
+    userExtraFields: Array<{
+      fieldName: string;
+      fieldType: number;
+      isRequired: boolean;
+      defaultValue: string | null;
+      maximumLength: string | null;
+      numberOfRows: number | null;
+      maximumValue: string | null;
+      listOfValue: string[] | null;
+      visibleToEnduser: boolean;
+      labelName: string;
+    }>;
+  };
+}
 
 export const getUsersExtraFieldsInfo = () =>
   B3Request.graphqlB2B({

--- a/apps/storefront/tests/test-utils.tsx
+++ b/apps/storefront/tests/test-utils.tsx
@@ -7,6 +7,7 @@ import { userEvent } from '@testing-library/user-event';
 import { Mock } from 'vitest';
 
 import { AppStore, RootState, setTimeFormat, setupStore, store as storeSingleton } from '@/store';
+import { setPermissionModules } from '@/store/slices/company';
 
 interface ExtendedRenderOptions extends Omit<RenderOptions, 'queries'> {
   preloadedState?: Partial<RootState>;
@@ -37,6 +38,11 @@ export const renderWithProviders = (
   // until this is fixed, we need manually sync the time format to the store singleton
   if (preloadedState.storeInfo?.timeFormat) {
     storeSingleton.dispatch(setTimeFormat(preloadedState.storeInfo.timeFormat));
+  }
+
+  // As above, `validatePermissionWithComparisonType` reaches to the store singleton
+  if (preloadedState.company?.permissions) {
+    storeSingleton.dispatch(setPermissionModules(preloadedState.company.permissions));
   }
 
   const navigation = vi.fn<[string]>();

--- a/commit-validation.json
+++ b/commit-validation.json
@@ -11,6 +11,7 @@
     "carts",
     "orders",
     "addresses",
-    "headless"
+    "headless",
+    "user-management"
   ]
 }


### PR DESCRIPTION
Jira: [B2BCAT-22](https://bigcommercecloud.atlassian.net/browse/B2BCAT-22)

**N.B.**
- This PR should not introduce any behaviour changes, it should be purely test focussed
- Best read with "Hide whitespace"
- Some graphql queries have been given "operation names" to allow for mocking within tests, this does not change the query or the schema of the response

## What/Why?

- Add some basic, happy-path tests to the User Management page
- Not meant to be exhaustive, coupled to APIs, but a reasonable start

## Rollout/Rollback
- Revert if needed

## Testing
- New tests added




[B2BCAT-22]: https://bigcommercecloud.atlassian.net/browse/B2BCAT-22?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ