### PR TITLE
refactor(user-management): B2BCAT-22 improve type safety of graphqlB2B and thus getUsers

### DIFF
--- a/apps/storefront/src/pages/UserManagement/index.test.tsx
+++ b/apps/storefront/src/pages/UserManagement/index.test.tsx
@@ -293,14 +293,14 @@ describe.each([
         .fn<unknown[], UsersResponse>()
         .mockReturnValue(buildUsersResponseWith(usersPageOne));
 
-      const getUsersQuerySpy = vi.fn();
+      const getUsersVariablesSpy = vi.fn();
 
       server.use(
         graphql.query('GetUserExtraFields', () =>
           HttpResponse.json(buildUserExtraFieldsResponseWith('WHATEVER_VALUES')),
         ),
-        graphql.query('GetUsers', ({ query }) => {
-          getUsersQuerySpy(query);
+        graphql.query('GetUsers', ({ variables }) => {
+          getUsersVariablesSpy(variables);
 
           return HttpResponse.json(getUsersResponse());
         }),
@@ -321,7 +321,7 @@ describe.each([
 
       // once queries/mutations are changed to use real graphql variables,
       // we can spy on the request "variables" instead of this hacky string matching
-      expect(getUsersQuerySpy).toHaveBeenCalledWith(expect.stringContaining('offset: 12'));
+      expect(getUsersVariablesSpy).toHaveBeenCalledWith(expect.objectContaining({ offset: 12 }));
     });
   });
 
@@ -356,14 +356,14 @@ describe.each([
         .fn<unknown[], UsersResponse>()
         .mockReturnValue(buildUsersResponseWith(usersPageOne));
 
-      const getUsersQuerySpy = vi.fn();
+      const getUsersVariablesSpy = vi.fn();
 
       server.use(
         graphql.query('GetUserExtraFields', () =>
           HttpResponse.json(buildUserExtraFieldsResponseWith('WHATEVER_VALUES')),
         ),
-        graphql.query('GetUsers', ({ query }) => {
-          getUsersQuerySpy(query);
+        graphql.query('GetUsers', ({ variables }) => {
+          getUsersVariablesSpy(variables);
 
           return HttpResponse.json(getUsersResponse());
         }),
@@ -388,7 +388,7 @@ describe.each([
 
       // once queries/mutations are changed to use real graphql variables,
       // we can spy on the request "variables" instead of this hacky string matching
-      expect(getUsersQuerySpy).toHaveBeenCalledWith(expect.stringContaining('offset: 0'));
+      expect(getUsersVariablesSpy).toHaveBeenCalledWith(expect.objectContaining({ offset: 0 }));
     });
   });
 

--- a/apps/storefront/src/pages/UserManagement/index.tsx
+++ b/apps/storefront/src/pages/UserManagement/index.tsx
@@ -7,7 +7,7 @@ import B3Filter from '@/components/filter/B3Filter';
 import B3Spin from '@/components/spin/B3Spin';
 import { B3PaginationTable, GetRequestList } from '@/components/table/B3PaginationTable';
 import { useCardListColumn, useMobile, useTableRef } from '@/hooks';
-import { deleteUsers, getUsers } from '@/shared/service/b2b';
+import { deleteUsers, getUsers, GetUsersVariables } from '@/shared/service/b2b';
 import { rolePermissionSelector, useAppSelector } from '@/store';
 import { CustomerRole } from '@/types';
 import { snackbar } from '@/utils';
@@ -15,7 +15,7 @@ import { verifyCreatePermission } from '@/utils/b3CheckPermissions';
 import { b2bPermissionsMap } from '@/utils/b3CheckPermissions/config';
 
 import B3AddEditUser from './AddEditUser';
-import { FilterProps, getFilterMoreList, UsersList } from './config';
+import { getFilterMoreList, UsersList } from './config';
 import { UserItemCard } from './UserItemCard';
 
 interface RefCurrentProps extends HTMLInputElement {
@@ -85,6 +85,8 @@ function UserManagement() {
   const [paginationTableRef] = useTableRef();
 
   const initSearch = {
+    first: 12,
+    offset: 0,
     search: '',
     companyRoleId: '',
     companyId,
@@ -92,13 +94,13 @@ function UserManagement() {
   };
   const filterMoreInfo = getFilterMoreList(b3Lang);
 
-  const [filterSearch, setFilterSearch] = useState<Partial<FilterProps>>(initSearch);
+  const [filterSearch, setFilterSearch] = useState<GetUsersVariables>(initSearch);
 
   const [translatedFilterInfo, setTranslatedFilterInfo] =
     useState<CustomFieldItems[]>(filterMoreInfo);
   const [valueName, setValueName] = useState<string>('');
 
-  const fetchList: GetRequestList<Partial<FilterProps>, UsersList> = async (params) => {
+  const fetchList: GetRequestList<GetUsersVariables, UsersList> = async (params) => {
     const data = await getUsers(params);
 
     const {

--- a/apps/storefront/src/shared/service/b2b/graphql/users.ts
+++ b/apps/storefront/src/shared/service/b2b/graphql/users.ts
@@ -192,7 +192,7 @@ export const getUsers = (data: GetUsersVariables) =>
       ...data,
       q: data.q || '',
       companyId: Number(data.companyId),
-      companyRoleId: (data.companyRoleId !== undefined && Number(data.companyRoleId)) ?? undefined,
+      companyRoleId: data.companyRoleId !== undefined ? Number(data.companyRoleId) : undefined,
     },
   });
 

--- a/apps/storefront/src/shared/service/b2b/graphql/users.ts
+++ b/apps/storefront/src/shared/service/b2b/graphql/users.ts
@@ -3,14 +3,14 @@ import { UserTypes } from '@/types';
 import { convertArrayToGraphql, storeHash } from '../../../../utils';
 import B3Request from '../../request/b3Fetch';
 
-const getUsersQl = (data: CustomFieldItems) => `
-  query GetUsers {
+const getUsersQl = `
+  query GetUsers($first: Int!, $offset: Int!, $q: String, $companyId: Int!, $companyRoleId: Decimal) {
     users (
-      first: ${data.first}
-      search: "${data.q || ''}"
-      offset: ${data.offset}
-      companyId: ${data.companyId}
-      ${data.companyRoleId === '' ? '' : `companyRoleId: ${data.companyRoleId}`}
+      first: $first
+      search: $q
+      offset: $offset
+      companyId: $companyId
+      companyRoleId: $companyRoleId
     ){
       totalCount,
       pageInfo{
@@ -177,9 +177,23 @@ export interface UsersResponse {
   };
 }
 
-export const getUsers = (data: CustomFieldItems) =>
+export interface GetUsersVariables {
+  first: number;
+  offset: number;
+  q?: string;
+  companyId: number | string;
+  companyRoleId?: number | string;
+}
+
+export const getUsers = (data: GetUsersVariables) =>
   B3Request.graphqlB2B<UsersResponse>({
-    query: getUsersQl(data),
+    query: getUsersQl,
+    variables: {
+      ...data,
+      q: data.q || '',
+      companyId: Number(data.companyId),
+      companyRoleId: Number(data.companyRoleId) || undefined,
+    },
   });
 
 export interface UserExtraFieldsInfoResponse {

--- a/apps/storefront/src/shared/service/b2b/graphql/users.ts
+++ b/apps/storefront/src/shared/service/b2b/graphql/users.ts
@@ -178,7 +178,7 @@ export interface UsersResponse {
 }
 
 export const getUsers = (data: CustomFieldItems) =>
-  B3Request.graphqlB2B({
+  B3Request.graphqlB2B<UsersResponse>({
     query: getUsersQl(data),
   });
 

--- a/apps/storefront/src/shared/service/b2b/graphql/users.ts
+++ b/apps/storefront/src/shared/service/b2b/graphql/users.ts
@@ -192,7 +192,7 @@ export const getUsers = (data: GetUsersVariables) =>
       ...data,
       q: data.q || '',
       companyId: Number(data.companyId),
-      companyRoleId: Number(data.companyRoleId) || undefined,
+      companyRoleId: (data.companyRoleId !== undefined && Number(data.companyRoleId)) ?? undefined,
     },
   });
 

--- a/apps/storefront/src/shared/service/b2b/index.ts
+++ b/apps/storefront/src/shared/service/b2b/index.ts
@@ -123,6 +123,7 @@ import {
   deleteUsers,
   getUsers,
   getUsersExtraFieldsInfo,
+  GetUsersVariables,
 } from './graphql/users';
 
 export {
@@ -229,6 +230,7 @@ export {
   getTaxZoneRates,
   getUserCompany,
   getUsers,
+  type GetUsersVariables,
   getUsersExtraFieldsInfo,
   getProductPricing,
   guestProductsBulkUploadCSV,

--- a/apps/storefront/src/shared/service/request/b3Fetch.ts
+++ b/apps/storefront/src/shared/service/request/b3Fetch.ts
@@ -73,14 +73,18 @@ export interface GQLRequest {
   variables?: any;
 }
 
+interface DataWrapper {
+  data: unknown;
+}
+
 const B3Request = {
   /**
    * Request to B2B graphql API using B2B token
    */
-  graphqlB2B: function post<T = CustomFieldItems>(
+  graphqlB2B: function post<T extends DataWrapper | CustomFieldItems = CustomFieldItems>(
     data: GQLRequest,
     customMessage = false,
-  ): Promise<T> {
+  ): Promise<T extends DataWrapper ? T['data'] : T> {
     const { B2BToken } = store.getState().company.tokens;
     const config = {
       Authorization: `Bearer  ${B2BToken}`,


### PR DESCRIPTION
Jira: [B2BCAT-22](https://bigcommercecloud.atlassian.net/browse/B2BCAT-22)

**N.B.** Best read a commit at a time

## What/Why?

- extend `graphqlB2B` to be type safe (but fallback to current vague-ness by default)
- add type definition to `getUsers`
- move `getUsers` to use true graphql variables
- update `UserManagement` to define its `filterSearch` as the new `GetUsersVariables`

## Rollout/Rollback

- Revert

## Testing

- Updated tests (to match new `variables` usage in the query)
- Passing feature tests

### Video of general usage still working (B2B user)


https://github.com/user-attachments/assets/eaf5d2c6-8da2-4f56-8eb9-a5630c2365fc




[B2BCAT-22]: https://bigcommercecloud.atlassian.net/browse/B2BCAT-22?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ