### PR TITLE
refactor(user-management): B2BCAT-22 add tests for editing and deleting in Users Management

### DIFF
--- a/apps/storefront/src/shared/service/b2b/graphql/users.ts
+++ b/apps/storefront/src/shared/service/b2b/graphql/users.ts
@@ -53,36 +53,40 @@ const getUsersQl = (data: CustomFieldItems) => `
   }
 `;
 
-const addOrUpdateUsersQl = (data: CustomFieldItems) => `mutation{
-  ${data?.userId ? 'userUpdate' : 'userCreate'} (
-    userData: {
-      companyId: ${data.companyId}
-      ${data?.email ? `email: "${data.email}"` : ''}
-      firstName: "${data.firstName || ''}"
-      lastName: "${data.lastName || ''}"
-      phone: "${data.phone || ''}"
-      ${data?.companyRoleId ? `companyRoleId: ${data.companyRoleId}` : ''}
-      ${data?.userId ? `userId: ${data.userId}` : ''}
-      ${data?.addChannel ? `addChannel: ${data.addChannel}` : ''}
-      extraFields: ${convertArrayToGraphql(data?.extraFields || [])}
-      ${data?.companyRoleName ? `companyRoleName: ${data.companyRoleName}` : ''}
-    }
-  ){
-    user{
-      id,
-      bcId,
+const addOrUpdateUsersQl = (data: CustomFieldItems) => `
+  mutation ${data?.userId ? 'UpdateUser' : 'CreateUser'} {
+    ${data?.userId ? 'userUpdate' : 'userCreate'} (
+      userData: {
+        companyId: ${data.companyId}
+        ${data?.email ? `email: "${data.email}"` : ''}
+        firstName: "${data.firstName || ''}"
+        lastName: "${data.lastName || ''}"
+        phone: "${data.phone || ''}"
+        ${data?.companyRoleId ? `companyRoleId: ${data.companyRoleId}` : ''}
+        ${data?.userId ? `userId: ${data.userId}` : ''}
+        ${data?.addChannel ? `addChannel: ${data.addChannel}` : ''}
+        extraFields: ${convertArrayToGraphql(data?.extraFields || [])}
+        ${data?.companyRoleName ? `companyRoleName: ${data.companyRoleName}` : ''}
+      }
+    ){
+      user{
+        id,
+        bcId,
+      }
     }
   }
-}`;
+`;
 
-const deleteUsersQl = (data: CustomFieldItems) => `mutation{
-  userDelete (
-    companyId: ${data.companyId}
-    userId: ${data.userId}
-  ){
-    message
+const deleteUsersQl = (data: CustomFieldItems) => `
+  mutation DeleteUser {
+    userDelete (
+      companyId: ${data.companyId}
+      userId: ${data.userId}
+    ) {
+      message
+    }
   }
-}`;
+`;
 
 const checkUserB2BEmail = (data: CustomFieldItems) => `{
   userEmailCheck (


### PR DESCRIPTION
Jira: [B2BCAT-22](https://bigcommercecloud.atlassian.net/browse/B2BCAT-22)

**N.B.**
- This PR should not introduce any behaviour changes, it should be purely test focussed
- Best read with "Hide whitespace"
- Some graphql queries have been given "operation names" to allow for mocking within tests, this does not change the query or the schema of the response

## What/Why?

- Add happy path test for editing a user
- Add happy path test for deleting a user
- Add happy path test for moving to the next page
- Add happy path test for moving to the previous page

## Rollout/Rollback
- Revert if needed

## Testing
- New tests added




[B2BCAT-22]: https://bigcommercecloud.atlassian.net/browse/B2BCAT-22?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ