### PR TITLE
feat(catalyst): B2B-2626 adding styles for catalyst notifications

### DIFF
--- a/apps/storefront/src/components/B3AddToQuoteTip.tsx
+++ b/apps/storefront/src/components/B3AddToQuoteTip.tsx
@@ -1,9 +1,35 @@
+import { ReactNode } from 'react';
 import { useB3Lang } from '@b3/lang';
 import { Box, Button } from '@mui/material';
+
+import { platform } from '@/utils';
 
 interface B3AddToQuoteTipProps {
   gotoQuoteDraft: () => void;
   msg: string;
+}
+
+function CatalystButton({
+  goToQuoteDraft,
+  children,
+}: {
+  goToQuoteDraft: () => void;
+  children: ReactNode;
+}) {
+  return (
+    <Button
+      onClick={() => goToQuoteDraft()}
+      variant="text"
+      sx={{
+        color: '#000',
+        fontWeight: 800,
+        padding: 0,
+        textTransform: 'none',
+      }}
+    >
+      {children}
+    </Button>
+  );
 }
 
 export default function B3AddToQuoteTip(props: B3AddToQuoteTipProps) {
@@ -18,21 +44,27 @@ export default function B3AddToQuoteTip(props: B3AddToQuoteTipProps) {
     >
       <Box
         sx={{
-          mr: '15px',
+          mr: platform === 'catalyst' ? '52px' : '15px',
         }}
       >
         {b3Lang(msg)}
       </Box>
-      <Button
-        onClick={() => gotoQuoteDraft()}
-        variant="text"
-        sx={{
-          color: '#ffffff',
-          padding: 0,
-        }}
-      >
-        {b3Lang('quoteDraft.notification.openQuote')}
-      </Button>
+      {platform === 'catalyst' ? (
+        <CatalystButton goToQuoteDraft={gotoQuoteDraft}>
+          {b3Lang('quoteDraft.notification.openQuote')}
+        </CatalystButton>
+      ) : (
+        <Button
+          onClick={() => gotoQuoteDraft()}
+          variant="text"
+          sx={{
+            color: '#ffffff',
+            padding: 0,
+          }}
+        >
+          {b3Lang('quoteDraft.notification.openQuote')}
+        </Button>
+      )}
     </Box>
   );
 }

--- a/apps/storefront/src/components/B3Tip.tsx
+++ b/apps/storefront/src/components/B3Tip.tsx
@@ -2,19 +2,19 @@ import { Alert, AlertTitle, Box, Snackbar } from '@mui/material';
 
 import useMobile from '@/hooks/useMobile';
 import { MsgsProps, TipMessagesProps } from '@/shared/dynamicallyVariable/context/config';
+import { platform } from '@/utils';
 
 interface B3TipProps extends TipMessagesProps {
   handleItemClose: (id: number | string) => void;
   handleAllClose: (id: string | number, reason: string) => void;
 }
 
-function MessageAlert({
-  msg,
-  onClose,
-}: {
+interface AlertProps {
   msg: MsgsProps;
   onClose: (id: string | number) => void;
-}) {
+}
+
+function MessageAlert({ msg, onClose }: AlertProps) {
   const Body = msg.jsx ? msg.jsx : () => <span>{msg.msg}</span>;
 
   return (
@@ -32,6 +32,69 @@ function MessageAlert({
         },
       }}
       variant="filled"
+      key={msg.id}
+      severity={msg.type}
+      onClose={() => msg.isClose && onClose(msg.id)}
+    >
+      {msg.title && <AlertTitle>{msg.title}</AlertTitle>}
+      <Body />
+    </Alert>
+  );
+}
+
+const CatalystColors = {
+  success: 'color-mix(in oklab, oklch(83.77% 0.214 142.31), white 75%)',
+  warning: 'color-mix(in oklab, oklch(83.42% 0.159 79.51), white 75%)',
+  info: 'color-mix(in oklab, oklch(49.07% 0.177 262.04), white 75%)',
+  error: 'color-mix(in oklab, oklch(64.89% 0.237 26.97), white 75%)',
+};
+
+function CatalystAlert({ msg, onClose }: AlertProps) {
+  const Body = msg.jsx
+    ? msg.jsx
+    : () => (
+        <span
+          style={{
+            textWrap: 'wrap',
+          }}
+        >
+          {msg.msg}
+        </span>
+      );
+
+  return (
+    <Alert
+      sx={{
+        background: CatalystColors[msg.type],
+        boxShadow: '0 0 #0000, 0 0 #0000, 0 0 #0000, 0 0 #0000, 0 1px 2px 0 rgba(0, 0, 0, 0.05);',
+        borderStyle: 'solid',
+        borderWidth: '1px',
+        borderColor: 'oklab(0.1822 0 0 / 0.1)',
+        borderRadius: '12px',
+        alignItems: 'center',
+        minWidth: '284px',
+        mb: '5px',
+        padding: '12px 12px 12px 16px',
+        color: '#000',
+        fontWeight: 400,
+        letterSpacing: 'normal',
+        fontSize: '14px',
+        fontFamily:
+          'ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji',
+        textWrap: 'auto',
+
+        '& button[title="Close"]': {
+          display: msg.isClose ? 'flex' : 'none',
+        },
+
+        '& .MuiAlert-message': {
+          overflow: 'unset',
+          padding: 0,
+          whiteSpace: 'nowrap',
+        },
+      }}
+      variant="filled"
+      icon={false}
       key={msg.id}
       severity={msg.type}
       onClose={() => msg.isClose && onClose(msg.id)}
@@ -76,7 +139,11 @@ export default function B3Tip({
                   display: 'flex',
                 }}
               >
-                <MessageAlert msg={msg} onClose={handleItemClose} />
+                {platform === 'catalyst' ? (
+                  <CatalystAlert msg={msg} onClose={handleItemClose} />
+                ) : (
+                  <MessageAlert msg={msg} onClose={handleItemClose} />
+                )}
               </Box>
             </Snackbar>
           ))

--- a/apps/storefront/src/pages/PDP/useAddedToShoppingListAlert.tsx
+++ b/apps/storefront/src/pages/PDP/useAddedToShoppingListAlert.tsx
@@ -1,8 +1,32 @@
+import { ReactNode } from 'react';
 import { useB3Lang } from '@b3/lang';
 import { Box, Button } from '@mui/material';
 
 import { useAppSelector } from '@/store';
-import { globalSnackbar } from '@/utils';
+import { globalSnackbar, platform } from '@/utils';
+
+function CatalystButton({
+  goToShoppingDetail,
+  children,
+}: {
+  goToShoppingDetail: () => void | undefined;
+  children: ReactNode;
+}) {
+  return (
+    <Button
+      onClick={() => goToShoppingDetail()}
+      variant="text"
+      sx={{
+        color: '#000',
+        padding: 0,
+        fontWeight: 800,
+        textTransform: 'none',
+      }}
+    >
+      {children}
+    </Button>
+  );
+}
 
 export function useAddedToShoppingListAlert() {
   const b3Lang = useB3Lang();
@@ -28,21 +52,27 @@ export function useAddedToShoppingListAlert() {
         >
           <Box
             sx={{
-              mr: '15px',
+              mr: platform === 'catalyst' ? '52px' : '15px',
             }}
           >
             {b3Lang('pdp.notification.productsAdded')}
           </Box>
-          <Button
-            onClick={() => gotoShoppingDetail(id)}
-            variant="text"
-            sx={{
-              color: '#ffffff',
-              padding: 0,
-            }}
-          >
-            {b3Lang('pdp.notification.viewShoppingList')}
-          </Button>
+          {platform === 'catalyst' ? (
+            <CatalystButton goToShoppingDetail={() => gotoShoppingDetail(id)}>
+              {b3Lang('pdp.notification.viewShoppingList')}
+            </CatalystButton>
+          ) : (
+            <Button
+              onClick={() => gotoShoppingDetail(id)}
+              variant="text"
+              sx={{
+                color: '#ffffff',
+                padding: 0,
+              }}
+            >
+              {b3Lang('pdp.notification.viewShoppingList')}
+            </Button>
+          )}
         </Box>
       ),
       isClose: true,

--- a/packages/lang/locales/en.json
+++ b/packages/lang/locales/en.json
@@ -698,7 +698,7 @@
   "login.loginText.missingCaptcha": "The captcha you entered is incorrect. Please try again.",
 
   "pdp.notification.productsAdded": "Products were added to your shopping list",
-  "pdp.notification.viewShoppingList": "view shopping list",
+  "pdp.notification.viewShoppingList": "View shopping list",
   "pdp.addToShoppingList": "Add to shopping list",
 
   "forgotPassword.resetPassword": "Reset password",


### PR DESCRIPTION
Jira: [B2B-2626](https://bigcommercecloud.atlassian.net/browse/B2B-2626)

## What/Why?
Adding styles for Catalyst notifications.

## Rollout/Rollback
Revert

## Testing

<img width="391" alt="Screenshot 2025-06-17 at 1 49 31 p m" src="https://github.com/user-attachments/assets/b0c405fd-2e73-4ff4-9026-783f1d0fc208" />
<img width="608" alt="Screenshot 2025-06-17 at 2 56 25 p m" src="https://github.com/user-attachments/assets/256e3cf9-0e30-4a8f-95c6-7dd52e7f9712" />
<img width="519" alt="Screenshot 2025-06-17 at 2 57 03 p m" src="https://github.com/user-attachments/assets/6b75f879-550e-45c4-a9b7-c05a2d60c8d8" />
