### PR TITLE
fix(common): B2B-2812 update close button to not show order views

### DIFF
--- a/apps/storefront/src/components/layout/B3CloseAppButton.tsx
+++ b/apps/storefront/src/components/layout/B3CloseAppButton.tsx
@@ -18,7 +18,7 @@ export default function B3CloseAppButton() {
   const navigate = useNavigate();
 
   const handleCloseForm = () => {
-    if (isCloseGotoBCHome) {
+    if (isCloseGotoBCHome || window.location.search.includes('action=order_status')) {
       window.location.href = '/';
     } else {
       navigate('/');


### PR DESCRIPTION
## What/Why?
When logging as a customer we are redirected to STORE_URL.com/account.php?action=order_status#/orders but when using the close button is possible to see the storefront's order view which is causing confusion for the users. 
So if we are located in a page with search action=order_status we need to be redirected to the home page of the storefront.

## Rollout/Rollback
Revert

## Testing
Before:

https://github.com/user-attachments/assets/908df075-b0f9-45e3-8679-28fa5387c360

After:

https://github.com/user-attachments/assets/bfa7b9c3-fedd-4c56-a555-dd7e4b9911ca
