### PR TITLE
fix(quotes): B2B-2882 rendering modifier values in quotes

### DIFF
--- a/apps/storefront/src/pages/quote/components/QuoteDetailTable.tsx
+++ b/apps/storefront/src/pages/quote/components/QuoteDetailTable.tsx
@@ -53,7 +53,8 @@ interface SearchProps {
 
 interface OptionProps {
   optionId: number;
-  optionLabel: string;
+  optionLabel?: string;
+  optionType: string;
   optionName: string;
   optionValue: string | number;
 }
@@ -180,16 +181,16 @@ function QuoteDetailTable(props: ShoppingDetailTableProps, ref: Ref<unknown>) {
                 <Box>
                   {optionsValue.map(
                     (option: OptionProps) =>
-                      option.optionLabel && (
+                      option.optionName && (
                         <Typography
                           sx={{
                             fontSize: '0.75rem',
                             lineHeight: '1.5',
                             color: '#455A64',
                           }}
-                          key={`${option.optionName}_${option.optionLabel}`}
+                          key={`${option.optionName}_${option.optionValue}`}
                         >
-                          {`${option.optionName}: ${option.optionLabel}`}
+                          {`${option.optionName}: ${option.optionValue}`}
                         </Typography>
                       ),
                   )}


### PR DESCRIPTION
## What/Why?
In quotes we are currently not rendering the modifier values of a product because we are relying on the optionLabel key to display the values. The modifiers are not being sent from the api with optionLabel, so instead we need to use the optionName that is part of the response for both modifiers and variants.

## Rollout/Rollback
Revert PR

## Testing
Before:
![image](https://github.com/user-attachments/assets/14bb8d92-060b-4434-8737-eb202652ef52)

After:
<img width="579" alt="image" src="https://github.com/user-attachments/assets/0951e99e-dd3f-41c1-b704-70aadcf3938e" />
