### PR TITLE
refactor(quotes): B2BCAT-17 change shopping lists test to use graphql mocks

### DIFF
--- a/apps/storefront/src/shared/service/b2b/graphql/shoppingList.ts
+++ b/apps/storefront/src/shared/service/b2b/graphql/shoppingList.ts
@@ -117,16 +117,16 @@ const getShoppingListInfo = `shoppingList {
   },
 }`;
 
-const updateShoppingList = (
-  fn: string,
-) => `mutation($id: Int!, $shoppingListData: ShoppingListsInputType!){
-  ${fn}(
-    id: $id
-    shoppingListData: $shoppingListData
-  ) {
-    ${getShoppingListInfo}
+const updateShoppingList = (fn: string) => `
+  mutation UpdateB2BShoppingList ($id: Int!, $shoppingListData: ShoppingListsInputType!) {
+    ${fn}(
+      id: $id
+      shoppingListData: $shoppingListData
+    ) {
+      ${getShoppingListInfo}
+    }
   }
-}`;
+`;
 
 const createShoppingList = (fn: string) => `mutation($shoppingListData: ShoppingListsInputType!){
   ${fn}(
@@ -182,75 +182,142 @@ const updateShoppingListsItem = (data: CustomFieldItems) => `mutation {
   }
 }`;
 
-const getShoppingListDetails = (data: CustomFieldItems) => `{
-  shoppingList (
-    id: ${data.id}
-  ) {
-    id,
-    createdAt,
-    updatedAt,
-    name,
-    description,
-    status,
-    reason,
-    customerInfo {
-      firstName,
-      lastName,
-      userId,
-      email,
-      role,
-    },
-    isOwner,
-    grandTotal,
-    totalDiscount,
-    totalTax,
-    isShowGrandTotal,
-    channelId,
-    channelName,
-    approvedFlag,
-    companyInfo {
-      companyId,
-      companyName,
-      companyAddress,
-      companyCountry,
-      companyState,
-      companyCity,
-      companyZipCode,
-      phoneNumber,
-      bcId,
-    },
-    products (
-      offset: ${data.offset || 0}
-      first: ${data.first || 100},
-      search: "${data.search || ''}",
-      orderBy: "${data?.orderBy || '-updatedAt'}"
+export interface CustomerShoppingListB2B {
+  data: {
+    shoppingList: {
+      id: string;
+      createdAt: number;
+      updatedAt: number;
+      name: string;
+      description: string;
+      status: number;
+      reason: string | null;
+      customerInfo: {
+        firstName: string;
+        lastName: string;
+        userId: number;
+        email: string;
+        role: string;
+      };
+      isOwner: boolean;
+      grandTotal: string;
+      totalDiscount: string;
+      totalTax: string;
+      isShowGrandTotal: boolean;
+      channelId: string | null;
+      channelName: string;
+      approvedFlag: boolean;
+      companyInfo: {
+        companyId: string;
+        companyName: string;
+        companyAddress: string;
+        companyCountry: string;
+        companyState: string;
+        companyCity: string;
+        companyZipCode: string;
+        phoneNumber: string;
+        bcId: string;
+      };
+      products: {
+        totalCount: number;
+        edges: Array<{
+          node: {
+            id: string;
+            createdAt: number;
+            updatedAt: number;
+            productId: number;
+            variantId: number;
+            quantity: number;
+            productName: string;
+            optionList: string;
+            itemId: number;
+            baseSku: string;
+            variantSku: string;
+            basePrice: string;
+            discount: string;
+            tax: string;
+            enteredInclusive: boolean;
+            productUrl: string;
+            primaryImage: string;
+            productNote: string;
+          };
+        }>;
+      };
+    };
+  };
+}
+
+const getShoppingListDetails = (data: CustomFieldItems) => `
+  query B2BShoppingListDetails {
+    shoppingList (
+      id: ${data.id}
     ) {
-      totalCount,
-      edges {
-        node {
-          id,
-          createdAt,
-          updatedAt,
-          productId,
-          variantId,
-          quantity,
-          productName,
-          optionList,
-          itemId,
-          baseSku,
-          variantSku,
-          basePrice,
-          discount,
-          tax,
-          enteredInclusive,
-          productUrl,
-          primaryImage,
-          productNote,
+      id,
+      createdAt,
+      updatedAt,
+      name,
+      description,
+      status,
+      reason,
+      customerInfo {
+        firstName,
+        lastName,
+        userId,
+        email,
+        role,
+      },
+      isOwner,
+      grandTotal,
+      totalDiscount,
+      totalTax,
+      isShowGrandTotal,
+      channelId,
+      channelName,
+      approvedFlag,
+      companyInfo {
+        companyId,
+        companyName,
+        companyAddress,
+        companyCountry,
+        companyState,
+        companyCity,
+        companyZipCode,
+        phoneNumber,
+        bcId,
+      },
+      products (
+        offset: ${data.offset || 0}
+        first: ${data.first || 100},
+        search: "${data.search || ''}",
+        orderBy: "${data?.orderBy || '-updatedAt'}"
+      ) {
+        totalCount,
+        edges {
+          node {
+            id,
+            createdAt,
+            updatedAt,
+            productId,
+            variantId,
+            quantity,
+            productName,
+            optionList,
+            itemId,
+            baseSku,
+            variantSku,
+            basePrice,
+            discount,
+            tax,
+            enteredInclusive,
+            productUrl,
+            primaryImage,
+            productNote,
+          }
         }
       }
     }
   }
-}`;
+`;
 
 const addItemsToShoppingList = (data: CustomFieldItems) => `mutation {
   shoppingListsItemsCreate(

--- a/apps/storefront/tests/test-utils.tsx
+++ b/apps/storefront/tests/test-utils.tsx
@@ -70,7 +70,7 @@ export const renderWithProviders = (
 };
 
 export { startMockServer } from './mockServer';
-export { http, HttpResponse } from 'msw';
+export { graphql, http, HttpResponse } from 'msw';
 export { assertQueryParams } from './assertQueryParams';
 export * from '@testing-library/react';
 export { default as userEvent } from '@testing-library/user-event';


### PR DESCRIPTION
Jira: [B2BCAT-17](https://bigcommercecloud.atlassian.net/browse/B2BCAT-17)

**N.B.**
- Best read one commit at a time (each commit builds and tests pass at all times)
- This PR should not introduce any behaviour changes, it should be purely test focussed
- Best read with "Hide whitespace"
- Some graphql queries have been given "operation names" to allow for mocking within tests, this does not change the query or the schema of the response

## What/Why?

- Existing tests mocked graphQL queries incorrectly (one mock accidentally resolved _all_ queries)
- Existing tests mocked internal permission logic
- Existing tests did not yet use faker or builders based on strict types

## Rollout/Rollback

- Revert 

## Testing

- Refactored tests


[B2BCAT-17]: https://bigcommercecloud.atlassian.net/browse/B2BCAT-17?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ