### PR TITLE
fix(user-management): B2BCAT-22 fix user management role id filter

### DIFF
--- a/apps/storefront/src/pages/UserManagement/index.test.tsx
+++ b/apps/storefront/src/pages/UserManagement/index.test.tsx
@@ -238,6 +238,35 @@ describe.each([
     expect(screen.getByText('Junior buyer')).toBeInTheDocument();
   });
 
+  it('does not apply any filters by default', async () => {
+    const getUsersVariablesSpy = vi.fn();
+    server.use(
+      graphql.query('GetUserExtraFields', () =>
+        HttpResponse.json(buildUserExtraFieldsResponseWith('WHATEVER_VALUES')),
+      ),
+      graphql.query('GetUsers', ({ variables }) => {
+        getUsersVariablesSpy(variables);
+
+        return HttpResponse.json(buildUsersResponseWith('WHATEVER_VALUES'));
+      }),
+    );
+
+    renderWithProviders(<UserManagement />, { preloadedState });
+
+    await waitFor(() =>
+      expect(getUsersVariablesSpy).toHaveBeenCalledWith({
+        first: 12,
+        offset: 0,
+        search: '',
+        companyId: 82828,
+        q: '',
+        createdBy: '',
+        email: '',
+        companyRoleId: undefined,
+      }),
+    );
+  });
+
   it('displays users with custom roles', async () => {
     const joeSwanson = buildUserEdgeWith({
       node: {

--- a/apps/storefront/src/shared/service/b2b/graphql/users.ts
+++ b/apps/storefront/src/shared/service/b2b/graphql/users.ts
@@ -192,7 +192,10 @@ export const getUsers = (data: GetUsersVariables) =>
       ...data,
       q: data.q || '',
       companyId: Number(data.companyId),
-      companyRoleId: data.companyRoleId !== undefined ? Number(data.companyRoleId) : undefined,
+      companyRoleId:
+        data.companyRoleId !== undefined && data.companyRoleId !== ''
+          ? Number(data.companyRoleId)
+          : undefined,
     },
   });
 


### PR DESCRIPTION
Jira: [B2BCAT-22](https://bigcommercecloud.atlassian.net/browse/B2BCAT-22)

## What/Why?

- Fix issue where the User Management search returns no results unless a role filter is used
 
### Root cause

1. The view models the _lack_ of a company role filter as an empty string `''`
2. The anti-corruption for the graphql query fed this value through `Number(data.companyRoleId)`
3. `Number('')` returns `0`
4. That `0` is then honoured as a filter value be the BE
5. As no users match that role id, none are returned

## Rollout/Rollback

- Revert this PR

## Testing

### Before 

https://github.com/user-attachments/assets/b0e913ac-e060-40f2-a7ed-9670d47bd5f7

### After

https://github.com/user-attachments/assets/79f2d86d-61ca-4e33-a4b6-bfee99beb0ff




- New test added to ensure a lack of role filter reaches the BE as `undefined`


[B2BCAT-22]: https://bigcommercecloud.atlassian.net/browse/B2BCAT-22?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ