### PR TITLE
fix(shopping-lists): B2B-2559 fixed an issue where error alert and success alert are both triggered when product without required variant is added to shopping list

### DIFF
--- a/apps/storefront/src/components/HeadlessController/index.tsx
+++ b/apps/storefront/src/components/HeadlessController/index.tsx
@@ -31,6 +31,7 @@ import { endMasquerade, startMasquerade } from '@/utils/masquerade';
 import { globalSnackbar } from '@/utils/b3Tip';
 
 import { getSku } from './getSku';
+import { ValidationError } from '@/utils';
 
 export interface FormattedQuoteItem
   extends Omit<QuoteItem['node'], 'optionList' | 'calculatedValue' | 'productsSearch'> {
@@ -257,7 +258,11 @@ export default function HeadlessController({ setOpenPage }: HeadlessControllerPr
               customerGroupId: customerRef.current.customerGroupId,
             })
               .then(() => displayAddedToShoppingListAlert(shoppingListId.toString()))
-              .catch(({ message }) => {
+              .catch((error) => {
+                const message =
+                  error instanceof ValidationError
+                    ? error.message
+                    : 'Something went wrong. Please try again.';
                 globalSnackbar.error(message, {
                   isClose: true,
                 });

--- a/apps/storefront/src/components/HeadlessController/index.tsx
+++ b/apps/storefront/src/components/HeadlessController/index.tsx
@@ -28,6 +28,7 @@ import { LineItem } from '@/utils/b3Product/b3Product';
 import createShoppingList from '@/utils/b3ShoppingList/b3ShoppingList';
 import { getCurrentCustomerInfo } from '@/utils/loginInfo';
 import { endMasquerade, startMasquerade } from '@/utils/masquerade';
+import { globalSnackbar } from '@/utils/b3Tip';
 
 import { getSku } from './getSku';
 
@@ -254,7 +255,13 @@ export default function HeadlessController({ setOpenPage }: HeadlessControllerPr
               items: transformOptionSelectionsToAttributes(items),
               isB2BUser: isB2BUserRef.current,
               customerGroupId: customerRef.current.customerGroupId,
-            }).then(() => displayAddedToShoppingListAlert(shoppingListId.toString())),
+            })
+              .then(() => displayAddedToShoppingListAlert(shoppingListId.toString()))
+              .catch(({ message }) => {
+                globalSnackbar.error(message, {
+                  isClose: true,
+                });
+              }),
           createNewShoppingList: async (name, description) => {
             const { shoppingListsCreate } = await createShoppingList({
               data: { name, description },

--- a/apps/storefront/src/components/HeadlessController/index.tsx
+++ b/apps/storefront/src/components/HeadlessController/index.tsx
@@ -21,17 +21,17 @@ import {
 } from '@/store';
 import { setB2BToken } from '@/store/slices/company';
 import { QuoteItem } from '@/types/quotes';
+import { ValidationError } from '@/utils';
 import CallbackManager from '@/utils/b3CallbackManager';
 import b2bLogger from '@/utils/b3Logger';
 import { logoutSession } from '@/utils/b3logout';
 import { LineItem } from '@/utils/b3Product/b3Product';
 import createShoppingList from '@/utils/b3ShoppingList/b3ShoppingList';
+import { globalSnackbar } from '@/utils/b3Tip';
 import { getCurrentCustomerInfo } from '@/utils/loginInfo';
 import { endMasquerade, startMasquerade } from '@/utils/masquerade';
-import { globalSnackbar } from '@/utils/b3Tip';
 
 import { getSku } from './getSku';
-import { ValidationError } from '@/utils';
 
 export interface FormattedQuoteItem
   extends Omit<QuoteItem['node'], 'optionList' | 'calculatedValue' | 'productsSearch'> {

--- a/apps/storefront/src/components/HeadlessController/index.tsx
+++ b/apps/storefront/src/components/HeadlessController/index.tsx
@@ -5,7 +5,11 @@ import Cookies from 'js-cookie';
 import { HeadlessRoutes } from '@/constants';
 import { addProductFromPage as addProductFromPageToShoppingList } from '@/hooks/dom/useOpenPDP';
 import { addProductsFromCartToQuote, addProductsToDraftQuote } from '@/hooks/dom/utils';
-import { addProductsToShoppingList, useAddedToShoppingListAlert } from '@/pages/PDP';
+import {
+  addProductsToShoppingList,
+  addProductsToShoppingListErrorHandler,
+  useAddedToShoppingListAlert,
+} from '@/pages/PDP';
 import { type SetOpenPage } from '@/pages/SetOpenPage';
 import { CustomStyleContext } from '@/shared/customStyleButton';
 import { GlobalContext } from '@/shared/global';
@@ -21,13 +25,11 @@ import {
 } from '@/store';
 import { setB2BToken } from '@/store/slices/company';
 import { QuoteItem } from '@/types/quotes';
-import { ValidationError } from '@/utils';
 import CallbackManager from '@/utils/b3CallbackManager';
 import b2bLogger from '@/utils/b3Logger';
 import { logoutSession } from '@/utils/b3logout';
 import { LineItem } from '@/utils/b3Product/b3Product';
 import createShoppingList from '@/utils/b3ShoppingList/b3ShoppingList';
-import { globalSnackbar } from '@/utils/b3Tip';
 import { getCurrentCustomerInfo } from '@/utils/loginInfo';
 import { endMasquerade, startMasquerade } from '@/utils/masquerade';
 
@@ -258,15 +260,7 @@ export default function HeadlessController({ setOpenPage }: HeadlessControllerPr
               customerGroupId: customerRef.current.customerGroupId,
             })
               .then(() => displayAddedToShoppingListAlert(shoppingListId.toString()))
-              .catch((error) => {
-                const message =
-                  error instanceof ValidationError
-                    ? error.message
-                    : 'Something went wrong. Please try again.';
-                globalSnackbar.error(message, {
-                  isClose: true,
-                });
-              }),
+              .catch(addProductsToShoppingListErrorHandler),
           createNewShoppingList: async (name, description) => {
             const { shoppingListsCreate } = await createShoppingList({
               data: { name, description },

--- a/apps/storefront/src/pages/PDP/addProductsToShoppingListErrorHandler.ts
+++ b/apps/storefront/src/pages/PDP/addProductsToShoppingListErrorHandler.ts
@@ -1,0 +1,9 @@
+import { globalSnackbar, ValidationError } from '@/utils';
+
+export const addProductsToShoppingListErrorHandler = (error: Error) => {
+  const message =
+    error instanceof ValidationError ? error.message : 'Something went wrong. Please try again.';
+  globalSnackbar.error(message, {
+    isClose: true,
+  });
+};

--- a/apps/storefront/src/pages/PDP/index.test.tsx
+++ b/apps/storefront/src/pages/PDP/index.test.tsx
@@ -1,0 +1,383 @@
+import {
+  builder,
+  buildGlobalStateWith,
+  buildCompanyStateWith,
+  renderWithProviders,
+  screen,
+  waitForElementToBeRemoved,
+  buildCustomerWith,
+  faker,
+  userEvent,
+} from 'tests/test-utils';
+import PDP from '.';
+import { CustomerRole, ShoppingListStatus } from '@/types';
+import { globalSnackbar } from '@/utils/b3Tip';
+import * as graphqlModule from '@/shared/service/b2b';
+
+const buildShoppingListGraphQLResponseNodeWith = builder(() => ({
+  id: faker.string.uuid(),
+  name: faker.lorem.words(),
+  description: faker.lorem.words(),
+  status: faker.helpers.arrayElement([
+    ShoppingListStatus.Approved,
+    ShoppingListStatus.Deleted,
+    ShoppingListStatus.Draft,
+    ShoppingListStatus.ReadyForApproval,
+    ShoppingListStatus.Rejected,
+  ]),
+  customerInfo: {
+    firstName: faker.person.firstName(),
+    lastName: faker.person.lastName(),
+    userId: faker.number.int(),
+    email: faker.internet.email(),
+    role: faker.helpers.arrayElement([
+      CustomerRole.SUPER_ADMIN,
+      CustomerRole.ADMIN,
+      CustomerRole.B2C,
+      CustomerRole.JUNIOR_BUYER,
+    ]),
+  },
+  updatedAt: faker.date.past(),
+  isOwner: faker.datatype.boolean(),
+  products: { totalCount: faker.number.int() },
+  approvedFlag: faker.datatype.boolean(),
+  companyInfo: {
+    companyId: faker.string.uuid(),
+    companyName: faker.company.name(),
+    companyAddress: faker.location.streetAddress(),
+    companyCountry: faker.location.country(),
+    companyState: faker.location.state(),
+    companyCity: faker.location.city(),
+    companyZipCode: faker.location.zipCode(),
+    phoneNumber: faker.phone.number(),
+    bcId: faker.string.uuid(),
+  },
+}));
+
+describe('when a product without a required variant is added to a shopping list', () => {
+  it('triggers an error alert', async () => {
+    window.b2b = {
+      ...window.b2b,
+      utils: {
+        ...window.b2b?.utils,
+        shoppingList: {
+          ...window.b2b?.utils?.shoppingList,
+          itemFromCurrentPage: [
+            {
+              productId: 123,
+              selectedOptions: { 'attribute 1': 2 },
+              quantity: 1,
+              productEntityId: 234,
+              optionSelections: { 'attribute 1': 2 },
+            },
+          ],
+        },
+      },
+    };
+
+    const globalState = buildGlobalStateWith({
+      storeInfo: {
+        platform: 'others',
+      },
+    });
+
+    const superAdminCustomer = buildCustomerWith({
+      role: CustomerRole.SUPER_ADMIN,
+    });
+
+    const companyStateWithSuperAdminUser = buildCompanyStateWith({
+      customer: superAdminCustomer,
+      permissions: [{ code: 'submit_shopping_list_for_approval', permissionLevel: 1 }],
+    });
+
+    const shoppingList = buildShoppingListGraphQLResponseNodeWith({
+      name: 'Test Shopping List 1',
+      status: ShoppingListStatus.Draft,
+    });
+
+    const shoppingListResponse = {
+      totalCount: 1,
+      pageInfo: { hasNextPage: false, hasPreviousPage: false },
+      edges: [
+        {
+          node: shoppingList,
+        },
+      ],
+    };
+
+    const productsResponse = {
+      productsSearch: [
+        {
+          id: 114,
+          name: 'Product with variant',
+          sku: 'test-1',
+          variants: [
+            {
+              variant_id: 179,
+              product_id: 114,
+              sku: 'test-1-1',
+              option_values: [
+                {
+                  id: 103,
+                  label: 'Silver',
+                  option_id: 114,
+                  option_display_name: 'Color',
+                },
+              ],
+            },
+            {
+              variant_id: 180,
+              product_id: 114,
+              sku: 'test-1-2',
+              option_values: [
+                {
+                  id: 104,
+                  label: 'Black',
+                  option_id: 114,
+                  option_display_name: 'Color',
+                },
+              ],
+            },
+          ],
+          imageUrl: '',
+          modifiers: [],
+          options: [
+            {
+              option_id: 114,
+              display_name: 'Color',
+              sort_order: 0,
+              is_required: true,
+            },
+          ],
+          optionsV3: [
+            {
+              id: 114,
+              product_id: 114,
+              name: 'Color1742885038-114',
+              display_name: 'Color',
+              option_values: [
+                {
+                  id: 103,
+                  label: 'Silver',
+                  sort_order: 0,
+                  is_default: false,
+                },
+                {
+                  id: 104,
+                  label: 'Black',
+                  sort_order: 1,
+                  is_default: false,
+                },
+              ],
+              config: [],
+            },
+          ],
+          channelId: [],
+          productUrl: '',
+        },
+      ],
+    };
+
+    vi.spyOn(graphqlModule, 'getB2BShoppingList').mockResolvedValue(shoppingListResponse);
+    vi.spyOn(graphqlModule, 'searchB2BProducts').mockResolvedValue(productsResponse);
+
+    vi.mock('@/utils/b3Tip', () => ({
+      globalSnackbar: {
+        error: vi.fn(),
+        success: vi.fn(),
+      },
+    }));
+
+    renderWithProviders(<PDP />, {
+      preloadedState: {
+        global: globalState,
+        company: companyStateWithSuperAdminUser,
+      },
+    });
+
+    await waitForElementToBeRemoved(() => screen.queryByText(/loading/i));
+
+    expect(screen.getByText('Add to shopping list')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByText('Test Shopping List 1'));
+    await userEvent.click(screen.getByText('OK'));
+
+    expect(globalSnackbar.error).toHaveBeenCalledWith(
+      'Please fill out product options first.',
+      expect.anything(),
+    );
+
+    expect(globalSnackbar.success).not.toHaveBeenCalled();
+  });
+});
+
+describe('when a product with required variants is added to a shopping list', () => {
+  it('triggers an alert that indicates the product is added to the shopping list', async () => {
+    window.b2b = {
+      ...window.b2b,
+      utils: {
+        ...window.b2b?.utils,
+        shoppingList: {
+          ...window.b2b?.utils?.shoppingList,
+          itemFromCurrentPage: [
+            {
+              productId: 123,
+              selectedOptions: { 'attribute[114]': 104 },
+              quantity: 1,
+              productEntityId: 234,
+              optionSelections: { 'attribute[114]': 104 },
+            },
+          ],
+        },
+      },
+    };
+
+    const globalState = buildGlobalStateWith({
+      storeInfo: {
+        platform: 'others',
+      },
+    });
+
+    const superAdminCustomer = buildCustomerWith({
+      role: CustomerRole.SUPER_ADMIN,
+    });
+
+    const companyStateWithSuperAdminUser = buildCompanyStateWith({
+      customer: superAdminCustomer,
+      permissions: [{ code: 'submit_shopping_list_for_approval', permissionLevel: 1 }],
+    });
+
+    const shoppingList = buildShoppingListGraphQLResponseNodeWith({
+      name: 'Test Shopping List 1',
+      status: ShoppingListStatus.Draft,
+    });
+
+    const shoppingListResponse = {
+      totalCount: 1,
+      pageInfo: { hasNextPage: false, hasPreviousPage: false },
+      edges: [
+        {
+          node: shoppingList,
+        },
+      ],
+    };
+
+    const productsResponse = {
+      productsSearch: [
+        {
+          id: 114,
+          name: 'Product with variant',
+          sku: 'test-1',
+          variants: [
+            {
+              variant_id: 179,
+              product_id: 114,
+              sku: 'test-1-1',
+              option_values: [
+                {
+                  id: 103,
+                  label: 'Silver',
+                  option_id: 114,
+                  option_display_name: 'Color',
+                },
+              ],
+            },
+            {
+              variant_id: 180,
+              product_id: 114,
+              sku: 'test-1-2',
+              option_values: [
+                {
+                  id: 104,
+                  label: 'Black',
+                  option_id: 114,
+                  option_display_name: 'Color',
+                },
+              ],
+            },
+          ],
+          imageUrl: '',
+          modifiers: [],
+          options: [
+            {
+              option_id: 114,
+              display_name: 'Color',
+              sort_order: 0,
+              is_required: true,
+            },
+          ],
+          optionsV3: [
+            {
+              id: 114,
+              product_id: 114,
+              name: 'Color1742885038-114',
+              display_name: 'Color',
+              option_values: [
+                {
+                  id: 103,
+                  label: 'Silver',
+                  sort_order: 0,
+                  is_default: false,
+                },
+                {
+                  id: 104,
+                  label: 'Black',
+                  sort_order: 1,
+                  is_default: false,
+                },
+              ],
+              config: [],
+            },
+          ],
+          channelId: [],
+          productUrl: '',
+        },
+      ],
+    };
+
+    const addProductToShoppingListResponse = {
+      data: {
+        shoppingListsItemsCreate: {
+          shoppingListsItems: [
+            {
+              id: '12',
+            },
+          ],
+        },
+      },
+    };
+
+    vi.spyOn(graphqlModule, 'getB2BShoppingList').mockResolvedValue(shoppingListResponse);
+    vi.spyOn(graphqlModule, 'searchB2BProducts').mockResolvedValue(productsResponse);
+    vi.spyOn(graphqlModule, 'addProductToShoppingList').mockResolvedValue(
+      addProductToShoppingListResponse,
+    );
+
+    vi.mock('@/utils/b3Tip', () => ({
+      globalSnackbar: {
+        error: vi.fn(),
+        success: vi.fn(),
+      },
+    }));
+
+    renderWithProviders(<PDP />, {
+      preloadedState: {
+        global: globalState,
+        company: companyStateWithSuperAdminUser,
+      },
+    });
+
+    await waitForElementToBeRemoved(() => screen.queryByText(/loading/i));
+
+    expect(screen.getByText('Add to shopping list')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByText('Test Shopping List 1'));
+    await userEvent.click(screen.getByText('OK'));
+
+    expect(globalSnackbar.error).not.toHaveBeenCalled();
+    expect(globalSnackbar.success).toHaveBeenCalledWith(
+      'Products were added to your shopping list',
+      expect.anything(),
+    );
+  });
+});

--- a/apps/storefront/src/pages/PDP/index.test.tsx
+++ b/apps/storefront/src/pages/PDP/index.test.tsx
@@ -82,7 +82,7 @@ const buildShoppingListGraphQLResponseNodeWith = builder(() => ({
 }));
 
 describe('when a product without a required variant is added to a shopping list', () => {
-  it('triggers an error alert', async () => {
+  it('triggers an error alert that indicates the product is missing required variant', async () => {
     window.b2b = {
       ...window.b2b,
       utils: {
@@ -404,6 +404,164 @@ describe('when a product with required variants is added to a shopping list', ()
     expect(globalSnackbar.error).not.toHaveBeenCalled();
     expect(globalSnackbar.success).toHaveBeenCalledWith(
       'Products were added to your shopping list',
+      expect.anything(),
+    );
+  });
+});
+
+describe('when an unexpected error occurred during adding a product to shopping list', () => {
+  it('triggers an error alert that indicates something went wrong', async () => {
+    window.b2b = {
+      ...window.b2b,
+      utils: {
+        ...window.b2b?.utils,
+        shoppingList: {
+          ...window.b2b?.utils?.shoppingList,
+          itemFromCurrentPage: [
+            {
+              productId: 123,
+              selectedOptions: { 'attribute[114]': 104 },
+              quantity: 1,
+              productEntityId: 234,
+              optionSelections: { 'attribute[114]': 104 },
+            },
+          ],
+        },
+      },
+    };
+
+    const globalState = buildGlobalStateWith({
+      storeInfo: {
+        platform: 'others',
+      },
+    });
+
+    const superAdminCustomer = buildCustomerWith({
+      role: CustomerRole.SUPER_ADMIN,
+    });
+
+    const companyStateWithSuperAdminUser = buildCompanyStateWith({
+      customer: superAdminCustomer,
+      permissions: [{ code: 'submit_shopping_list_for_approval', permissionLevel: 1 }],
+    });
+
+    const shoppingList = buildShoppingListGraphQLResponseNodeWith({
+      name: 'Test Shopping List 1',
+      status: ShoppingListStatus.Draft,
+    });
+
+    const shoppingListResponse = {
+      totalCount: 1,
+      pageInfo: { hasNextPage: false, hasPreviousPage: false },
+      edges: [
+        {
+          node: shoppingList,
+        },
+      ],
+    };
+
+    const productsResponse = {
+      productsSearch: [
+        {
+          id: 114,
+          name: 'Product with variant',
+          sku: 'test-1',
+          variants: [
+            {
+              variant_id: 179,
+              product_id: 114,
+              sku: 'test-1-1',
+              option_values: [
+                {
+                  id: 103,
+                  label: 'Silver',
+                  option_id: 114,
+                  option_display_name: 'Color',
+                },
+              ],
+            },
+            {
+              variant_id: 180,
+              product_id: 114,
+              sku: 'test-1-2',
+              option_values: [
+                {
+                  id: 104,
+                  label: 'Black',
+                  option_id: 114,
+                  option_display_name: 'Color',
+                },
+              ],
+            },
+          ],
+          imageUrl: '',
+          modifiers: [],
+          options: [
+            {
+              option_id: 114,
+              display_name: 'Color',
+              sort_order: 0,
+              is_required: true,
+            },
+          ],
+          optionsV3: [
+            {
+              id: 114,
+              product_id: 114,
+              name: 'Color1742885038-114',
+              display_name: 'Color',
+              option_values: [
+                {
+                  id: 103,
+                  label: 'Silver',
+                  sort_order: 0,
+                  is_default: false,
+                },
+                {
+                  id: 104,
+                  label: 'Black',
+                  sort_order: 1,
+                  is_default: false,
+                },
+              ],
+              config: [],
+            },
+          ],
+          channelId: [],
+          productUrl: '',
+        },
+      ],
+    };
+
+    vi.spyOn(graphqlModule, 'getB2BShoppingList').mockResolvedValue(shoppingListResponse);
+    vi.spyOn(graphqlModule, 'searchB2BProducts').mockResolvedValue(productsResponse);
+    vi.spyOn(graphqlModule, 'addProductToShoppingList').mockRejectedValue(
+      new Error('Unexpected error'),
+    );
+
+    vi.mock('@/utils/b3Tip', () => ({
+      globalSnackbar: {
+        error: vi.fn(),
+        success: vi.fn(),
+      },
+    }));
+
+    renderWithProviders(<PDP />, {
+      preloadedState: {
+        global: globalState,
+        company: companyStateWithSuperAdminUser,
+      },
+    });
+
+    await waitForElementToBeRemoved(() => screen.queryByText(/loading/i));
+
+    expect(screen.getByText('Add to shopping list')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByText('Test Shopping List 1'));
+    await userEvent.click(screen.getByText('OK'));
+
+    expect(globalSnackbar.error).toHaveBeenCalledWith(
+      'Something went wrong. Please try again.',
       expect.anything(),
     );
   });

--- a/apps/storefront/src/pages/PDP/index.test.tsx
+++ b/apps/storefront/src/pages/PDP/index.test.tsx
@@ -1,18 +1,45 @@
 import {
+  buildCompanyStateWith,
   builder,
   buildGlobalStateWith,
-  buildCompanyStateWith,
+  faker,
   renderWithProviders,
   screen,
-  waitForElementToBeRemoved,
-  buildCustomerWith,
-  faker,
   userEvent,
+  waitForElementToBeRemoved,
 } from 'tests/test-utils';
-import PDP from '.';
-import { CustomerRole, ShoppingListStatus } from '@/types';
-import { globalSnackbar } from '@/utils/b3Tip';
+
 import * as graphqlModule from '@/shared/service/b2b';
+import { Customer, CustomerRole, LoginTypes, ShoppingListStatus, UserTypes } from '@/types';
+import { globalSnackbar } from '@/utils/b3Tip';
+
+import PDP from '.';
+
+const buildCustomerWith = builder<Customer>(() => ({
+  id: faker.number.int(),
+  phoneNumber: faker.phone.number(),
+  firstName: faker.person.firstName(),
+  lastName: faker.person.lastName(),
+  emailAddress: faker.internet.email(),
+  customerGroupId: faker.number.int(),
+  role: faker.helpers.arrayElement([
+    CustomerRole.SUPER_ADMIN,
+    CustomerRole.ADMIN,
+    CustomerRole.B2C,
+    CustomerRole.JUNIOR_BUYER,
+  ]),
+  userType: faker.helpers.arrayElement([
+    UserTypes.B2B_SUPER_ADMIN,
+    UserTypes.B2C,
+    UserTypes.CURRENT_B2B_COMPANY,
+  ]),
+  loginType: faker.helpers.arrayElement([
+    LoginTypes.FIRST_LOGIN,
+    LoginTypes.GENERAL_LOGIN,
+    LoginTypes.WAITING_LOGIN,
+  ]),
+  companyRoleName: faker.lorem.word(),
+}));
 
 const buildShoppingListGraphQLResponseNodeWith = builder(() => ({
   id: faker.string.uuid(),

--- a/apps/storefront/src/pages/PDP/index.test.tsx
+++ b/apps/storefront/src/pages/PDP/index.test.tsx
@@ -229,10 +229,9 @@ describe('when a product without a required variant is added to a shopping list'
     await userEvent.click(screen.getByText('Test Shopping List 1'));
     await userEvent.click(screen.getByText('OK'));
 
-    expect(globalSnackbar.error).toHaveBeenCalledWith(
-      'Please fill out product options first.',
-      expect.anything(),
-    );
+    expect(globalSnackbar.error).toHaveBeenCalledWith('Please fill out product options first.', {
+      isClose: true,
+    });
 
     expect(globalSnackbar.success).not.toHaveBeenCalled();
   });
@@ -560,9 +559,8 @@ describe('when an unexpected error occurred during adding a product to shopping 
     await userEvent.click(screen.getByText('Test Shopping List 1'));
     await userEvent.click(screen.getByText('OK'));
 
-    expect(globalSnackbar.error).toHaveBeenCalledWith(
-      'Something went wrong. Please try again.',
-      expect.anything(),
-    );
+    expect(globalSnackbar.error).toHaveBeenCalledWith('Something went wrong. Please try again.', {
+      isClose: true,
+    });
   });
 });

--- a/apps/storefront/src/pages/PDP/index.tsx
+++ b/apps/storefront/src/pages/PDP/index.tsx
@@ -11,14 +11,13 @@ import {
   searchBcProducts,
 } from '@/shared/service/b2b';
 import { isB2BUserSelector, store, useAppSelector } from '@/store';
-import { getActiveCurrencyInfo, globalSnackbar, serialize } from '@/utils';
+import { getActiveCurrencyInfo, globalSnackbar, serialize, ValidationError } from '@/utils';
 import { getProductOptionList, isAllRequiredOptionFilled } from '@/utils/b3AddToShoppingList';
 import { getValidOptionsList } from '@/utils/b3Product/b3Product';
 
 import { conversionProductsList } from '../../utils/b3Product/shared/config';
 
 import { useAddedToShoppingListAlert } from './useAddedToShoppingListAlert';
-import { ValidationError } from '@/utils';
 
 export { useAddedToShoppingListAlert } from './useAddedToShoppingListAlert';
 
@@ -66,7 +65,7 @@ export const addProductsToShoppingList = async ({
     const { isValid, message } = isAllRequiredOptionFilled(requiredOptions, optionList);
 
     if (!isValid) {
-      return Promise.reject(new ValidationError(message));
+      throw new ValidationError(message);
     }
 
     const newOptionLists = getValidOptionsList(optionList, productsInfo[index]);

--- a/apps/storefront/src/pages/PDP/index.tsx
+++ b/apps/storefront/src/pages/PDP/index.tsx
@@ -11,15 +11,17 @@ import {
   searchBcProducts,
 } from '@/shared/service/b2b';
 import { isB2BUserSelector, store, useAppSelector } from '@/store';
-import { getActiveCurrencyInfo, globalSnackbar, serialize, ValidationError } from '@/utils';
+import { getActiveCurrencyInfo, serialize, ValidationError } from '@/utils';
 import { getProductOptionList, isAllRequiredOptionFilled } from '@/utils/b3AddToShoppingList';
 import { getValidOptionsList } from '@/utils/b3Product/b3Product';
 
 import { conversionProductsList } from '../../utils/b3Product/shared/config';
 
+import { addProductsToShoppingListErrorHandler } from './addProductsToShoppingListErrorHandler';
 import { useAddedToShoppingListAlert } from './useAddedToShoppingListAlert';
 
 export { useAddedToShoppingListAlert } from './useAddedToShoppingListAlert';
+export { addProductsToShoppingListErrorHandler } from './addProductsToShoppingListErrorHandler';
 
 const CreateShoppingList = lazy(() => import('../OrderDetail/components/CreateShoppingList'));
 const OrderShoppingList = lazy(() => import('../OrderDetail/components/OrderShoppingList'));
@@ -168,15 +170,7 @@ function PDP() {
       setIsRequestLoading(true);
       await addToShoppingList({ shoppingListId, product })
         .then(() => displayAddedToShoppingListAlert(shoppingListId))
-        .catch((error) => {
-          const message =
-            error instanceof ValidationError
-              ? error.message
-              : 'Something went wrong. Please try again.';
-          globalSnackbar.error(message, {
-            isClose: true,
-          });
-        });
+        .catch(addProductsToShoppingListErrorHandler);
 
       handleShoppingClose();
     } finally {

--- a/apps/storefront/src/pages/PDP/index.tsx
+++ b/apps/storefront/src/pages/PDP/index.tsx
@@ -18,6 +18,7 @@ import { getValidOptionsList } from '@/utils/b3Product/b3Product';
 import { conversionProductsList } from '../../utils/b3Product/shared/config';
 
 import { useAddedToShoppingListAlert } from './useAddedToShoppingListAlert';
+import { ValidationError } from '@/utils';
 
 export { useAddedToShoppingListAlert } from './useAddedToShoppingListAlert';
 
@@ -65,7 +66,7 @@ export const addProductsToShoppingList = async ({
     const { isValid, message } = isAllRequiredOptionFilled(requiredOptions, optionList);
 
     if (!isValid) {
-      return Promise.reject(new Error(message));
+      return Promise.reject(new ValidationError(message));
     }
 
     const newOptionLists = getValidOptionsList(optionList, productsInfo[index]);
@@ -168,7 +169,11 @@ function PDP() {
       setIsRequestLoading(true);
       await addToShoppingList({ shoppingListId, product })
         .then(() => displayAddedToShoppingListAlert(shoppingListId))
-        .catch(({ message }) => {
+        .catch((error) => {
+          const message =
+            error instanceof ValidationError
+              ? error.message
+              : 'Something went wrong. Please try again.';
           globalSnackbar.error(message, {
             isClose: true,
           });

--- a/apps/storefront/src/pages/PDP/index.tsx
+++ b/apps/storefront/src/pages/PDP/index.tsx
@@ -50,7 +50,6 @@ export const addProductsToShoppingList = async ({
 
   const productsInfo = conversionProductsList(productsSearch);
   const products = [];
-  let isError = false;
 
   for (let index = 0; index < productsInfo.length; index += 1) {
     const { allOptions: requiredOptions, variants } = productsInfo[index];
@@ -66,11 +65,7 @@ export const addProductsToShoppingList = async ({
     const { isValid, message } = isAllRequiredOptionFilled(requiredOptions, optionList);
 
     if (!isValid) {
-      isError = true;
-      globalSnackbar.error(message, {
-        isClose: true,
-      });
-      break;
+      return Promise.reject(new Error(message));
     }
 
     const newOptionLists = getValidOptionsList(optionList, productsInfo[index]);
@@ -81,8 +76,6 @@ export const addProductsToShoppingList = async ({
       optionList: newOptionLists,
     });
   }
-
-  if (isError) return;
 
   const addToShoppingList = isB2BUser ? addProductToShoppingList : addProductToBcShoppingList;
 
@@ -173,9 +166,13 @@ function PDP() {
     if (!product) return;
     try {
       setIsRequestLoading(true);
-      await addToShoppingList({ shoppingListId, product }).then(() =>
-        displayAddedToShoppingListAlert(shoppingListId),
-      );
+      await addToShoppingList({ shoppingListId, product })
+        .then(() => displayAddedToShoppingListAlert(shoppingListId))
+        .catch(({ message }) => {
+          globalSnackbar.error(message, {
+            isClose: true,
+          });
+        });
 
       handleShoppingClose();
     } finally {

--- a/apps/storefront/src/utils/index.ts
+++ b/apps/storefront/src/utils/index.ts
@@ -30,8 +30,8 @@ import {
   convertObjectToGraphql,
 } from './graphqlDataConvert';
 import { memoWithGenerics } from './memoWithGenerics';
-import { validatorRules } from './validatorRules';
 import ValidationError from './validationError';
+import { validatorRules } from './validatorRules';
 
 export * from './basicConfig';
 

--- a/apps/storefront/src/utils/index.ts
+++ b/apps/storefront/src/utils/index.ts
@@ -31,6 +31,7 @@ import {
 } from './graphqlDataConvert';
 import { memoWithGenerics } from './memoWithGenerics';
 import { validatorRules } from './validatorRules';
+import ValidationError from './validationError';
 
 export * from './basicConfig';
 
@@ -77,6 +78,7 @@ export {
   showPageMask,
   snackbar,
   validatorRules,
+  ValidationError,
   handleGetCorrespondingCurrencyToken,
   forwardRefWithGenerics,
   memoWithGenerics,

--- a/apps/storefront/src/utils/validationError.ts
+++ b/apps/storefront/src/utils/validationError.ts
@@ -1,0 +1,8 @@
+class ValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ValidationError';
+  }
+}
+
+export default ValidationError;

--- a/apps/storefront/tests/storeStateBuilders/companyStateBuilder.ts
+++ b/apps/storefront/tests/storeStateBuilders/companyStateBuilder.ts
@@ -1,8 +1,35 @@
 import { PersistPartial } from 'redux-persist/es/persistReducer';
 import { builder } from 'tests/builder';
+import { faker } from 'tests/test-utils';
 
 import { CompanyState } from '@/store/slices/company';
-import { CompanyStatus, CustomerRole, LoginTypes, UserTypes } from '@/types';
+import { CompanyStatus, Customer, CustomerRole, LoginTypes, UserTypes } from '@/types';
+
+export const buildCustomerWith = builder<Customer>(() => ({
+  id: faker.number.int(),
+  phoneNumber: faker.phone.number(),
+  firstName: faker.person.firstName(),
+  lastName: faker.person.lastName(),
+  emailAddress: faker.internet.email(),
+  customerGroupId: faker.number.int(),
+  role: faker.helpers.arrayElement([
+    CustomerRole.SUPER_ADMIN,
+    CustomerRole.ADMIN,
+    CustomerRole.B2C,
+    CustomerRole.JUNIOR_BUYER,
+  ]),
+  userType: faker.helpers.arrayElement([
+    UserTypes.B2B_SUPER_ADMIN,
+    UserTypes.B2C,
+    UserTypes.CURRENT_B2B_COMPANY,
+  ]),
+  loginType: faker.helpers.arrayElement([
+    LoginTypes.FIRST_LOGIN,
+    LoginTypes.GENERAL_LOGIN,
+    LoginTypes.WAITING_LOGIN,
+  ]),
+  companyRoleName: faker.lorem.word(),
+}));
 
 // TODO: we should use faker to generate random data once faker is in place
 export const buildCompanyStateWith = builder<CompanyState & PersistPartial>(() => ({
@@ -11,6 +38,7 @@ export const buildCompanyStateWith = builder<CompanyState & PersistPartial>(() =
     companyName: '',
     status: CompanyStatus.DEFAULT,
   },
+  // TODO: need to replace it with buildCustomerWith
   customer: {
     id: 0,
     phoneNumber: '',

--- a/apps/storefront/tests/storeStateBuilders/companyStateBuilder.ts
+++ b/apps/storefront/tests/storeStateBuilders/companyStateBuilder.ts
@@ -1,35 +1,8 @@
 import { PersistPartial } from 'redux-persist/es/persistReducer';
 import { builder } from 'tests/builder';
-import { faker } from 'tests/test-utils';
 
 import { CompanyState } from '@/store/slices/company';
-import { CompanyStatus, Customer, CustomerRole, LoginTypes, UserTypes } from '@/types';
-
-export const buildCustomerWith = builder<Customer>(() => ({
-  id: faker.number.int(),
-  phoneNumber: faker.phone.number(),
-  firstName: faker.person.firstName(),
-  lastName: faker.person.lastName(),
-  emailAddress: faker.internet.email(),
-  customerGroupId: faker.number.int(),
-  role: faker.helpers.arrayElement([
-    CustomerRole.SUPER_ADMIN,
-    CustomerRole.ADMIN,
-    CustomerRole.B2C,
-    CustomerRole.JUNIOR_BUYER,
-  ]),
-  userType: faker.helpers.arrayElement([
-    UserTypes.B2B_SUPER_ADMIN,
-    UserTypes.B2C,
-    UserTypes.CURRENT_B2B_COMPANY,
-  ]),
-  loginType: faker.helpers.arrayElement([
-    LoginTypes.FIRST_LOGIN,
-    LoginTypes.GENERAL_LOGIN,
-    LoginTypes.WAITING_LOGIN,
-  ]),
-  companyRoleName: faker.lorem.word(),
-}));
+import { CompanyStatus, CustomerRole, LoginTypes, UserTypes } from '@/types';
 
 // TODO: we should use faker to generate random data once faker is in place
 export const buildCompanyStateWith = builder<CompanyState & PersistPartial>(() => ({
@@ -38,7 +11,6 @@ export const buildCompanyStateWith = builder<CompanyState & PersistPartial>(() =
     companyName: '',
     status: CompanyStatus.DEFAULT,
   },
-  // TODO: need to replace it with buildCustomerWith
   customer: {
     id: 0,
     phoneNumber: '',

--- a/apps/storefront/tests/storeStateBuilders/globalStateBuilder.ts
+++ b/apps/storefront/tests/storeStateBuilders/globalStateBuilder.ts
@@ -1,0 +1,52 @@
+import { faker } from '@faker-js/faker';
+import { PersistPartial } from 'redux-persist/es/persistReducer';
+import { builder } from 'tests/builder';
+
+import { GlobalState } from '@/store/slices/global';
+
+export const buildGlobalStateWith = builder<GlobalState & PersistPartial>(() => ({
+  taxZoneRates: [],
+  isClickEnterBtn: faker.datatype.boolean(),
+  currentClickedUrl: faker.internet.url(),
+  isRegisterAndLogin: faker.datatype.boolean(),
+  isPageComplete: faker.datatype.boolean(),
+  globalMessage: {
+    open: faker.datatype.boolean(),
+    title: faker.lorem.sentence(),
+    message: faker.lorem.sentence(),
+    cancelText: faker.lorem.word(),
+  },
+  setOpenPageFn: faker.datatype.boolean() ? () => {} : undefined,
+  showInclusiveTaxPrice: faker.datatype.boolean(),
+  blockPendingAccountViewPrice: faker.datatype.boolean(),
+  cartNumber: faker.number.int({ min: 0, max: 100 }),
+  storeInfo: {
+    b2bEnabled: faker.datatype.boolean(),
+    b3ChannelId: faker.number.int({ min: 0, max: 100 }),
+    channelId: faker.number.int({ min: 0, max: 100 }),
+    channelLogo: faker.image.url(),
+    iconUrl: faker.image.url(),
+    isEnabled: faker.datatype.boolean(),
+    platform: faker.helpers.arrayElement(['bigcommerce', 'others']),
+    translationVersion: faker.number.int({ min: 0, max: 100 }),
+    type: faker.helpers.arrayElement(['b2b', 'b3']),
+    urls: [],
+  },
+  blockPendingQuoteNonPurchasableOOS: {
+    isEnableProduct: faker.datatype.boolean(),
+    isEnableRequest: faker.datatype.boolean(),
+  },
+  loginLandingLocation: faker.internet.url(),
+  recordOpenHash: faker.lorem.word(),
+  quoteSubmissionResponse: {
+    value: faker.lorem.sentence(),
+    key: faker.lorem.word(),
+    message: faker.lorem.sentence(),
+    title: faker.lorem.sentence(),
+  },
+  isOpenCompanyHierarchyDropDown: faker.datatype.boolean(),
+  _persist: {
+    version: 1,
+    rehydrated: true,
+  },
+}));

--- a/apps/storefront/tests/storeStateBuilders/index.ts
+++ b/apps/storefront/tests/storeStateBuilders/index.ts
@@ -1,3 +1,4 @@
-export { buildCompanyStateWith } from './companyStateBuilder';
+export { buildCompanyStateWith, buildCustomerWith } from './companyStateBuilder';
 export { buildStoreInfoStateWith } from './storeInfoStateBuilder';
 export { buildB2BFeaturesStateWith } from './b2bFeaturesStateBuilder';
+export { buildGlobalStateWith } from './globalStateBuilder';

--- a/apps/storefront/tests/storeStateBuilders/index.ts
+++ b/apps/storefront/tests/storeStateBuilders/index.ts
@@ -1,4 +1,4 @@
-export { buildCompanyStateWith, buildCustomerWith } from './companyStateBuilder';
+export { buildCompanyStateWith } from './companyStateBuilder';
 export { buildStoreInfoStateWith } from './storeInfoStateBuilder';
 export { buildB2BFeaturesStateWith } from './b2bFeaturesStateBuilder';
 export { buildGlobalStateWith } from './globalStateBuilder';


### PR DESCRIPTION
Jira: [B2B-2559](https://bigcommercecloud.atlassian.net/browse/B2B-2559)

## What/Why?
Fixed an issue where error alert and success alert are both triggered when product without required variant is added to shopping list.

The issue happened because the whether the success alert is triggered or not does not depend on whether the validation on product option is passed or not. 

## Rollout/Rollback
merge/revert.

## Testing
Before:

https://github.com/user-attachments/assets/d2f0a736-5771-4883-9178-61ab2e70923e

After: 

https://github.com/user-attachments/assets/ef3e445b-5d11-4f75-8305-b56caf917c8c



[B2B-2559]: https://bigcommercecloud.atlassian.net/browse/B2B-2559?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ