### PR TITLE
feat(common): B2B-2880 allow a way to override buyer portal event listener for sign in

### DIFF
--- a/apps/storefront/src/components/HeadlessController/index.tsx
+++ b/apps/storefront/src/components/HeadlessController/index.tsx
@@ -1,5 +1,5 @@
 import { useContext, useEffect, useRef } from 'react';
-import config from '@b3/global-b3';
+import { setElementsListenersConfig } from '@b3/global-b3';
 import Cookies from 'js-cookie';
 
 import { HeadlessRoutes } from '@/constants';
@@ -141,13 +141,8 @@ export default function HeadlessController({ setOpenPage }: HeadlessControllerPr
             const openUrl = page.startsWith('/') ? page : HeadlessRoutes[page];
             setOpenPage({ isOpen: true, openUrl });
           }, 0),
-        updateDomConfig: (newConfigs: Record<string, string>) => {
-          const keys = Object.keys(newConfigs);
-          keys.forEach((key: string) => {
-            if (key in config) {
-              config[key as keyof typeof config] = newConfigs[key];
-            }
-          });
+        setB3ConfigEventListeners: (newConfigs: Record<string, string>) => {
+          setElementsListenersConfig(newConfigs);
         },
         quote: {
           addProductFromPage: async (item) => {

--- a/apps/storefront/src/components/HeadlessController/index.tsx
+++ b/apps/storefront/src/components/HeadlessController/index.tsx
@@ -141,7 +141,7 @@ export default function HeadlessController({ setOpenPage }: HeadlessControllerPr
             const openUrl = page.startsWith('/') ? page : HeadlessRoutes[page];
             setOpenPage({ isOpen: true, openUrl });
           }, 0),
-        setB3ConfigEventListeners: (key: string, value: string) => {
+        setConfig: (key: string, value: string) => {
           setElementsListenersConfig(key, value);
         },
         quote: {

--- a/apps/storefront/src/components/HeadlessController/index.tsx
+++ b/apps/storefront/src/components/HeadlessController/index.tsx
@@ -1,4 +1,5 @@
 import { useContext, useEffect, useRef } from 'react';
+import config from '@b3/global-b3';
 import Cookies from 'js-cookie';
 
 import { HeadlessRoutes } from '@/constants';
@@ -140,6 +141,14 @@ export default function HeadlessController({ setOpenPage }: HeadlessControllerPr
             const openUrl = page.startsWith('/') ? page : HeadlessRoutes[page];
             setOpenPage({ isOpen: true, openUrl });
           }, 0),
+        updateDomConfig: (newConfigs: Record<string, string>) => {
+          const keys = Object.keys(newConfigs);
+          keys.forEach((key: string) => {
+            if (key in config) {
+              config[key as keyof typeof config] = newConfigs[key];
+            }
+          });
+        },
         quote: {
           addProductFromPage: async (item) => {
             const productWithSku = {

--- a/apps/storefront/src/components/HeadlessController/index.tsx
+++ b/apps/storefront/src/components/HeadlessController/index.tsx
@@ -141,8 +141,8 @@ export default function HeadlessController({ setOpenPage }: HeadlessControllerPr
             const openUrl = page.startsWith('/') ? page : HeadlessRoutes[page];
             setOpenPage({ isOpen: true, openUrl });
           }, 0),
-        setB3ConfigEventListeners: (newConfigs: Record<string, string>) => {
-          setElementsListenersConfig(newConfigs);
+        setB3ConfigEventListeners: (key: string, value: string) => {
+          setElementsListenersConfig(key, value);
         },
         quote: {
           addProductFromPage: async (item) => {

--- a/apps/storefront/src/hooks/useB3AppOpen.ts
+++ b/apps/storefront/src/hooks/useB3AppOpen.ts
@@ -80,7 +80,11 @@ const useB3AppOpen = (initOpenState: OpenPageState) => {
         ? document.querySelectorAll(config['dom.registerElement'])
         : [],
     );
-    const allOtherArr = Array.from(document.querySelectorAll(config['dom.allOtherElement']));
+    const allOtherArr = Array.from(
+      config['dom.allOtherElement'].length > 0
+        ? document.querySelectorAll(config['dom.allOtherElement'])
+        : [],
+    );
 
     if (registerArr.length || allOtherArr.length) {
       const handleTriggerClick = (e: MouseEvent) => {

--- a/apps/storefront/src/hooks/useB3AppOpen.ts
+++ b/apps/storefront/src/hooks/useB3AppOpen.ts
@@ -75,7 +75,11 @@ const useB3AppOpen = (initOpenState: OpenPageState) => {
   };
 
   useLayoutEffect(() => {
-    const registerArr = Array.from(config['dom.registerElement'].length > 0 ? document.querySelectorAll(config['dom.registerElement']) : []);
+    const registerArr = Array.from(
+      config['dom.registerElement'].length > 0
+        ? document.querySelectorAll(config['dom.registerElement'])
+        : [],
+    );
     const allOtherArr = Array.from(document.querySelectorAll(config['dom.allOtherElement']));
 
     if (registerArr.length || allOtherArr.length) {

--- a/apps/storefront/src/hooks/useB3AppOpen.ts
+++ b/apps/storefront/src/hooks/useB3AppOpen.ts
@@ -75,7 +75,7 @@ const useB3AppOpen = (initOpenState: OpenPageState) => {
   };
 
   useLayoutEffect(() => {
-    const registerArr = Array.from(document.querySelectorAll(config['dom.registerElement']));
+    const registerArr = Array.from(config['dom.registerElement'].length > 0 ? document.querySelectorAll(config['dom.registerElement']) : []);
     const allOtherArr = Array.from(document.querySelectorAll(config['dom.allOtherElement']));
 
     if (registerArr.length || allOtherArr.length) {

--- a/apps/storefront/src/index.d.ts
+++ b/apps/storefront/src/index.d.ts
@@ -40,7 +40,7 @@ declare interface Window {
     utils: {
       openPage: (page: import('./constants').HeadlessRoute) => void;
       getRoutes: () => import('@/shared/routeList').BuyerPortalRoute[];
-      setB3ConfigEventListeners: (key: string, value: string) => void;
+      setConfig: (key: string, value: string) => void;
       quote: {
         addProductFromPage: (item: import('@/utils').LineItems) => void;
         addProductsFromCart: () => Promise<void>;

--- a/apps/storefront/src/index.d.ts
+++ b/apps/storefront/src/index.d.ts
@@ -40,7 +40,7 @@ declare interface Window {
     utils: {
       openPage: (page: import('./constants').HeadlessRoute) => void;
       getRoutes: () => import('@/shared/routeList').BuyerPortalRoute[];
-      updateDomConfig: (newConfigs: Record<string, string>) => void;
+      setB3ConfigEventListeners: (newConfigs: Record<string, string>) => void;
       quote: {
         addProductFromPage: (item: import('@/utils').LineItems) => void;
         addProductsFromCart: () => Promise<void>;

--- a/apps/storefront/src/index.d.ts
+++ b/apps/storefront/src/index.d.ts
@@ -40,6 +40,7 @@ declare interface Window {
     utils: {
       openPage: (page: import('./constants').HeadlessRoute) => void;
       getRoutes: () => import('@/shared/routeList').BuyerPortalRoute[];
+      updateDomConfig: (newConfigs: Record<string, string>) => void;
       quote: {
         addProductFromPage: (item: import('@/utils').LineItems) => void;
         addProductsFromCart: () => Promise<void>;

--- a/apps/storefront/src/index.d.ts
+++ b/apps/storefront/src/index.d.ts
@@ -40,7 +40,7 @@ declare interface Window {
     utils: {
       openPage: (page: import('./constants').HeadlessRoute) => void;
       getRoutes: () => import('@/shared/routeList').BuyerPortalRoute[];
-      setB3ConfigEventListeners: (newConfigs: Record<string, string>) => void;
+      setB3ConfigEventListeners: (key: string, value: string) => void;
       quote: {
         addProductFromPage: (item: import('@/utils').LineItems) => void;
         addProductsFromCart: () => Promise<void>;

--- a/packages/global-b3/index.ts
+++ b/packages/global-b3/index.ts
@@ -36,8 +36,7 @@ const themeOtherElementConfig = () => {
   }
 }
 
-// eslint-disable-next-line prefer-const
-let config = {
+const config: Record<string, string> = {
   'dom.registerElement':
     '[href^="/login.php"], #checkout-customer-login, [href="/login.php"] .navUser-item-loginLabel, #checkout-customer-returning .form-legend-container [href="#"]',
   'dom.registerUrl': '/register',
@@ -60,10 +59,12 @@ let config = {
 }
 
 export const setElementsListenersConfig = (
-  newConfig: Record<string, string>
+  key: string,
+  value: string
 ) => {
-  config = { ...config, ...newConfig }
+  if (key in config) {
+    config[key] = value
+  }
 }
 
-// eslint-disable-next-line prefer-const
 export default config

--- a/packages/global-b3/index.ts
+++ b/packages/global-b3/index.ts
@@ -36,7 +36,8 @@ const themeOtherElementConfig = () => {
   }
 }
 
-const config = {
+
+let config = {
   'dom.registerElement':
     '[href^="/login.php"], #checkout-customer-login, [href="/login.php"] .navUser-item-loginLabel, #checkout-customer-returning .form-legend-container [href="#"]',
   'dom.registerUrl': '/register',
@@ -56,6 +57,10 @@ const config = {
   before_login_goto_page: '/account.php?action=order_status',
   checkout_super_clear_session: 'true',
   ...themeOtherElementConfig(),
+}
+
+export const setElementsListenersConfig = (newConfig: Record<string, string>) => {
+  config = {...config, ...newConfig}
 }
 
 export default config

--- a/packages/global-b3/index.ts
+++ b/packages/global-b3/index.ts
@@ -36,6 +36,7 @@ const themeOtherElementConfig = () => {
   }
 }
 
+// eslint-disable-next-line prefer-const
 let config = {
   'dom.registerElement':
     '[href^="/login.php"], #checkout-customer-login, [href="/login.php"] .navUser-item-loginLabel, #checkout-customer-returning .form-legend-container [href="#"]',

--- a/packages/global-b3/index.ts
+++ b/packages/global-b3/index.ts
@@ -36,7 +36,6 @@ const themeOtherElementConfig = () => {
   }
 }
 
-
 let config = {
   'dom.registerElement':
     '[href^="/login.php"], #checkout-customer-login, [href="/login.php"] .navUser-item-loginLabel, #checkout-customer-returning .form-legend-container [href="#"]',
@@ -59,8 +58,11 @@ let config = {
   ...themeOtherElementConfig(),
 }
 
-export const setElementsListenersConfig = (newConfig: Record<string, string>) => {
-  config = {...config, ...newConfig}
+export const setElementsListenersConfig = (
+  newConfig: Record<string, string>
+) => {
+  config = { ...config, ...newConfig }
 }
 
+// eslint-disable-next-line prefer-const
 export default config

--- a/packages/global-b3/index.ts
+++ b/packages/global-b3/index.ts
@@ -58,10 +58,7 @@ const config: Record<string, string> = {
   ...themeOtherElementConfig(),
 }
 
-export const setElementsListenersConfig = (
-  key: string,
-  value: string
-) => {
+export const setElementsListenersConfig = (key: string, value: string) => {
   if (key in config) {
     config[key] = value
   }


### PR DESCRIPTION
Jira: [B2B-2880](https://bigcommercecloud.atlassian.net/browse/B2B-2880)

## What/Why?
When loading catalyst checkout as a guest and clicking the Sign In button it gets redirected into a stencil page, becase the buyer portal configs map an event listener into the sign in and gets tracked by the apps/storefront/src/hooks/useB3AppOpen.ts file, so in order to detach this event listener and others, we need to expose a function that could be use by B2B checkout and override this.

## Rollout/Rollback
Revert this PR

## Testing

https://github.com/user-attachments/assets/7ca8a851-6a0f-4d27-95b9-a9056c0b1a08



[B2B-2880]: https://bigcommercecloud.atlassian.net/browse/B2B-2880?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ