### PR TITLE
test(common): B2BCAT-11 Improve the builder types, allowing for better autocomplete

### DIFF
--- a/apps/storefront/tests/builder.ts
+++ b/apps/storefront/tests/builder.ts
@@ -21,8 +21,8 @@ const mergeCustomizer = <T>(objValue: T, srcValue: T) =>
 type NonArray<T> = T extends unknown[] ? never : T;
 
 export const builder =
-  <T extends object, O = NonArray<T>>(getDefaults: () => O) =>
-  (overrides: DeepPartialObjects<T> | 'WHATEVER_VALUES'): O =>
+  <T extends object>(getDefaults: () => NonArray<T>) =>
+  (overrides: DeepPartialObjects<T> | 'WHATEVER_VALUES'): T =>
     overrides === 'WHATEVER_VALUES'
       ? getDefaults()
       : mergeWith({}, getDefaults(), overrides, mergeCustomizer);


### PR DESCRIPTION

Jira: [B2BCAT-11](https://bigcommercecloud.atlassian.net/browse/B2BCAT-11)

## What/Why?
The current types break TS' ability to autocomplete the results of the functions. Removing `O` from the definition still prevents arrays from being returned, let's TS autocomplete the return of the `getDefaults` method.

## Rollout/Rollback
Revert

## Testing
### Before
<img width="590" alt="image" src="https://github.com/user-attachments/assets/f0aa3da7-5d9b-4312-bb3b-e21ef4740b8e" />


### After
<img width="615" alt="image" src="https://github.com/user-attachments/assets/ecb0378a-462f-4d9b-b5bd-bc851fb6234f" />

