### PR TITLE
refactor(user-management): B2BCAT-40 move alerts setup out to renderWithProviders

### DIFF
--- a/apps/storefront/src/pages/UserManagement/index.test.tsx
+++ b/apps/storefront/src/pages/UserManagement/index.test.tsx
@@ -13,8 +13,6 @@ import {
   within,
 } from 'tests/test-utils';
 
-import B3LayoutTip from '@/components/layout/B3LayoutTip';
-import { DynamicallyVariableProvider } from '@/shared/dynamicallyVariable';
 import { CompanyRolesResponse } from '@/shared/service/b2b/graphql/roleAndPermissions';
 import {
   UserEmailCheckResponse,
@@ -503,15 +501,7 @@ describe.each([
         ),
       );
 
-      renderWithProviders(
-        // This can be rolled into "renderWithProviders" once
-        // we fix ShoppingListDetails/index.test.tsx
-        <DynamicallyVariableProvider>
-          <B3LayoutTip />
-          <UserManagement />
-        </DynamicallyVariableProvider>,
-        { preloadedState },
-      );
+      renderWithProviders(<UserManagement />, { preloadedState });
 
       expect(await screen.findByRole('heading', { name: 'Troy McClure' })).toBeInTheDocument();
 
@@ -653,15 +643,7 @@ describe.each([
         }),
       );
 
-      renderWithProviders(
-        // This can be rolled into "renderWithProviders" once
-        // we fix ShoppingListDetails/index.test.tsx
-        <DynamicallyVariableProvider>
-          <B3LayoutTip />
-          <UserManagement />
-        </DynamicallyVariableProvider>,
-        { preloadedState },
-      );
+      renderWithProviders(<UserManagement />, { preloadedState });
 
       expect(await screen.findByRole('heading', { name: 'Troy McClure' })).toBeInTheDocument();
 
@@ -752,15 +734,7 @@ describe.each([
         }),
       );
 
-      renderWithProviders(
-        // This can be rolled into "renderWithProviders" once
-        // we fix ShoppingListDetails/index.test.tsx
-        <DynamicallyVariableProvider>
-          <B3LayoutTip />
-          <UserManagement />
-        </DynamicallyVariableProvider>,
-        { preloadedState },
-      );
+      renderWithProviders(<UserManagement />, { preloadedState });
 
       await userEvent.click(await screen.findByRole('button', { name: 'Add new user' }));
 
@@ -828,15 +802,7 @@ describe.each([
         graphql.query('UserEmailCheck', () => HttpResponse.json(userTakenResponse)),
       );
 
-      renderWithProviders(
-        // This can be rolled into "renderWithProviders" once
-        // we fix ShoppingListDetails/index.test.tsx
-        <DynamicallyVariableProvider>
-          <B3LayoutTip />
-          <UserManagement />
-        </DynamicallyVariableProvider>,
-        { preloadedState },
-      );
+      renderWithProviders(<UserManagement />, { preloadedState });
 
       await userEvent.click(await screen.findByRole('button', { name: 'Add new user' }));
 

--- a/apps/storefront/tests/test-utils.tsx
+++ b/apps/storefront/tests/test-utils.tsx
@@ -6,6 +6,8 @@ import { render, RenderOptions } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import { Mock } from 'vitest';
 
+import B3LayoutTip from '@/components/layout/B3LayoutTip';
+import { DynamicallyVariableProvider } from '@/shared/dynamicallyVariable';
 import { GlobalContext, GlobalProvider } from '@/shared/global';
 import { GlobalState } from '@/shared/global/context/config';
 import { AppStore, RootState, setupStore } from '@/store';
@@ -59,9 +61,12 @@ export const renderWithProviders = (
           <MockGlobalProvider payload={initialGlobalContext} />
           <Provider store={store}>
             <LangProvider>
-              <MemoryRouter initialEntries={initialEntries}>
-                <NavigationSpy spy={navigation}>{children}</NavigationSpy>
-              </MemoryRouter>
+              <DynamicallyVariableProvider>
+                <B3LayoutTip />
+                <MemoryRouter initialEntries={initialEntries}>
+                  <NavigationSpy spy={navigation}>{children}</NavigationSpy>
+                </MemoryRouter>
+              </DynamicallyVariableProvider>
             </LangProvider>
           </Provider>
         </GlobalProvider>


### PR DESCRIPTION
Jira: [B2BCAT-40](https://bigcommercecloud.atlassian.net/browse/B2BCAT-40)

## What/Why?

- Move alert setup out of the User Management test file and into the `renderWithProviders` util
- Allows other tests to benefit from the setup, without adding noise to their own setup

## Rollout/Rollback

- Revert

## Testing

- Testing only, no user facing code changed


[B2BCAT-40]: https://bigcommercecloud.atlassian.net/browse/B2BCAT-40?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ