### PR TITLE
fix(common): B2B-3215 automatic deploy to AWS staging removed

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,9 +1,6 @@
 name: Deploy to Staging
 
 on:
-  push:
-    branches:
-      - main
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Jira: [3215](https://bigcommercecloud.atlassian.net/browse/3215)

## What/Why?
As part of the following up actions for Onboarding into cortex project we need to prevent the automatic deploy to AWS staging environment when we push changes to main

## Rollout/Rollback
Revert this PR

## Testing
Workflow related cleanup, no tests available
