### PR TITLE
fix(orders): B2B-2842 Add csv extension fallback to upload component

### DIFF
--- a/apps/storefront/src/components/upload/B3UploadLoading.tsx
+++ b/apps/storefront/src/components/upload/B3UploadLoading.tsx
@@ -32,11 +32,11 @@ function CircularProgressWithLabel(props: CircularProgressProps & { value: numbe
   );
 }
 
-interface B3UploadLoaddingProps {
+interface B3UploadLoadingProps {
   step: string;
 }
 
-export default function B3UploadLoadding(props: B3UploadLoaddingProps) {
+export default function B3UploadLoading(props: B3UploadLoadingProps) {
   const { step } = props;
   const [progress, setProgress] = useState<number>(0);
 

--- a/apps/storefront/src/components/upload/utils.ts
+++ b/apps/storefront/src/components/upload/utils.ts
@@ -26,3 +26,7 @@ export const parseEmptyData = (arr: string[]): ParseEmptyDataProps[] => {
   }
   return [];
 };
+
+export const isFileExtension = (fileType: string): fileType is `.${string}` => {
+  return fileType.startsWith('.');
+};


### PR DESCRIPTION
Jira: [B2B-2842](https://bigcommercecloud.atlassian.net/browse/B2B-2842)

## What/Why?
<!--
  A description about what this pull request implements and its purpose.
  Try to be detailed and describe any technical details to simplify the job
  of the reviewer and the individual on production support.
-->
This PR adds the CSV extension as a fallback for uploads in the `B3Upload` component. This is to fix a bug where Firefox reports the wrong MIME type for CSV files on Windows machines with Excel installed.

It also includes some slight refactoring/cleanup.

## Rollout/Rollback
<!--
Detail how this change will be rolled out. Include reference to any
experiments and how the success will be measured as the experiment is
ramped.

Document rollback procedures. Is rolling back the change as simple as
rolling back an experiment or does it require reverting code? Are there
database migrations that may change our decision to roll forward instead of
back?
-->
Revert.

## Testing
<!--
Provide as much information as you can about how you tested and how another
Engineer can test your change. Include screenshots, or test run output
where appropriate.
-->

https://github.com/user-attachments/assets/03f23271-46e5-46cb-8099-4897d47bbf57



[B2B-2842]: https://bigcommercecloud.atlassian.net/browse/B2B-2842?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ