### PR TITLE
fix(dashboard): B2B-2993 removing unused closeMasquerade param

### DIFF
--- a/apps/storefront/src/components/ConfirmMasqueradeDialog.tsx
+++ b/apps/storefront/src/components/ConfirmMasqueradeDialog.tsx
@@ -32,6 +32,7 @@ export function ConfirmMasqueradeDialog({
       handRightClick={handleConfirm}
       dialogWidth="480px"
       dialogSx={{
+        zIndex: 12006,
         '& .MuiPaper-elevation': {
           '& h2': {
             border: 'unset',

--- a/apps/storefront/src/components/layout/B3RenderRouter.tsx
+++ b/apps/storefront/src/components/layout/B3RenderRouter.tsx
@@ -30,13 +30,7 @@ export default function B3RenderRouter(props: B3RenderRouterProps) {
   const dispatch = useAppDispatch();
 
   useEffect(() => {
-    if (openUrl && openUrl === '/dashboard?closeMasquerade=1') {
-      navigate('/dashboard', {
-        state: {
-          closeMasquerade: '1',
-        },
-      });
-    } else if (openUrl === '/dashboard') {
+    if (openUrl === '/dashboard') {
       location.state = null;
       navigate(openUrl);
     } else if (typeof openUrl === 'string') {

--- a/apps/storefront/src/components/outSideComponents/B3MasqueradeGlobalTip.tsx
+++ b/apps/storefront/src/components/outSideComponents/B3MasqueradeGlobalTip.tsx
@@ -106,31 +106,24 @@ export default function B3MasqueradeGlobalTip(props: B3MasqueradeGlobalTipProps)
   const [isMobile] = useMobile();
 
   const endActing = async () => {
-    if (isOpen) {
-      setOpenPage({
-        isOpen: true,
-        openUrl: '/dashboard?closeMasquerade=1',
-      });
-    } else {
-      setIsLoading(true);
-      if (typeof b2bId === 'number') {
-        await superAdminEndMasquerade(Number(salesRepCompanyId));
-      }
-
-      const cartEntityId = Cookies.get('cartId');
-      if (cartEntityId) {
-        await deleteCart({ deleteCartInput: { cartEntityId } });
-        Cookies.remove('cartId');
-        dispatch(setCartNumber(0));
-      }
-
-      setIsLoading(false);
-      dispatch(clearMasqueradeCompany());
-      setOpenPage({
-        isOpen: true,
-        openUrl: '/dashboard',
-      });
+    setIsLoading(true);
+    if (typeof b2bId === 'number') {
+      await superAdminEndMasquerade(Number(salesRepCompanyId));
     }
+
+    const cartEntityId = Cookies.get('cartId');
+    if (cartEntityId) {
+      await deleteCart({ deleteCartInput: { cartEntityId } });
+      Cookies.remove('cartId');
+      dispatch(setCartNumber(0));
+    }
+
+    setIsLoading(false);
+    dispatch(clearMasqueradeCompany());
+    setOpenPage({
+      isOpen: true,
+      openUrl: '/dashboard',
+    });
   };
 
   const onEndActing = async () => {


### PR DESCRIPTION

Jira: [B2B-2993](https://bigcommercecloud.atlassian.net/browse/B2B-2993)

## What/Why?
Removing `closeMasquerade` search param usage as it was never implemented correctly. Also increasing modal zIndex so it can be display above the buyer portal UI.

## Rollout/Rollback
Revert

## Testing
<img width="1624" alt="Screenshot 2025-06-16 at 3 41 16 p m" src="https://github.com/user-attachments/assets/1372f396-87b0-45b5-9e81-880cf07c7717" />


[B2B-2993]: https://bigcommercecloud.atlassian.net/browse/B2B-2993?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ