### PR TITLE
fix(quotes): B2B-2415 getting site configs stencil request

### DIFF
--- a/apps/storefront/src/shared/service/bc/graphql/currency.ts
+++ b/apps/storefront/src/shared/service/bc/graphql/currency.ts
@@ -1,4 +1,5 @@
 import { platform } from '@/utils';
+
 import B3Request from '../../request/b3Fetch';
 
 const bcCurrencies = `query {

--- a/apps/storefront/src/shared/service/bc/graphql/currency.ts
+++ b/apps/storefront/src/shared/service/bc/graphql/currency.ts
@@ -1,5 +1,5 @@
-import B3Request from '../../request/b3Fetch';
 import { platform } from '@/utils';
+import B3Request from '../../request/b3Fetch';
 
 const bcCurrencies = `query {
   site{

--- a/apps/storefront/src/shared/service/bc/graphql/currency.ts
+++ b/apps/storefront/src/shared/service/bc/graphql/currency.ts
@@ -1,6 +1,7 @@
 import B3Request from '../../request/b3Fetch';
+import { platform } from '@/utils';
 
-const BcCurrencies = () => `{
+const bcCurrencies = `query {
   site{
     currencies{
       edges{
@@ -14,8 +15,12 @@ const BcCurrencies = () => `{
 }`;
 
 const getActiveBcCurrency = () =>
-  B3Request.graphqlBCProxy({
-    query: BcCurrencies(),
-  });
+  platform === 'bigcommerce'
+    ? B3Request.graphqlBC({
+        query: bcCurrencies,
+      })
+    : B3Request.graphqlBCProxy({
+        query: bcCurrencies,
+      });
 
 export default getActiveBcCurrency;

--- a/apps/storefront/src/shared/service/request/b3Fetch.ts
+++ b/apps/storefront/src/shared/service/request/b3Fetch.ts
@@ -116,8 +116,7 @@ const B3Request = {
     });
   },
   /**
-   * @deprecated use {@link B3Request.graphqlBCProxy} instead
-   * Request to BC graphql API using BC graphql token
+   * Request used in stencil store to call bigcommerce graphql storefront api
    */
   graphqlBC: function post<T = any>(data: GQLRequest): Promise<T> {
     const { bcGraphqlToken } = store.getState().company.tokens;
@@ -127,7 +126,7 @@ const B3Request = {
     return graphqlRequest(RequestType.BCGraphql, data, config);
   },
   /**
-   * Request to BC graphql API using B2B token
+   * Request used in headless context to talk to the bigcommerce graphql storefront api via proxy
    */
   graphqlBCProxy: function post<T = any>(data: GQLRequest): Promise<T> {
     const { B2BToken } = store.getState().company.tokens;

--- a/apps/storefront/src/utils/b3CurrencyFormat.ts
+++ b/apps/storefront/src/utils/b3CurrencyFormat.ts
@@ -1,7 +1,7 @@
 import { store } from '@/store';
 
 import b2bLogger from './b3Logger';
-import { getActiveCurrencyInfo, getDefaultCurrencyInfo } from './currencyUtils';
+import { getActiveCurrencyInfo } from './currencyUtils';
 
 interface MoneyFormat {
   currency_location: 'left' | 'right';
@@ -13,10 +13,7 @@ interface MoneyFormat {
 }
 
 export const currencyFormatInfo = () => {
-  const currentCurrency =
-    import.meta.env.VITE_IS_LOCAL_ENVIRONMENT === 'TRUE'
-      ? getDefaultCurrencyInfo()
-      : getActiveCurrencyInfo();
+  const currentCurrency = getActiveCurrencyInfo();
 
   return {
     currency_location: currentCurrency.token_location || 'left',


### PR DESCRIPTION
## What/Why?
When adding a new product to a draft quote we are seeing the price and currency always as the default currency instead of the one selected in the storefront. That happens because when we are getting the active currency we are using the bc proxy request to get the information, so the session in the proxy is not being sync properly since the change is coming from a stencil store. In stencil stores we don't have to use the proxy. Adding a validation to handle the request based on the platform will have stencil and headless stores using the correct flow.

## Rollout/Rollback
Revert PR

## Testing
https://github.com/user-attachments/assets/5b697758-d933-4133-a429-1a1b1620810f
