### PR TITLE
refactor(user-management): B2BCAT-22 add tests for custom field in Users Management

### DIFF
--- a/apps/storefront/src/pages/UserManagement/getUserExtraFields.ts
+++ b/apps/storefront/src/pages/UserManagement/getUserExtraFields.ts
@@ -29,7 +29,7 @@ const FIELD_TYPE = {
   1: 'multiline',
   2: 'number',
   3: 'dropdown',
-};
+} as const;
 
 const handleConversionExtraItemFormat = (userExtraFields: B2bExtraFieldsProps[]) => {
   const formattedUserExtraFields: FormattedItemsProps[] = userExtraFields.map(

--- a/apps/storefront/src/pages/UserManagement/getUserExtraFields.ts
+++ b/apps/storefront/src/pages/UserManagement/getUserExtraFields.ts
@@ -66,7 +66,7 @@ const handleConversionExtraItemFormat = (userExtraFields: B2bExtraFieldsProps[])
         case 'number':
           currentItems.max = item.maximumValue || '';
           break;
-        case 'mutiline':
+        case 'multiline':
           currentItems.rows = item.numberOfRows || '';
           break;
         default:


### PR DESCRIPTION
Jira: [B2BCAT-22](https://bigcommercecloud.atlassian.net/browse/B2BCAT-22)

## What/Why?

- Fix bug where custom multiline fields never received their configured number of rows
- Add test coverage for custom fields within User Management

## Rollout/Rollback

- Revert

## Testing

- New tests

[B2BCAT-22]: https://bigcommercecloud.atlassian.net/browse/B2BCAT-22?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ