### PR TITLE
fix(common): B2B-2508 Width of notifications

### DIFF
--- a/apps/storefront/src/components/B3Tip.tsx
+++ b/apps/storefront/src/components/B3Tip.tsx
@@ -20,7 +20,6 @@ function MessageAlert({
   return (
     <Alert
       sx={{
-        width: '320px',
         alignItems: 'center',
         '& button[title="Close"]': {
           display: msg.isClose ? 'block' : 'none',
@@ -29,6 +28,7 @@ function MessageAlert({
 
         '& .MuiAlert-message': {
           overflow: 'unset',
+          whiteSpace: 'nowrap',
         },
       }}
       variant="filled"


### PR DESCRIPTION
Jira: [JIRA_2508](https://bigcommercecloud.atlassian.net/browse/B2B-2508)

## What/Why?
Need to increase width of the snackbar notification to align with designs and improve user experience.

## Rollout/Rollback
Standard rollout + rollback procedure.

## Testing
Before:
![image](https://github.com/user-attachments/assets/7ece23f0-0093-4f5a-b43d-db72ab45f9d0)

After:
<img width="451" alt="Product was added to your quote OPEN QUOTE" src="https://github.com/user-attachments/assets/f5f3e3aa-c423-40dc-8dd8-c3d2950e00e0" />


