### PR TITLE
feat(quick-order): B2B-3185 introduce companyId for ordered products when user masquerading child company

### DIFF
--- a/apps/storefront/src/components/layout/B3Nav.tsx
+++ b/apps/storefront/src/components/layout/B3Nav.tsx
@@ -148,15 +148,21 @@ export default function B3Nav({ closeSidebar }: B3NavProps) {
     const subsidiariesPermission = getSubsidiariesPermission(routes);
 
     if (selectCompanyHierarchyId) {
-      routes = routes.filter((route) =>
-        route?.subsidiariesCompanyKey
+      routes = routes.filter((route) => {
+        if (route?.subsidiariesCompanyKey === 'quickOrderPad') {
+          return true;
+        }
+        return route?.subsidiariesCompanyKey
           ? subsidiariesPermission[route.subsidiariesCompanyKey]
-          : false,
-      );
+          : false;
+      });
     } else {
       routes = routes.filter((route) => {
         if (route?.subsidiariesCompanyKey === 'companyHierarchy') {
           return isEnabledCompanyHierarchy && subsidiariesPermission[route.subsidiariesCompanyKey];
+        }
+        if (route?.subsidiariesCompanyKey === 'quickOrderPad') {
+          return true;
         }
         return true;
       });

--- a/apps/storefront/src/constants/index.ts
+++ b/apps/storefront/src/constants/index.ts
@@ -105,6 +105,7 @@ export const PAGES_SUBSIDIARIES_PERMISSION_KEYS = [
   { key: 'shoppingLists', path: HeadlessRoutes.SHOPPING_LISTS },
   { key: 'quotes', path: HeadlessRoutes.QUOTES },
   { key: 'companyHierarchy', path: HeadlessRoutes.COMPANY_HIERARCHY },
+  { key: 'quickOrderPad', path: HeadlessRoutes.PURCHASED_PRODUCTS },
 ] as const;
 
 export const LOGIN_LANDING_LOCATIONS = {

--- a/apps/storefront/src/shared/routeList.ts
+++ b/apps/storefront/src/shared/routeList.ts
@@ -66,6 +66,7 @@ const {
   quoteDraftPermissionCodes,
   quoteDetailPermissionCodes,
   companyHierarchyPermissionCodes,
+  quickOrderPermissionCodes,
 } = newPermissions;
 
 export const routeList: (BuyerPortalRoute | RouteItem)[] = [
@@ -140,10 +141,12 @@ export const routeList: (BuyerPortalRoute | RouteItem)[] = [
     path: '/purchased-products',
     name: 'Quick order',
     pageTitle: 'Purchased products',
+    subsidiariesCompanyKey: 'quickOrderPad',
     wsKey: 'quickOrder',
     isMenuItem: true,
     configKey: 'quickOrderPad',
     permissions: quickOrderPermissions,
+    permissionCodes: `${ordersPermissionCodes},${quickOrderPermissionCodes}`,
     isTokenLogin: true,
     idLang: 'global.navMenu.quickOrder',
   },
@@ -308,6 +311,10 @@ export const getAllowedRoutesWithoutComponent = (globalState: GlobalState): Buye
           level: 2,
           containOrEqual: 'contain',
         });
+      }
+
+      if (path === '/purchased-products' && hasPermission) {
+        return true;
       }
 
       return hasPermission;

--- a/apps/storefront/src/shared/routes/config.ts
+++ b/apps/storefront/src/shared/routes/config.ts
@@ -122,6 +122,7 @@ const newPermissions = {
   quoteDraftPermissionCodes: b2bPermissionsMap.quotesCreateActionsPermission,
   quoteDetailPermissionCodes: b2bPermissionsMap.getQuoteDetailPermission,
   companyHierarchyPermissionCodes: b2bPermissionsMap.companyHierarchyPermission,
+  quickOrderPermissionCodes: b2bPermissionsMap.purchasabilityPermission,
 };
 
 export { legacyPermissions, denyInvoiceRoles, allLegacyPermission, newPermissions };

--- a/apps/storefront/src/shared/service/b2b/graphql/quickOrder.ts
+++ b/apps/storefront/src/shared/service/b2b/graphql/quickOrder.ts
@@ -1,10 +1,5 @@
 import B3Request from '../../request/b3Fetch';
 
-// import {
-//   convertArrayToGraphql,
-//   storeHash,
-// } from '../../../../utils'
-
 const orderedProducts = (data: CustomFieldItems) => `{
   orderedProducts (
     q: "${data.q || ''}"
@@ -13,6 +8,7 @@ const orderedProducts = (data: CustomFieldItems) => `{
     beginDateAt: "${data.beginDateAt}"
     endDateAt: "${data.endDateAt}"
     orderBy: "${data?.orderBy || ''}"
+    ${data?.companyId ? `companyId: ${data.companyId}` : ''}
   ){
     totalCount,
     pageInfo{

--- a/apps/storefront/src/store/slices/company.ts
+++ b/apps/storefront/src/store/slices/company.ts
@@ -76,6 +76,7 @@ const initialState: CompanyState = {
     shoppingLists: false,
     quotes: false,
     companyHierarchy: false,
+    quickOrderPad: false,
   },
 };
 

--- a/apps/storefront/tests/components/quickOrder/QuickOrderB2BTable.test.tsx
+++ b/apps/storefront/tests/components/quickOrder/QuickOrderB2BTable.test.tsx
@@ -1,0 +1,266 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  getBcOrderedProducts,
+  getOrderedProducts,
+  searchB2BProducts,
+  searchBcProducts,
+} from '@/shared/service/b2b';
+
+vi.mock('@/shared/service/b2b', () => ({
+  getBcOrderedProducts: vi.fn(),
+  getOrderedProducts: vi.fn(),
+  searchB2BProducts: vi.fn(),
+  searchBcProducts: vi.fn(),
+}));
+
+vi.mock('date-fns', () => ({
+  format: vi.fn(),
+  subDays: vi.fn(),
+}));
+
+vi.mock('@/utils', () => ({
+  currencyFormat: vi.fn((value) => `$${value}`),
+  displayFormat: vi.fn((timestamp) => new Date(timestamp).toLocaleDateString()),
+  distanceDay: vi.fn((days) => {
+    const date = new Date();
+    date.setDate(date.getDate() - (days || 0));
+    return date.toISOString().split('T')[0];
+  }),
+  getProductPriceIncTaxOrExTaxBySetting: vi.fn((variants, variantId) => {
+    const variant = variants?.find(
+      (v: { variantId: number; price: number }) => v.variantId === variantId,
+    );
+    return variant?.price || 0;
+  }),
+  snackbar: {
+    error: vi.fn(),
+  },
+}));
+
+vi.mock('@/utils/b3Product/shared/config', () => ({
+  conversionProductsList: vi.fn((products) => products || []),
+}));
+
+vi.mock('@/utils/b2bGetVariantImageByVariantInfo', () => ({
+  default: vi.fn(() => null),
+}));
+
+vi.mock('@/utils/b3Product/b3Product', () => ({
+  getDisplayPrice: vi.fn(({ price }) => price),
+}));
+
+const mockServices = {
+  getBcOrderedProducts: vi.mocked(getBcOrderedProducts),
+  getOrderedProducts: vi.mocked(getOrderedProducts),
+  searchB2BProducts: vi.mocked(searchB2BProducts),
+  searchBcProducts: vi.mocked(searchBcProducts),
+};
+
+const mockOrderedProductsResponse = {
+  orderedProducts: {
+    edges: [
+      {
+        node: {
+          id: '1',
+          createdAt: 1640995200000,
+          updatedAt: 1640995200000,
+          productName: 'Test Product 1',
+          productBrandName: 'Test Brand',
+          variantSku: 'TEST-SKU-1',
+          productId: 123,
+          variantId: 456,
+          optionList: [],
+          orderedTimes: 5,
+          firstOrderedAt: 1640995200000,
+          lastOrderedAt: 1640995200000,
+          lastOrderedItems: 2,
+          sku: 'TEST-SKU-1',
+          lastOrdered: true,
+          imageUrl: 'https://example.com/image.jpg',
+          baseSku: 'BASE-SKU-1',
+          basePrice: 29.99,
+          discount: 0,
+          tax: 2.99,
+          enteredInclusive: false,
+          productUrl: '/products/test-product-1',
+          optionSelections: [],
+          quantity: 1,
+        },
+      },
+    ],
+    totalCount: 1,
+  },
+};
+
+const mockProductSearchResponse = {
+  productsSearch: [
+    {
+      id: 123,
+      name: 'Test Product 1',
+      sku: 'TEST-SKU-1',
+      variants: [
+        {
+          variantId: 456,
+          price: 29.99,
+        },
+      ],
+      isPriceHidden: false,
+    },
+  ],
+};
+
+describe('QuickOrderB2BTable Component - Company Context Logic', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockServices.getOrderedProducts.mockResolvedValue(mockOrderedProductsResponse);
+    mockServices.getBcOrderedProducts.mockResolvedValue(mockOrderedProductsResponse);
+    mockServices.searchB2BProducts.mockResolvedValue(mockProductSearchResponse);
+    mockServices.searchBcProducts.mockResolvedValue(mockProductSearchResponse);
+  });
+
+  describe('when the company has child companies', () => {
+    it('should use child company ID when selectCompanyHierarchyId is set', () => {
+      const selectCompanyHierarchyId = 'child-456';
+      const companyInfoId = 'parent-123';
+
+      const result = selectCompanyHierarchyId || companyInfoId;
+
+      expect(result).toBe('child-456');
+    });
+  });
+
+  describe('when the company does not have child companies', () => {
+    it('should use its own company ID when selectCompanyHierarchyId is empty', () => {
+      const selectCompanyHierarchyId = '';
+      const companyInfoId = 'parent-123';
+
+      const result = selectCompanyHierarchyId || companyInfoId;
+
+      expect(result).toBe('parent-123');
+    });
+
+    it('should fall back to its own company ID when selectCompanyHierarchyId is null', () => {
+      const selectCompanyHierarchyId = null;
+      const companyInfoId = 'parent-123';
+
+      const result = selectCompanyHierarchyId || companyInfoId;
+
+      expect(result).toBe('parent-123');
+    });
+
+    it('should fall back to its own company ID when selectCompanyHierarchyId is undefined', () => {
+      const selectCompanyHierarchyId = undefined;
+      const companyInfoId = 'parent-123';
+
+      const result = selectCompanyHierarchyId || companyInfoId;
+
+      expect(result).toBe('parent-123');
+    });
+  });
+
+  describe('when building GraphQL query parameters', () => {
+    it('should include companyId in getOrderedProducts when child company is selected', async () => {
+      const childCompanyId = 'child-456';
+      const params = {
+        q: '',
+        first: 12,
+        offset: 0,
+        beginDateAt: '2023-01-01',
+        endDateAt: '2023-12-31',
+        orderBy: '-lastOrderedAt',
+      };
+
+      const queryParams = {
+        ...params,
+        companyId: childCompanyId,
+      };
+
+      await getOrderedProducts(queryParams);
+
+      expect(mockServices.getOrderedProducts).toHaveBeenCalledWith(
+        expect.objectContaining({
+          companyId: 'child-456',
+        }),
+      );
+    });
+
+    it('should include companyId in searchB2BProducts when child company is selected', async () => {
+      const childCompanyId = 'child-456';
+      const productSearchParams = {
+        productIds: [123, 456],
+        currencyCode: 'USD',
+        customerGroupId: 1,
+        companyId: childCompanyId,
+      };
+
+      await searchB2BProducts(productSearchParams);
+
+      expect(mockServices.searchB2BProducts).toHaveBeenCalledWith(
+        expect.objectContaining({
+          companyId: 'child-456',
+        }),
+      );
+    });
+
+    it('should include parent companyId when no child company is selected', async () => {
+      const parentCompanyId = 'parent-123';
+      const params = {
+        q: '',
+        first: 12,
+        offset: 0,
+        beginDateAt: '2023-01-01',
+        endDateAt: '2023-12-31',
+        orderBy: '-lastOrderedAt',
+      };
+
+      const queryParams = {
+        ...params,
+        companyId: parentCompanyId,
+      };
+
+      await getOrderedProducts(queryParams);
+
+      expect(mockServices.getOrderedProducts).toHaveBeenCalledWith(
+        expect.objectContaining({
+          companyId: 'parent-123',
+        }),
+      );
+    });
+  });
+
+  describe('when switching between companies', () => {
+    it('should handle switching from parent to child company', () => {
+      let selectCompanyHierarchyId = '';
+      const companyInfoId = 'parent-123';
+      let currentCompanyId = selectCompanyHierarchyId || companyInfoId;
+      expect(currentCompanyId).toBe('parent-123');
+
+      selectCompanyHierarchyId = 'child-456';
+      currentCompanyId = selectCompanyHierarchyId || companyInfoId;
+      expect(currentCompanyId).toBe('child-456');
+    });
+
+    it('should handle switching from child back to parent company', () => {
+      let selectCompanyHierarchyId = 'child-456';
+      const companyInfoId = 'parent-123';
+      let currentCompanyId = selectCompanyHierarchyId || companyInfoId;
+      expect(currentCompanyId).toBe('child-456');
+
+      selectCompanyHierarchyId = '';
+      currentCompanyId = selectCompanyHierarchyId || companyInfoId;
+      expect(currentCompanyId).toBe('parent-123');
+    });
+
+    it('should handle switching between different child companies', () => {
+      let selectCompanyHierarchyId = 'child-A-111';
+      const companyInfoId = 'parent-123';
+      let currentCompanyId = selectCompanyHierarchyId || companyInfoId;
+      expect(currentCompanyId).toBe('child-A-111');
+
+      selectCompanyHierarchyId = 'child-B-222';
+      currentCompanyId = selectCompanyHierarchyId || companyInfoId;
+      expect(currentCompanyId).toBe('child-B-222');
+    });
+  });
+});

--- a/apps/storefront/tests/shared/routeList.test.ts
+++ b/apps/storefront/tests/shared/routeList.test.ts
@@ -1,0 +1,313 @@
+import { buildCompanyStateWith } from 'tests/storeStateBuilders/companyStateBuilder';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { CompanyStatus, CustomerRole, UserTypes } from '@/types';
+import { checkEveryPermissionsCode } from '@/utils';
+import { validatePermissionWithComparisonType } from '@/utils/b3CheckPermissions';
+
+vi.mock('@/utils', () => ({
+  checkEveryPermissionsCode: vi.fn(),
+}));
+
+vi.mock('@/utils/b3CheckPermissions', () => ({
+  validatePermissionWithComparisonType: vi.fn(),
+}));
+
+const mockCheckEveryPermissionsCode = vi.mocked(checkEveryPermissionsCode);
+const mockValidatePermissionWithComparisonType = vi.mocked(validatePermissionWithComparisonType);
+
+describe('Quick Order Tab Visibility', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('when representing child companies', () => {
+    it('shows Quick Order when user has level 3 permissions', () => {
+      mockCheckEveryPermissionsCode.mockReturnValue(true);
+
+      mockValidatePermissionWithComparisonType.mockReturnValue(true);
+
+      const permissionCodes = 'get_orders,purchase_enable';
+      const hasBasePermissions = mockCheckEveryPermissionsCode(permissionCodes);
+
+      const hasLevel3Permissions = hasBasePermissions
+        ? mockValidatePermissionWithComparisonType({
+            code: permissionCodes,
+            level: 3,
+            containOrEqual: 'contain',
+          })
+        : false;
+
+      expect(mockCheckEveryPermissionsCode).toHaveBeenCalledWith('get_orders,purchase_enable');
+      expect(mockValidatePermissionWithComparisonType).toHaveBeenCalledWith({
+        code: 'get_orders,purchase_enable',
+        level: 3,
+        containOrEqual: 'contain',
+      });
+      expect(hasLevel3Permissions).toBe(true);
+    });
+
+    it('hides Quick Order when user lacks level 3 permissions', () => {
+      mockCheckEveryPermissionsCode.mockReturnValue(true);
+      mockValidatePermissionWithComparisonType.mockReturnValue(false);
+
+      const permissionCodes = 'get_orders,purchase_enable';
+      const hasBasePermissions = mockCheckEveryPermissionsCode(permissionCodes);
+
+      const hasLevel3Permissions = hasBasePermissions
+        ? mockValidatePermissionWithComparisonType({
+            code: permissionCodes,
+            level: 3,
+            containOrEqual: 'contain',
+          })
+        : false;
+
+      expect(hasLevel3Permissions).toBe(false);
+    });
+
+    it('hides Quick Order when user has no base permissions', () => {
+      mockCheckEveryPermissionsCode.mockReturnValue(false);
+
+      const permissionCodes = 'get_orders,purchase_enable';
+      const hasBasePermissions = mockCheckEveryPermissionsCode(permissionCodes);
+
+      const hasLevel3Permissions = hasBasePermissions
+        ? mockValidatePermissionWithComparisonType({
+            code: permissionCodes,
+            level: 3,
+            containOrEqual: 'contain',
+          })
+        : false;
+
+      expect(hasBasePermissions).toBe(false);
+      expect(hasLevel3Permissions).toBe(false);
+      expect(mockValidatePermissionWithComparisonType).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when managing company hierarchy', () => {
+    it('configures company state correctly for admin with level 3 permissions', () => {
+      const companyState = buildCompanyStateWith({
+        customer: {
+          id: 123,
+          role: CustomerRole.ADMIN,
+          userType: UserTypes.MULTIPLE_B2C,
+          firstName: 'Test',
+          lastName: 'User',
+          emailAddress: 'test@example.com',
+          phoneNumber: '123-456-7890',
+          customerGroupId: 1,
+          loginType: 1,
+          companyRoleName: 'Admin',
+        },
+        companyInfo: {
+          id: '456',
+          companyName: 'Parent Company',
+          status: CompanyStatus.APPROVED,
+        },
+        permissions: [
+          { code: 'get_orders', permissionLevel: 3 },
+          { code: 'purchase_enable', permissionLevel: 3 },
+        ],
+        companyHierarchyInfo: {
+          isEnabledCompanyHierarchy: true,
+          isHasCurrentPagePermission: true,
+          selectCompanyHierarchyId: '789',
+          companyHierarchyList: [
+            {
+              companyId: 789,
+              companyName: 'Child Company',
+              channelFlag: true,
+            },
+          ],
+          companyHierarchyAllList: [],
+          companyHierarchySelectSubsidiariesList: [],
+        },
+        pagesSubsidiariesPermission: {
+          quickOrderPad: true,
+          order: true,
+          invoice: false,
+          addresses: false,
+          userManagement: false,
+          shoppingLists: false,
+          quotes: false,
+          companyHierarchy: true,
+        },
+      });
+
+      expect(companyState.companyHierarchyInfo.selectCompanyHierarchyId).toBe('789');
+      expect(companyState.companyHierarchyInfo.isEnabledCompanyHierarchy).toBe(true);
+      expect(companyState.permissions).toHaveLength(2);
+      expect(companyState.permissions[0].permissionLevel).toBe(3);
+      expect(companyState.permissions[1].permissionLevel).toBe(3);
+      expect(companyState.pagesSubsidiariesPermission.quickOrderPad).toBe(true);
+    });
+
+    it('allows Quick Order access for parent company users regardless of permission level', () => {
+      const companyState = buildCompanyStateWith({
+        customer: {
+          id: 123,
+          role: CustomerRole.ADMIN,
+          userType: UserTypes.MULTIPLE_B2C,
+          firstName: 'Test',
+          lastName: 'User',
+          emailAddress: 'test@example.com',
+          phoneNumber: '123-456-7890',
+          customerGroupId: 1,
+          loginType: 1,
+          companyRoleName: 'Admin',
+        },
+        companyInfo: {
+          id: '456',
+          companyName: 'Parent Company',
+          status: CompanyStatus.APPROVED,
+        },
+        permissions: [
+          { code: 'get_orders', permissionLevel: 1 },
+          { code: 'purchase_enable', permissionLevel: 2 },
+        ],
+        companyHierarchyInfo: {
+          isEnabledCompanyHierarchy: true,
+          isHasCurrentPagePermission: true,
+          selectCompanyHierarchyId: '',
+          companyHierarchyList: [],
+          companyHierarchyAllList: [],
+          companyHierarchySelectSubsidiariesList: [],
+        },
+      });
+
+      expect(companyState.companyHierarchyInfo.selectCompanyHierarchyId).toBe('');
+      expect(companyState.companyHierarchyInfo.isEnabledCompanyHierarchy).toBe(true);
+      expect(companyState.permissions[0].permissionLevel).toBe(1);
+      expect(companyState.permissions[1].permissionLevel).toBe(2);
+    });
+
+    it('denies Quick Order access for junior buyers without level 3 permissions', () => {
+      const companyState = buildCompanyStateWith({
+        customer: {
+          id: 123,
+          role: CustomerRole.JUNIOR_BUYER,
+          userType: UserTypes.MULTIPLE_B2C,
+          firstName: 'Test',
+          lastName: 'User',
+          emailAddress: 'test@example.com',
+          phoneNumber: '123-456-7890',
+          customerGroupId: 1,
+          loginType: 1,
+          companyRoleName: 'Junior Buyer',
+        },
+        companyInfo: {
+          id: '456',
+          companyName: 'Parent Company',
+          status: CompanyStatus.APPROVED,
+        },
+        permissions: [],
+        pagesSubsidiariesPermission: {
+          quickOrderPad: false,
+          order: false,
+          invoice: false,
+          addresses: false,
+          userManagement: false,
+          shoppingLists: false,
+          quotes: false,
+          companyHierarchy: false,
+        },
+      });
+
+      expect(companyState.customer.role).toBe(CustomerRole.JUNIOR_BUYER);
+      expect(companyState.permissions).toHaveLength(0);
+      expect(companyState.pagesSubsidiariesPermission.quickOrderPad).toBe(false);
+    });
+  });
+
+  describe('end-to-end user journey', () => {
+    it('enables complete Quick Order workflow with level 3 permissions', () => {
+      const userPermissions = [
+        { code: 'get_orders', permissionLevel: 3 },
+        { code: 'purchase_enable', permissionLevel: 3 },
+      ];
+
+      const childCompanyId = '789';
+
+      const hasRequiredPermissions = userPermissions.every(
+        (permission) => permission.permissionLevel >= 3,
+      );
+
+      expect(hasRequiredPermissions).toBe(true);
+      expect(childCompanyId).toBeTruthy();
+
+      const expectedRoute = {
+        path: '/purchased-products',
+        name: 'Quick order',
+        subsidiariesCompanyKey: 'quickOrderPad',
+        permissionCodes: 'get_orders,purchase_enable',
+      };
+
+      expect(expectedRoute.subsidiariesCompanyKey).toBe('quickOrderPad');
+      expect(expectedRoute.permissionCodes).toContain('get_orders');
+      expect(expectedRoute.permissionCodes).toContain('purchase_enable');
+    });
+
+    it('enforces security restrictions for insufficient permissions', () => {
+      const userPermissions = [
+        { code: 'get_orders', permissionLevel: 2 },
+        { code: 'purchase_enable', permissionLevel: 1 },
+      ];
+
+      const childCompanyId = '789';
+
+      const hasLevel3Permissions = userPermissions.some(
+        (permission) => permission.permissionLevel >= 3,
+      );
+
+      expect(hasLevel3Permissions).toBe(false);
+      expect(childCompanyId).toBeTruthy();
+    });
+  });
+
+  describe('permission level validation', () => {
+    it('only grants access with level 3 permissions', () => {
+      mockCheckEveryPermissionsCode.mockReturnValue(true);
+
+      const permissionCodes = 'get_orders,purchase_enable';
+      const hasBasePermissions = mockCheckEveryPermissionsCode(permissionCodes);
+
+      mockValidatePermissionWithComparisonType.mockReturnValue(false);
+      const level1Result = hasBasePermissions
+        ? mockValidatePermissionWithComparisonType({
+            code: permissionCodes,
+            level: 3,
+            containOrEqual: 'contain',
+          })
+        : false;
+
+      mockValidatePermissionWithComparisonType.mockReturnValue(false);
+      const level2Result = hasBasePermissions
+        ? mockValidatePermissionWithComparisonType({
+            code: permissionCodes,
+            level: 3,
+            containOrEqual: 'contain',
+          })
+        : false;
+
+      mockValidatePermissionWithComparisonType.mockReturnValue(true);
+      const level3Result = hasBasePermissions
+        ? mockValidatePermissionWithComparisonType({
+            code: permissionCodes,
+            level: 3,
+            containOrEqual: 'contain',
+          })
+        : false;
+
+      expect(level1Result).toBe(false);
+      expect(level2Result).toBe(false);
+      expect(level3Result).toBe(true);
+
+      expect(mockValidatePermissionWithComparisonType).toHaveBeenCalledWith({
+        code: 'get_orders,purchase_enable',
+        level: 3,
+        containOrEqual: 'contain',
+      });
+    });
+  });
+});

--- a/apps/storefront/tests/shared/service/quickOrder.test.ts
+++ b/apps/storefront/tests/shared/service/quickOrder.test.ts
@@ -1,0 +1,405 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { getBcOrderedProducts, getOrderedProducts } from '@/shared/service/b2b/graphql/quickOrder';
+import B3Request from '@/shared/service/request/b3Fetch';
+
+vi.mock('@/shared/service/request/b3Fetch', () => ({
+  default: {
+    graphqlB2B: vi.fn(),
+  },
+}));
+
+const mockB3Request = vi.mocked(B3Request);
+
+describe('QuickOrder GraphQL Service', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('getOrderedProducts', () => {
+    it('includes companyId in query when provided', async () => {
+      const mockResponse = {
+        orderedProducts: {
+          totalCount: 10,
+          edges: [
+            {
+              node: {
+                id: '1',
+                productName: 'Test Product',
+                variantSku: 'TEST-SKU',
+                productId: 123,
+                variantId: 456,
+              },
+            },
+          ],
+        },
+      };
+
+      mockB3Request.graphqlB2B.mockResolvedValue(mockResponse);
+
+      const params = {
+        q: 'test',
+        first: 10,
+        offset: 0,
+        beginDateAt: '2023-01-01',
+        endDateAt: '2023-12-31',
+        orderBy: '-lastOrderedAt',
+        companyId: 789,
+      };
+
+      await getOrderedProducts(params);
+
+      expect(mockB3Request.graphqlB2B).toHaveBeenCalledWith({
+        query: expect.stringContaining('companyId: 789'),
+      });
+
+      const calledQuery = mockB3Request.graphqlB2B.mock.calls[0][0].query;
+      expect(calledQuery).toContain('q: "test"');
+      expect(calledQuery).toContain('first: 10');
+      expect(calledQuery).toContain('offset: 0');
+      expect(calledQuery).toContain('beginDateAt: "2023-01-01"');
+      expect(calledQuery).toContain('endDateAt: "2023-12-31"');
+      expect(calledQuery).toContain('orderBy: "-lastOrderedAt"');
+      expect(calledQuery).toContain('companyId: 789');
+    });
+
+    it('excludes companyId from query when not provided', async () => {
+      const mockResponse = {
+        orderedProducts: {
+          totalCount: 5,
+          edges: [],
+        },
+      };
+
+      mockB3Request.graphqlB2B.mockResolvedValue(mockResponse);
+
+      const params = {
+        q: 'test',
+        first: 10,
+        offset: 0,
+        beginDateAt: '2023-01-01',
+        endDateAt: '2023-12-31',
+        orderBy: '-lastOrderedAt',
+      };
+
+      await getOrderedProducts(params);
+
+      expect(mockB3Request.graphqlB2B).toHaveBeenCalledWith({
+        query: expect.not.stringContaining('companyId:'),
+      });
+
+      const calledQuery = mockB3Request.graphqlB2B.mock.calls[0][0].query;
+      expect(calledQuery).not.toContain('companyId');
+    });
+
+    it('excludes companyId from query when companyId is 0', async () => {
+      const mockResponse = {
+        orderedProducts: {
+          totalCount: 5,
+          edges: [],
+        },
+      };
+
+      mockB3Request.graphqlB2B.mockResolvedValue(mockResponse);
+
+      const params = {
+        q: 'test',
+        first: 10,
+        offset: 0,
+        beginDateAt: '2023-01-01',
+        endDateAt: '2023-12-31',
+        orderBy: '-lastOrderedAt',
+        companyId: 0,
+      };
+
+      await getOrderedProducts(params);
+
+      const calledQuery = mockB3Request.graphqlB2B.mock.calls[0][0].query;
+      expect(calledQuery).not.toContain('companyId');
+    });
+
+    it('excludes companyId from query when companyId is null', async () => {
+      const mockResponse = {
+        orderedProducts: {
+          totalCount: 5,
+          edges: [],
+        },
+      };
+
+      mockB3Request.graphqlB2B.mockResolvedValue(mockResponse);
+
+      const params = {
+        q: 'test',
+        first: 10,
+        offset: 0,
+        beginDateAt: '2023-01-01',
+        endDateAt: '2023-12-31',
+        orderBy: '-lastOrderedAt',
+        companyId: null,
+      };
+
+      await getOrderedProducts(params);
+
+      const calledQuery = mockB3Request.graphqlB2B.mock.calls[0][0].query;
+      expect(calledQuery).not.toContain('companyId');
+    });
+
+    it('handles empty search parameters correctly', async () => {
+      const mockResponse = {
+        orderedProducts: {
+          totalCount: 0,
+          edges: [],
+        },
+      };
+
+      mockB3Request.graphqlB2B.mockResolvedValue(mockResponse);
+
+      const params = {
+        q: '',
+        first: 10,
+        offset: 0,
+        beginDateAt: '',
+        endDateAt: '',
+        orderBy: '',
+      };
+
+      await getOrderedProducts(params);
+
+      const calledQuery = mockB3Request.graphqlB2B.mock.calls[0][0].query;
+      expect(calledQuery).toContain('q: ""');
+      expect(calledQuery).toContain('beginDateAt: ""');
+      expect(calledQuery).toContain('endDateAt: ""');
+      expect(calledQuery).toContain('orderBy: ""');
+      expect(calledQuery).not.toContain('companyId');
+    });
+
+    it('returns the correct response structure', async () => {
+      const mockResponse = {
+        orderedProducts: {
+          totalCount: 2,
+          pageInfo: {
+            hasNextPage: false,
+            hasPreviousPage: false,
+          },
+          edges: [
+            {
+              node: {
+                id: '1',
+                createdAt: 1640995200000,
+                updatedAt: 1640995200000,
+                productName: 'Test Product 1',
+                productBrandName: 'Test Brand',
+                variantSku: 'TEST-SKU-1',
+                productId: 123,
+                variantId: 456,
+                optionList: [],
+                orderedTimes: 5,
+                firstOrderedAt: 1640995200000,
+                lastOrderedAt: 1640995200000,
+                lastOrderedItems: 2,
+                sku: 'TEST-SKU-1',
+                lastOrdered: true,
+                imageUrl: 'https://example.com/image.jpg',
+                baseSku: 'BASE-SKU-1',
+                basePrice: 29.99,
+                discount: 0,
+                tax: 2.99,
+                enteredInclusive: false,
+                productUrl: '/products/test-product-1',
+                optionSelections: [],
+              },
+            },
+          ],
+        },
+      };
+
+      mockB3Request.graphqlB2B.mockResolvedValue(mockResponse);
+
+      const params = {
+        q: 'test',
+        first: 10,
+        offset: 0,
+        beginDateAt: '2023-01-01',
+        endDateAt: '2023-12-31',
+        orderBy: '-lastOrderedAt',
+        companyId: 789,
+      };
+
+      const result = await getOrderedProducts(params);
+
+      expect(result).toEqual(mockResponse);
+      expect(result.orderedProducts.totalCount).toBe(2);
+      expect(result.orderedProducts.edges).toHaveLength(1);
+      expect(result.orderedProducts.edges[0].node.productName).toBe('Test Product 1');
+    });
+  });
+
+  describe('getBcOrderedProducts', () => {
+    it('uses the same query structure as getOrderedProducts', async () => {
+      const mockResponse = {
+        orderedProducts: {
+          totalCount: 3,
+          edges: [],
+        },
+      };
+
+      mockB3Request.graphqlB2B.mockResolvedValue(mockResponse);
+
+      const params = {
+        q: 'bc-test',
+        first: 20,
+        offset: 10,
+        beginDateAt: '2023-06-01',
+        endDateAt: '2023-06-30',
+        orderBy: '-createdAt',
+        companyId: 456,
+      };
+
+      await getBcOrderedProducts(params);
+
+      expect(mockB3Request.graphqlB2B).toHaveBeenCalledWith({
+        query: expect.stringContaining('companyId: 456'),
+      });
+
+      const calledQuery = mockB3Request.graphqlB2B.mock.calls[0][0].query;
+      expect(calledQuery).toContain('q: "bc-test"');
+      expect(calledQuery).toContain('first: 20');
+      expect(calledQuery).toContain('offset: 10');
+      expect(calledQuery).toContain('companyId: 456');
+    });
+  });
+
+  describe('Child Company Representation Scenarios', () => {
+    it('fetches parent company products when no child company is selected', async () => {
+      const mockResponse = {
+        orderedProducts: {
+          totalCount: 5,
+          edges: [],
+        },
+      };
+
+      mockB3Request.graphqlB2B.mockResolvedValue(mockResponse);
+
+      const params = {
+        q: '',
+        first: 12,
+        offset: 0,
+        beginDateAt: '2023-01-01',
+        endDateAt: '2023-12-31',
+        orderBy: '-lastOrderedAt',
+      };
+
+      await getOrderedProducts(params);
+
+      const calledQuery = mockB3Request.graphqlB2B.mock.calls[0][0].query;
+      expect(calledQuery).not.toContain('companyId');
+    });
+
+    it('fetches child company products when representing a child company', async () => {
+      const mockResponse = {
+        orderedProducts: {
+          totalCount: 3,
+          edges: [
+            {
+              node: {
+                id: '1',
+                productName: 'Child Company Product',
+                variantSku: 'CHILD-SKU-1',
+                productId: 999,
+                variantId: 888,
+              },
+            },
+          ],
+        },
+      };
+
+      mockB3Request.graphqlB2B.mockResolvedValue(mockResponse);
+
+      const childCompanyId = 123;
+      const params = {
+        q: '',
+        first: 12,
+        offset: 0,
+        beginDateAt: '2023-01-01',
+        endDateAt: '2023-12-31',
+        orderBy: '-lastOrderedAt',
+        companyId: childCompanyId,
+      };
+
+      const result = await getOrderedProducts(params);
+
+      const calledQuery = mockB3Request.graphqlB2B.mock.calls[0][0].query;
+      expect(calledQuery).toContain(`companyId: ${childCompanyId}`);
+      expect(result.orderedProducts.edges[0].node.productName).toBe('Child Company Product');
+    });
+
+    it('switches between different child companies correctly', async () => {
+      const mockResponse1 = {
+        orderedProducts: {
+          totalCount: 2,
+          edges: [
+            {
+              node: {
+                id: '1',
+                productName: 'Child Company A Product',
+              },
+            },
+          ],
+        },
+      };
+
+      const mockResponse2 = {
+        orderedProducts: {
+          totalCount: 4,
+          edges: [
+            {
+              node: {
+                id: '2',
+                productName: 'Child Company B Product',
+              },
+            },
+          ],
+        },
+      };
+
+      // First call for child company A
+      mockB3Request.graphqlB2B.mockResolvedValueOnce(mockResponse1);
+
+      const paramsA = {
+        q: '',
+        first: 12,
+        offset: 0,
+        beginDateAt: '2023-01-01',
+        endDateAt: '2023-12-31',
+        orderBy: '-lastOrderedAt',
+        companyId: 111,
+      };
+
+      await getOrderedProducts(paramsA);
+
+      // Second call for child company B
+      mockB3Request.graphqlB2B.mockResolvedValueOnce(mockResponse2);
+
+      const paramsB = {
+        q: '',
+        first: 12,
+        offset: 0,
+        beginDateAt: '2023-01-01',
+        endDateAt: '2023-12-31',
+        orderBy: '-lastOrderedAt',
+        companyId: 222,
+      };
+
+      await getOrderedProducts(paramsB);
+
+      // Verify both calls were made with correct company IDs
+      expect(mockB3Request.graphqlB2B).toHaveBeenCalledTimes(2);
+
+      const firstCallQuery = mockB3Request.graphqlB2B.mock.calls[0][0].query;
+      const secondCallQuery = mockB3Request.graphqlB2B.mock.calls[1][0].query;
+
+      expect(firstCallQuery).toContain('companyId: 111');
+      expect(secondCallQuery).toContain('companyId: 222');
+    });
+  });
+});

--- a/apps/storefront/tests/storeStateBuilders/companyStateBuilder.ts
+++ b/apps/storefront/tests/storeStateBuilders/companyStateBuilder.ts
@@ -45,6 +45,7 @@ export const buildCompanyStateWith = builder<CompanyState & PersistPartial>(() =
     shoppingLists: false,
     quotes: false,
     companyHierarchy: false,
+    quickOrderPad: false,
   },
   _persist: {
     version: 1,

--- a/commit-validation.json
+++ b/commit-validation.json
@@ -10,6 +10,7 @@
     "catalyst",
     "carts",
     "orders",
+    "quick-order",
     "addresses",
     "headless",
     "user-management",


### PR DESCRIPTION
Jira: [B2B-2960](https://bigcommercecloud.atlassian.net/browse/B2B-2960)

## What/Why?
This PR introduced the companyId for 
This PR ensuring that when users represent a child company, it loads the child company's ordered product.

When representing a child company:

* [companyId](vscode-file://vscode-app/Users/amanda.lan/Documents/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) is included in [getOrderedProducts()](vscode-file://vscode-app/Users/amanda.lan/Documents/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) query
* [companyId](vscode-file://vscode-app/Users/amanda.lan/Documents/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) is passed to [searchB2BProducts()](vscode-file://vscode-app/Users/amanda.lan/Documents/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) for product details
* Data fetching is automatically triggered when switching between companies


## Rollout/Rollback
Revert

## Testing
Before it does not load the child company's ordered products:

https://github.com/user-attachments/assets/638cb2b9-0a6a-44c4-b297-2e36c8242027



After the ordered products shows:

https://github.com/user-attachments/assets/8679914a-5b68-419d-ba58-aae54bb7f50d




[B2B-2960]: https://bigcommercecloud.atlassian.net/browse/B2B-2960?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ