### PR TITLE
refactor(orders): B2BCAT-39 Fork the table component for Orders

### DIFF
--- a/apps/storefront/src/pages/order/Order.tsx
+++ b/apps/storefront/src/pages/order/Order.tsx
@@ -387,13 +387,9 @@ function Order({ isCompanyOrder = false }: OrderProps) {
 
         <B3PaginationTable
           columnItems={columnItems}
-          rowsPerPageOptions={[10, 20, 30]}
           getRequestList={fetchList}
           searchParams={filterData || {}}
-          isCustomRender={false}
           requestLoading={setIsRequestLoading}
-          tableKey="orderId"
-          pageType="orderListPage"
           isAutoRefresh={isAutoRefresh}
           sortDirection={order}
           orderBy={orderBy}
@@ -413,7 +409,6 @@ function Order({ isCompanyOrder = false }: OrderProps) {
               goToDetail(item, index);
             }
           }}
-          hover
         />
       </Box>
     </B3Spin>

--- a/apps/storefront/src/pages/order/Order.tsx
+++ b/apps/storefront/src/pages/order/Order.tsx
@@ -399,16 +399,9 @@ function Order({ isCompanyOrder = false }: OrderProps) {
           orderBy={orderBy}
           sortByFn={handleSetOrderBy}
           renderItem={(row, index) => (
-            <OrderItemCard
-              key={row.orderId}
-              item={row}
-              index={index}
-              allTotal={allTotal}
-              filterData={filterData}
-              isCompanyOrder={isCompanyOrder}
-            />
+            <OrderItemCard key={row.orderId} goToDetail={() => goToDetail(row, index)} item={row} />
           )}
-          onClickRow={(item, index) => goToDetail(item, index)}
+          onClickRow={goToDetail}
         />
       </Box>
     </B3Spin>

--- a/apps/storefront/src/pages/order/Order.tsx
+++ b/apps/storefront/src/pages/order/Order.tsx
@@ -404,11 +404,7 @@ function Order({ isCompanyOrder = false }: OrderProps) {
               isCompanyOrder={isCompanyOrder}
             />
           )}
-          onClickRow={(item, index) => {
-            if (index !== undefined) {
-              goToDetail(item, index);
-            }
-          }}
+          onClickRow={(item, index) => goToDetail(item, index)}
         />
       </Box>
     </B3Spin>

--- a/apps/storefront/src/pages/order/Order.tsx
+++ b/apps/storefront/src/pages/order/Order.tsx
@@ -6,8 +6,6 @@ import { Box } from '@mui/material';
 import { B2BAutoCompleteCheckbox } from '@/components';
 import B3Filter from '@/components/filter/B3Filter';
 import B3Spin from '@/components/spin/B3Spin';
-import { B3PaginationTable, GetRequestList } from '@/components/table/B3PaginationTable';
-import { TableColumnItem } from '@/components/table/B3Table';
 import { useMobile, useSort } from '@/hooks';
 import {
   getB2BAllOrders,
@@ -22,6 +20,8 @@ import { currencyFormat, displayFormat, ordersCurrencyFormat } from '@/utils';
 
 import OrderStatus from './components/OrderStatus';
 import { orderStatusTranslationVariables } from './shared/getOrderStatus';
+import { B3PaginationTable, GetRequestList } from './table/B3PaginationTable';
+import { TableColumnItem } from './table/B3Table';
 import {
   defaultSortKey,
   FilterSearchProps,

--- a/apps/storefront/src/pages/order/Order.tsx
+++ b/apps/storefront/src/pages/order/Order.tsx
@@ -182,9 +182,16 @@ function Order({ isCompanyOrder = false }: OrderProps) {
     };
 
     initFilter();
-    // disabling as we only need to run this once and values at starting render are good enough
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectCompanyHierarchyId]);
+  }, [
+    b3Lang,
+    companyId,
+    currentCompanyId,
+    isAgenting,
+    isB2BUser,
+    isCompanyOrder,
+    role,
+    selectCompanyHierarchyId,
+  ]);
 
   const fetchList: GetRequestList<Partial<FilterSearchProps>, ListItem> = async (params) => {
     const { edges = [], totalCount } = isB2BUser
@@ -226,26 +233,24 @@ function Order({ isCompanyOrder = false }: OrderProps) {
       title: b3Lang('orders.company'),
       width: '10%',
       isSortable: false,
-      render: (item: ListItem) => {
-        const { companyInfo } = item;
-
+      render: ({ companyInfo }) => {
         return <Box>{companyInfo?.companyName || '–'}</Box>;
       },
     },
     {
       key: 'poNumber',
       title: b3Lang('orders.poReference'),
-      render: (item: ListItem) => <Box>{item.poNumber ? item.poNumber : '–'}</Box>,
+      render: ({ poNumber }) => <Box>{poNumber || '–'}</Box>,
       width: '10%',
       isSortable: true,
     },
     {
       key: 'totalIncTax',
       title: b3Lang('orders.grandTotal'),
-      render: (item: ListItem) =>
-        item?.money
-          ? ordersCurrencyFormat(JSON.parse(JSON.parse(item.money)), item.totalIncTax)
-          : currencyFormat(item.totalIncTax),
+      render: ({ money, totalIncTax }) =>
+        money
+          ? ordersCurrencyFormat(JSON.parse(JSON.parse(money)), totalIncTax)
+          : currencyFormat(totalIncTax),
       width: '8%',
       style: {
         textAlign: 'right',
@@ -255,8 +260,8 @@ function Order({ isCompanyOrder = false }: OrderProps) {
     {
       key: 'status',
       title: b3Lang('orders.orderStatus'),
-      render: (item: ListItem) => (
-        <OrderStatus text={getOrderStatusText(item.status, getOrderStatuses)} code={item.status} />
+      render: ({ status }) => (
+        <OrderStatus text={getOrderStatusText(status, getOrderStatuses)} code={status} />
       ),
       width: '10%',
       isSortable: true,
@@ -264,14 +269,14 @@ function Order({ isCompanyOrder = false }: OrderProps) {
     {
       key: 'placedBy',
       title: b3Lang('orders.placedBy'),
-      render: (item: ListItem) => `${item.firstName} ${item.lastName}`,
+      render: ({ firstName, lastName }) => `${firstName} ${lastName}`,
       width: '10%',
       isSortable: true,
     },
     {
       key: 'createdAt',
       title: b3Lang('orders.createdOn'),
-      render: (item: ListItem) => `${displayFormat(Number(item.createdAt))}`,
+      render: ({ createdAt }) => `${displayFormat(Number(createdAt))}`,
       width: '10%',
       isSortable: true,
     },

--- a/apps/storefront/src/pages/order/Order.tsx
+++ b/apps/storefront/src/pages/order/Order.tsx
@@ -21,7 +21,7 @@ import { currencyFormat, displayFormat, ordersCurrencyFormat } from '@/utils';
 import OrderStatus from './components/OrderStatus';
 import { orderStatusTranslationVariables } from './shared/getOrderStatus';
 import { B3PaginationTable, GetRequestList } from './table/B3PaginationTable';
-import { TableColumnItem } from './table/B3Table';
+import { PossibleNodeWrapper, TableColumnItem } from './table/B3Table';
 import {
   defaultSortKey,
   FilterSearchProps,
@@ -95,9 +95,9 @@ function useData() {
     isAgenting,
     isB2BUser,
     orderSubViewPermission,
-    selectCompanyHierarchyId,
+    selectCompanyHierarchyId: Number(selectCompanyHierarchyId),
     isEnabledCompanyHierarchy,
-    currentCompanyId,
+    currentCompanyId: Number(currentCompanyId),
     companyId,
   };
 }
@@ -133,7 +133,7 @@ function Order({ isCompanyOrder = false }: OrderProps) {
   useEffect(() => {
     const search = getInitFilter(isCompanyOrder, isB2BUser);
     if (isB2BUser) {
-      search.companyIds = [Number(selectCompanyHierarchyId) || Number(currentCompanyId)];
+      search.companyIds = [selectCompanyHierarchyId || currentCompanyId];
     }
     setFilterData(search);
     setIsAutoRefresh(true);
@@ -200,8 +200,9 @@ function Order({ isCompanyOrder = false }: OrderProps) {
 
     setAllTotal(totalCount);
     setIsAutoRefresh(false);
+
     return {
-      edges,
+      edges: edges.map((row: PossibleNodeWrapper<object>) => ('node' in row ? row.node : row)),
       totalCount,
     };
   };

--- a/apps/storefront/src/pages/order/Order.tsx
+++ b/apps/storefront/src/pages/order/Order.tsx
@@ -227,6 +227,7 @@ function Order({ isCompanyOrder = false }: OrderProps) {
       title: b3Lang('orders.order'),
       width: '10%',
       isSortable: true,
+      render: ({ orderId }) => orderId,
     },
     {
       key: 'companyName',
@@ -251,10 +252,8 @@ function Order({ isCompanyOrder = false }: OrderProps) {
         money
           ? ordersCurrencyFormat(JSON.parse(JSON.parse(money)), totalIncTax)
           : currencyFormat(totalIncTax),
+      align: 'right',
       width: '8%',
-      style: {
-        textAlign: 'right',
-      },
       isSortable: true,
     },
     {

--- a/apps/storefront/src/pages/order/OrderItemCard.tsx
+++ b/apps/storefront/src/pages/order/OrderItemCard.tsx
@@ -1,4 +1,3 @@
-import { useNavigate } from 'react-router-dom';
 import styled from '@emotion/styled';
 import { useTheme } from '@mui/material';
 import Box from '@mui/material/Box';
@@ -22,11 +21,8 @@ interface ListItem {
 }
 
 export interface OrderItemCardProps {
-  allTotal: number;
-  filterData: any;
-  index?: number;
+  goToDetail: () => void;
   item: ListItem;
-  isCompanyOrder: boolean;
 }
 
 const Flex = styled('div')(() => ({
@@ -37,28 +33,10 @@ const Flex = styled('div')(() => ({
   },
 }));
 
-export function OrderItemCard({
-  item,
-  allTotal,
-  filterData,
-  index = 0,
-  isCompanyOrder,
-}: OrderItemCardProps) {
+export function OrderItemCard({ item, goToDetail }: OrderItemCardProps) {
   const theme = useTheme();
   const isB2BUser = useAppSelector(isB2BUserSelector);
   const customer = useAppSelector(({ company }) => company.customer);
-  const navigate = useNavigate();
-
-  const goToDetail = (item: ListItem) => {
-    navigate(`/orderDetail/${item.orderId}`, {
-      state: {
-        currentIndex: index || 0,
-        searchParams: filterData,
-        totalCount: allTotal,
-        isCompanyOrder,
-      },
-    });
-  };
 
   const getName = (item: ListItem) => {
     if (isB2BUser) {
@@ -69,12 +47,7 @@ export function OrderItemCard({
 
   return (
     <Card key={item.orderId}>
-      <CardContent
-        sx={{
-          color: 'rgba(0, 0, 0, 0.6)',
-        }}
-        onClick={() => goToDetail(item)}
-      >
+      <CardContent sx={{ color: 'rgba(0, 0, 0, 0.6)' }} onClick={goToDetail}>
         <Flex className="between-flex">
           <Box
             sx={{

--- a/apps/storefront/src/pages/order/table/B3NoData.tsx
+++ b/apps/storefront/src/pages/order/table/B3NoData.tsx
@@ -2,41 +2,27 @@ import { useB3Lang } from '@b3/lang';
 import styled from '@emotion/styled';
 import { DataUsageRounded } from '@mui/icons-material';
 
-interface B3NoDataProps {
-  text?: string;
-  backgroundColor?: string;
-  minHeight?: string;
-  isLoading?: boolean;
-}
-
-const NoDataContainer = styled('div')(
-  ({ backgroundColor = '#fff', minHeight = '400px' }: B3NoDataProps) => ({
-    height: '100%',
-    minHeight,
-    backgroundColor,
-    display: 'flex',
-    justifyContent: 'center',
-    alignItems: 'center',
-    color: '#aaa',
-    fontSize: '18px',
-  }),
-);
+const NoDataContainer = styled('div')(() => ({
+  height: '100%',
+  minHeight: '400px',
+  backgroundColor: '#fff',
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+  color: '#aaa',
+  fontSize: '18px',
+}));
 
 const NoDataText = styled('span')(() => ({
   marginLeft: '10px',
 }));
 
-export default function B3NoData({
-  text,
-  backgroundColor,
-  minHeight,
-  isLoading = false,
-}: B3NoDataProps) {
+export default function B3NoData() {
   const b3Lang = useB3Lang();
   return (
-    <NoDataContainer backgroundColor={backgroundColor} minHeight={minHeight}>
-      {!isLoading && <DataUsageRounded fontSize="large" />}
-      <NoDataText>{isLoading ? '' : text || b3Lang('global.table.noData')}</NoDataText>
+    <NoDataContainer>
+      <DataUsageRounded fontSize="large" />
+      <NoDataText>{b3Lang('global.table.noData')}</NoDataText>
     </NoDataContainer>
   );
 }

--- a/apps/storefront/src/pages/order/table/B3NoData.tsx
+++ b/apps/storefront/src/pages/order/table/B3NoData.tsx
@@ -1,0 +1,42 @@
+import { useB3Lang } from '@b3/lang';
+import styled from '@emotion/styled';
+import { DataUsageRounded } from '@mui/icons-material';
+
+interface B3NoDataProps {
+  text?: string;
+  backgroundColor?: string;
+  minHeight?: string;
+  isLoading?: boolean;
+}
+
+const NoDataContainer = styled('div')(
+  ({ backgroundColor = '#fff', minHeight = '400px' }: B3NoDataProps) => ({
+    height: '100%',
+    minHeight,
+    backgroundColor,
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+    color: '#aaa',
+    fontSize: '18px',
+  }),
+);
+
+const NoDataText = styled('span')(() => ({
+  marginLeft: '10px',
+}));
+
+export default function B3NoData({
+  text,
+  backgroundColor,
+  minHeight,
+  isLoading = false,
+}: B3NoDataProps) {
+  const b3Lang = useB3Lang();
+  return (
+    <NoDataContainer backgroundColor={backgroundColor} minHeight={minHeight}>
+      {!isLoading && <DataUsageRounded fontSize="large" />}
+      <NoDataText>{isLoading ? '' : text || b3Lang('global.table.noData')}</NoDataText>
+    </NoDataContainer>
+  );
+}

--- a/apps/storefront/src/pages/order/table/B3PaginationTable.tsx
+++ b/apps/storefront/src/pages/order/table/B3PaginationTable.tsx
@@ -1,5 +1,4 @@
 import {
-  FC,
   ReactElement,
   Ref,
   useCallback,
@@ -226,26 +225,6 @@ function PaginationTable<GetRequestListParams, Row extends object>(
     [getList, getCacheList, getSelectedValue, refresh],
   );
 
-  const handleSelectAllItems = () => {
-    const singlePageCheckbox = () => {
-      if (selectCheckbox.length === list.length) {
-        setSelectCheckbox([]);
-      } else {
-        const selects: Array<string | number> = [];
-        list.forEach((item) => {
-          const option = isNodeWrapper(item) ? item.node : item;
-          if (option) {
-            // @ts-expect-error typed previously as an any
-            selects.push(option.id);
-          }
-        });
-        setSelectCheckbox(selects);
-      }
-    };
-
-    singlePageCheckbox();
-  };
-
   const handleSelectOneItem = (id: string | number) => {
     const selects = [...selectCheckbox];
     const index = selects.indexOf(id);
@@ -259,39 +238,16 @@ function PaginationTable<GetRequestListParams, Row extends object>(
 
   return (
     <B3Table
-      hover
       columnItems={columnItems || []}
       listItems={list}
       pagination={tablePagination}
-      rowsPerPageOptions={[10, 20, 30]}
       onPaginationChange={handlePaginationChange}
-      isCustomRender={false}
       isInfiniteScroll={isMobile}
       isLoading={loading}
       renderItem={renderItem}
-      tableFixed={false}
-      tableHeaderHide={false}
-      itemSpacing={2}
-      itemXs={4}
-      noDataText=""
-      tableKey="orderId"
-      itemIsMobileSpacing={2}
-      showCheckbox={false}
-      showSelectAllCheckbox={false}
-      disableCheckbox={false}
-      selectedSymbol="id"
-      isSelectOtherPageCheckbox={false}
-      isAllSelect={false}
       selectCheckbox={selectCheckbox}
-      handleSelectAllItems={handleSelectAllItems}
       handleSelectOneItem={handleSelectOneItem}
-      showBorder
-      labelRowsPerPage=""
       onClickRow={onClickRow}
-      showPagination
-      showRowsPerPageOptions
-      CollapseComponent={undefined}
-      applyAllDisableCheckbox
       sortDirection={sortDirection}
       sortByFn={sortByFn}
       orderBy={orderBy}

--- a/apps/storefront/src/pages/order/table/B3PaginationTable.tsx
+++ b/apps/storefront/src/pages/order/table/B3PaginationTable.tsx
@@ -35,7 +35,7 @@ export type GetRequestList<Params, Item extends object> =
   | GetRequestListSync<Params, Item>
   | GetRequestListAsync<Params, Item>;
 
-interface B3PaginationTableProps<GetRequestListParams, Row extends object> {
+interface B3PaginationTableProps<GetRequestListParams, Row extends Record<'orderId', string>> {
   columnItems?: TableColumnItem<Row>[];
   renderItem?: (row: Row, index?: number, checkBox?: () => ReactElement) => ReactElement;
   getRequestList: GetRequestList<GetRequestListParams, WithRowControls<Row>>;
@@ -48,7 +48,7 @@ interface B3PaginationTableProps<GetRequestListParams, Row extends object> {
   isAutoRefresh?: boolean;
 }
 
-function PaginationTable<GetRequestListParams, Row extends object>({
+function PaginationTable<GetRequestListParams, Row extends Record<'orderId', string>>({
   columnItems,
   getRequestList,
   searchParams,
@@ -169,7 +169,6 @@ function PaginationTable<GetRequestListParams, Row extends object>({
         fetchList();
       }
     }
-    // ignore pageType because is not a reactive value
   }, [fetchList, searchParams, selectCompanyHierarchyId, pagination, isAutoRefresh]);
 
   const handlePaginationChange = async (pagination: TablePagination) => {

--- a/apps/storefront/src/pages/order/table/B3PaginationTable.tsx
+++ b/apps/storefront/src/pages/order/table/B3PaginationTable.tsx
@@ -41,7 +41,7 @@ interface B3PaginationTableProps<GetRequestListParams, Row extends Record<'order
   getRequestList: GetRequestList<GetRequestListParams, WithRowControls<Row>>;
   searchParams: GetRequestListParams & { createdBy?: string };
   requestLoading?: (bool: boolean) => void;
-  onClickRow?: (row: Row, index?: number) => void;
+  onClickRow: (row: Row, index?: number) => void;
   sortDirection?: 'asc' | 'desc';
   sortByFn?: (e: { key: string }) => void;
   orderBy?: string;
@@ -108,7 +108,7 @@ function PaginationTable<GetRequestListParams, Row extends Record<'orderId', str
   const fetchList = useCallback(
     async (b3Pagination?: TablePagination, isRefresh?: boolean) => {
       try {
-        if (cache?.current && isEqual(cache.current, searchParams) && !isRefresh && !b3Pagination) {
+        if (cache.current && isEqual(cache.current, searchParams) && !isRefresh && !b3Pagination) {
           return;
         }
         cache.current = searchParams;

--- a/apps/storefront/src/pages/order/table/B3PaginationTable.tsx
+++ b/apps/storefront/src/pages/order/table/B3PaginationTable.tsx
@@ -37,7 +37,7 @@ export type GetRequestList<Params, Item extends object> =
 
 interface B3PaginationTableProps<GetRequestListParams, Row extends Record<'orderId', string>> {
   columnItems?: TableColumnItem<Row>[];
-  renderItem?: (row: Row, index?: number, checkBox?: () => ReactElement) => ReactElement;
+  renderItem?: (row: Row, index?: number) => ReactElement;
   getRequestList: GetRequestList<GetRequestListParams, WithRowControls<Row>>;
   searchParams: GetRequestListParams & { createdBy?: string };
   requestLoading: (bool: boolean) => void;

--- a/apps/storefront/src/pages/order/table/B3PaginationTable.tsx
+++ b/apps/storefront/src/pages/order/table/B3PaginationTable.tsx
@@ -37,7 +37,7 @@ export type GetRequestList<Params, Item extends object> =
 
 interface B3PaginationTableProps<GetRequestListParams, Row extends Record<'orderId', string>> {
   columnItems?: TableColumnItem<Row>[];
-  renderItem?: (row: Row, index?: number) => ReactElement;
+  renderItem: (row: Row, index: number) => ReactElement;
   getRequestList: GetRequestList<GetRequestListParams, WithRowControls<Row>>;
   searchParams: GetRequestListParams & { createdBy?: string };
   requestLoading: (bool: boolean) => void;
@@ -76,7 +76,7 @@ function PaginationTable<GetRequestListParams, Row extends Record<'orderId', str
 
   const [cacheAllList, setCacheAllList] = useState<PossibleNodeWrapper<WithRowControls<Row>>[]>([]);
 
-  const [list, setList] = useState<PossibleNodeWrapper<WithRowControls<Row>>[]>([]);
+  const [list, setList] = useState<WithRowControls<Row>[]>([]);
 
   const [isMobile] = useMobile();
 
@@ -132,7 +132,7 @@ function PaginationTable<GetRequestListParams, Row extends Record<'orderId', str
         const requestList = await getRequestList(params);
         const { edges, totalCount } = requestList;
 
-        setList(edges);
+        setList(edges.map((row) => (isNodeWrapper(row) ? row.node : row)));
 
         cacheList(edges);
 

--- a/apps/storefront/src/pages/order/table/B3PaginationTable.tsx
+++ b/apps/storefront/src/pages/order/table/B3PaginationTable.tsx
@@ -1,0 +1,422 @@
+import {
+  FC,
+  ReactElement,
+  Ref,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  useState,
+} from 'react';
+import isEmpty from 'lodash-es/isEmpty';
+import isEqual from 'lodash-es/isEqual';
+
+import { useMobile } from '@/hooks';
+import { useAppSelector } from '@/store';
+import { forwardRefWithGenerics, memoWithGenerics } from '@/utils';
+
+import {
+  B3Table,
+  isNodeWrapper,
+  PossibleNodeWrapper,
+  TableColumnItem,
+  WithRowControls,
+} from './B3Table';
+
+export interface TablePagination {
+  offset: number;
+  first: number;
+}
+
+interface GetRequestListResult<T extends object> {
+  edges: PossibleNodeWrapper<T>[];
+  totalCount: number;
+}
+
+type GetRequestListSync<Params, Item extends object> = (
+  params: Params,
+) => GetRequestListResult<Item>;
+type GetRequestListAsync<Params, Item extends object> = (
+  params: Params,
+) => Promise<GetRequestListResult<Item>>;
+
+export type GetRequestList<Params, Item extends object> =
+  | GetRequestListSync<Params, Item>
+  | GetRequestListAsync<Params, Item>;
+
+interface B3PaginationTableProps<GetRequestListParams, Row extends object> {
+  tableFixed?: boolean;
+  columnItems?: TableColumnItem<Row>[];
+  tableHeaderHide?: boolean;
+  itemSpacing?: number;
+  itemXs?: number;
+  rowsPerPageOptions?: number[];
+  showPagination?: boolean;
+  renderItem?: (row: Row, index?: number, checkBox?: () => ReactElement) => ReactElement;
+  CollapseComponent?: FC<{ row: Row }>;
+  isCustomRender?: boolean;
+  noDataText?: string;
+  tableKey?: string;
+  getRequestList: GetRequestList<GetRequestListParams, WithRowControls<Row>>;
+  searchParams: GetRequestListParams & { createdBy?: string };
+  requestLoading?: (bool: boolean) => void;
+  showCheckbox?: boolean;
+  showSelectAllCheckbox?: boolean;
+  selectedSymbol?: string;
+  isSelectOtherPageCheckbox?: boolean;
+  showBorder?: boolean;
+  getSelectCheckbox?: (arr: Array<string | number>) => void;
+  hover?: boolean;
+  labelRowsPerPage?: string;
+  itemIsMobileSpacing?: number;
+  disableCheckbox?: boolean;
+  applyAllDisableCheckbox?: boolean;
+  onClickRow?: (row: Row, index?: number) => void;
+  showRowsPerPageOptions?: boolean;
+  sortDirection?: 'asc' | 'desc';
+  sortByFn?: (e: { key: string }) => void;
+  orderBy?: string;
+  pageType?: string;
+  isAutoRefresh?: boolean;
+}
+
+function PaginationTable<GetRequestListParams, Row extends object>(
+  {
+    columnItems,
+    isCustomRender = false,
+    tableKey,
+    renderItem,
+    noDataText = '',
+    tableFixed = false,
+    tableHeaderHide = false,
+    rowsPerPageOptions = [10, 20, 30],
+    itemSpacing = 2,
+    itemXs = 4,
+    getRequestList,
+    searchParams,
+    requestLoading,
+    showCheckbox = false,
+    showSelectAllCheckbox = false,
+    selectedSymbol = 'id',
+    isSelectOtherPageCheckbox = false,
+    showBorder = true,
+    getSelectCheckbox,
+    hover = false,
+    labelRowsPerPage = '',
+    itemIsMobileSpacing = 2,
+    disableCheckbox = false,
+    onClickRow,
+    showPagination = true,
+    showRowsPerPageOptions = true,
+    CollapseComponent,
+    applyAllDisableCheckbox = true,
+    sortDirection = 'asc',
+    sortByFn = () => {},
+    orderBy = '',
+    pageType = '',
+    isAutoRefresh = true,
+  }: B3PaginationTableProps<GetRequestListParams, Row>,
+  ref?: Ref<unknown>,
+) {
+  const initPagination = {
+    offset: 0,
+    first: rowsPerPageOptions[0],
+  };
+
+  const { selectCompanyHierarchyId } = useAppSelector(
+    ({ company }) => company.companyHierarchyInfo,
+  );
+  const selectCompanyHierarchyIdCache = useRef(selectCompanyHierarchyId);
+
+  const cache = useRef<GetRequestListParams | null>(null);
+
+  const [loading, setLoading] = useState<boolean>();
+
+  const [pagination, setPagination] = useState<TablePagination>(initPagination);
+
+  const [count, setAllCount] = useState<number>(0);
+
+  const [isAllSelect, setAllSelect] = useState<boolean>(false);
+
+  const [cacheAllList, setCacheAllList] = useState<PossibleNodeWrapper<WithRowControls<Row>>[]>([]);
+
+  const [list, setList] = useState<PossibleNodeWrapper<WithRowControls<Row>>[]>([]);
+
+  const [selectCheckbox, setSelectCheckbox] = useState<Array<string | number>>([]);
+
+  const [isMobile] = useMobile();
+
+  const cacheList = useCallback(
+    (edges: PossibleNodeWrapper<WithRowControls<Row>>[]) => {
+      if (!cacheAllList.length) setCacheAllList(edges);
+
+      const copyCacheAllList = [...cacheAllList];
+
+      edges.forEach((item) => {
+        const option = isNodeWrapper(item) ? item.node : item;
+        const isExist = cacheAllList.some((cache) => {
+          const cacheOption = isNodeWrapper(cache) ? cache.node : cache;
+          // @ts-expect-error typed previously as an any
+          return cacheOption[selectedSymbol] === option[selectedSymbol];
+        });
+
+        if (!isExist) {
+          copyCacheAllList.push(item);
+        }
+      });
+
+      setCacheAllList(copyCacheAllList);
+    },
+    [cacheAllList, selectedSymbol],
+  );
+
+  const fetchList = useCallback(
+    async (b3Pagination?: TablePagination, isRefresh?: boolean) => {
+      try {
+        if (cache?.current && isEqual(cache.current, searchParams) && !isRefresh && !b3Pagination) {
+          return;
+        }
+        cache.current = searchParams;
+
+        setLoading(true);
+        if (requestLoading) requestLoading(true);
+        const { createdBy = '' } = searchParams;
+
+        const getEmailReg = /\((.+)\)/g;
+        const getCreatedByReg = /^[^(]+/;
+        const emailRegArr = getEmailReg.exec(createdBy);
+        const createdByUserRegArr = getCreatedByReg.exec(createdBy);
+        const createdByUser = createdByUserRegArr?.length ? createdByUserRegArr[0].trim() : '';
+        const newSearchParams = {
+          ...searchParams,
+          createdBy: createdByUser,
+          email: emailRegArr?.length ? emailRegArr[1] : '',
+        };
+        const params = {
+          ...newSearchParams,
+          first: b3Pagination?.first || pagination.first,
+          offset: b3Pagination?.offset || 0,
+        };
+        const requestList = await getRequestList(params);
+        const { edges, totalCount } = requestList;
+
+        setList(edges);
+
+        cacheList(edges);
+
+        if (!isSelectOtherPageCheckbox) setSelectCheckbox([]);
+
+        if (!b3Pagination) {
+          setPagination({
+            first: pagination.first,
+            offset: 0,
+          });
+        }
+
+        setAllCount(totalCount);
+        setLoading(false);
+        if (requestLoading) requestLoading(false);
+      } catch (e) {
+        setLoading(false);
+        if (requestLoading) requestLoading(false);
+      }
+    },
+    [
+      cacheList,
+      getRequestList,
+      isSelectOtherPageCheckbox,
+      pagination.first,
+      requestLoading,
+      searchParams,
+    ],
+  );
+
+  const refresh = useCallback(() => {
+    fetchList(pagination, true);
+  }, [fetchList, pagination]);
+
+  useEffect(() => {
+    const isChangeCompany =
+      Number(selectCompanyHierarchyIdCache.current) !== Number(selectCompanyHierarchyId);
+    if (!isEmpty(searchParams)) {
+      if (isChangeCompany) {
+        if (isAutoRefresh) fetchList(pagination, true);
+        selectCompanyHierarchyIdCache.current = selectCompanyHierarchyId;
+      } else {
+        if (isAutoRefresh && pageType === 'orderListPage') fetchList(pagination, true);
+        fetchList();
+      }
+    }
+    // ignore pageType because is not a reactive value
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [fetchList, searchParams, selectCompanyHierarchyId, pagination, isAutoRefresh]);
+
+  useEffect(() => {
+    if (getSelectCheckbox) getSelectCheckbox(selectCheckbox);
+    // disabling as getSelectCheckbox will trigger rerenders if the user passes a function that is not memoized
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectCheckbox, list]);
+
+  const handlePaginationChange = async (pagination: TablePagination) => {
+    await fetchList(pagination);
+    setPagination(pagination);
+  };
+
+  const tablePagination = {
+    ...pagination,
+    count,
+  };
+
+  const getSelectedValue = useCallback(
+    () => ({
+      selectCheckbox,
+    }),
+    [selectCheckbox],
+  );
+
+  const getList = useCallback(() => list, [list]);
+
+  const getCacheList = useCallback(() => cacheAllList, [cacheAllList]);
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      getSelectedValue,
+      setList,
+      setCacheAllList,
+      getList,
+      getCacheList,
+      refresh,
+    }),
+    [getList, getCacheList, getSelectedValue, refresh],
+  );
+
+  const getCurrentAllItemsSelect = useCallback(() => {
+    if (!selectCheckbox.length) return false;
+    return list.every((item) => {
+      const option = isNodeWrapper(item) ? item.node : item;
+
+      // @ts-expect-error typed previously as an any
+      return selectCheckbox.includes(option[selectedSymbol]);
+    });
+  }, [list, selectCheckbox, selectedSymbol]);
+
+  useEffect(() => {
+    if (isSelectOtherPageCheckbox) {
+      const flag = getCurrentAllItemsSelect();
+      setAllSelect(flag);
+    }
+  }, [selectCheckbox, pagination, isSelectOtherPageCheckbox, getCurrentAllItemsSelect]);
+
+  const handleSelectAllItems = () => {
+    const singlePageCheckbox = () => {
+      if (selectCheckbox.length === list.length) {
+        setSelectCheckbox([]);
+      } else {
+        const selects: Array<string | number> = [];
+        list.forEach((item) => {
+          const option = isNodeWrapper(item) ? item.node : item;
+          if (option) {
+            if (pageType === 'shoppingListDetailsTable') {
+              selects.push(
+                // @ts-expect-error typed previously as an any
+                option.quantity > 0 || !option.disableCurrentCheckbox ? option[selectedSymbol] : '',
+              );
+            } else {
+              // @ts-expect-error typed previously as an any
+              selects.push(option[selectedSymbol]);
+            }
+          }
+        });
+        setSelectCheckbox(selects);
+      }
+    };
+
+    const otherPageCheckbox = () => {
+      const flag = getCurrentAllItemsSelect();
+
+      const newSelectCheckbox = [...selectCheckbox];
+      if (flag) {
+        list.forEach((item) => {
+          const option = isNodeWrapper(item) ? item.node : item;
+          // @ts-expect-error typed previously as an any
+          const index = newSelectCheckbox.findIndex((item) => item === option[selectedSymbol]);
+          newSelectCheckbox.splice(index, 1);
+        });
+      } else {
+        list.forEach((item: PossibleNodeWrapper<Row>) => {
+          const option = isNodeWrapper(item) ? item.node : item;
+          // @ts-expect-error typed previously as an any
+          if (!selectCheckbox.includes(option[selectedSymbol])) {
+            // @ts-expect-error typed previously as an any
+            newSelectCheckbox.push(option[selectedSymbol]);
+          }
+        });
+      }
+
+      setSelectCheckbox(newSelectCheckbox);
+    };
+
+    if (isSelectOtherPageCheckbox) {
+      otherPageCheckbox();
+    } else {
+      singlePageCheckbox();
+    }
+  };
+
+  const handleSelectOneItem = (id: string | number) => {
+    const selects = [...selectCheckbox];
+    const index = selects.indexOf(id);
+    if (index !== -1) {
+      selects.splice(index, 1);
+    } else {
+      selects.push(id);
+    }
+    setSelectCheckbox(selects);
+  };
+
+  return (
+    <B3Table
+      hover={hover}
+      columnItems={columnItems || []}
+      listItems={list}
+      pagination={tablePagination}
+      rowsPerPageOptions={rowsPerPageOptions}
+      onPaginationChange={handlePaginationChange}
+      isCustomRender={isCustomRender}
+      isInfiniteScroll={isMobile}
+      isLoading={loading}
+      renderItem={renderItem}
+      tableFixed={tableFixed}
+      tableHeaderHide={tableHeaderHide}
+      itemSpacing={itemSpacing}
+      itemXs={itemXs}
+      noDataText={noDataText}
+      tableKey={tableKey}
+      itemIsMobileSpacing={itemIsMobileSpacing}
+      showCheckbox={showCheckbox}
+      showSelectAllCheckbox={showSelectAllCheckbox}
+      disableCheckbox={disableCheckbox}
+      selectedSymbol={selectedSymbol}
+      isSelectOtherPageCheckbox={isSelectOtherPageCheckbox}
+      isAllSelect={isAllSelect}
+      selectCheckbox={selectCheckbox}
+      handleSelectAllItems={handleSelectAllItems}
+      handleSelectOneItem={handleSelectOneItem}
+      showBorder={showBorder}
+      labelRowsPerPage={labelRowsPerPage}
+      onClickRow={onClickRow}
+      showPagination={showPagination}
+      showRowsPerPageOptions={showRowsPerPageOptions}
+      CollapseComponent={CollapseComponent}
+      applyAllDisableCheckbox={applyAllDisableCheckbox}
+      sortDirection={sortDirection}
+      sortByFn={sortByFn}
+      orderBy={orderBy}
+    />
+  );
+}
+
+const B3PaginationTable = memoWithGenerics(forwardRefWithGenerics(PaginationTable));
+
+export { B3PaginationTable };

--- a/apps/storefront/src/pages/order/table/B3PaginationTable.tsx
+++ b/apps/storefront/src/pages/order/table/B3PaginationTable.tsx
@@ -40,7 +40,7 @@ interface B3PaginationTableProps<GetRequestListParams, Row extends Record<'order
   renderItem?: (row: Row, index?: number, checkBox?: () => ReactElement) => ReactElement;
   getRequestList: GetRequestList<GetRequestListParams, WithRowControls<Row>>;
   searchParams: GetRequestListParams & { createdBy?: string };
-  requestLoading?: (bool: boolean) => void;
+  requestLoading: (bool: boolean) => void;
   onClickRow: (row: Row, index?: number) => void;
   sortDirection?: 'asc' | 'desc';
   sortByFn?: (e: { key: string }) => void;
@@ -66,8 +66,6 @@ function PaginationTable<GetRequestListParams, Row extends Record<'orderId', str
   const selectCompanyHierarchyIdCache = useRef(selectCompanyHierarchyId);
 
   const cache = useRef<GetRequestListParams | null>(null);
-
-  const [loading, setLoading] = useState<boolean>();
 
   const [pagination, setPagination] = useState<TablePagination>({
     offset: 0,
@@ -113,8 +111,7 @@ function PaginationTable<GetRequestListParams, Row extends Record<'orderId', str
         }
         cache.current = searchParams;
 
-        setLoading(true);
-        if (requestLoading) requestLoading(true);
+        requestLoading(true);
         const { createdBy = '' } = searchParams;
 
         const getEmailReg = /\((.+)\)/g;
@@ -147,11 +144,9 @@ function PaginationTable<GetRequestListParams, Row extends Record<'orderId', str
         }
 
         setAllCount(totalCount);
-        setLoading(false);
-        if (requestLoading) requestLoading(false);
+        requestLoading(false);
       } catch (e) {
-        setLoading(false);
-        if (requestLoading) requestLoading(false);
+        requestLoading(false);
       }
     },
     [cacheList, getRequestList, pagination.first, requestLoading, searchParams],
@@ -188,7 +183,6 @@ function PaginationTable<GetRequestListParams, Row extends Record<'orderId', str
       pagination={tablePagination}
       onPaginationChange={handlePaginationChange}
       isInfiniteScroll={isMobile}
-      isLoading={loading}
       renderItem={renderItem}
       onClickRow={onClickRow}
       sortDirection={sortDirection}

--- a/apps/storefront/src/pages/order/table/B3PaginationTable.tsx
+++ b/apps/storefront/src/pages/order/table/B3PaginationTable.tsx
@@ -1,18 +1,10 @@
-import {
-  ReactElement,
-  Ref,
-  useCallback,
-  useEffect,
-  useImperativeHandle,
-  useRef,
-  useState,
-} from 'react';
+import { ReactElement, useCallback, useEffect, useRef, useState } from 'react';
 import isEmpty from 'lodash-es/isEmpty';
 import isEqual from 'lodash-es/isEqual';
 
 import { useMobile } from '@/hooks';
 import { useAppSelector } from '@/store';
-import { forwardRefWithGenerics, memoWithGenerics } from '@/utils';
+import { memoWithGenerics } from '@/utils';
 
 import {
   B3Table,
@@ -56,21 +48,18 @@ interface B3PaginationTableProps<GetRequestListParams, Row extends object> {
   isAutoRefresh?: boolean;
 }
 
-function PaginationTable<GetRequestListParams, Row extends object>(
-  {
-    columnItems,
-    getRequestList,
-    searchParams,
-    requestLoading,
-    isAutoRefresh = true,
-    sortDirection = 'asc',
-    orderBy = '',
-    sortByFn = () => {},
-    renderItem,
-    onClickRow,
-  }: B3PaginationTableProps<GetRequestListParams, Row>,
-  ref?: Ref<unknown>,
-) {
+function PaginationTable<GetRequestListParams, Row extends object>({
+  columnItems,
+  getRequestList,
+  searchParams,
+  requestLoading,
+  isAutoRefresh = true,
+  sortDirection = 'asc',
+  orderBy = '',
+  sortByFn = () => {},
+  renderItem,
+  onClickRow,
+}: B3PaginationTableProps<GetRequestListParams, Row>) {
   const { selectCompanyHierarchyId } = useAppSelector(
     ({ company }) => company.companyHierarchyInfo,
   );
@@ -90,8 +79,6 @@ function PaginationTable<GetRequestListParams, Row extends object>(
   const [cacheAllList, setCacheAllList] = useState<PossibleNodeWrapper<WithRowControls<Row>>[]>([]);
 
   const [list, setList] = useState<PossibleNodeWrapper<WithRowControls<Row>>[]>([]);
-
-  const [selectCheckbox, setSelectCheckbox] = useState<Array<string | number>>([]);
 
   const [isMobile] = useMobile();
 
@@ -152,8 +139,6 @@ function PaginationTable<GetRequestListParams, Row extends object>(
 
         cacheList(edges);
 
-        setSelectCheckbox([]);
-
         if (!b3Pagination) {
           setPagination({
             first: pagination.first,
@@ -171,10 +156,6 @@ function PaginationTable<GetRequestListParams, Row extends object>(
     },
     [cacheList, getRequestList, pagination.first, requestLoading, searchParams],
   );
-
-  const refresh = useCallback(() => {
-    fetchList(pagination, true);
-  }, [fetchList, pagination]);
 
   useEffect(() => {
     const isChangeCompany =
@@ -201,41 +182,6 @@ function PaginationTable<GetRequestListParams, Row extends object>(
     count,
   };
 
-  const getSelectedValue = useCallback(
-    () => ({
-      selectCheckbox,
-    }),
-    [selectCheckbox],
-  );
-
-  const getList = useCallback(() => list, [list]);
-
-  const getCacheList = useCallback(() => cacheAllList, [cacheAllList]);
-
-  useImperativeHandle(
-    ref,
-    () => ({
-      getSelectedValue,
-      setList,
-      setCacheAllList,
-      getList,
-      getCacheList,
-      refresh,
-    }),
-    [getList, getCacheList, getSelectedValue, refresh],
-  );
-
-  const handleSelectOneItem = (id: string | number) => {
-    const selects = [...selectCheckbox];
-    const index = selects.indexOf(id);
-    if (index !== -1) {
-      selects.splice(index, 1);
-    } else {
-      selects.push(id);
-    }
-    setSelectCheckbox(selects);
-  };
-
   return (
     <B3Table
       columnItems={columnItems || []}
@@ -245,8 +191,6 @@ function PaginationTable<GetRequestListParams, Row extends object>(
       isInfiniteScroll={isMobile}
       isLoading={loading}
       renderItem={renderItem}
-      selectCheckbox={selectCheckbox}
-      handleSelectOneItem={handleSelectOneItem}
       onClickRow={onClickRow}
       sortDirection={sortDirection}
       sortByFn={sortByFn}
@@ -255,6 +199,6 @@ function PaginationTable<GetRequestListParams, Row extends object>(
   );
 }
 
-const B3PaginationTable = memoWithGenerics(forwardRefWithGenerics(PaginationTable));
+const B3PaginationTable = memoWithGenerics(PaginationTable);
 
 export { B3PaginationTable };

--- a/apps/storefront/src/pages/order/table/B3PaginationTable.tsx
+++ b/apps/storefront/src/pages/order/table/B3PaginationTable.tsx
@@ -41,7 +41,7 @@ interface B3PaginationTableProps<GetRequestListParams, Row extends Record<'order
   getRequestList: GetRequestList<GetRequestListParams, WithRowControls<Row>>;
   searchParams: GetRequestListParams & { createdBy?: string };
   requestLoading: (bool: boolean) => void;
-  onClickRow: (row: Row, index?: number) => void;
+  onClickRow: (row: Row, index: number) => void;
   sortDirection?: 'asc' | 'desc';
   sortByFn?: (e: { key: string }) => void;
   orderBy?: string;

--- a/apps/storefront/src/pages/order/table/B3PaginationTable.tsx
+++ b/apps/storefront/src/pages/order/table/B3PaginationTable.tsx
@@ -6,13 +6,7 @@ import { useMobile } from '@/hooks';
 import { useAppSelector } from '@/store';
 import { memoWithGenerics } from '@/utils';
 
-import {
-  B3Table,
-  isNodeWrapper,
-  PossibleNodeWrapper,
-  TableColumnItem,
-  WithRowControls,
-} from './B3Table';
+import { B3Table, isNodeWrapper, TableColumnItem, WithRowControls } from './B3Table';
 
 export interface TablePagination {
   offset: number;
@@ -20,7 +14,7 @@ export interface TablePagination {
 }
 
 interface GetRequestListResult<T extends object> {
-  edges: PossibleNodeWrapper<T>[];
+  edges: T[];
   totalCount: number;
 }
 
@@ -74,14 +68,14 @@ function PaginationTable<GetRequestListParams, Row extends Record<'orderId', str
 
   const [count, setAllCount] = useState<number>(0);
 
-  const [cacheAllList, setCacheAllList] = useState<PossibleNodeWrapper<WithRowControls<Row>>[]>([]);
+  const [cacheAllList, setCacheAllList] = useState<WithRowControls<Row>[]>([]);
 
   const [list, setList] = useState<WithRowControls<Row>[]>([]);
 
   const [isMobile] = useMobile();
 
   const cacheList = useCallback(
-    (edges: PossibleNodeWrapper<WithRowControls<Row>>[]) => {
+    (edges: WithRowControls<Row>[]) => {
       if (!cacheAllList.length) setCacheAllList(edges);
 
       const copyCacheAllList = [...cacheAllList];
@@ -132,7 +126,7 @@ function PaginationTable<GetRequestListParams, Row extends Record<'orderId', str
         const requestList = await getRequestList(params);
         const { edges, totalCount } = requestList;
 
-        setList(edges.map((row) => (isNodeWrapper(row) ? row.node : row)));
+        setList(edges);
 
         cacheList(edges);
 

--- a/apps/storefront/src/pages/order/table/B3Table.tsx
+++ b/apps/storefront/src/pages/order/table/B3Table.tsx
@@ -41,7 +41,11 @@ export interface Pagination {
   count: number;
 }
 
-export interface TableColumnItem<Row> {
+interface OrderIdRow {
+  orderId: string;
+}
+
+export interface TableColumnItem<Row extends OrderIdRow> {
   key: string;
   title: string;
   width?: string;
@@ -50,7 +54,7 @@ export interface TableColumnItem<Row> {
   isSortable?: boolean;
 }
 
-interface RowProps<Row> {
+interface RowProps<Row extends OrderIdRow> {
   columnItems: TableColumnItem<Row>[];
   node: WithRowControls<Row>;
   index: number;
@@ -62,7 +66,13 @@ const MOUSE_POINTER_STYLE = {
   cursor: 'pointer',
 };
 
-function Row<Row>({ columnItems, node, index, clickableRowStyles, onClickRow }: RowProps<Row>) {
+function Row<Row extends OrderIdRow>({
+  columnItems,
+  node,
+  index,
+  clickableRowStyles,
+  onClickRow,
+}: RowProps<Row>) {
   return (
     <TableRow
       hover
@@ -87,7 +97,7 @@ function Row<Row>({ columnItems, node, index, clickableRowStyles, onClickRow }: 
   );
 }
 
-interface TableProps<Row> {
+interface TableProps<Row extends OrderIdRow> {
   columnItems: TableColumnItem<Row>[];
   listItems: PossibleNodeWrapper<WithRowControls<Row>>[];
   onPaginationChange?: (pagination: Pagination) => void;
@@ -95,14 +105,13 @@ interface TableProps<Row> {
   renderItem?: (row: Row, index?: number) => ReactElement;
   isInfiniteScroll?: boolean;
   isLoading?: boolean;
-  setNeedUpdate?: (boolean: boolean) => void;
   onClickRow?: (row: Row, index?: number) => void;
   sortDirection?: 'asc' | 'desc';
   sortByFn?: (e: { key: string }) => void;
   orderBy?: string;
 }
 
-export function B3Table<Row>({
+export function B3Table<Row extends OrderIdRow>({
   columnItems,
   listItems = [],
   pagination = {
@@ -114,7 +123,6 @@ export function B3Table<Row>({
   renderItem,
   isInfiniteScroll = false,
   isLoading = false,
-  setNeedUpdate = () => {},
   onClickRow,
   sortDirection = 'asc',
   sortByFn,
@@ -148,8 +156,6 @@ export function B3Table<Row>({
       ...pagination,
       offset: page * first,
     });
-
-    setNeedUpdate(true);
   };
 
   const handleChangeRowsPerPage = (event: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) => {
@@ -169,8 +175,7 @@ export function B3Table<Row>({
               const node = isNodeWrapper(row) ? row.node : row;
 
               return (
-                // @ts-expect-error typed previously as an any
-                <Grid item xs={12} key={`${node.orderId + index}`}>
+                <Grid item xs={12} key={node.orderId}>
                   {node && renderItem && renderItem(node, index)}
                 </Grid>
               );
@@ -251,8 +256,7 @@ export function B3Table<Row>({
 
                   return (
                     <Row
-                      // @ts-expect-error typed previously as an any
-                      key={`row-${node.orderId + index}`}
+                      key={`row-${node.orderId}`}
                       columnItems={columnItems}
                       node={node}
                       index={index}

--- a/apps/storefront/src/pages/order/table/B3Table.tsx
+++ b/apps/storefront/src/pages/order/table/B3Table.tsx
@@ -1,0 +1,522 @@
+import { ChangeEvent, FC, MouseEvent, ReactElement, ReactNode, useContext, useState } from 'react';
+import { useB3Lang } from '@b3/lang';
+import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
+import KeyboardArrowRightIcon from '@mui/icons-material/KeyboardArrowRight';
+import {
+  Box,
+  Card,
+  Checkbox,
+  Collapse,
+  Grid,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TablePagination,
+  TableRow,
+} from '@mui/material';
+import IconButton from '@mui/material/IconButton';
+import TableSortLabel from '@mui/material/TableSortLabel';
+
+import { b3HexToRgb, getContrastColor } from '@/components/outSideComponents/utils/b3CustomStyles';
+import { useMobile } from '@/hooks';
+import { CustomStyleContext } from '@/shared/customStyleButton';
+
+import B3NoData from './B3NoData';
+
+interface NodeWrapper<T extends object> {
+  node: T;
+}
+
+export type PossibleNodeWrapper<T extends object> = T | NodeWrapper<T>;
+
+export const isNodeWrapper = <T extends object>(
+  item: PossibleNodeWrapper<T>,
+): item is NodeWrapper<T> => 'node' in item;
+
+export type WithRowControls<T> = T & {
+  id?: string | number;
+  isCollapse?: boolean;
+  disableCurrentCheckbox?: boolean;
+};
+
+export interface Pagination {
+  offset: number;
+  first: number;
+  count: number;
+}
+
+export interface TableColumnItem<Row> {
+  key: string;
+  title: string;
+  width?: string;
+  render?: (row: Row, index: number) => ReactNode;
+  style?: { [key: string]: string };
+  isSortable?: boolean;
+}
+
+interface TableProps<Row> {
+  tableFixed?: boolean;
+  tableHeaderHide?: boolean;
+  columnItems: TableColumnItem<Row>[];
+  listItems: PossibleNodeWrapper<WithRowControls<Row>>[];
+  itemSpacing?: number;
+  itemIsMobileSpacing?: number;
+  itemXs?: number;
+  onPaginationChange?: (pagination: Pagination) => void;
+  pagination?: Pagination;
+  rowsPerPageOptions?: number[];
+  showPagination?: boolean;
+  renderItem?: (
+    row: Row,
+    index?: number,
+    checkBox?: (disable?: boolean) => ReactElement,
+  ) => ReactElement;
+  CollapseComponent?: FC<{ row: Row }>;
+  isCustomRender?: boolean;
+  isInfiniteScroll?: boolean;
+  isLoading?: boolean;
+  noDataText?: string;
+  tableKey?: string;
+  showCheckbox?: boolean;
+  showSelectAllCheckbox?: boolean;
+  setNeedUpdate?: (boolean: boolean) => void;
+  handleSelectAllItems?: () => void;
+  handleSelectOneItem?: (id: number | string) => void;
+  hover?: boolean;
+  showBorder?: boolean;
+  selectedSymbol?: string;
+  selectCheckbox?: Array<number | string>;
+  labelRowsPerPage?: string;
+  disableCheckbox?: boolean;
+  applyAllDisableCheckbox?: boolean;
+  onClickRow?: (row: Row, index?: number) => void;
+  showRowsPerPageOptions?: boolean;
+  isSelectOtherPageCheckbox?: boolean;
+  isAllSelect?: boolean;
+  sortDirection?: 'asc' | 'desc';
+  sortByFn?: (e: { key: string }) => void;
+  orderBy?: string;
+}
+
+interface RowProps<Row> {
+  CollapseComponent?: FC<{ row: Row }>;
+  columnItems: TableColumnItem<Row>[];
+  node: WithRowControls<Row>;
+  index: number;
+  showBorder?: boolean;
+  showCheckbox?: boolean;
+  selectedSymbol?: string;
+  selectCheckbox?: Array<number | string>;
+  disableCheckbox?: boolean;
+  applyAllDisableCheckbox?: boolean;
+  handleSelectOneItem?: (id: number | string) => void;
+  tableKey?: string;
+  onClickRow?: (row: Row, index?: number) => void;
+  hover?: boolean;
+  clickableRowStyles?: { [key: string]: string };
+  lastItemBorderBottom: string;
+}
+
+const MOUSE_POINTER_STYLE = {
+  cursor: 'pointer',
+};
+
+function Row<Row>({
+  columnItems,
+  node,
+  index,
+  showCheckbox,
+  selectCheckbox = [],
+  selectedSymbol,
+  disableCheckbox,
+  showBorder,
+  handleSelectOneItem,
+  clickableRowStyles,
+  lastItemBorderBottom,
+  tableKey,
+  onClickRow,
+  hover,
+  CollapseComponent,
+  applyAllDisableCheckbox,
+}: RowProps<Row>) {
+  const { isCollapse = false, disableCurrentCheckbox } = node;
+
+  const [open, setOpen] = useState<boolean>(isCollapse || false);
+
+  return (
+    <>
+      <TableRow
+        // @ts-expect-error typed previously as an any
+        key={`${node[tableKey || 'id'] + index}`}
+        hover={hover}
+        onClick={() => onClickRow?.(node, index)}
+        sx={clickableRowStyles}
+        data-testid="tableBody-Row"
+      >
+        {showCheckbox && selectedSymbol && (
+          <TableCell
+            key={`showItemCheckbox-${node.id}`}
+            sx={{
+              borderBottom: showBorder ? '1px solid rgba(224, 224, 224, 1)' : lastItemBorderBottom,
+            }}
+          >
+            <Checkbox
+              // @ts-expect-error typed previously as an any
+              checked={selectCheckbox.includes(node[selectedSymbol])}
+              onChange={() => {
+                // @ts-expect-error typed previously as an any
+                if (handleSelectOneItem) handleSelectOneItem(node[selectedSymbol]);
+              }}
+              disabled={applyAllDisableCheckbox ? disableCheckbox : disableCurrentCheckbox}
+            />
+          </TableCell>
+        )}
+
+        {CollapseComponent && (
+          <TableCell>
+            <IconButton aria-label="expand row" size="small" onClick={() => setOpen(!open)}>
+              {open ? <KeyboardArrowDownIcon /> : <KeyboardArrowRightIcon />}
+            </IconButton>
+          </TableCell>
+        )}
+
+        {columnItems.map((column) => (
+          <TableCell
+            key={column.title}
+            sx={{
+              ...column?.style,
+              borderBottom: showBorder ? '1px solid rgba(224, 224, 224, 1)' : lastItemBorderBottom,
+            }}
+            data-testid={column?.key ? `tableBody-${column?.key}` : ''}
+          >
+            {/* @ts-expect-error typed previously as an any */}
+            {column.render ? column.render(node, index) : node[column.key]}
+          </TableCell>
+        ))}
+      </TableRow>
+      {CollapseComponent && (
+        <TableRow>
+          <TableCell style={{ padding: 0 }} colSpan={24}>
+            <Collapse in={open} timeout="auto" unmountOnExit>
+              <CollapseComponent row={node} />
+            </Collapse>
+          </TableCell>
+        </TableRow>
+      )}
+    </>
+  );
+}
+
+export function B3Table<Row>({
+  tableFixed = true,
+  columnItems,
+  listItems = [],
+  pagination = {
+    offset: 0,
+    count: 0,
+    first: 10,
+  },
+  onPaginationChange = () => {},
+  rowsPerPageOptions = [10, 20, 50],
+  showPagination = true,
+  renderItem,
+  isCustomRender = false,
+  isInfiniteScroll = false,
+  isLoading = false,
+  itemSpacing = 2,
+  itemIsMobileSpacing = 2,
+  itemXs = 4,
+  noDataText,
+  tableHeaderHide = false,
+  tableKey,
+  showCheckbox = false,
+  showSelectAllCheckbox = false,
+  setNeedUpdate = () => {},
+  handleSelectAllItems,
+  handleSelectOneItem,
+  hover = false,
+  showBorder = true,
+  selectedSymbol = 'id',
+  isSelectOtherPageCheckbox = false,
+  isAllSelect = false,
+  selectCheckbox = [],
+  labelRowsPerPage = '',
+  disableCheckbox = false,
+  onClickRow,
+  showRowsPerPageOptions = true,
+  CollapseComponent,
+  applyAllDisableCheckbox = true,
+  sortDirection = 'asc',
+  sortByFn,
+  orderBy = '',
+}: TableProps<Row>) {
+  const {
+    state: {
+      portalStyle: { backgroundColor = '#FEF9F5' },
+    },
+  } = useContext(CustomStyleContext);
+
+  const customColor = getContrastColor(backgroundColor);
+
+  const [isMobile] = useMobile();
+
+  const b3Lang = useB3Lang();
+
+  const { offset, count, first } = pagination;
+  const clickableRowStyles = typeof onClickRow === 'function' ? MOUSE_POINTER_STYLE : undefined;
+
+  const handlePaginationChange = (pagination: Pagination) => {
+    if (!isLoading) {
+      onPaginationChange(pagination);
+    }
+  };
+
+  const handleChangePage = (_: MouseEvent<HTMLButtonElement> | null, page: number) => {
+    handlePaginationChange({
+      ...pagination,
+      offset: page * first,
+    });
+
+    setNeedUpdate(true);
+  };
+
+  const handleChangeRowsPerPage = (event: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) => {
+    handlePaginationChange({
+      ...pagination,
+      offset: 0,
+      first: parseInt(event.target.value, 10) || first,
+    });
+  };
+
+  return listItems.length > 0 ? (
+    <>
+      {isInfiniteScroll && (
+        <>
+          {showSelectAllCheckbox && (
+            <Box
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+              }}
+            >
+              <Checkbox
+                checked={
+                  isSelectOtherPageCheckbox
+                    ? isAllSelect
+                    : selectCheckbox.length === listItems.length
+                }
+                onChange={handleSelectAllItems}
+                disabled={disableCheckbox}
+              />
+              Select all
+            </Box>
+          )}
+          <Grid container spacing={itemIsMobileSpacing}>
+            {listItems.map((row, index) => {
+              const node = isNodeWrapper(row) ? row.node : row;
+
+              const checkBox = (disable = false) => (
+                <Checkbox
+                  // @ts-expect-error typed previously as an any
+                  checked={selectCheckbox.includes(node[selectedSymbol])}
+                  onChange={() => {
+                    // @ts-expect-error typed previously as an any
+                    if (handleSelectOneItem) handleSelectOneItem(node[selectedSymbol]);
+                  }}
+                  disabled={disable || disableCheckbox}
+                />
+              );
+              return (
+                // @ts-expect-error typed previously as an any
+                <Grid item xs={12} key={`${node[tableKey || 'id'] + index}`}>
+                  {node && renderItem && renderItem(node, index, checkBox)}
+                </Grid>
+              );
+            })}
+          </Grid>
+          {showPagination && (
+            <TablePagination
+              rowsPerPageOptions={showRowsPerPageOptions ? rowsPerPageOptions : []}
+              labelRowsPerPage={labelRowsPerPage || b3Lang('global.pagination.perPage')}
+              component="div"
+              sx={{
+                color: isMobile ? b3HexToRgb(customColor, 0.87) : 'rgba(0, 0, 0, 0.87)',
+                marginTop: '1.5rem',
+                '::-webkit-scrollbar': {
+                  display: 'none',
+                },
+                '& svg': {
+                  color: isMobile ? b3HexToRgb(customColor, 0.87) : 'rgba(0, 0, 0, 0.87)',
+                },
+              }}
+              count={count}
+              rowsPerPage={first}
+              page={first === 0 ? 0 : offset / first}
+              onPageChange={handleChangePage}
+              onRowsPerPageChange={handleChangeRowsPerPage}
+            />
+          )}
+        </>
+      )}
+      {!isInfiniteScroll && isCustomRender && (
+        <>
+          <Grid container spacing={itemSpacing}>
+            {listItems.map((row, index) => {
+              const node = isNodeWrapper(row) ? row.node : row;
+
+              return (
+                // @ts-expect-error typed previously as an any
+                <Grid item xs={itemXs} key={`${node[tableKey || 'id'] + index}`}>
+                  {node && renderItem && renderItem(node, index)}
+                </Grid>
+              );
+            })}
+          </Grid>
+          {showPagination && (
+            <TablePagination
+              rowsPerPageOptions={showRowsPerPageOptions ? rowsPerPageOptions : []}
+              labelRowsPerPage={labelRowsPerPage || b3Lang('global.pagination.cardsPerPage')}
+              component="div"
+              sx={{
+                color: customColor,
+                marginTop: '1.5rem',
+                '::-webkit-scrollbar': {
+                  display: 'none',
+                },
+                '& svg': {
+                  color: customColor,
+                },
+              }}
+              count={count}
+              rowsPerPage={first}
+              page={first === 0 ? 0 : offset / first}
+              onPageChange={handleChangePage}
+              onRowsPerPageChange={handleChangeRowsPerPage}
+            />
+          )}
+        </>
+      )}
+      {!isInfiniteScroll && !isCustomRender && (
+        <Card
+          sx={{
+            height: '100%',
+            boxShadow: showBorder
+              ? '0px 2px 1px -1px rgb(0 0 0 / 20%), 0px 1px 1px 0px rgb(0 0 0 / 14%), 0px 1px 3px 0px rgb(0 0 0 / 12%)'
+              : 'none',
+          }}
+        >
+          <TableContainer>
+            <Table
+              sx={{
+                tableLayout: tableFixed ? 'fixed' : 'initial',
+              }}
+            >
+              {!tableHeaderHide && (
+                <TableHead>
+                  <TableRow data-testid="tableHead-Row">
+                    {showSelectAllCheckbox && (
+                      <TableCell key="showSelectAllCheckbox">
+                        <Checkbox
+                          checked={
+                            isSelectOtherPageCheckbox
+                              ? isAllSelect
+                              : selectCheckbox.length === listItems.length
+                          }
+                          onChange={handleSelectAllItems}
+                          disabled={disableCheckbox}
+                        />
+                      </TableCell>
+                    )}
+                    {CollapseComponent && <TableCell width="2%" />}
+
+                    {columnItems.map((column) => (
+                      <TableCell
+                        key={column.title}
+                        width={column.width}
+                        sx={
+                          column?.style
+                            ? {
+                                ...column.style,
+                              }
+                            : {}
+                        }
+                        sortDirection={column.key === orderBy ? sortDirection : false}
+                        data-testid={column?.key ? `tableHead-${column?.key}` : ''}
+                      >
+                        {column?.isSortable ? (
+                          <TableSortLabel
+                            active={column.key === orderBy}
+                            direction={column.key === orderBy ? sortDirection : 'desc'}
+                            hideSortIcon={column.key !== orderBy}
+                            onClick={() => sortByFn && sortByFn(column)}
+                          >
+                            {column.title}
+                          </TableSortLabel>
+                        ) : (
+                          column.title
+                        )}
+                      </TableCell>
+                    ))}
+                  </TableRow>
+                </TableHead>
+              )}
+
+              <TableBody>
+                {listItems.map((row, index) => {
+                  const node = isNodeWrapper(row) ? row.node : row;
+
+                  const lastItemBorderBottom =
+                    index === listItems.length - 1 ? '1px solid rgba(224, 224, 224, 1)' : 'none';
+                  return (
+                    <Row
+                      // @ts-expect-error typed previously as an any
+                      key={`row-${node[tableKey || 'id'] + index}`}
+                      columnItems={columnItems}
+                      node={node}
+                      index={index}
+                      showCheckbox={showCheckbox}
+                      selectCheckbox={selectCheckbox}
+                      selectedSymbol={selectedSymbol}
+                      disableCheckbox={disableCheckbox}
+                      applyAllDisableCheckbox={applyAllDisableCheckbox}
+                      showBorder={showBorder}
+                      handleSelectOneItem={handleSelectOneItem}
+                      clickableRowStyles={clickableRowStyles}
+                      lastItemBorderBottom={lastItemBorderBottom}
+                      hover={hover}
+                      tableKey={tableKey}
+                      onClickRow={onClickRow}
+                      CollapseComponent={CollapseComponent}
+                    />
+                  );
+                })}
+              </TableBody>
+            </Table>
+          </TableContainer>
+          {showPagination && (
+            <TablePagination
+              rowsPerPageOptions={showRowsPerPageOptions ? rowsPerPageOptions : []}
+              labelRowsPerPage={labelRowsPerPage || b3Lang('global.pagination.rowsPerPage')}
+              component="div"
+              sx={{
+                marginTop: '1.5rem',
+                '::-webkit-scrollbar': {
+                  display: 'none',
+                },
+              }}
+              count={count}
+              rowsPerPage={first}
+              page={first === 0 ? 0 : offset / first}
+              onPageChange={handleChangePage}
+              onRowsPerPageChange={handleChangeRowsPerPage}
+            />
+          )}
+        </Card>
+      )}
+    </>
+  ) : (
+    <B3NoData isLoading={isLoading} text={noDataText} />
+  );
+}

--- a/apps/storefront/src/pages/order/table/B3Table.tsx
+++ b/apps/storefront/src/pages/order/table/B3Table.tsx
@@ -83,10 +83,10 @@ function Row<Row extends OrderIdRow>({ columnItems, node, onClickRow }: RowProps
 
 interface TableProps<Row extends OrderIdRow> {
   columnItems: TableColumnItem<Row>[];
-  listItems: PossibleNodeWrapper<WithRowControls<Row>>[];
+  listItems: WithRowControls<Row>[];
   onPaginationChange?: (pagination: Pagination) => void;
   pagination?: Pagination;
-  renderItem?: (row: Row, index?: number) => ReactElement;
+  renderItem: (row: Row, index: number) => ReactElement;
   isInfiniteScroll?: boolean;
   onClickRow: (row: Row, index: number) => void;
   sortDirection?: 'asc' | 'desc';
@@ -151,11 +151,9 @@ export function B3Table<Row extends OrderIdRow>({
         <>
           <Grid container spacing={2}>
             {listItems.map((row, index) => {
-              const node = isNodeWrapper(row) ? row.node : row;
-
               return (
-                <Grid item xs={12} key={node.orderId}>
-                  {renderItem && renderItem(node, index)}
+                <Grid item xs={12} key={row.orderId}>
+                  {renderItem(row, index)}
                 </Grid>
               );
             })}

--- a/apps/storefront/src/pages/order/table/B3Table.tsx
+++ b/apps/storefront/src/pages/order/table/B3Table.tsx
@@ -58,7 +58,7 @@ interface RowProps<Row extends OrderIdRow> {
   columnItems: TableColumnItem<Row>[];
   node: WithRowControls<Row>;
   index: number;
-  onClickRow?: (row: Row, index?: number) => void;
+  onClickRow: (row: Row, index?: number) => void;
   clickableRowStyles?: { [key: string]: string };
 }
 
@@ -76,7 +76,7 @@ function Row<Row extends OrderIdRow>({
   return (
     <TableRow
       hover
-      onClick={() => onClickRow?.(node, index)}
+      onClick={() => onClickRow(node, index)}
       sx={clickableRowStyles}
       data-testid="tableBody-Row"
     >
@@ -84,10 +84,10 @@ function Row<Row extends OrderIdRow>({
         <TableCell
           key={column.title}
           sx={{
-            ...column?.style,
+            ...column.style,
             borderBottom: '1px solid rgba(224, 224, 224, 1)',
           }}
-          data-testid={column?.key ? `tableBody-${column?.key}` : ''}
+          data-testid={column.key ? `tableBody-${column.key}` : ''}
         >
           {/* @ts-expect-error typed previously as an any */}
           {column.render ? column.render(node, index) : node[column.key]}
@@ -105,7 +105,7 @@ interface TableProps<Row extends OrderIdRow> {
   renderItem?: (row: Row, index?: number) => ReactElement;
   isInfiniteScroll?: boolean;
   isLoading?: boolean;
-  onClickRow?: (row: Row, index?: number) => void;
+  onClickRow: (row: Row, index?: number) => void;
   sortDirection?: 'asc' | 'desc';
   sortByFn?: (e: { key: string }) => void;
   orderBy?: string;
@@ -176,7 +176,7 @@ export function B3Table<Row extends OrderIdRow>({
 
               return (
                 <Grid item xs={12} key={node.orderId}>
-                  {node && renderItem && renderItem(node, index)}
+                  {renderItem && renderItem(node, index)}
                 </Grid>
               );
             })}
@@ -224,16 +224,16 @@ export function B3Table<Row extends OrderIdRow>({
                       key={column.title}
                       width={column.width}
                       sx={
-                        column?.style
+                        column.style
                           ? {
                               ...column.style,
                             }
                           : {}
                       }
                       sortDirection={column.key === orderBy ? sortDirection : false}
-                      data-testid={column?.key ? `tableHead-${column?.key}` : ''}
+                      data-testid={column.key ? `tableHead-${column.key}` : ''}
                     >
-                      {column?.isSortable ? (
+                      {column.isSortable ? (
                         <TableSortLabel
                           active={column.key === orderBy}
                           direction={column.key === orderBy ? sortDirection : 'desc'}

--- a/apps/storefront/src/pages/order/table/B3Table.tsx
+++ b/apps/storefront/src/pages/order/table/B3Table.tsx
@@ -3,7 +3,6 @@ import { useB3Lang } from '@b3/lang';
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import KeyboardArrowRightIcon from '@mui/icons-material/KeyboardArrowRight';
 import {
-  Box,
   Card,
   Checkbox,
   Collapse,
@@ -54,50 +53,6 @@ export interface TableColumnItem<Row> {
   render?: (row: Row, index: number) => ReactNode;
   style?: { [key: string]: string };
   isSortable?: boolean;
-}
-
-interface TableProps<Row> {
-  tableFixed?: boolean;
-  tableHeaderHide?: boolean;
-  columnItems: TableColumnItem<Row>[];
-  listItems: PossibleNodeWrapper<WithRowControls<Row>>[];
-  itemSpacing?: number;
-  itemIsMobileSpacing?: number;
-  itemXs?: number;
-  onPaginationChange?: (pagination: Pagination) => void;
-  pagination?: Pagination;
-  rowsPerPageOptions?: number[];
-  showPagination?: boolean;
-  renderItem?: (
-    row: Row,
-    index?: number,
-    checkBox?: (disable?: boolean) => ReactElement,
-  ) => ReactElement;
-  CollapseComponent?: FC<{ row: Row }>;
-  isCustomRender?: boolean;
-  isInfiniteScroll?: boolean;
-  isLoading?: boolean;
-  noDataText?: string;
-  tableKey?: string;
-  showCheckbox?: boolean;
-  showSelectAllCheckbox?: boolean;
-  setNeedUpdate?: (boolean: boolean) => void;
-  handleSelectAllItems?: () => void;
-  handleSelectOneItem?: (id: number | string) => void;
-  hover?: boolean;
-  showBorder?: boolean;
-  selectedSymbol?: string;
-  selectCheckbox?: Array<number | string>;
-  labelRowsPerPage?: string;
-  disableCheckbox?: boolean;
-  applyAllDisableCheckbox?: boolean;
-  onClickRow?: (row: Row, index?: number) => void;
-  showRowsPerPageOptions?: boolean;
-  isSelectOtherPageCheckbox?: boolean;
-  isAllSelect?: boolean;
-  sortDirection?: 'asc' | 'desc';
-  sortByFn?: (e: { key: string }) => void;
-  orderBy?: string;
 }
 
 interface RowProps<Row> {
@@ -209,8 +164,28 @@ function Row<Row>({
   );
 }
 
+interface TableProps<Row> {
+  columnItems: TableColumnItem<Row>[];
+  listItems: PossibleNodeWrapper<WithRowControls<Row>>[];
+  onPaginationChange?: (pagination: Pagination) => void;
+  pagination?: Pagination;
+  renderItem?: (
+    row: Row,
+    index?: number,
+    checkBox?: (disable?: boolean) => ReactElement,
+  ) => ReactElement;
+  isInfiniteScroll?: boolean;
+  isLoading?: boolean;
+  setNeedUpdate?: (boolean: boolean) => void;
+  handleSelectOneItem?: (id: number | string) => void;
+  selectCheckbox?: Array<number | string>;
+  onClickRow?: (row: Row, index?: number) => void;
+  sortDirection?: 'asc' | 'desc';
+  sortByFn?: (e: { key: string }) => void;
+  orderBy?: string;
+}
+
 export function B3Table<Row>({
-  tableFixed = true,
   columnItems,
   listItems = [],
   pagination = {
@@ -219,39 +194,19 @@ export function B3Table<Row>({
     first: 10,
   },
   onPaginationChange = () => {},
-  rowsPerPageOptions = [10, 20, 50],
-  showPagination = true,
   renderItem,
-  isCustomRender = false,
   isInfiniteScroll = false,
   isLoading = false,
-  itemSpacing = 2,
-  itemIsMobileSpacing = 2,
-  itemXs = 4,
-  noDataText,
-  tableHeaderHide = false,
-  tableKey,
-  showCheckbox = false,
-  showSelectAllCheckbox = false,
   setNeedUpdate = () => {},
-  handleSelectAllItems,
   handleSelectOneItem,
-  hover = false,
-  showBorder = true,
-  selectedSymbol = 'id',
-  isSelectOtherPageCheckbox = false,
-  isAllSelect = false,
   selectCheckbox = [],
-  labelRowsPerPage = '',
-  disableCheckbox = false,
   onClickRow,
-  showRowsPerPageOptions = true,
-  CollapseComponent,
-  applyAllDisableCheckbox = true,
   sortDirection = 'asc',
   sortByFn,
   orderBy = '',
 }: TableProps<Row>) {
+  const rowsPerPageOptions = [10, 20, 30];
+
   const {
     state: {
       portalStyle: { backgroundColor = '#FEF9F5' },
@@ -294,174 +249,97 @@ export function B3Table<Row>({
     <>
       {isInfiniteScroll && (
         <>
-          {showSelectAllCheckbox && (
-            <Box
-              sx={{
-                display: 'flex',
-                alignItems: 'center',
-              }}
-            >
-              <Checkbox
-                checked={
-                  isSelectOtherPageCheckbox
-                    ? isAllSelect
-                    : selectCheckbox.length === listItems.length
-                }
-                onChange={handleSelectAllItems}
-                disabled={disableCheckbox}
-              />
-              Select all
-            </Box>
-          )}
-          <Grid container spacing={itemIsMobileSpacing}>
+          <Grid container spacing={2}>
             {listItems.map((row, index) => {
               const node = isNodeWrapper(row) ? row.node : row;
 
               const checkBox = (disable = false) => (
                 <Checkbox
                   // @ts-expect-error typed previously as an any
-                  checked={selectCheckbox.includes(node[selectedSymbol])}
+                  checked={selectCheckbox.includes(node.id)}
                   onChange={() => {
                     // @ts-expect-error typed previously as an any
-                    if (handleSelectOneItem) handleSelectOneItem(node[selectedSymbol]);
+                    if (handleSelectOneItem) handleSelectOneItem(node.id);
                   }}
-                  disabled={disable || disableCheckbox}
+                  disabled={disable || false}
                 />
               );
               return (
                 // @ts-expect-error typed previously as an any
-                <Grid item xs={12} key={`${node[tableKey || 'id'] + index}`}>
+                <Grid item xs={12} key={`${node['orderId' || 'id'] + index}`}>
                   {node && renderItem && renderItem(node, index, checkBox)}
                 </Grid>
               );
             })}
           </Grid>
-          {showPagination && (
-            <TablePagination
-              rowsPerPageOptions={showRowsPerPageOptions ? rowsPerPageOptions : []}
-              labelRowsPerPage={labelRowsPerPage || b3Lang('global.pagination.perPage')}
-              component="div"
-              sx={{
+          <TablePagination
+            rowsPerPageOptions={rowsPerPageOptions}
+            labelRowsPerPage={b3Lang('global.pagination.perPage')}
+            component="div"
+            sx={{
+              color: isMobile ? b3HexToRgb(customColor, 0.87) : 'rgba(0, 0, 0, 0.87)',
+              marginTop: '1.5rem',
+              '::-webkit-scrollbar': {
+                display: 'none',
+              },
+              '& svg': {
                 color: isMobile ? b3HexToRgb(customColor, 0.87) : 'rgba(0, 0, 0, 0.87)',
-                marginTop: '1.5rem',
-                '::-webkit-scrollbar': {
-                  display: 'none',
-                },
-                '& svg': {
-                  color: isMobile ? b3HexToRgb(customColor, 0.87) : 'rgba(0, 0, 0, 0.87)',
-                },
-              }}
-              count={count}
-              rowsPerPage={first}
-              page={first === 0 ? 0 : offset / first}
-              onPageChange={handleChangePage}
-              onRowsPerPageChange={handleChangeRowsPerPage}
-            />
-          )}
+              },
+            }}
+            count={count}
+            rowsPerPage={first}
+            page={first === 0 ? 0 : offset / first}
+            onPageChange={handleChangePage}
+            onRowsPerPageChange={handleChangeRowsPerPage}
+          />
         </>
       )}
-      {!isInfiniteScroll && isCustomRender && (
-        <>
-          <Grid container spacing={itemSpacing}>
-            {listItems.map((row, index) => {
-              const node = isNodeWrapper(row) ? row.node : row;
-
-              return (
-                // @ts-expect-error typed previously as an any
-                <Grid item xs={itemXs} key={`${node[tableKey || 'id'] + index}`}>
-                  {node && renderItem && renderItem(node, index)}
-                </Grid>
-              );
-            })}
-          </Grid>
-          {showPagination && (
-            <TablePagination
-              rowsPerPageOptions={showRowsPerPageOptions ? rowsPerPageOptions : []}
-              labelRowsPerPage={labelRowsPerPage || b3Lang('global.pagination.cardsPerPage')}
-              component="div"
-              sx={{
-                color: customColor,
-                marginTop: '1.5rem',
-                '::-webkit-scrollbar': {
-                  display: 'none',
-                },
-                '& svg': {
-                  color: customColor,
-                },
-              }}
-              count={count}
-              rowsPerPage={first}
-              page={first === 0 ? 0 : offset / first}
-              onPageChange={handleChangePage}
-              onRowsPerPageChange={handleChangeRowsPerPage}
-            />
-          )}
-        </>
-      )}
-      {!isInfiniteScroll && !isCustomRender && (
+      {!isInfiniteScroll && (
         <Card
           sx={{
             height: '100%',
-            boxShadow: showBorder
-              ? '0px 2px 1px -1px rgb(0 0 0 / 20%), 0px 1px 1px 0px rgb(0 0 0 / 14%), 0px 1px 3px 0px rgb(0 0 0 / 12%)'
-              : 'none',
+            boxShadow:
+              '0px 2px 1px -1px rgb(0 0 0 / 20%), 0px 1px 1px 0px rgb(0 0 0 / 14%), 0px 1px 3px 0px rgb(0 0 0 / 12%)',
           }}
         >
           <TableContainer>
             <Table
               sx={{
-                tableLayout: tableFixed ? 'fixed' : 'initial',
+                tableLayout: 'initial',
               }}
             >
-              {!tableHeaderHide && (
-                <TableHead>
-                  <TableRow data-testid="tableHead-Row">
-                    {showSelectAllCheckbox && (
-                      <TableCell key="showSelectAllCheckbox">
-                        <Checkbox
-                          checked={
-                            isSelectOtherPageCheckbox
-                              ? isAllSelect
-                              : selectCheckbox.length === listItems.length
-                          }
-                          onChange={handleSelectAllItems}
-                          disabled={disableCheckbox}
-                        />
-                      </TableCell>
-                    )}
-                    {CollapseComponent && <TableCell width="2%" />}
-
-                    {columnItems.map((column) => (
-                      <TableCell
-                        key={column.title}
-                        width={column.width}
-                        sx={
-                          column?.style
-                            ? {
-                                ...column.style,
-                              }
-                            : {}
-                        }
-                        sortDirection={column.key === orderBy ? sortDirection : false}
-                        data-testid={column?.key ? `tableHead-${column?.key}` : ''}
-                      >
-                        {column?.isSortable ? (
-                          <TableSortLabel
-                            active={column.key === orderBy}
-                            direction={column.key === orderBy ? sortDirection : 'desc'}
-                            hideSortIcon={column.key !== orderBy}
-                            onClick={() => sortByFn && sortByFn(column)}
-                          >
-                            {column.title}
-                          </TableSortLabel>
-                        ) : (
-                          column.title
-                        )}
-                      </TableCell>
-                    ))}
-                  </TableRow>
-                </TableHead>
-              )}
+              <TableHead>
+                <TableRow data-testid="tableHead-Row">
+                  {columnItems.map((column) => (
+                    <TableCell
+                      key={column.title}
+                      width={column.width}
+                      sx={
+                        column?.style
+                          ? {
+                              ...column.style,
+                            }
+                          : {}
+                      }
+                      sortDirection={column.key === orderBy ? sortDirection : false}
+                      data-testid={column?.key ? `tableHead-${column?.key}` : ''}
+                    >
+                      {column?.isSortable ? (
+                        <TableSortLabel
+                          active={column.key === orderBy}
+                          direction={column.key === orderBy ? sortDirection : 'desc'}
+                          hideSortIcon={column.key !== orderBy}
+                          onClick={() => sortByFn && sortByFn(column)}
+                        >
+                          {column.title}
+                        </TableSortLabel>
+                      ) : (
+                        column.title
+                      )}
+                    </TableCell>
+                  ))}
+                </TableRow>
+              </TableHead>
 
               <TableBody>
                 {listItems.map((row, index) => {
@@ -472,51 +350,49 @@ export function B3Table<Row>({
                   return (
                     <Row
                       // @ts-expect-error typed previously as an any
-                      key={`row-${node[tableKey || 'id'] + index}`}
+                      key={`row-${node['orderId' || 'id'] + index}`}
                       columnItems={columnItems}
                       node={node}
                       index={index}
-                      showCheckbox={showCheckbox}
+                      showCheckbox={false}
                       selectCheckbox={selectCheckbox}
-                      selectedSymbol={selectedSymbol}
-                      disableCheckbox={disableCheckbox}
-                      applyAllDisableCheckbox={applyAllDisableCheckbox}
-                      showBorder={showBorder}
+                      selectedSymbol="id"
+                      disableCheckbox={false}
+                      applyAllDisableCheckbox
+                      showBorder
                       handleSelectOneItem={handleSelectOneItem}
                       clickableRowStyles={clickableRowStyles}
                       lastItemBorderBottom={lastItemBorderBottom}
-                      hover={hover}
-                      tableKey={tableKey}
+                      hover
+                      tableKey="orderId"
                       onClickRow={onClickRow}
-                      CollapseComponent={CollapseComponent}
+                      CollapseComponent={undefined}
                     />
                   );
                 })}
               </TableBody>
             </Table>
           </TableContainer>
-          {showPagination && (
-            <TablePagination
-              rowsPerPageOptions={showRowsPerPageOptions ? rowsPerPageOptions : []}
-              labelRowsPerPage={labelRowsPerPage || b3Lang('global.pagination.rowsPerPage')}
-              component="div"
-              sx={{
-                marginTop: '1.5rem',
-                '::-webkit-scrollbar': {
-                  display: 'none',
-                },
-              }}
-              count={count}
-              rowsPerPage={first}
-              page={first === 0 ? 0 : offset / first}
-              onPageChange={handleChangePage}
-              onRowsPerPageChange={handleChangeRowsPerPage}
-            />
-          )}
+          <TablePagination
+            rowsPerPageOptions={rowsPerPageOptions}
+            labelRowsPerPage={b3Lang('global.pagination.rowsPerPage')}
+            component="div"
+            sx={{
+              marginTop: '1.5rem',
+              '::-webkit-scrollbar': {
+                display: 'none',
+              },
+            }}
+            count={count}
+            rowsPerPage={first}
+            page={first === 0 ? 0 : offset / first}
+            onPageChange={handleChangePage}
+            onRowsPerPageChange={handleChangeRowsPerPage}
+          />
         </Card>
       )}
     </>
   ) : (
-    <B3NoData isLoading={isLoading} text={noDataText} />
+    <B3NoData isLoading={isLoading} text="" />
   );
 }

--- a/apps/storefront/src/pages/order/table/B3Table.tsx
+++ b/apps/storefront/src/pages/order/table/B3Table.tsx
@@ -104,7 +104,6 @@ interface TableProps<Row extends OrderIdRow> {
   pagination?: Pagination;
   renderItem?: (row: Row, index?: number) => ReactElement;
   isInfiniteScroll?: boolean;
-  isLoading?: boolean;
   onClickRow: (row: Row, index?: number) => void;
   sortDirection?: 'asc' | 'desc';
   sortByFn?: (e: { key: string }) => void;
@@ -122,7 +121,6 @@ export function B3Table<Row extends OrderIdRow>({
   onPaginationChange = () => {},
   renderItem,
   isInfiniteScroll = false,
-  isLoading = false,
   onClickRow,
   sortDirection = 'asc',
   sortByFn,
@@ -146,9 +144,7 @@ export function B3Table<Row extends OrderIdRow>({
   const clickableRowStyles = typeof onClickRow === 'function' ? MOUSE_POINTER_STYLE : undefined;
 
   const handlePaginationChange = (pagination: Pagination) => {
-    if (!isLoading) {
-      onPaginationChange(pagination);
-    }
+    onPaginationChange(pagination);
   };
 
   const handleChangePage = (_: MouseEvent<HTMLButtonElement> | null, page: number) => {
@@ -288,6 +284,6 @@ export function B3Table<Row extends OrderIdRow>({
       )}
     </>
   ) : (
-    <B3NoData isLoading={isLoading} text="" />
+    <B3NoData />
   );
 }

--- a/apps/storefront/src/pages/order/table/B3Table.tsx
+++ b/apps/storefront/src/pages/order/table/B3Table.tsx
@@ -58,7 +58,7 @@ interface RowProps<Row extends OrderIdRow> {
   columnItems: TableColumnItem<Row>[];
   node: WithRowControls<Row>;
   index: number;
-  onClickRow: (row: Row, index?: number) => void;
+  onClickRow: (row: Row, index: number) => void;
   clickableRowStyles?: { [key: string]: string };
 }
 
@@ -104,7 +104,7 @@ interface TableProps<Row extends OrderIdRow> {
   pagination?: Pagination;
   renderItem?: (row: Row, index?: number) => ReactElement;
   isInfiniteScroll?: boolean;
-  onClickRow: (row: Row, index?: number) => void;
+  onClickRow: (row: Row, index: number) => void;
   sortDirection?: 'asc' | 'desc';
   sortByFn?: (e: { key: string }) => void;
   orderBy?: string;

--- a/apps/storefront/src/pages/order/table/B3Table.tsx
+++ b/apps/storefront/src/pages/order/table/B3Table.tsx
@@ -31,8 +31,6 @@ export const isNodeWrapper = <T extends object>(
 
 export type WithRowControls<T> = T & {
   id?: string | number;
-  isCollapse?: boolean;
-  disableCurrentCheckbox?: boolean;
 };
 
 export interface Pagination {
@@ -48,49 +46,35 @@ interface OrderIdRow {
 export interface TableColumnItem<Row extends OrderIdRow> {
   key: string;
   title: string;
+  align?: 'right';
   width?: string;
-  render?: (row: Row, index: number) => ReactNode;
-  style?: { [key: string]: string };
+  render: (row: Row) => ReactNode;
   isSortable?: boolean;
 }
 
 interface RowProps<Row extends OrderIdRow> {
   columnItems: TableColumnItem<Row>[];
   node: WithRowControls<Row>;
-  index: number;
-  onClickRow: (row: Row, index: number) => void;
-  clickableRowStyles?: { [key: string]: string };
+  onClickRow: () => void;
 }
 
-const MOUSE_POINTER_STYLE = {
-  cursor: 'pointer',
-};
-
-function Row<Row extends OrderIdRow>({
-  columnItems,
-  node,
-  index,
-  clickableRowStyles,
-  onClickRow,
-}: RowProps<Row>) {
+function Row<Row extends OrderIdRow>({ columnItems, node, onClickRow }: RowProps<Row>) {
   return (
     <TableRow
       hover
-      onClick={() => onClickRow(node, index)}
-      sx={clickableRowStyles}
+      onClick={onClickRow}
+      sx={{
+        cursor: 'pointer',
+      }}
       data-testid="tableBody-Row"
     >
       {columnItems.map((column) => (
         <TableCell
+          align={column.align === 'right' ? 'right' : 'left'}
           key={column.title}
-          sx={{
-            ...column.style,
-            borderBottom: '1px solid rgba(224, 224, 224, 1)',
-          }}
           data-testid={column.key ? `tableBody-${column.key}` : ''}
         >
-          {/* @ts-expect-error typed previously as an any */}
-          {column.render ? column.render(node, index) : node[column.key]}
+          {column.render(node)}
         </TableCell>
       ))}
     </TableRow>
@@ -141,7 +125,6 @@ export function B3Table<Row extends OrderIdRow>({
   const b3Lang = useB3Lang();
 
   const { offset, count, first } = pagination;
-  const clickableRowStyles = typeof onClickRow === 'function' ? MOUSE_POINTER_STYLE : undefined;
 
   const handlePaginationChange = (pagination: Pagination) => {
     onPaginationChange(pagination);
@@ -219,13 +202,7 @@ export function B3Table<Row extends OrderIdRow>({
                     <TableCell
                       key={column.title}
                       width={column.width}
-                      sx={
-                        column.style
-                          ? {
-                              ...column.style,
-                            }
-                          : {}
-                      }
+                      align={column.align === 'right' ? 'right' : 'left'}
                       sortDirection={column.key === orderBy ? sortDirection : false}
                       data-testid={column.key ? `tableHead-${column.key}` : ''}
                     >
@@ -255,9 +232,7 @@ export function B3Table<Row extends OrderIdRow>({
                       key={`row-${node.orderId}`}
                       columnItems={columnItems}
                       node={node}
-                      index={index}
-                      clickableRowStyles={clickableRowStyles}
-                      onClickRow={onClickRow}
+                      onClickRow={() => onClickRow(node, index)}
                     />
                   );
                 })}


### PR DESCRIPTION
Jira: [B2BCAT-39](https://bigcommercecloud.atlassian.net/browse/B2BCAT-39)

ℹ️ This PR is split in multiple commits to ease review.

## What/Why?
- Remove unnecessary PossibleNodeWrapper from B3PaginationTable
- Streamline Order and OrderItemCard components by simplifying props and rendering logic
- Simplify row rendering and alignments in B3Table and Order components
- Update dependencies in useEffect and simplify render functions in Order component
- Make onClickRow prop required for B3Table and B3PaginationTable
- Remove unused props and simplify B3NoData and B3orders components
- Make onClickRow prop required and simplify optional chaining
- Enforce Row type constraint and simplify key usage in B3orders
- Simplify Row component and remove unused props
- Simplify B3Table by removing unused props and abstraction layers
- Simplify B3PaginationTable props and remove complex selection logic
- Fork the table component for Orders

## Rollout/Rollback
Revert

## Testing
This PR is covered by all the unit tests we wrote in preparation for these changes.