### PR TITLE
refactor(quick-order): B2BCAT-18 Decouple searchProducts/ProductListDialog/ChooseOptionsDialog

### DIFF
--- a/apps/storefront/src/pages/QuickOrder/components/ChooseOptionsDialog.tsx
+++ b/apps/storefront/src/pages/QuickOrder/components/ChooseOptionsDialog.tsx
@@ -1,0 +1,612 @@
+import {
+  ChangeEvent,
+  Dispatch,
+  KeyboardEvent,
+  SetStateAction,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
+import { FieldValues, useForm } from 'react-hook-form';
+import { useB3Lang } from '@b3/lang';
+import styled from '@emotion/styled';
+import { Box, Divider, TextField, Typography } from '@mui/material';
+import isEqual from 'lodash-es/isEqual';
+
+import { B3CustomForm } from '@/components';
+import B3Dialog from '@/components/B3Dialog';
+import B3Spin from '@/components/spin/B3Spin';
+import { PRODUCT_DEFAULT_IMAGE } from '@/constants';
+import { searchProducts } from '@/shared/service/b2b';
+import { useAppSelector } from '@/store';
+import { AllOptionProps, ShoppingListProductItem, SimpleObject, Variant } from '@/types';
+import { currencyFormat, snackbar } from '@/utils';
+import b2bLogger from '@/utils/b3Logger';
+import {
+  calculateProductListPrice,
+  getBCPrice,
+  getProductInfoDisplayPrice,
+  getVariantInfoDisplayPrice,
+} from '@/utils/b3Product/b3Product';
+import {
+  Base64,
+  getOptionRequestData,
+  getProductOptionsFields,
+} from '@/utils/b3Product/shared/config';
+
+const Flex = styled('div')({
+  display: 'flex',
+  wordBreak: 'break-word',
+  gap: '8px',
+  flexWrap: 'wrap',
+  padding: '12px 0 12px',
+  '&:first-of-type': {
+    marginTop: '12px',
+  },
+});
+
+interface FlexItemProps {
+  padding?: string;
+}
+
+const FlexItem = styled('div')(({ padding }: FlexItemProps) => ({
+  display: 'flex',
+  flexGrow: 1,
+  flexShrink: 1,
+  alignItems: 'flex-start',
+  width: '100%',
+  padding: padding || '0 0 0 16px',
+}));
+
+const ProductImage = styled('img')(() => ({
+  width: '60px',
+  height: '60px',
+  borderRadius: '4px',
+  marginTop: '12px',
+  flexShrink: 0,
+}));
+
+const ProductOptionText = styled('div')(() => ({
+  fontSize: '0.75rem',
+  lineHeight: '1.5',
+  color: '#455A64',
+}));
+
+const StyleTextField = styled(TextField)(() => ({
+  '& input::-webkit-outer-spin-button, input::-webkit-inner-spin-button': {
+    marginTop: '-8px',
+    marginBottom: '8px',
+  },
+}));
+
+interface ChooseOptionsDialogProps {
+  isOpen: boolean;
+  product?: ShoppingListProductItem;
+  onCancel: () => void;
+  onConfirm: (products: CustomFieldItems[]) => void;
+  isEdit?: boolean;
+  isLoading: boolean;
+  setIsLoading: Dispatch<SetStateAction<boolean>>;
+  addButtonText?: string;
+  type?: string;
+}
+
+interface ChooseOptionsProductProps extends ShoppingListProductItem {
+  newSelectOptionList: {
+    optionId: string;
+    optionValue: unknown;
+  }[];
+  productId: number;
+  quantity: number;
+  variantId: number;
+  additionalProducts: CustomFieldItems;
+}
+
+export default function ChooseOptionsDialog(props: ChooseOptionsDialogProps) {
+  const {
+    isOpen,
+    onCancel,
+    onConfirm,
+    product,
+    isEdit = false,
+    isLoading,
+    setIsLoading,
+    type,
+    ...restProps
+  } = props;
+
+  const b3Lang = useB3Lang();
+  const { addButtonText = b3Lang('shoppingList.chooseOptionsDialog.addToList') } = restProps;
+
+  const showInclusiveTaxPrice = useAppSelector(({ global }) => global.showInclusiveTaxPrice);
+  const isEnableProduct = useAppSelector(
+    ({ global }) => global.blockPendingQuoteNonPurchasableOOS.isEnableProduct,
+  );
+  const salesRepCompanyId = useAppSelector(({ b2bFeatures }) => b2bFeatures.masqueradeCompany.id);
+  const customerGroupId = useAppSelector((state) => state.company.customer.customerGroupId);
+  const companyInfoId = useAppSelector((state) => state.company.companyInfo.id);
+  const [quantity, setQuantity] = useState<number | string>(1);
+  const [formFields, setFormFields] = useState<CustomFieldItems[]>([]);
+  const [variantInfo, setVariantInfo] = useState<Partial<Variant> | null>(null);
+  const [variantSku, setVariantSku] = useState('');
+  const [currentImage, setCurrentImage] = useState<string>(product?.imageUrl || '');
+  const [isShowPrice, setShowPrice] = useState<boolean>(true);
+  const [additionalProducts, setAdditionalProducts] = useState<CustomFieldItems>({});
+  const [productPriceChangeOptions, setProductPriceChangeOptions] = useState<
+    Partial<AllOptionProps>[]
+  >([]);
+  const [newPrice, setNewPrice] = useState<number>(0);
+  const [chooseOptionsProduct, setChooseOptionsProduct] = useState<ChooseOptionsProductProps[]>([]);
+  const [isRequestLoading, setIsRequestLoading] = useState<boolean>(false);
+
+  useEffect(() => {
+    if (type === 'quote' && product) {
+      if (variantSku) {
+        const newProduct = product as CustomFieldItems;
+        newProduct.quantity = quantity;
+        const isPrice = !!getVariantInfoDisplayPrice(newProduct.base_price, newProduct, {
+          sku: variantSku,
+        });
+        setShowPrice(isPrice);
+      } else {
+        const newProduct = product as CustomFieldItems;
+        newProduct.quantity = quantity;
+        const isPrice = !!getProductInfoDisplayPrice(newProduct.base_price, newProduct);
+        if (!isPrice) {
+          setShowPrice(false);
+        }
+      }
+    } else if ((type === 'shoppingList' || type === 'quickOrder') && product) {
+      setShowPrice(!product?.isPriceHidden);
+    }
+  }, [variantSku, quantity, product, type]);
+
+  const setChooseOptionsForm = async (product: ShoppingListProductItem) => {
+    try {
+      setIsLoading(true);
+
+      const modifiers =
+        product?.modifiers?.filter(
+          (modifier) =>
+            modifier.type === 'product_list_with_images' || modifier.type === 'product_list',
+        ) || [];
+      const productImages: SimpleObject = {};
+      const additionalProductsParams: CustomFieldItems = {};
+      if (modifiers.length > 0) {
+        const productIds = modifiers.reduce((arr: number[], modifier) => {
+          const { option_values: optionValues } = modifier;
+          optionValues.forEach((option) => {
+            if (option?.value_data?.product_id) {
+              arr.push(option.value_data.product_id);
+            }
+          });
+          return arr;
+        }, []);
+
+        if (productIds.length > 0) {
+          const companyId = companyInfoId || salesRepCompanyId;
+          const { productsSearch } = await searchProducts({
+            productIds,
+            companyId,
+            customerGroupId,
+          });
+
+          productsSearch.forEach((product: CustomFieldItems) => {
+            productImages[product.id] = product.imageUrl;
+            additionalProductsParams[product.id] = product;
+          });
+        }
+      }
+
+      setAdditionalProducts(additionalProductsParams);
+
+      setQuantity(product.quantity);
+      if (product.variants?.length === 1 && product.variants[0]) {
+        setVariantInfo(product.variants[0]);
+      }
+
+      const productOptionsFields = getProductOptionsFields(product, productImages);
+      setFormFields([...productOptionsFields]);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const getProductPriceOptions = (product: ShoppingListProductItem) => {
+    const newProductPriceChangeOptionLists: Partial<AllOptionProps>[] = [];
+    product.allOptions?.forEach((item) => {
+      if (
+        item.type === 'product_list_with_images' ||
+        item.type === 'product_list' ||
+        item.type === 'checkbox' ||
+        item.type === 'rectangles' ||
+        item.type === 'swatch' ||
+        item.type === 'radio_buttons' ||
+        item.type === 'dropdown'
+      ) {
+        newProductPriceChangeOptionLists.push(item);
+      }
+    });
+
+    setProductPriceChangeOptions(newProductPriceChangeOptionLists);
+  };
+
+  useEffect(() => {
+    if (product) {
+      setChooseOptionsForm(product);
+      setChooseOptionsProduct([]);
+      setNewPrice(0);
+      if (product?.allOptions?.length) {
+        getProductPriceOptions(product);
+      }
+    } else {
+      setQuantity(1);
+      setFormFields([]);
+    }
+    // disabling as we don't need dispatchers here
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [product]);
+
+  const getProductPrice = (product: ShoppingListProductItem) => {
+    const { variants = [] } = product;
+
+    let priceNumber = 0;
+    if (variantSku) {
+      const variantCalculatePrice = variants.find(
+        (variant) => variant.sku === variantSku,
+      )?.bc_calculated_price;
+      priceNumber =
+        (showInclusiveTaxPrice
+          ? variantCalculatePrice?.tax_inclusive
+          : variantCalculatePrice?.tax_exclusive) || 0;
+    } else {
+      const variantCalculatePrice = variants[0]?.bc_calculated_price;
+      priceNumber =
+        parseFloat(
+          (showInclusiveTaxPrice
+            ? variantCalculatePrice?.tax_inclusive
+            : variantCalculatePrice?.tax_exclusive
+          )?.toString(),
+        ) || 0;
+    }
+
+    return priceNumber;
+  };
+
+  const handleProductQuantityChange = (e: ChangeEvent<HTMLInputElement>) => {
+    if (!e.target.value || parseInt(e.target.value, 10) > 0) {
+      setQuantity(e.target.value);
+    }
+  };
+
+  const handleNumberInputKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (['KeyE', 'Equal', 'Minus'].indexOf(event.code) > -1) {
+      event.preventDefault();
+    }
+  };
+
+  const handleNumberInputBlur = () => {
+    if (!quantity) {
+      setQuantity(1);
+    }
+
+    if (Number(quantity) > 1000000) {
+      setQuantity(1000000);
+    }
+  };
+
+  const {
+    control,
+    handleSubmit,
+    getValues,
+    formState: { errors },
+    watch,
+    setValue,
+    reset,
+  } = useForm({
+    mode: 'all',
+  });
+
+  const formValues = watch();
+  const cache = useRef(formValues);
+
+  const getProductVariantId = useCallback(
+    async (value: CustomFieldItems, changeName = '') => {
+      const isVariantOptionChange =
+        formFields.find((item: CustomFieldItems) => item.name === changeName)?.isVariantOption ||
+        false;
+
+      if (!isVariantOptionChange || !product || !changeName) {
+        return;
+      }
+
+      const { variants = [] } = product || {};
+
+      const variantInfo =
+        variants.find((variant) => {
+          const { option_values: optionValues = [] } = variant;
+
+          const isSelectVariant = optionValues.reduce((isSelect, option) => {
+            if (
+              value[Base64.encode(`attribute[${option.option_id}]`)].toString() !==
+              (option.id || '').toString()
+            ) {
+              return false;
+            }
+            return isSelect;
+          }, true);
+
+          return isSelectVariant;
+        }) || null;
+
+      setVariantSku(variantInfo ? variantInfo.sku : '');
+      setVariantInfo(variantInfo);
+
+      if (variantInfo && (variantInfo.sku || variantInfo.variant_id)) {
+        const currentVariant = variants.find(
+          (variant) =>
+            variant.sku === variantInfo.sku || variant.variant_id === variantInfo.variant_id,
+        );
+
+        setCurrentImage(currentVariant?.image_url || product.imageUrl || '');
+      }
+    },
+    [formFields, product],
+  );
+
+  useEffect(() => {
+    const subscription = watch((value, { name }) => {
+      getProductVariantId(value, name);
+    });
+
+    if (formFields[0]) {
+      const defaultValues: SimpleObject = formFields.reduce((value: SimpleObject, fields) => {
+        const formFieldValue = value;
+        formFieldValue[fields.name] = fields.default;
+        setValue(fields.name, fields.default);
+        return value;
+      }, {});
+      getProductVariantId(defaultValues, formFields[0].name);
+    }
+
+    return () => subscription.unsubscribe();
+    // disabling as we don't need dispatchers or subscribers in the dep array
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [formFields, getProductVariantId]);
+
+  const validateQuantityNumber = useCallback(() => {
+    const { purchasing_disabled: purchasingDisabled = true } = variantInfo || {};
+
+    if (type !== 'shoppingList' && purchasingDisabled === true && !isEnableProduct) {
+      snackbar.error(b3Lang('shoppingList.chooseOptionsDialog.productNoLongerForSale'));
+      return false;
+    }
+
+    return true;
+    // disabling as b3Lang will render errors
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isEnableProduct, type, variantInfo]);
+
+  const getOptionList = useCallback(
+    (value: FieldValues) => {
+      const optionsData = getOptionRequestData(formFields, {}, value);
+      return Object.keys(optionsData).map((optionId) => ({
+        optionId,
+        optionValue: optionsData[optionId]?.toString(),
+      }));
+    },
+    [formFields],
+  );
+
+  useEffect(() => {
+    if (cache?.current && isEqual(cache?.current, formValues)) {
+      return;
+    }
+
+    cache.current = formValues;
+    if (Object.keys(formValues).length && formFields.length && productPriceChangeOptions.length) {
+      const optionList = getOptionList(formValues);
+      const { variant_id: variantId = '' } = variantInfo || {};
+      if (!product || !product.id || !variantId || !validateQuantityNumber()) {
+        return;
+      }
+
+      const newChooseOptionsProduct = [
+        {
+          ...product,
+          newSelectOptionList: optionList,
+          productId: product?.id,
+          quantity: parseInt(quantity.toString(), 10) || 1,
+          variantId: parseInt(variantId.toString(), 10) || 1,
+          additionalProducts,
+        },
+      ];
+
+      if (chooseOptionsProduct[0]) {
+        let optionChangeFlag = false;
+        const { newSelectOptionList } = chooseOptionsProduct[0];
+        newSelectOptionList.forEach((option) => {
+          const findAttributeId = productPriceChangeOptions.findIndex((item) =>
+            option.optionId.includes(String(item.id)),
+          );
+          optionList.forEach((newOption) => {
+            if (
+              option.optionId === newOption.optionId &&
+              option.optionValue !== newOption.optionValue &&
+              findAttributeId !== -1
+            ) {
+              optionChangeFlag = true;
+            }
+          });
+        });
+        if (optionChangeFlag) {
+          setChooseOptionsProduct(newChooseOptionsProduct);
+        }
+      } else {
+        setChooseOptionsProduct(newChooseOptionsProduct);
+      }
+    }
+  }, [
+    additionalProducts,
+    chooseOptionsProduct,
+    formFields.length,
+    formValues,
+    getOptionList,
+    product,
+    productPriceChangeOptions,
+    quantity,
+    validateQuantityNumber,
+    variantInfo,
+  ]);
+
+  useEffect(() => {
+    const getNewProductPrice = async () => {
+      try {
+        if (chooseOptionsProduct.length) {
+          setIsRequestLoading(true);
+          const products = await calculateProductListPrice(chooseOptionsProduct);
+
+          if (products[0]) {
+            const { basePrice, taxPrice } = products[0];
+            const price = getBCPrice(Number(basePrice), Number(taxPrice));
+            setNewPrice(price);
+          }
+        }
+      } catch (err) {
+        b2bLogger.error(err);
+      } finally {
+        setIsRequestLoading(false);
+      }
+    };
+
+    getNewProductPrice();
+  }, [chooseOptionsProduct]);
+
+  const handleConfirmClicked = () => {
+    handleSubmit((value) => {
+      const optionList = getOptionList(value);
+
+      const { variant_id: variantId = '' } = variantInfo || {};
+
+      if (!product || !product.id || !variantId || !validateQuantityNumber()) {
+        return;
+      }
+
+      onConfirm([
+        {
+          ...product,
+          newSelectOptionList: optionList,
+          productId: product?.id,
+          quantity: parseInt(quantity.toString(), 10) || 1,
+          variantId: parseInt(variantId.toString(), 10) || 1,
+          additionalProducts,
+        },
+      ]);
+    })();
+  };
+
+  const handleCancelClicked = () => {
+    setQuantity(1);
+    onCancel();
+  };
+
+  useEffect(() => {
+    if (!isOpen) {
+      reset();
+    }
+    // disabling as reset does not change between renders
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen]);
+
+  return (
+    <B3Dialog
+      isOpen={isOpen}
+      rightSizeBtn={isEdit ? b3Lang('shoppingList.chooseOptionsDialog.saveOption') : addButtonText}
+      handleLeftClick={handleCancelClicked}
+      handRightClick={handleConfirmClicked}
+      title={b3Lang('shoppingList.chooseOptionsDialog.chooseOptions')}
+      loading={isLoading || isRequestLoading}
+    >
+      <B3Spin isSpinning={isLoading}>
+        {product && (
+          <Box>
+            <Box
+              sx={{
+                display: 'flex',
+                flexDirection: 'column',
+              }}
+            >
+              <Box
+                sx={{
+                  display: 'flex',
+                }}
+              >
+                <ProductImage src={currentImage || product.imageUrl || PRODUCT_DEFAULT_IMAGE} />
+                <Flex>
+                  <FlexItem padding="0">
+                    <Box
+                      sx={{
+                        marginLeft: '16px',
+                      }}
+                    >
+                      <Typography variant="body1" color="#212121">
+                        {product.name}
+                      </Typography>
+                      <Typography variant="body1" color="#616161">
+                        {variantSku || product.sku}
+                      </Typography>
+                      {(product.product_options || []).map((option) => (
+                        <ProductOptionText
+                          key={`${option.option_id}`}
+                        >{`${option.display_name}: ${option.display_value}`}</ProductOptionText>
+                      ))}
+                    </Box>
+                  </FlexItem>
+
+                  <FlexItem>
+                    <span>{b3Lang('shoppingList.chooseOptionsDialog.price')}</span>
+                    {!isShowPrice
+                      ? ''
+                      : currencyFormat(newPrice * Number(quantity) || getProductPrice(product))}
+                  </FlexItem>
+
+                  <FlexItem>
+                    <StyleTextField
+                      type="number"
+                      variant="filled"
+                      label={b3Lang('shoppingList.chooseOptionsDialog.quantity')}
+                      value={quantity}
+                      onChange={handleProductQuantityChange}
+                      onKeyDown={handleNumberInputKeyDown}
+                      onBlur={handleNumberInputBlur}
+                      size="small"
+                      sx={{
+                        width: '60%',
+                        maxWidth: '100px',
+                      }}
+                    />
+                  </FlexItem>
+                </Flex>
+              </Box>
+
+              <Divider
+                sx={{
+                  margin: '16px 0 24px',
+                }}
+              />
+
+              <B3CustomForm
+                formFields={formFields}
+                errors={errors}
+                control={control}
+                getValues={getValues}
+                setValue={setValue}
+              />
+            </Box>
+          </Box>
+        )}
+      </B3Spin>
+    </B3Dialog>
+  );
+}

--- a/apps/storefront/src/pages/QuickOrder/components/ProductListDialog.tsx
+++ b/apps/storefront/src/pages/QuickOrder/components/ProductListDialog.tsx
@@ -1,0 +1,221 @@
+import { ChangeEvent, KeyboardEvent, useCallback, useContext } from 'react';
+import { useB3Lang } from '@b3/lang';
+import { Search as SearchIcon } from '@mui/icons-material';
+import { Box, InputAdornment, TextField, Typography } from '@mui/material';
+
+import { B3ProductList } from '@/components';
+import B3Dialog from '@/components/B3Dialog';
+import CustomButton from '@/components/button/CustomButton';
+import B3Spin from '@/components/spin/B3Spin';
+import { useMobile } from '@/hooks';
+import { ShoppingListDetailsContext } from '@/pages/ShoppingListDetails/context/ShoppingListDetailsContext';
+import { useAppSelector } from '@/store';
+import { ShoppingListProductItem } from '@/types';
+import { snackbar } from '@/utils';
+
+interface ProductTableActionProps {
+  product: ShoppingListProductItem;
+  onAddToListClick: (id: number) => void;
+  onChooseOptionsClick: (id: number) => void;
+  addButtonText: string;
+}
+
+function ProductTableAction(props: ProductTableActionProps) {
+  const {
+    product: { id, allOptions: productOptions },
+    onAddToListClick,
+    onChooseOptionsClick,
+    addButtonText,
+  } = props;
+
+  const {
+    state: { isLoading = false },
+  } = useContext(ShoppingListDetailsContext);
+
+  const [isMobile] = useMobile();
+
+  const b3Lang = useB3Lang();
+
+  return productOptions && productOptions.length > 0 ? (
+    <CustomButton
+      variant="outlined"
+      onClick={() => {
+        onChooseOptionsClick(id);
+      }}
+      disabled={isLoading}
+      fullWidth={isMobile}
+    >
+      {b3Lang('global.searchProduct.chooseOptionsButton')}
+    </CustomButton>
+  ) : (
+    <CustomButton
+      variant="outlined"
+      onClick={() => {
+        onAddToListClick(id);
+      }}
+      disabled={isLoading}
+      fullWidth={isMobile}
+    >
+      {addButtonText}
+    </CustomButton>
+  );
+}
+
+interface ProductListDialogProps {
+  isOpen: boolean;
+  searchText: string;
+  productList: ShoppingListProductItem[];
+  onCancel: () => void;
+  onSearchTextChange: (e: ChangeEvent<HTMLInputElement>) => void;
+  onSearch: () => void;
+  onProductQuantityChange: (id: number, newQuantity: number) => void;
+  onAddToListClick: (products: CustomFieldItems[]) => void;
+  onChooseOptionsClick: (id: number) => void;
+  isLoading: boolean;
+  searchDialogTitle?: string;
+  addButtonText?: string;
+  type?: string;
+}
+
+const ProductTable = B3ProductList<ShoppingListProductItem>;
+
+export default function ProductListDialog(props: ProductListDialogProps) {
+  const b3Lang = useB3Lang();
+  const {
+    isOpen,
+    onCancel,
+    searchText,
+    productList,
+    onSearchTextChange,
+    onSearch,
+    onProductQuantityChange,
+    onAddToListClick,
+    onChooseOptionsClick,
+    isLoading,
+    type,
+    searchDialogTitle = b3Lang('shoppingLists.title'),
+    addButtonText = b3Lang('shoppingLists.addButtonText'),
+  } = props;
+
+  const isEnableProduct = useAppSelector(
+    ({ global }) => global.blockPendingQuoteNonPurchasableOOS.isEnableProduct,
+  );
+
+  const [isMobile] = useMobile();
+
+  const handleCancelClicked = () => {
+    onCancel();
+  };
+
+  const handleSearchKeyDown = (e: KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      onSearch();
+    }
+  };
+
+  const validateQuantityNumber = useCallback(
+    (product: ShoppingListProductItem) => {
+      const { variants = [] } = product || {};
+      const { purchasing_disabled: purchasingDisabled = true } = variants[0] || {};
+
+      if (type !== 'shoppingList' && purchasingDisabled === true && !isEnableProduct) {
+        snackbar.error(b3Lang('shoppingList.chooseOptionsDialog.productNoLongerForSale'));
+        return false;
+      }
+
+      return true;
+    },
+    // ignore b3Lang it's not reactive
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [isEnableProduct, type],
+  );
+
+  const handleAddToList = (id: number) => {
+    const product = productList.find((product) => product.id === id);
+
+    if (product && validateQuantityNumber(product || {})) {
+      let variantId: number | string = product.variantId || 0;
+
+      if (!product.variantId && product.variants?.[0]) {
+        variantId = product.variants[0].variant_id;
+      }
+
+      onAddToListClick([
+        {
+          ...product,
+          newSelectOptionList: [],
+          quantity: parseInt(product.quantity.toString(), 10) || 1,
+          variantId,
+        },
+      ]);
+    }
+  };
+
+  return (
+    <B3Dialog
+      fullWidth
+      isOpen={isOpen}
+      handleLeftClick={handleCancelClicked}
+      title={searchDialogTitle}
+      showRightBtn={false}
+      loading={isLoading}
+      maxWidth="md"
+      leftSizeBtn={b3Lang('shoppingLists.close')}
+    >
+      <B3Spin isSpinning={isLoading}>
+        <Box
+          sx={{
+            minWidth: isMobile ? 'initial' : '100%',
+            flex: 1,
+          }}
+        >
+          <TextField
+            hiddenLabel
+            variant="filled"
+            fullWidth
+            size="small"
+            value={searchText}
+            onChange={onSearchTextChange}
+            onKeyDown={handleSearchKeyDown}
+            error={!productList || productList.length <= 0}
+            InputProps={{
+              startAdornment: (
+                <InputAdornment position="start">
+                  <SearchIcon />
+                </InputAdornment>
+              ),
+            }}
+            sx={{
+              margin: '12px 0',
+              '& input': {
+                padding: '12px 12px 12px 0',
+              },
+            }}
+          />
+
+          {productList && productList.length > 0 ? (
+            <ProductTable
+              products={productList}
+              quantityEditable
+              type={type}
+              textAlign={isMobile ? 'left' : 'right'}
+              canToProduct
+              onProductQuantityChange={onProductQuantityChange}
+              renderAction={(product) => (
+                <ProductTableAction
+                  product={product}
+                  onAddToListClick={handleAddToList}
+                  onChooseOptionsClick={onChooseOptionsClick}
+                  addButtonText={addButtonText}
+                />
+              )}
+              actionWidth="180px"
+            />
+          ) : (
+            <Typography>No products found</Typography>
+          )}
+        </Box>
+      </B3Spin>
+    </B3Dialog>
+  );
+}

--- a/apps/storefront/src/pages/QuickOrder/components/ProductListDialog.tsx
+++ b/apps/storefront/src/pages/QuickOrder/components/ProductListDialog.tsx
@@ -62,6 +62,7 @@ function ProductTableAction(props: ProductTableActionProps) {
 }
 
 interface ProductListDialogProps {
+  isLoading: boolean;
   isOpen: boolean;
   searchText: string;
   productList: ShoppingListProductItem[];
@@ -71,16 +72,13 @@ interface ProductListDialogProps {
   onProductQuantityChange: (id: number, newQuantity: number) => void;
   onAddToListClick: (products: CustomFieldItems[]) => void;
   onChooseOptionsClick: (id: number) => void;
-  isLoading: boolean;
-  searchDialogTitle?: string;
-  addButtonText?: string;
-  type?: string;
 }
 
 const ProductTable = B3ProductList<ShoppingListProductItem>;
 
 export default function ProductListDialog(props: ProductListDialogProps) {
   const b3Lang = useB3Lang();
+
   const {
     isOpen,
     onCancel,
@@ -92,9 +90,6 @@ export default function ProductListDialog(props: ProductListDialogProps) {
     onAddToListClick,
     onChooseOptionsClick,
     isLoading,
-    type,
-    searchDialogTitle = b3Lang('shoppingLists.title'),
-    addButtonText = b3Lang('shoppingLists.addButtonText'),
   } = props;
 
   const isEnableProduct = useAppSelector(
@@ -118,16 +113,14 @@ export default function ProductListDialog(props: ProductListDialogProps) {
       const { variants = [] } = product || {};
       const { purchasing_disabled: purchasingDisabled = true } = variants[0] || {};
 
-      if (type !== 'shoppingList' && purchasingDisabled === true && !isEnableProduct) {
+      if (purchasingDisabled && !isEnableProduct) {
         snackbar.error(b3Lang('shoppingList.chooseOptionsDialog.productNoLongerForSale'));
         return false;
       }
 
       return true;
     },
-    // ignore b3Lang it's not reactive
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [isEnableProduct, type],
+    [b3Lang, isEnableProduct],
   );
 
   const handleAddToList = (id: number) => {
@@ -156,7 +149,7 @@ export default function ProductListDialog(props: ProductListDialogProps) {
       fullWidth
       isOpen={isOpen}
       handleLeftClick={handleCancelClicked}
-      title={searchDialogTitle}
+      title={b3Lang('purchasedProducts.quickOrderPad.quickOrderPad')}
       showRightBtn={false}
       loading={isLoading}
       maxWidth="md"
@@ -197,7 +190,7 @@ export default function ProductListDialog(props: ProductListDialogProps) {
             <ProductTable
               products={productList}
               quantityEditable
-              type={type}
+              type="quickOrder"
               textAlign={isMobile ? 'left' : 'right'}
               canToProduct
               onProductQuantityChange={onProductQuantityChange}
@@ -206,7 +199,7 @@ export default function ProductListDialog(props: ProductListDialogProps) {
                   product={product}
                   onAddToListClick={handleAddToList}
                   onChooseOptionsClick={onChooseOptionsClick}
-                  addButtonText={addButtonText}
+                  addButtonText={b3Lang('purchasedProducts.quickOrderPad.addToCart')}
                 />
               )}
               actionWidth="180px"

--- a/apps/storefront/src/pages/QuickOrder/components/QuickAdd.tsx
+++ b/apps/storefront/src/pages/QuickOrder/components/QuickAdd.tsx
@@ -16,24 +16,19 @@ import { ShoppingListAddProductOption, SimpleObject } from '../../../types';
 import { getCartProductInfo } from '../utils';
 
 interface AddToListContentProps {
-  updateList?: () => void;
   quickAddToList: (products: CustomFieldItems[]) => CustomFieldItems;
-  level?: number;
-  buttonText?: string;
 }
+
+const LEVEL = 3;
 
 export default function QuickAdd(props: AddToListContentProps) {
   const b3Lang = useB3Lang();
-  const {
-    updateList = () => {},
-    quickAddToList,
-    level = 3,
-    buttonText = b3Lang('purchasedProducts.quickAdd.addProductToList'),
-  } = props;
+  const { quickAddToList } = props;
+  const buttonText = b3Lang('purchasedProducts.quickOrderPad.addProductsToCart');
 
   const isB2BUser = useAppSelector(isB2BUserSelector);
   const companyStatus = useAppSelector(({ company }) => company.companyInfo.status);
-  const [rows, setRows] = useState(level);
+  const [rows, setRows] = useState(LEVEL);
   const [formFields, setFormFields] = useState<CustomFieldItems[]>([]);
   const [isLoading, setIsLoading] = useState(false);
 
@@ -47,14 +42,12 @@ export default function QuickAdd(props: AddToListContentProps) {
       formFields = [...formFields, ...getQuickAddRowFields(index, b3Lang)];
     });
     setFormFields(formFields);
-    // disabling since b3Lang since it has rendering issues
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [rows]);
+  }, [b3Lang, rows]);
 
   const [blockPendingAccountViewPrice] = useBlockPendingAccountViewPrice();
 
   const handleAddRowsClick = () => {
-    setRows(rows + level);
+    setRows(rows + LEVEL);
   };
 
   const {
@@ -382,8 +375,6 @@ export default function QuickAdd(props: AddToListContentProps) {
         if (productItems.length > 0) {
           await quickAddToList(productItems);
           clearInputValue(value, passSku);
-
-          updateList();
         }
       } finally {
         setIsLoading(false);

--- a/apps/storefront/src/pages/QuickOrder/components/QuickOrderPad.tsx
+++ b/apps/storefront/src/pages/QuickOrder/components/QuickOrderPad.tsx
@@ -323,54 +323,27 @@ export default function QuickOrderPad() {
         }),
       );
     }
-    // disabling this rule as b3Lang has rendering issues
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [productData]);
+  }, [b3Lang, productData]);
 
   return (
-    <Card
-      sx={{
-        marginBottom: isMobile ? '8.5rem' : '50px',
-      }}
-    >
+    <Card sx={{ marginBottom: isMobile ? '8.5rem' : '50px' }}>
       <CardContent>
         <Box>
-          <Typography
-            variant="h5"
-            sx={{
-              marginBottom: '1rem',
-            }}
-          >
+          <Typography variant="h5" sx={{ marginBottom: '1rem' }}>
             {b3Lang('purchasedProducts.quickOrderPad.quickOrderPad')}
           </Typography>
 
-          <SearchProduct
-            addToList={handleQuickSearchAddCart}
-            searchDialogTitle={b3Lang('purchasedProducts.quickOrderPad.quickOrderPad')}
-            type="quickOrder"
-            addButtonText={b3Lang('purchasedProducts.quickOrderPad.addToCart')}
-          />
+          <SearchProduct addToList={handleQuickSearchAddCart} />
 
           <Divider />
 
-          <QuickAdd
-            quickAddToList={quickAddToList}
-            buttonText={b3Lang('purchasedProducts.quickOrderPad.addProductsToCart')}
-          />
+          <QuickAdd quickAddToList={quickAddToList} />
 
           <Divider />
 
-          <Box
-            sx={{
-              margin: '20px 0 0',
-            }}
-          >
+          <Box sx={{ margin: '20px 0 0' }}>
             <CustomButton variant="text" onClick={() => handleOpenUploadDiag()}>
-              <UploadFileIcon
-                sx={{
-                  marginRight: '8px',
-                }}
-              />
+              <UploadFileIcon sx={{ marginRight: '8px' }} />
               {b3Lang('purchasedProducts.quickOrderPad.bulkUploadCSV')}
             </CustomButton>
           </Box>

--- a/apps/storefront/src/pages/QuickOrder/components/QuickOrderPad.tsx
+++ b/apps/storefront/src/pages/QuickOrder/components/QuickOrderPad.tsx
@@ -14,10 +14,10 @@ import b2bLogger from '@/utils/b3Logger';
 import b3TriggerCartNumber from '@/utils/b3TriggerCartNumber';
 import { callCart } from '@/utils/cartUtils';
 
-import SearchProduct from '../../ShoppingListDetails/components/SearchProduct';
 import { addCartProductToVerify } from '../utils';
 
 import QuickAdd from './QuickAdd';
+import SearchProduct from './SearchProduct';
 
 export default function QuickOrderPad() {
   const [isMobile] = useMobile();

--- a/apps/storefront/src/pages/QuickOrder/components/SearchProduct.tsx
+++ b/apps/storefront/src/pages/QuickOrder/components/SearchProduct.tsx
@@ -1,0 +1,240 @@
+import { ChangeEvent, KeyboardEvent, useState } from 'react';
+import { useB3Lang } from '@b3/lang';
+import { Search as SearchIcon } from '@mui/icons-material';
+import { Box, InputAdornment, TextField, Typography } from '@mui/material';
+
+import CustomButton from '@/components/button/CustomButton';
+import B3Spin from '@/components/spin/B3Spin';
+import { useBlockPendingAccountViewPrice } from '@/hooks';
+import { searchProducts } from '@/shared/service/b2b';
+import { useAppSelector } from '@/store';
+import { snackbar } from '@/utils';
+import { calculateProductListPrice } from '@/utils/b3Product/b3Product';
+import { conversionProductsList } from '@/utils/b3Product/shared/config';
+
+import { ShoppingListProductItem } from '../../../types';
+
+import ChooseOptionsDialog from './ChooseOptionsDialog';
+import ProductListDialog from './ProductListDialog';
+
+interface SearchProductProps {
+  updateList?: () => void;
+  addToList: (products: CustomFieldItems[]) => void;
+  searchDialogTitle?: string;
+  addButtonText?: string;
+  type?: string;
+}
+
+export default function SearchProduct({
+  updateList = () => {},
+  addToList,
+  searchDialogTitle,
+  addButtonText,
+  type,
+}: SearchProductProps) {
+  const b3Lang = useB3Lang();
+  const companyInfoId = useAppSelector(({ company }) => company.companyInfo.id);
+  const customerGroupId = useAppSelector((state) => state.company.customer.customerGroupId);
+  const companyStatus = useAppSelector(({ company }) => company.companyInfo.status);
+  const salesRepCompanyId = useAppSelector(({ b2bFeatures }) => b2bFeatures.masqueradeCompany.id);
+  const companyId = companyInfoId || salesRepCompanyId;
+  const [isLoading, setIsLoading] = useState(false);
+  const [productListOpen, setProductListOpen] = useState(false);
+  const [isAdded, setIsAdded] = useState(false);
+  const [searchText, setSearchText] = useState('');
+  const [productList, setProductList] = useState<ShoppingListProductItem[]>([]);
+  const [chooseOptionsOpen, setChooseOptionsOpen] = useState(false);
+  const [optionsProduct, setOptionsProduct] = useState<ShoppingListProductItem>();
+
+  const [blockPendingAccountViewPrice] = useBlockPendingAccountViewPrice();
+
+  const handleSearchTextChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setSearchText(e.target.value);
+  };
+
+  const searchProduct = async () => {
+    if (!searchText || isLoading) {
+      return;
+    }
+
+    if (blockPendingAccountViewPrice && companyStatus === 0) {
+      snackbar.info(b3Lang('global.searchProductAddProduct.businessAccountPendingApproval'));
+      return;
+    }
+
+    setIsLoading(true);
+    try {
+      const { productsSearch } = await searchProducts({
+        search: searchText,
+        companyId,
+        customerGroupId,
+        categoryFilter: true,
+      });
+
+      const product = conversionProductsList(productsSearch);
+
+      setProductList(product);
+      setProductListOpen(true);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleSearchTextKeyDown = (e: KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      searchProduct();
+    }
+  };
+
+  const handleSearchButtonClicked = () => {
+    searchProduct();
+  };
+
+  const clearProductInfo = () => {
+    setProductList([]);
+  };
+
+  const handleProductListDialogCancel = () => {
+    setChooseOptionsOpen(false);
+    setProductListOpen(false);
+
+    if (isAdded) {
+      setIsAdded(false);
+      updateList();
+    }
+
+    clearProductInfo();
+  };
+
+  const handleProductQuantityChange = (id: number, newQuantity: number) => {
+    const product = productList.find((product) => product.id === id);
+    if (product) {
+      product.quantity = newQuantity;
+    }
+
+    setProductList([...productList]);
+  };
+
+  const handleAddToListClick = async (products: CustomFieldItems[]) => {
+    try {
+      setIsLoading(true);
+      await calculateProductListPrice(products);
+      await addToList(products);
+
+      updateList();
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleProductListAddToList = async (products: CustomFieldItems[]) => {
+    await handleAddToListClick(products);
+  };
+
+  const handleChangeOptionsClick = (productId: number) => {
+    const product = productList.find((product) => product.id === productId);
+    if (product) {
+      setOptionsProduct({
+        ...product,
+      });
+    }
+    setProductListOpen(false);
+    setChooseOptionsOpen(true);
+  };
+
+  const handleChooseOptionsDialogCancel = () => {
+    setChooseOptionsOpen(false);
+    setProductListOpen(true);
+  };
+
+  const handleChooseOptionsDialogConfirm = async (products: CustomFieldItems[]) => {
+    try {
+      setIsLoading(true);
+      await calculateProductListPrice(products);
+      await handleAddToListClick(products);
+      setChooseOptionsOpen(false);
+      setProductListOpen(true);
+    } catch (error) {
+      setIsLoading(false);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <Box
+      sx={{
+        margin: '24px 0',
+      }}
+    >
+      <Typography>{b3Lang('global.searchProductAddProduct.searchBySkuOrName')}</Typography>
+      <TextField
+        hiddenLabel
+        placeholder={b3Lang(`global.searchProduct.placeholder.${type}`)}
+        variant="filled"
+        fullWidth
+        size="small"
+        value={searchText}
+        onChange={handleSearchTextChange}
+        onKeyDown={handleSearchTextKeyDown}
+        InputProps={{
+          startAdornment: (
+            <InputAdornment position="start">
+              <SearchIcon />
+            </InputAdornment>
+          ),
+        }}
+        sx={{
+          margin: '12px 0',
+          '& input': {
+            padding: '12px 12px 12px 0',
+          },
+        }}
+      />
+      <CustomButton
+        variant="outlined"
+        fullWidth
+        disabled={isLoading}
+        onClick={handleSearchButtonClicked}
+      >
+        <B3Spin isSpinning={isLoading} tip="" size={16}>
+          <Box
+            sx={{
+              flex: 1,
+              textAlign: 'center',
+            }}
+          >
+            {b3Lang('global.searchProductAddProduct.searchProduct')}
+          </Box>
+        </B3Spin>
+      </CustomButton>
+
+      <ProductListDialog
+        isOpen={productListOpen}
+        isLoading={isLoading}
+        productList={productList}
+        searchText={searchText}
+        type={type}
+        onSearchTextChange={handleSearchTextChange}
+        onSearch={handleSearchButtonClicked}
+        onCancel={handleProductListDialogCancel}
+        onProductQuantityChange={handleProductQuantityChange}
+        onChooseOptionsClick={handleChangeOptionsClick}
+        onAddToListClick={handleProductListAddToList}
+        searchDialogTitle={searchDialogTitle}
+        addButtonText={addButtonText}
+      />
+
+      <ChooseOptionsDialog
+        isOpen={chooseOptionsOpen}
+        isLoading={isLoading}
+        type={type}
+        setIsLoading={setIsLoading}
+        product={optionsProduct}
+        onCancel={handleChooseOptionsDialogCancel}
+        onConfirm={handleChooseOptionsDialogConfirm}
+        addButtonText={addButtonText}
+      />
+    </Box>
+  );
+}

--- a/apps/storefront/src/pages/QuickOrder/components/SearchProduct.tsx
+++ b/apps/storefront/src/pages/QuickOrder/components/SearchProduct.tsx
@@ -18,21 +18,12 @@ import ChooseOptionsDialog from './ChooseOptionsDialog';
 import ProductListDialog from './ProductListDialog';
 
 interface SearchProductProps {
-  updateList?: () => void;
   addToList: (products: CustomFieldItems[]) => void;
-  searchDialogTitle?: string;
-  addButtonText?: string;
-  type?: string;
 }
 
-export default function SearchProduct({
-  updateList = () => {},
-  addToList,
-  searchDialogTitle,
-  addButtonText,
-  type,
-}: SearchProductProps) {
+export default function SearchProduct({ addToList }: SearchProductProps) {
   const b3Lang = useB3Lang();
+
   const companyInfoId = useAppSelector(({ company }) => company.companyInfo.id);
   const customerGroupId = useAppSelector((state) => state.company.customer.customerGroupId);
   const companyStatus = useAppSelector(({ company }) => company.companyInfo.status);
@@ -100,7 +91,6 @@ export default function SearchProduct({
 
     if (isAdded) {
       setIsAdded(false);
-      updateList();
     }
 
     clearProductInfo();
@@ -120,8 +110,6 @@ export default function SearchProduct({
       setIsLoading(true);
       await calculateProductListPrice(products);
       await addToList(products);
-
-      updateList();
     } finally {
       setIsLoading(false);
     }
@@ -170,7 +158,7 @@ export default function SearchProduct({
       <Typography>{b3Lang('global.searchProductAddProduct.searchBySkuOrName')}</Typography>
       <TextField
         hiddenLabel
-        placeholder={b3Lang(`global.searchProduct.placeholder.${type}`)}
+        placeholder={b3Lang('global.searchProduct.placeholder.quickOrder')}
         variant="filled"
         fullWidth
         size="small"
@@ -214,26 +202,21 @@ export default function SearchProduct({
         isLoading={isLoading}
         productList={productList}
         searchText={searchText}
-        type={type}
         onSearchTextChange={handleSearchTextChange}
         onSearch={handleSearchButtonClicked}
         onCancel={handleProductListDialogCancel}
         onProductQuantityChange={handleProductQuantityChange}
         onChooseOptionsClick={handleChangeOptionsClick}
         onAddToListClick={handleProductListAddToList}
-        searchDialogTitle={searchDialogTitle}
-        addButtonText={addButtonText}
       />
 
       <ChooseOptionsDialog
         isOpen={chooseOptionsOpen}
         isLoading={isLoading}
-        type={type}
         setIsLoading={setIsLoading}
         product={optionsProduct}
         onCancel={handleChooseOptionsDialogCancel}
         onConfirm={handleChooseOptionsDialogConfirm}
-        addButtonText={addButtonText}
       />
     </Box>
   );

--- a/commit-validation.json
+++ b/commit-validation.json
@@ -13,6 +13,7 @@
     "addresses",
     "headless",
     "user-management",
-    "dashboard"
+    "dashboard",
+    "quick-order"
   ]
 }


### PR DESCRIPTION
Jira: [B2BCAT-18](https://bigcommercecloud.atlassian.net/browse/B2BCAT-18)

## What/Why?
These 3 components were reused from shoppingLists, decouple them so we
can narrow the use-cases.

## Rollout/Rollback
Revert

## Testing
First commit is a straight copy of the current components in `ShoppingList/*`
Second commit is about in-lining variables and removing unused props.

[B2BCAT-18]: https://bigcommercecloud.atlassian.net/browse/B2BCAT-18?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ