### PR TITLE
fix(orders): B2B-2820 passing money data to products list

### DIFF
--- a/apps/storefront/src/pages/OrderDetail/components/OrderBilling.tsx
+++ b/apps/storefront/src/pages/OrderDetail/components/OrderBilling.tsx
@@ -14,7 +14,7 @@ type OrderBillingProps = {
 
 export default function OrderBilling({ isCurrentCompany }: OrderBillingProps) {
   const {
-    state: { billings = [], addressLabelPermission, orderId },
+    state: { billings = [], addressLabelPermission, orderId, money },
   } = useContext(OrderDetailsContext);
 
   const [isMobile] = useMobile();
@@ -109,6 +109,7 @@ export default function OrderBilling({ isCurrentCompany }: OrderBillingProps) {
               totalText="Total"
               canToProduct={isCurrentCompany}
               textAlign={isMobile ? 'left' : 'right'}
+              money={money}
             />
           </CardContent>
         </Card>


### PR DESCRIPTION
## What/Why?
When loading digital products in OrderDetails page we use OrderBilling component to render the products and right now we are not passing the money prop of the order loaded so instead of using the currency from the order it's using the active currency in the storefront to display the symbol of the products.

## Rollout/Rollback
Revert PR

## Testing

Before:

https://github.com/user-attachments/assets/2f229f38-5b2e-404f-af44-975badf66e4d

After: 

https://github.com/user-attachments/assets/16a353ee-2edb-442f-9d72-a23ec3241acc
