### PR TITLE
Fix silent fail on quick order add to cart

### DIFF
--- a/apps/storefront/src/pages/QuickOrder/components/QuickAdd.tsx
+++ b/apps/storefront/src/pages/QuickOrder/components/QuickAdd.tsx
@@ -385,6 +385,8 @@ export default function QuickAdd(props: AddToListContentProps) {
 
           updateList();
         }
+      } catch (error: unknown) {
+        snackbar.error((error as Error).message);
       } finally {
         setIsLoading(false);
       }


### PR DESCRIPTION
Jira: [JIRA_TOKEN](https://bigcommercecloud.atlassian.net/browse/JIRA_TOKEN)

## What/Why?
The quick order was silently failing under unexpected circumstances.
Try to define a minimum quantity for a product ad use the quick order.
The expected result is to receive an error. The actual result is a silent failure.

## Testing
- Create a product with a minimum quantity
- Use the quick order to add this product using a quantity below the minimum
- Expect to see an error
