### PR TITLE
fix(common): B2B-3031 fix after.sh script

### DIFF
--- a/config/deploy/after.sh
+++ b/config/deploy/after.sh
@@ -43,6 +43,13 @@ if [[ $ENVIRONMENT =~ "production" ]]; then
 "revision": "${REVISION_TITLE}"
 }
 EOF
+else
+  tee deploy_revision_payload.json <<EOF >/dev/null
+{
+"deploy_all": true,
+"revision": "${REVISION_TITLE}"
+}
+EOF
 fi
 
 # create revision


### PR DESCRIPTION
Jira: [B2B-3031](https://bigcommercecloud.atlassian.net/browse/B2B-3031)

## What/Why?
We removed  by mistake the creation for the payload required for non production environments in the after.sh script used by LaunchBay
I recovered such fragment of code

## Rollout/Rollback
Revert this PR

## Testing
<img width="939" alt="Captura de pantalla 2025-06-25 a la(s) 7 36 58 p m" src="https://github.com/user-attachments/assets/d77b0228-d43e-4024-98a2-c5a6ba29403f" />

