### PR TITLE
test(shopping-lists): B2B-2549 Add tests for scrollTo after closing the PDP modal

### DIFF
--- a/apps/storefront/src/pages/PDP/index.test.tsx
+++ b/apps/storefront/src/pages/PDP/index.test.tsx
@@ -15,6 +15,10 @@ import { globalSnackbar } from '@/utils/b3Tip';
 
 import PDP from '.';
 
+beforeEach(() => {
+  vi.spyOn(window, 'scrollTo').mockReturnValue();
+});
+
 const buildCustomerWith = builder<Customer>(() => ({
   id: faker.number.int(),
   phoneNumber: faker.phone.number(),
@@ -234,6 +238,7 @@ describe('when a product without a required variant is added to a shopping list'
     });
 
     expect(globalSnackbar.success).not.toHaveBeenCalled();
+    expect(window.scrollTo).toHaveBeenCalledWith(0, 0);
   });
 });
 
@@ -405,6 +410,7 @@ describe('when a product with required variants is added to a shopping list', ()
       'Products were added to your shopping list',
       expect.anything(),
     );
+    expect(window.scrollTo).toHaveBeenCalledWith(0, 0);
   });
 });
 
@@ -562,5 +568,6 @@ describe('when an unexpected error occurred during adding a product to shopping 
     expect(globalSnackbar.error).toHaveBeenCalledWith('Something went wrong. Please try again.', {
       isClose: true,
     });
+    expect(window.scrollTo).toHaveBeenCalledWith(0, 0);
   });
 });


### PR DESCRIPTION
Jira: [B2B-2549](https://bigcommercecloud.atlassian.net/browse/B2B-2549)

## What/Why?

These were not added when the scrollTo method call was introduced. It is causing undesired console.logs during the test run.

## Rollout/Rollback
Revert

## Testing
This PR is only tests.
### Before
<img width="807" alt="image" src="https://github.com/user-attachments/assets/9b7f42a1-6cfb-48a7-a3f0-ddd35f282767" />


### After
<img width="747" alt="image" src="https://github.com/user-attachments/assets/e7859329-dfb7-4ce9-8731-9db27f96124b" />
