### PR TITLE
fix(headless): B2BCAT-25 Allow for empty selectedOptions array

### DIFF
--- a/apps/storefront/src/components/HeadlessController/getSku.tsx
+++ b/apps/storefront/src/components/HeadlessController/getSku.tsx
@@ -30,7 +30,10 @@ const graphqlRequest: typeof B3Request.graphqlBC | typeof B3Request.graphqlBCPro
     : B3Request.graphqlBCProxy({ query, variables });
 };
 
-export const getSku = async ({ selectedOptions, productEntityId }: LineItem): Promise<string> => {
+export const getSku = async ({
+  selectedOptions = [],
+  productEntityId,
+}: LineItem): Promise<string> => {
   const { data } = await graphqlRequest<ProductsWithOptionSelections>({
     query: `
     query ProductsWithOptionSelections (


### PR DESCRIPTION
Jira: [B2BCAT-25](https://bigcommercecloud.atlassian.net/browse/B2BCAT-25)

## What/Why?
Allow `selectedOptions` to be `undefined` when adding products to quote.

For products that don't have options, we don't need to provide an array. 

## Rollout/Rollback
Revert

## Testing

### Before

https://github.com/user-attachments/assets/ffd605ae-11c4-4c45-9bf9-42c6b52eb657


### After

https://github.com/user-attachments/assets/1da3757b-bed2-4c6e-a11f-ade43c9fa026

[B2BCAT-25]: https://bigcommercecloud.atlassian.net/browse/B2BCAT-25?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ