### PR TITLE
test(company-orders): B2BCAT-12 Add test harness for CompanyOrders

### DIFF
--- a/apps/storefront/src/components/form/B3ControlSelect.tsx
+++ b/apps/storefront/src/components/form/B3ControlSelect.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent } from 'react';
+import { ChangeEvent, useId } from 'react';
 import { Controller } from 'react-hook-form';
 import { useB3Lang } from '@b3/lang';
 import { FormControl, FormHelperText, InputLabel, MenuItem, Select } from '@mui/material';
@@ -22,7 +22,7 @@ export default function B3ControlSelect({ control, errors, ...rest }: Form.B3UIP
     disabled = false,
     extraPadding,
   } = rest;
-
+  const id = useId();
   const b3Lang = useB3Lang();
 
   const muiAttributeProps = muiSelectProps || {};
@@ -69,6 +69,7 @@ export default function B3ControlSelect({ control, errors, ...rest }: Form.B3UIP
           }}
           error={!!errors[name]}
           required={required}
+          id={`${id}-label`}
         >
           {label}
         </InputLabel>
@@ -83,6 +84,8 @@ export default function B3ControlSelect({ control, errors, ...rest }: Form.B3UIP
             {...onChangeProps}
             size={size}
             error={!!errors[name]}
+            labelId={`${id}-label`}
+            id={`${id}-select`}
             sx={{
               ...extraPadding,
             }}

--- a/apps/storefront/src/pages/CompanyOrderList/index.mobile.test.tsx
+++ b/apps/storefront/src/pages/CompanyOrderList/index.mobile.test.tsx
@@ -1,0 +1,763 @@
+import {
+  buildB2BFeaturesStateWith,
+  buildCompanyStateWith,
+  builder,
+  buildStoreInfoStateWith,
+  bulk,
+  faker,
+  getUnixTime,
+  graphql,
+  HttpResponse,
+  renderWithProviders,
+  screen,
+  startMockServer,
+  stringContainingAll,
+  userEvent,
+  waitFor,
+  waitForElementToBeRemoved,
+  within,
+} from 'tests/test-utils';
+import { when } from 'vitest-when';
+
+import {
+  CompanyOrderNode,
+  CompanyOrderStatuses,
+  CustomerOrderStatus,
+  GetCompanyOrders,
+} from '@/shared/service/b2b/graphql/orders';
+import { CompanyStatus, CustomerRole, UserTypes } from '@/types';
+
+import MyOrders from '.';
+
+const { server } = startMockServer();
+
+const buildOrderStatusWith = builder<CustomerOrderStatus>(() => ({
+  statusCode: faker.number.int().toString(),
+  systemLabel: faker.word.noun(),
+  customLabel: faker.word.noun(),
+}));
+
+beforeEach(() => {
+  vi.spyOn(document.body, 'clientWidth', 'get').mockReturnValue(500);
+});
+
+const buildCompanyOrderNodeWith = builder<CompanyOrderNode>(() => ({
+  node: {
+    orderId: faker.number.int().toString(),
+    firstName: faker.person.firstName(),
+    lastName: faker.person.lastName(),
+    createdAt: getUnixTime(faker.date.past()),
+    updatedAt: getUnixTime(faker.date.recent()),
+    isArchived: faker.datatype.boolean(),
+    isInvoiceOrder: faker.helpers.arrayElement(['A_1', 'A_0']),
+    totalIncTax: faker.number.float(),
+    currencyCode: faker.finance.currencyCode(),
+    usdIncTax: faker.number.float(),
+    items: faker.number.int(),
+    userId: faker.number.int(),
+    poNumber: faker.number.int().toString(),
+    referenceNumber: faker.number.int().toString(),
+    status: faker.word.noun(),
+    customStatus: faker.word.noun(),
+    statusCode: faker.number.int(),
+    ipStatus: faker.helpers.arrayElement(['A_0', 'A_1', 'A_2']),
+    flag: faker.helpers.arrayElement(['A_0', 'A_1', 'A_2', 'A_3']),
+    billingName: faker.person.fullName(),
+    merchantEmail: faker.internet.email(),
+    companyName: faker.company.name(),
+    companyInfo: {
+      companyName: faker.company.name(),
+    },
+  },
+}));
+
+const buildCompanyOrdersWith = builder<GetCompanyOrders>(() => ({
+  data: {
+    allOrders: {
+      totalCount: faker.number.int({ min: 1, max: 10 }),
+      pageInfo: {
+        hasNextPage: faker.datatype.boolean(),
+        hasPreviousPage: faker.datatype.boolean(),
+      },
+      edges: bulk(buildCompanyOrderNodeWith, 'WHATEVER_VALUES').times(10),
+    },
+  },
+}));
+
+const buildCompanyOrderStatusesWith = builder<CompanyOrderStatuses>(() => ({
+  data: {
+    orderStatuses: bulk(buildOrderStatusWith, 'WHATEVER_VALUES').times(3),
+  },
+}));
+
+const preloadedState = {
+  company: buildCompanyStateWith({
+    customer: {
+      role: CustomerRole.SENIOR_BUYER,
+      userType: UserTypes.MULTIPLE_B2C,
+    },
+    companyInfo: {
+      status: CompanyStatus.APPROVED,
+    },
+  }),
+  storeInfo: buildStoreInfoStateWith({ timeFormat: { display: 'j F Y' } }),
+};
+
+beforeEach(() => {
+  server.use(
+    graphql.query('GetOrderStatuses', () =>
+      HttpResponse.json(buildCompanyOrderStatusesWith('WHATEVER_VALUES')),
+    ),
+  );
+});
+
+describe('has placed orders', () => {
+  it('displays all the orders associated with the customer', async () => {
+    server.use(
+      graphql.query('GetAllOrders', () =>
+        HttpResponse.json(
+          buildCompanyOrdersWith({
+            data: {
+              allOrders: {
+                totalCount: 2,
+                edges: [
+                  buildCompanyOrderNodeWith({ node: { orderId: '66996' } }),
+                  buildCompanyOrderNodeWith({ node: { orderId: '66986' } }),
+                ],
+              },
+            },
+          }),
+        ),
+      ),
+    );
+
+    renderWithProviders(<MyOrders />, { preloadedState });
+
+    await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+    expect(screen.getByRole('heading', { name: /66996/ })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /66986/ })).toBeInTheDocument();
+  });
+
+  it('displays all the information associated with an order', async () => {
+    const order66996 = buildCompanyOrderNodeWith({
+      node: {
+        orderId: '66996',
+        poNumber: '0022',
+        totalIncTax: 100,
+        status: 'Pending',
+        createdAt: getUnixTime(new Date('13 March 2025')),
+        firstName: 'Mike',
+        lastName: 'Wazowski',
+        companyInfo: {
+          companyName: 'Monsters Inc.',
+        },
+      },
+    });
+
+    server.use(
+      graphql.query('GetOrderStatuses', () =>
+        HttpResponse.json(
+          buildCompanyOrderStatusesWith({
+            data: {
+              orderStatuses: [
+                buildOrderStatusWith({ systemLabel: 'Pending', customLabel: 'Pending' }),
+              ],
+            },
+          }),
+        ),
+      ),
+      graphql.query('GetAllOrders', () =>
+        HttpResponse.json(
+          buildCompanyOrdersWith({
+            data: {
+              allOrders: {
+                totalCount: 1,
+                edges: [order66996],
+              },
+            },
+          }),
+        ),
+      ),
+    );
+
+    renderWithProviders(<MyOrders />, { preloadedState });
+
+    await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+    expect(screen.getByRole('heading', { name: '# 66996' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: '$100.00' })).toBeInTheDocument();
+
+    // TODO: Add company name to the UI
+    // expect(screen.getByText('Monsters Inc.')).toBeInTheDocument();
+
+    expect(screen.getByText('0022')).toBeInTheDocument();
+    expect(screen.getByText('by Mike Wazowski')).toBeInTheDocument();
+    expect(screen.getByText('Pending')).toBeInTheDocument();
+    expect(screen.getByText('13 March 2025')).toBeInTheDocument();
+  });
+
+  it('displays `-` when the poNumber is missing', async () => {
+    const order66996 = buildCompanyOrderNodeWith({
+      node: {
+        orderId: '66996',
+        poNumber: '',
+      },
+    });
+
+    server.use(
+      graphql.query('GetAllOrders', () =>
+        HttpResponse.json(
+          buildCompanyOrdersWith({
+            data: {
+              allOrders: {
+                totalCount: 1,
+                edges: [order66996],
+              },
+            },
+          }),
+        ),
+      ),
+    );
+
+    renderWithProviders(<MyOrders />, { preloadedState });
+
+    await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+    // The character U+2013 "–" could be confused with the ASCII character U+002d "-", which is more common in source code.
+    expect(screen.getByText('–')).toBeInTheDocument();
+  });
+
+  it.todo('formats the total price based on the money property', async () => {
+    const order66996 = buildCompanyOrderNodeWith({
+      node: {
+        orderId: '66996',
+        totalIncTax: 1000,
+        money: JSON.stringify(
+          JSON.stringify({
+            currency_location: 'right',
+            currency_token: '€',
+            decimal_token: ',',
+            decimal_places: 1,
+            thousands_token: '.',
+          }),
+        ),
+      },
+    });
+
+    server.use(
+      graphql.query('GetAllOrders', () =>
+        HttpResponse.json(
+          buildCompanyOrdersWith({
+            data: {
+              allOrders: {
+                totalCount: 1,
+                edges: [order66996],
+              },
+            },
+          }),
+        ),
+      ),
+    );
+
+    renderWithProviders(<MyOrders />, { preloadedState });
+
+    await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+    expect(screen.getByRole('cell', { name: '1.000,0€' })).toBeInTheDocument();
+  });
+
+  it('can change the number of rows per page', async () => {
+    const getOrders = vi.fn().mockReturnValue(buildCompanyOrdersWith('WHATEVER_VALUES'));
+
+    server.use(graphql.query('GetAllOrders', ({ query }) => HttpResponse.json(getOrders(query))));
+
+    renderWithProviders(<MyOrders />, { preloadedState });
+
+    await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+    when(getOrders)
+      .calledWith(stringContainingAll('first: 20', 'offset: 0'))
+      .thenReturn(
+        buildCompanyOrdersWith({
+          data: {
+            allOrders: {
+              totalCount: 1,
+              edges: [buildCompanyOrderNodeWith({ node: { orderId: '66996' } })],
+            },
+          },
+        }),
+      );
+
+    await userEvent.click(screen.getByRole('combobox', { name: /per page/ }));
+    await userEvent.click(screen.getByRole('option', { name: '20' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: /66996/ })).toBeInTheDocument();
+    });
+  });
+
+  it('can go to the next page', async () => {
+    const getOrders = vi.fn().mockReturnValue(
+      buildCompanyOrdersWith({
+        data: {
+          allOrders: {
+            totalCount: 100,
+          },
+        },
+      }),
+    );
+
+    server.use(graphql.query('GetAllOrders', ({ query }) => HttpResponse.json(getOrders(query))));
+
+    renderWithProviders(<MyOrders />, { preloadedState });
+
+    await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+    when(getOrders)
+      .calledWith(stringContainingAll('first: 10', 'offset: 10'))
+      .thenReturn(
+        buildCompanyOrdersWith({
+          data: {
+            allOrders: {
+              totalCount: 100,
+              edges: [buildCompanyOrderNodeWith({ node: { orderId: '66996' } })],
+            },
+          },
+        }),
+      );
+
+    const nextPageButton = screen.getByRole('button', { name: /next page/ });
+    await userEvent.click(nextPageButton);
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: /66996/ })).toBeInTheDocument();
+    });
+  });
+
+  it('can go to the previous page', async () => {
+    const getOrders = vi.fn().mockReturnValue(
+      buildCompanyOrdersWith({
+        data: {
+          allOrders: {
+            totalCount: 100,
+          },
+        },
+      }),
+    );
+
+    server.use(graphql.query('GetAllOrders', ({ query }) => HttpResponse.json(getOrders(query))));
+
+    renderWithProviders(<MyOrders />, { preloadedState });
+
+    await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+    const nextPageButton = screen.getByRole('button', { name: /next page/ });
+    await userEvent.click(nextPageButton);
+
+    when(getOrders)
+      .calledWith(stringContainingAll('first: 10', 'offset: 0'))
+      .thenReturn(
+        buildCompanyOrdersWith({
+          data: {
+            allOrders: {
+              totalCount: 100,
+              edges: [buildCompanyOrderNodeWith({ node: { orderId: '66996' } })],
+            },
+          },
+        }),
+      );
+
+    const previousPageButton = screen.getByRole('button', { name: /previous page/ });
+    await userEvent.click(previousPageButton);
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: /66996/ })).toBeInTheDocument();
+    });
+  });
+
+  it('can search for orders', async () => {
+    const getOrders = vi.fn().mockReturnValue(buildCompanyOrdersWith('WHATEVER_VALUES'));
+
+    server.use(graphql.query('GetAllOrders', ({ query }) => HttpResponse.json(getOrders(query))));
+
+    renderWithProviders(<MyOrders />, { preloadedState });
+
+    await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+    when(getOrders)
+      .calledWith(stringContainingAll('search: "66996"'))
+      .thenReturn(
+        buildCompanyOrdersWith({
+          data: {
+            allOrders: {
+              totalCount: 1,
+              edges: [buildCompanyOrderNodeWith({ node: { orderId: '66996' } })],
+            },
+          },
+        }),
+      );
+
+    const searchBox = screen.getByPlaceholderText(/Search/);
+
+    await userEvent.type(searchBox, '66996');
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: /66996/ })).toBeInTheDocument();
+    });
+  });
+
+  it('can filter orders', async () => {
+    vi.setSystemTime(new Date('21 November 2022'));
+
+    const getOrders = vi.fn().mockReturnValue(
+      buildCompanyOrdersWith({
+        data: {
+          allOrders: {
+            totalCount: 1,
+            edges: [buildCompanyOrderNodeWith({ node: { status: 'Pending' } })],
+          },
+        },
+      }),
+    );
+
+    server.use(
+      graphql.query('GetOrderStatuses', () =>
+        HttpResponse.json(
+          buildCompanyOrderStatusesWith({
+            data: {
+              orderStatuses: [
+                buildOrderStatusWith({ systemLabel: 'Pending', customLabel: 'Pending' }),
+                buildOrderStatusWith('WHATEVER_VALUES'),
+              ],
+            },
+          }),
+        ),
+      ),
+      graphql.query('GetOrdersCreatedByUser', () =>
+        HttpResponse.json({ data: { createdByUser: { results: [] } } }),
+      ),
+      graphql.query('GetAllOrders', ({ query }) => HttpResponse.json(getOrders(query))),
+    );
+
+    renderWithProviders(<MyOrders />, { preloadedState });
+
+    await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+    when(getOrders)
+      .calledWith(
+        stringContainingAll(
+          'status: "Pending"',
+          'beginDateAt: "2022-11-15"',
+          'endDateAt: "2022-11-26"',
+        ),
+      )
+      .thenReturn(
+        buildCompanyOrdersWith({
+          data: {
+            allOrders: {
+              totalCount: 1,
+              edges: [buildCompanyOrderNodeWith({ node: { orderId: '66996' } })],
+            },
+          },
+        }),
+      );
+
+    await userEvent.click(screen.getByRole('button', { name: /edit/ }));
+
+    const dialog = await screen.findByRole('dialog', { name: 'Filters' });
+
+    await userEvent.click(within(dialog).getByRole('combobox', { name: 'Order status' }));
+
+    await userEvent.click(screen.getByRole('option', { name: 'Pending' }));
+
+    await userEvent.click(screen.getByRole('textbox', { name: 'From' }));
+    await userEvent.click(screen.getByRole('gridcell', { name: /15/ }));
+
+    await userEvent.click(screen.getByRole('textbox', { name: 'To' }));
+    await userEvent.click(screen.getByRole('gridcell', { name: /26/ }));
+
+    await userEvent.click(screen.getByRole('button', { name: 'Apply' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: /66996/ })).toBeInTheDocument();
+    });
+  });
+
+  it('can filter orders based on dates', async () => {
+    vi.setSystemTime(new Date('21 November 2022'));
+
+    const getOrders = vi.fn().mockReturnValue(buildCompanyOrdersWith('WHATEVER_VALUES'));
+
+    server.use(
+      graphql.query('GetAllOrders', ({ query }) => HttpResponse.json(getOrders(query))),
+      graphql.query('GetOrdersCreatedByUser', () =>
+        HttpResponse.json({ data: { createdByUser: { results: [] } } }),
+      ),
+    );
+
+    renderWithProviders(<MyOrders />, { preloadedState });
+
+    await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+    when(getOrders)
+      .calledWith(stringContainingAll('beginDateAt: "2022-11-15"', 'endDateAt: "2022-11-26"'))
+      .thenReturn(
+        buildCompanyOrdersWith({
+          data: {
+            allOrders: {
+              totalCount: 1,
+              edges: [buildCompanyOrderNodeWith({ node: { orderId: '66996' } })],
+            },
+          },
+        }),
+      );
+
+    await userEvent.click(screen.getByRole('button', { name: /edit/ }));
+
+    const dialog = await screen.findByRole('dialog', { name: 'Filters' });
+
+    await userEvent.click(within(dialog).getByRole('textbox', { name: 'From' }));
+    await userEvent.click(screen.getByRole('gridcell', { name: /15/ }));
+
+    await userEvent.click(within(dialog).getByRole('textbox', { name: 'To' }));
+    await userEvent.click(screen.getByRole('gridcell', { name: /26/ }));
+
+    await userEvent.click(screen.getByRole('button', { name: 'Apply' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: /66996/ })).toBeInTheDocument();
+    });
+  });
+
+  it('can filter orders based on custom status labels', async () => {
+    const getOrders = vi.fn().mockReturnValue(
+      buildCompanyOrdersWith({
+        data: {
+          allOrders: {
+            totalCount: 1,
+            edges: [buildCompanyOrderNodeWith({ node: { status: 'Pending' } })],
+          },
+        },
+      }),
+    );
+
+    server.use(
+      graphql.query('GetOrderStatuses', () =>
+        HttpResponse.json(
+          buildCompanyOrderStatusesWith({
+            data: {
+              orderStatuses: [
+                buildOrderStatusWith({ systemLabel: 'Pending', customLabel: 'Awaiting' }),
+              ],
+            },
+          }),
+        ),
+      ),
+      graphql.query('GetOrdersCreatedByUser', () =>
+        HttpResponse.json({ data: { createdByUser: { results: [] } } }),
+      ),
+      graphql.query('GetAllOrders', ({ query }) => HttpResponse.json(getOrders(query))),
+    );
+
+    renderWithProviders(<MyOrders />, { preloadedState });
+
+    await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+    when(getOrders)
+      .calledWith(stringContainingAll('status: "Pending"'))
+      .thenReturn(
+        buildCompanyOrdersWith({
+          data: {
+            allOrders: {
+              totalCount: 1,
+              edges: [buildCompanyOrderNodeWith({ node: { orderId: '66996' } })],
+            },
+          },
+        }),
+      );
+
+    await userEvent.click(screen.getByRole('button', { name: /edit/ }));
+
+    const dialog = await screen.findByRole('dialog', { name: 'Filters' });
+
+    await userEvent.click(within(dialog).getByRole('combobox', { name: 'Order status' }));
+
+    await userEvent.click(screen.getByRole('option', { name: 'Awaiting' }));
+
+    await userEvent.click(screen.getByRole('button', { name: 'Apply' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: /66996/ })).toBeInTheDocument();
+    });
+  });
+
+  it('navigates to the order details page when clicking on an element', async () => {
+    server.use(
+      graphql.query('GetAllOrders', () =>
+        HttpResponse.json(
+          buildCompanyOrdersWith({
+            data: {
+              allOrders: {
+                totalCount: 1,
+                edges: [buildCompanyOrderNodeWith({ node: { orderId: '66996' } })],
+              },
+            },
+          }),
+        ),
+      ),
+    );
+
+    const { navigation } = renderWithProviders(<MyOrders />, { preloadedState });
+
+    await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+    const heading = screen.getByRole('heading', { name: /66996/ });
+
+    await userEvent.click(heading);
+
+    expect(navigation).toHaveBeenCalledWith('/orderDetail/66996');
+  });
+});
+
+describe('has no placed orders', () => {
+  it('displays a -no data- message', async () => {
+    const getOrders = vi.fn().mockReturnValue(
+      buildCompanyOrdersWith({
+        data: {
+          allOrders: {
+            edges: [],
+          },
+        },
+      }),
+    );
+
+    server.use(graphql.query('GetAllOrders', ({ query }) => getOrders(query)));
+
+    renderWithProviders(<MyOrders />, { preloadedState });
+
+    await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+    expect(screen.getByText(/No data/)).toBeInTheDocument();
+  });
+});
+
+describe('when a super admin is masquerading as a company customer', () => {
+  const preloadedState = {
+    company: buildCompanyStateWith({
+      customer: {
+        role: CustomerRole.SUPER_ADMIN,
+      },
+    }),
+    storeInfo: buildStoreInfoStateWith({ timeFormat: { display: 'j F Y' } }),
+    b2bFeatures: buildB2BFeaturesStateWith({
+      masqueradeCompany: {
+        id: 433,
+        isAgenting: true,
+      },
+    }),
+  };
+
+  beforeEach(() => {
+    server.use(
+      graphql.query('GetOrderStatuses', () =>
+        HttpResponse.json(buildCompanyOrderStatusesWith('WHATEVER_VALUES')),
+      ),
+    );
+  });
+
+  it('displays all the orders associated with the company', async () => {
+    const getAllOrders = vi.fn();
+
+    server.use(
+      graphql.query('GetAllOrders', ({ query }) => HttpResponse.json(getAllOrders(query))),
+    );
+
+    when(getAllOrders)
+      .calledWith(
+        // isShowMy controls whether to show the orders for the current user, setting it to "0" will get all the orders for a company.
+        stringContainingAll('companyIds: [433,]', 'isShowMy: "0"', 'orderBy: "-bcOrderId"'),
+      )
+      .thenReturn(
+        buildCompanyOrdersWith({
+          data: {
+            allOrders: {
+              totalCount: 2,
+              edges: [
+                buildCompanyOrderNodeWith({ node: { orderId: '66996' } }),
+                buildCompanyOrderNodeWith({ node: { orderId: '66986' } }),
+              ],
+            },
+          },
+        }),
+      );
+
+    renderWithProviders(<MyOrders />, { preloadedState });
+
+    await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+    expect(screen.getByRole('heading', { name: '# 66996' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: '# 66986' })).toBeInTheDocument();
+  });
+
+  it('displays all the information associated with an order', async () => {
+    const order66996 = buildCompanyOrderNodeWith({
+      node: {
+        orderId: '66996',
+        firstName: 'Mike',
+        lastName: 'Wazowski',
+        poNumber: '0022',
+        totalIncTax: 100,
+        status: 'Pending',
+        createdAt: getUnixTime(new Date('13 March 2025')),
+        companyInfo: {
+          companyName: 'Monsters Inc.',
+        },
+      },
+    });
+
+    const getAllOrders = vi.fn();
+
+    server.use(
+      graphql.query('GetOrderStatuses', () => {
+        return HttpResponse.json(
+          buildCompanyOrderStatusesWith({
+            data: {
+              orderStatuses: [
+                buildOrderStatusWith({ systemLabel: 'Pending', customLabel: 'Pending' }),
+                buildOrderStatusWith('WHATEVER_VALUES'),
+              ],
+            },
+          }),
+        );
+      }),
+      graphql.query('GetAllOrders', ({ query }) => HttpResponse.json(getAllOrders(query))),
+    );
+
+    when(getAllOrders)
+      .calledWith(stringContainingAll('companyIds: [433,]', 'orderBy: "-bcOrderId"'))
+      .thenReturn(
+        buildCompanyOrdersWith({
+          data: {
+            allOrders: {
+              totalCount: 1,
+              edges: [order66996],
+            },
+          },
+        }),
+      );
+
+    renderWithProviders(<MyOrders />, { preloadedState });
+
+    await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+    expect(screen.getByRole('heading', { name: '# 66996' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: '$100.00' })).toBeInTheDocument();
+
+    expect(screen.getByText('Pending')).toBeInTheDocument();
+    expect(screen.getByText('13 March 2025')).toBeInTheDocument();
+    expect(screen.getByText('by Mike Wazowski')).toBeInTheDocument();
+  });
+});
+
+describe.todo('when a customer is part of a company hierarchy');

--- a/apps/storefront/src/pages/CompanyOrderList/index.test.tsx
+++ b/apps/storefront/src/pages/CompanyOrderList/index.test.tsx
@@ -1,0 +1,824 @@
+import {
+  buildCompanyStateWith,
+  builder,
+  buildStoreInfoStateWith,
+  bulk,
+  faker,
+  getUnixTime,
+  graphql,
+  HttpResponse,
+  renderWithProviders,
+  screen,
+  startMockServer,
+  stringContainingAll,
+  userEvent,
+  waitFor,
+  waitForElementToBeRemoved,
+  within,
+} from 'tests/test-utils';
+import { when } from 'vitest-when';
+
+import {
+  CompanyOrderNode,
+  CompanyOrderStatuses,
+  CustomerOrderStatus,
+  GetCompanyOrders,
+} from '@/shared/service/b2b/graphql/orders';
+import { CompanyStatus, CustomerRole, UserTypes } from '@/types';
+
+import CompanyOrders from '.';
+
+const { server } = startMockServer();
+
+const buildOrderStatusWith = builder<CustomerOrderStatus>(() => ({
+  statusCode: faker.number.int().toString(),
+  systemLabel: faker.word.noun(),
+  customLabel: faker.word.noun(),
+}));
+
+const buildCompanyOrderNodeWith = builder<CompanyOrderNode>(() => ({
+  node: {
+    orderId: faker.number.int().toString(),
+    firstName: faker.person.firstName(),
+    lastName: faker.person.lastName(),
+    createdAt: getUnixTime(faker.date.past()),
+    updatedAt: getUnixTime(faker.date.recent()),
+    isArchived: faker.datatype.boolean(),
+    isInvoiceOrder: faker.helpers.arrayElement(['A_1', 'A_0']),
+    totalIncTax: faker.number.float(),
+    currencyCode: faker.finance.currencyCode(),
+    usdIncTax: faker.number.float(),
+    items: faker.number.int(),
+    userId: faker.number.int(),
+    poNumber: faker.number.int().toString(),
+    referenceNumber: faker.number.int().toString(),
+    status: faker.word.noun(),
+    customStatus: faker.word.noun(),
+    statusCode: faker.number.int(),
+    ipStatus: faker.helpers.arrayElement(['A_0', 'A_1', 'A_2']),
+    flag: faker.helpers.arrayElement(['A_0', 'A_1', 'A_2', 'A_3']),
+    billingName: faker.person.fullName(),
+    merchantEmail: faker.internet.email(),
+    companyName: faker.company.name(),
+    companyInfo: {
+      companyName: faker.company.name(),
+    },
+  },
+}));
+
+const buildCompanyOrdersWith = builder<GetCompanyOrders>(() => ({
+  data: {
+    allOrders: {
+      totalCount: faker.number.int({ min: 1, max: 10 }),
+      pageInfo: {
+        hasNextPage: faker.datatype.boolean(),
+        hasPreviousPage: faker.datatype.boolean(),
+      },
+      edges: bulk(buildCompanyOrderNodeWith, 'WHATEVER_VALUES').times(10),
+    },
+  },
+}));
+
+const buildCompanyOrderStatusesWith = builder<CompanyOrderStatuses>(() => ({
+  data: {
+    orderStatuses: bulk(buildOrderStatusWith, 'WHATEVER_VALUES').times(3),
+  },
+}));
+
+const preloadedState = {
+  company: buildCompanyStateWith({
+    customer: {
+      role: CustomerRole.SENIOR_BUYER,
+      userType: UserTypes.MULTIPLE_B2C,
+    },
+    companyInfo: {
+      status: CompanyStatus.APPROVED,
+    },
+  }),
+  storeInfo: buildStoreInfoStateWith({ timeFormat: { display: 'j F Y' } }),
+};
+
+beforeEach(() => {
+  server.use(
+    graphql.query('GetOrderStatuses', () =>
+      HttpResponse.json(buildCompanyOrderStatusesWith('WHATEVER_VALUES')),
+    ),
+  );
+});
+
+describe('has placed orders', () => {
+  it('displays a table with order information', async () => {
+    const getAllOrders = vi.fn();
+
+    server.use(
+      graphql.query('GetAllOrders', ({ query }) => HttpResponse.json(getAllOrders(query))),
+    );
+
+    when(getAllOrders)
+      // isShowMy controls whether to show the orders for the current user, setting it to "0" will get all the orders for a company.
+      .calledWith(stringContainingAll('isShowMy: "0"', 'first: 10', 'offset: 0'))
+      .thenReturn(buildCompanyOrdersWith('WHATEVER_VALUES'));
+
+    renderWithProviders(<CompanyOrders />, { preloadedState });
+
+    await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+    const table = screen.getByRole('table');
+
+    const columnHeaders = within(table).getAllByRole('columnheader');
+
+    expect(columnHeaders[0]).toHaveTextContent('Order');
+    expect(columnHeaders[1]).toHaveTextContent('Company');
+    expect(columnHeaders[2]).toHaveTextContent('PO / Reference');
+    expect(columnHeaders[3]).toHaveTextContent('Grand total');
+    expect(columnHeaders[4]).toHaveTextContent('Order status');
+    expect(columnHeaders[5]).toHaveTextContent('Placed by');
+    expect(columnHeaders[6]).toHaveTextContent('Created on');
+  });
+
+  it('displays all the orders associated with the current company', async () => {
+    const getAllOrders = vi.fn();
+
+    server.use(
+      graphql.query('GetAllOrders', ({ query }) => HttpResponse.json(getAllOrders(query))),
+    );
+
+    when(getAllOrders)
+      // isShowMy controls whether to show the orders for the current user, setting it to "0" will get all the orders for a company.
+      .calledWith(stringContainingAll('isShowMy: "0"', 'first: 10', 'offset: 0'))
+      .thenReturn(
+        buildCompanyOrdersWith({
+          data: {
+            allOrders: {
+              totalCount: 2,
+              edges: [
+                buildCompanyOrderNodeWith({ node: { orderId: '66996' } }),
+                buildCompanyOrderNodeWith({ node: { orderId: '66986' } }),
+              ],
+            },
+          },
+        }),
+      );
+
+    renderWithProviders(<CompanyOrders />, { preloadedState });
+
+    await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+    expect(screen.getByRole('row', { name: /66996/ })).toBeInTheDocument();
+    expect(screen.getByRole('row', { name: /66986/ })).toBeInTheDocument();
+  });
+
+  it('displays all the information associated with an order', async () => {
+    const order66996 = buildCompanyOrderNodeWith({
+      node: {
+        firstName: 'Mike',
+        lastName: 'Wazowski',
+        orderId: '66996',
+        poNumber: '0022',
+        totalIncTax: 100,
+        status: 'Pending',
+        createdAt: getUnixTime(new Date('13 March 2025')),
+        companyInfo: {
+          companyName: 'Monsters Inc.',
+        },
+      },
+    });
+
+    server.use(
+      graphql.query('GetOrderStatuses', () =>
+        HttpResponse.json(
+          buildCompanyOrderStatusesWith({
+            data: {
+              orderStatuses: [
+                buildOrderStatusWith({ systemLabel: 'Pending', customLabel: 'Pending' }),
+                buildOrderStatusWith('WHATEVER_VALUES'),
+              ],
+            },
+          }),
+        ),
+      ),
+      graphql.query('GetAllOrders', () =>
+        HttpResponse.json(
+          buildCompanyOrdersWith({
+            data: {
+              allOrders: {
+                totalCount: 1,
+                edges: [order66996],
+              },
+            },
+          }),
+        ),
+      ),
+    );
+
+    renderWithProviders(<CompanyOrders />, { preloadedState });
+
+    await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+    const row = screen.getByRole('row', { name: /66996/ });
+
+    expect(within(row).getByRole('cell', { name: '66996' })).toBeInTheDocument();
+    expect(within(row).getByRole('cell', { name: 'Monsters Inc.' })).toBeInTheDocument();
+    expect(within(row).getByRole('cell', { name: '0022' })).toBeInTheDocument();
+    expect(within(row).getByRole('cell', { name: '$100.00' })).toBeInTheDocument();
+    expect(within(row).getByRole('cell', { name: 'Pending' })).toBeInTheDocument();
+    expect(within(row).getByRole('cell', { name: 'Mike Wazowski' })).toBeInTheDocument();
+    expect(within(row).getByRole('cell', { name: '13 March 2025' })).toBeInTheDocument();
+  });
+
+  it('displays `-` when the poNumber is missing', async () => {
+    const order66996 = buildCompanyOrderNodeWith({
+      node: {
+        orderId: '66996',
+        poNumber: '',
+      },
+    });
+
+    server.use(
+      graphql.query('GetAllOrders', () =>
+        HttpResponse.json(
+          buildCompanyOrdersWith({
+            data: {
+              allOrders: {
+                totalCount: 1,
+                edges: [order66996],
+              },
+            },
+          }),
+        ),
+      ),
+    );
+
+    renderWithProviders(<CompanyOrders />, { preloadedState });
+
+    await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+    const row = screen.getByRole('row', { name: /66996/ });
+
+    // The character U+2013 "–" could be confused with the ASCII character U+002d "-", which is more common in source code.
+    expect(within(row).getByRole('cell', { name: '–' })).toBeInTheDocument();
+  });
+
+  it('displays `-` when the company name is missing', async () => {
+    const order66996 = buildCompanyOrderNodeWith({
+      node: {
+        orderId: '66996',
+        companyInfo: {
+          companyName: '',
+        },
+      },
+    });
+
+    server.use(
+      graphql.query('GetAllOrders', () =>
+        HttpResponse.json(
+          buildCompanyOrdersWith({
+            data: {
+              allOrders: {
+                totalCount: 1,
+                edges: [order66996],
+              },
+            },
+          }),
+        ),
+      ),
+    );
+
+    renderWithProviders(<CompanyOrders />, { preloadedState });
+
+    await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+    const row = screen.getByRole('row', { name: /66996/ });
+
+    // The character U+2013 "–" could be confused with the ASCII character U+002d "-", which is more common in source code.
+    expect(within(row).getByRole('cell', { name: '–' })).toBeInTheDocument();
+  });
+
+  it('formats the total price based on the money property', async () => {
+    const order66996 = buildCompanyOrderNodeWith({
+      node: {
+        orderId: '66996',
+        totalIncTax: 1000,
+        money: JSON.stringify(
+          JSON.stringify({
+            currency_location: 'right',
+            currency_token: '€',
+            decimal_token: ',',
+            decimal_places: 1,
+            thousands_token: '.',
+          }),
+        ),
+      },
+    });
+
+    server.use(
+      graphql.query('GetAllOrders', () =>
+        HttpResponse.json(
+          buildCompanyOrdersWith({
+            data: {
+              allOrders: {
+                totalCount: 1,
+                edges: [order66996],
+              },
+            },
+          }),
+        ),
+      ),
+    );
+
+    renderWithProviders(<CompanyOrders />, { preloadedState });
+
+    await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+    const row = screen.getByRole('row', { name: /66996/ });
+
+    expect(within(row).getByRole('cell', { name: '1.000,0€' })).toBeInTheDocument();
+  });
+
+  it('sorts orders by ID by default', async () => {
+    const getOrders = vi.fn();
+
+    server.use(graphql.query('GetAllOrders', ({ query }) => HttpResponse.json(getOrders(query))));
+
+    when(getOrders)
+      .calledWith(stringContainingAll('orderBy: "-bcOrderId"'))
+      .thenReturn(buildCompanyOrdersWith('WHATEVER_VALUES'));
+
+    renderWithProviders(<CompanyOrders />, { preloadedState });
+
+    await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+    const table = screen.getByRole('table');
+    const orderHeader = within(table).getByRole('columnheader', { name: 'Order' });
+
+    expect(orderHeader).toHaveAttribute('aria-sort', 'descending');
+  });
+
+  it('toggles sort order when clicking the current sort column', async () => {
+    const getOrders = vi.fn().mockReturnValue(buildCompanyOrdersWith('WHATEVER_VALUES'));
+
+    server.use(graphql.query('GetAllOrders', ({ query }) => HttpResponse.json(getOrders(query))));
+
+    renderWithProviders(<CompanyOrders />, { preloadedState });
+
+    await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+    const orderHeader = screen.getByRole('columnheader', { name: 'Order' });
+
+    expect(orderHeader).toHaveAttribute('aria-sort', 'descending');
+
+    when(getOrders)
+      .calledWith(stringContainingAll('orderBy: "bcOrderId"'))
+      .thenReturn(
+        buildCompanyOrdersWith({
+          data: {
+            allOrders: {
+              totalCount: 1,
+              edges: [buildCompanyOrderNodeWith({ node: { orderId: '66996' } })],
+            },
+          },
+        }),
+      );
+
+    await userEvent.click(within(orderHeader).getByRole('button'));
+
+    await waitFor(() => {
+      expect(screen.getByRole('row', { name: /66996/ })).toBeInTheDocument();
+    });
+
+    expect(screen.getByRole('columnheader', { name: 'Order' })).toHaveAttribute(
+      'aria-sort',
+      'ascending',
+    );
+  });
+
+  it('sorts orders by different columns', async () => {
+    const getOrders = vi.fn().mockReturnValue(buildCompanyOrdersWith('WHATEVER_VALUES'));
+
+    server.use(graphql.query('GetAllOrders', ({ query }) => HttpResponse.json(getOrders(query))));
+
+    renderWithProviders(<CompanyOrders />, { preloadedState });
+
+    await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+    const createdOnHeader = screen.getByRole('columnheader', { name: 'Created on' });
+
+    expect(createdOnHeader).not.toHaveAttribute('aria-sort');
+
+    when(getOrders)
+      .calledWith(stringContainingAll('orderBy: "-createdAt"'))
+      .thenReturn(
+        buildCompanyOrdersWith({
+          data: {
+            allOrders: {
+              totalCount: 1,
+              edges: [buildCompanyOrderNodeWith({ node: { orderId: '66996' } })],
+            },
+          },
+        }),
+      );
+
+    await userEvent.click(within(createdOnHeader).getByRole('button'));
+
+    await waitFor(() => {
+      expect(screen.getByRole('row', { name: /66996/ })).toBeInTheDocument();
+    });
+
+    expect(screen.getByRole('columnheader', { name: 'Created on' })).toHaveAttribute(
+      'aria-sort',
+      'descending',
+    );
+  });
+
+  it('can change the number of rows per page', async () => {
+    const getOrders = vi.fn().mockReturnValue(buildCompanyOrdersWith('WHATEVER_VALUES'));
+
+    server.use(graphql.query('GetAllOrders', ({ query }) => HttpResponse.json(getOrders(query))));
+
+    renderWithProviders(<CompanyOrders />, { preloadedState });
+
+    await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+    when(getOrders)
+      .calledWith(stringContainingAll('first: 20', 'offset: 0'))
+      .thenReturn(
+        buildCompanyOrdersWith({
+          data: {
+            allOrders: {
+              totalCount: 1,
+              edges: [buildCompanyOrderNodeWith({ node: { orderId: '66996' } })],
+            },
+          },
+        }),
+      );
+
+    await userEvent.click(screen.getByRole('combobox', { name: /Rows per page/ }));
+    await userEvent.click(screen.getByRole('option', { name: '20' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('row', { name: /66996/ })).toBeInTheDocument();
+    });
+  });
+
+  it('can go to the next page', async () => {
+    const getOrders = vi.fn().mockReturnValue(
+      buildCompanyOrdersWith({
+        data: {
+          allOrders: {
+            totalCount: 100,
+          },
+        },
+      }),
+    );
+
+    server.use(graphql.query('GetAllOrders', ({ query }) => HttpResponse.json(getOrders(query))));
+
+    renderWithProviders(<CompanyOrders />, { preloadedState });
+
+    await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+    when(getOrders)
+      .calledWith(stringContainingAll('first: 10', 'offset: 10'))
+      .thenReturn(
+        buildCompanyOrdersWith({
+          data: {
+            allOrders: {
+              totalCount: 100,
+              edges: [buildCompanyOrderNodeWith({ node: { orderId: '66996' } })],
+            },
+          },
+        }),
+      );
+
+    const nextPageButton = screen.getByRole('button', { name: /next page/ });
+    await userEvent.click(nextPageButton);
+
+    await waitFor(() => {
+      expect(screen.getByRole('row', { name: /66996/ })).toBeInTheDocument();
+    });
+  });
+
+  it('can go to the previous page', async () => {
+    const getOrders = vi.fn().mockReturnValue(
+      buildCompanyOrdersWith({
+        data: {
+          allOrders: {
+            totalCount: 100,
+          },
+        },
+      }),
+    );
+
+    server.use(graphql.query('GetAllOrders', ({ query }) => HttpResponse.json(getOrders(query))));
+
+    renderWithProviders(<CompanyOrders />, { preloadedState });
+
+    await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+    const nextPageButton = screen.getByRole('button', { name: /next page/ });
+    await userEvent.click(nextPageButton);
+
+    when(getOrders)
+      .calledWith(stringContainingAll('first: 10', 'offset: 0'))
+      .thenReturn(
+        buildCompanyOrdersWith({
+          data: {
+            allOrders: {
+              totalCount: 100,
+              edges: [buildCompanyOrderNodeWith({ node: { orderId: '66996' } })],
+            },
+          },
+        }),
+      );
+
+    const previousPageButton = screen.getByRole('button', { name: /previous page/ });
+    await userEvent.click(previousPageButton);
+
+    await waitFor(() => {
+      expect(screen.getByRole('row', { name: /66996/ })).toBeInTheDocument();
+    });
+  });
+
+  it('can search for orders', async () => {
+    const getOrders = vi.fn().mockReturnValue(buildCompanyOrdersWith('WHATEVER_VALUES'));
+
+    server.use(graphql.query('GetAllOrders', ({ query }) => HttpResponse.json(getOrders(query))));
+
+    renderWithProviders(<CompanyOrders />, { preloadedState });
+
+    await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+    when(getOrders)
+      .calledWith(stringContainingAll('search: "66996"'))
+      .thenReturn(
+        buildCompanyOrdersWith({
+          data: {
+            allOrders: {
+              totalCount: 1,
+              edges: [buildCompanyOrderNodeWith({ node: { orderId: '66996' } })],
+            },
+          },
+        }),
+      );
+
+    const searchBox = screen.getByPlaceholderText(/Search/);
+
+    await userEvent.type(searchBox, '66996');
+
+    await waitFor(() => {
+      expect(screen.getByRole('row', { name: /66996/ })).toBeInTheDocument();
+    });
+  });
+
+  it('can filter orders', async () => {
+    vi.setSystemTime(new Date('21 November 2022'));
+
+    const getOrders = vi.fn().mockReturnValue(
+      buildCompanyOrdersWith({
+        data: {
+          allOrders: {
+            totalCount: 1,
+            edges: [buildCompanyOrderNodeWith({ node: { status: 'Pending' } })],
+          },
+        },
+      }),
+    );
+
+    server.use(
+      graphql.query('GetOrderStatuses', () =>
+        HttpResponse.json(
+          buildCompanyOrderStatusesWith({
+            data: {
+              orderStatuses: [
+                buildOrderStatusWith({ systemLabel: 'Pending', customLabel: 'Pending' }),
+                buildOrderStatusWith({ systemLabel: 'Shipped', customLabel: 'Shipped' }),
+                buildOrderStatusWith({ systemLabel: 'Cancelled', customLabel: 'Cancelled' }),
+              ],
+            },
+          }),
+        ),
+      ),
+      graphql.query('GetOrdersCreatedByUser', () =>
+        HttpResponse.json({
+          data: {
+            createdByUser: {
+              results: [
+                { firstName: 'Mike', lastName: 'Wazowski', email: 'm.wazowski@monstersinc.com' },
+                { firstName: 'James', lastName: 'Sullivan', email: 'j.sullivan@monstersinc.com' },
+              ],
+            },
+          },
+        }),
+      ),
+      graphql.query('GetAllOrders', ({ query }) => HttpResponse.json(getOrders(query))),
+    );
+
+    renderWithProviders(<CompanyOrders />, { preloadedState });
+
+    await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+    when(getOrders)
+      .calledWith(
+        stringContainingAll(
+          'createdBy: "Mike Wazowski"',
+          'email: "m.wazowski@monstersinc.com"',
+          'status: "Pending"',
+          'beginDateAt: "2022-11-15"',
+          'endDateAt: "2022-11-26"',
+        ),
+      )
+      .thenReturn(
+        buildCompanyOrdersWith({
+          data: {
+            allOrders: {
+              totalCount: 1,
+              edges: [buildCompanyOrderNodeWith({ node: { orderId: '66996' } })],
+            },
+          },
+        }),
+      );
+
+    await userEvent.click(screen.getByRole('button', { name: /edit/ }));
+
+    const dialog = await screen.findByRole('dialog', { name: 'Filters' });
+
+    await userEvent.click(within(dialog).getByRole('combobox', { name: 'Order status' }));
+
+    await userEvent.click(screen.getByRole('option', { name: 'Pending' }));
+
+    await userEvent.click(screen.getByRole('textbox', { name: 'From' }));
+    await userEvent.click(screen.getByRole('gridcell', { name: /15/ }));
+
+    await userEvent.click(screen.getByRole('textbox', { name: 'To' }));
+    await userEvent.click(screen.getByRole('gridcell', { name: /26/ }));
+
+    await userEvent.click(within(dialog).getByRole('combobox', { name: 'Placed by' }));
+
+    await userEvent.click(
+      screen.getByRole('option', { name: 'Mike Wazowski (m.wazowski@monstersinc.com)' }),
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'Apply' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('row', { name: /66996/ })).toBeInTheDocument();
+    });
+  });
+
+  it('can filter orders based on dates', async () => {
+    vi.setSystemTime(new Date('21 November 2022'));
+
+    const getOrders = vi.fn().mockReturnValue(buildCompanyOrdersWith('WHATEVER_VALUES'));
+
+    server.use(
+      graphql.query('GetAllOrders', ({ query }) => HttpResponse.json(getOrders(query))),
+      graphql.query('GetOrdersCreatedByUser', () =>
+        HttpResponse.json({ data: { createdByUser: { results: [] } } }),
+      ),
+    );
+
+    renderWithProviders(<CompanyOrders />, { preloadedState });
+
+    await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+    when(getOrders)
+      .calledWith(stringContainingAll('beginDateAt: "2022-11-15"', 'endDateAt: "2022-11-26"'))
+      .thenReturn(
+        buildCompanyOrdersWith({
+          data: {
+            allOrders: {
+              totalCount: 1,
+              edges: [buildCompanyOrderNodeWith({ node: { orderId: '66996' } })],
+            },
+          },
+        }),
+      );
+
+    await userEvent.click(screen.getByRole('button', { name: /edit/ }));
+
+    const dialog = await screen.findByRole('dialog', { name: 'Filters' });
+
+    await userEvent.click(within(dialog).getByRole('textbox', { name: 'From' }));
+    await userEvent.click(screen.getByRole('gridcell', { name: /15/ }));
+
+    await userEvent.click(within(dialog).getByRole('textbox', { name: 'To' }));
+    await userEvent.click(screen.getByRole('gridcell', { name: /26/ }));
+
+    await userEvent.click(screen.getByRole('button', { name: 'Apply' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('row', { name: /66996/ })).toBeInTheDocument();
+    });
+  });
+
+  it('can filter orders based on custom status labels', async () => {
+    const getOrders = vi.fn().mockReturnValue(
+      buildCompanyOrdersWith({
+        data: {
+          allOrders: {
+            totalCount: 1,
+            edges: [buildCompanyOrderNodeWith({ node: { status: 'Pending' } })],
+          },
+        },
+      }),
+    );
+
+    server.use(
+      graphql.query('GetOrderStatuses', () =>
+        HttpResponse.json(
+          buildCompanyOrderStatusesWith({
+            data: {
+              orderStatuses: [
+                buildOrderStatusWith({ systemLabel: 'Pending', customLabel: 'Awaiting' }),
+              ],
+            },
+          }),
+        ),
+      ),
+      graphql.query('GetAllOrders', ({ query }) => HttpResponse.json(getOrders(query))),
+      graphql.query('GetOrdersCreatedByUser', () =>
+        HttpResponse.json({ data: { createdByUser: { results: [] } } }),
+      ),
+    );
+
+    renderWithProviders(<CompanyOrders />, { preloadedState });
+
+    await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+    when(getOrders)
+      .calledWith(stringContainingAll('status: "Pending"'))
+      .thenReturn(
+        buildCompanyOrdersWith({
+          data: {
+            allOrders: {
+              totalCount: 1,
+              edges: [buildCompanyOrderNodeWith({ node: { orderId: '66996' } })],
+            },
+          },
+        }),
+      );
+
+    await userEvent.click(screen.getByRole('button', { name: /edit/ }));
+
+    const dialog = await screen.findByRole('dialog', { name: 'Filters' });
+
+    await userEvent.click(within(dialog).getByRole('combobox', { name: 'Order status' }));
+
+    await userEvent.click(screen.getByRole('option', { name: 'Awaiting' }));
+
+    await userEvent.click(screen.getByRole('button', { name: 'Apply' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('row', { name: /66996/ })).toBeInTheDocument();
+    });
+  });
+
+  it('navigates to the order details page when clicking on a row', async () => {
+    server.use(
+      graphql.query('GetAllOrders', () =>
+        HttpResponse.json(
+          buildCompanyOrdersWith({
+            data: {
+              allOrders: {
+                totalCount: 1,
+                edges: [buildCompanyOrderNodeWith({ node: { orderId: '66996' } })],
+              },
+            },
+          }),
+        ),
+      ),
+    );
+
+    const { navigation } = renderWithProviders(<CompanyOrders />, { preloadedState });
+
+    await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+    const row = screen.getByRole('row', { name: /66996/ });
+
+    await userEvent.click(row);
+
+    expect(navigation).toHaveBeenCalledWith('/orderDetail/66996');
+  });
+});
+
+describe('has no placed orders', () => {
+  it('displays a -no data- message', async () => {
+    const getOrders = vi.fn().mockReturnValue(
+      buildCompanyOrdersWith({
+        data: {
+          allOrders: {
+            edges: [],
+          },
+        },
+      }),
+    );
+
+    server.use(graphql.query('GetAllOrders', ({ query }) => getOrders(query)));
+
+    renderWithProviders(<CompanyOrders />, { preloadedState });
+
+    await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+    expect(screen.getByText(/No data/)).toBeInTheDocument();
+  });
+});

--- a/apps/storefront/src/pages/MyOrders/index.mobile.test.tsx
+++ b/apps/storefront/src/pages/MyOrders/index.mobile.test.tsx
@@ -1267,6 +1267,7 @@ describe('when a super admin is masquerading as a company customer', () => {
 
     when(getAllOrders)
       .calledWith(
+        // isShowMy controls whether to show the orders for the current user, setting it to "1" will filter for currentUser
         stringContainingAll('companyIds: [433,]', 'isShowMy: "1"', 'orderBy: "-bcOrderId"'),
       )
       .thenReturn(

--- a/apps/storefront/src/pages/MyOrders/index.test.tsx
+++ b/apps/storefront/src/pages/MyOrders/index.test.tsx
@@ -116,7 +116,7 @@ describe('when a personal customer', () => {
       );
 
       when(getOrders)
-        .calledWith(stringContainingAll('isShowMy: "0"', 'first: 10', 'offset: 0'))
+        .calledWith(stringContainingAll('first: 10', 'offset: 0'))
         .thenReturn(buildGetCustomerOrdersWith('WHATEVER_VALUES'));
 
       renderWithProviders(<MyOrders />, { preloadedState });
@@ -868,6 +868,7 @@ describe('when a company customer', () => {
       );
 
       when(getAllOrders)
+        // isShowMy controls whether to show the orders for the current user, setting it to "1" will filter for currentUser
         .calledWith(stringContainingAll('isShowMy: "1"', 'first: 10', 'offset: 0'))
         .thenReturn(buildCompanyOrdersWith('WHATEVER_VALUES'));
 
@@ -895,6 +896,7 @@ describe('when a company customer', () => {
       );
 
       when(getAllOrders)
+        // isShowMy controls whether to show the orders for the current user, setting it to "1" will filter for currentUser
         .calledWith(stringContainingAll('isShowMy: "1"', 'first: 10', 'offset: 0'))
         .thenReturn(
           buildCompanyOrdersWith({
@@ -1601,6 +1603,7 @@ describe('when a customer is masquerading as a company customer', () => {
 
     when(getAllOrders)
       .calledWith(
+        // isShowMy controls whether to show the orders for the current user, setting it to "1" will filter for currentUser
         stringContainingAll('companyIds: [433,]', 'isShowMy: "1"', 'orderBy: "-bcOrderId"'),
       )
       .thenReturn(

--- a/apps/storefront/src/pages/MyOrders/index.test.tsx
+++ b/apps/storefront/src/pages/MyOrders/index.test.tsx
@@ -616,7 +616,7 @@ describe('when a personal customer', () => {
 
       expect(within(dialog).getByRole('heading', { name: 'Filters' })).toBeInTheDocument();
 
-      await userEvent.click(within(dialog).getByRole('combobox'));
+      await userEvent.click(within(dialog).getByRole('combobox', { name: 'Order status' }));
 
       await userEvent.click(screen.getByRole('option', { name: 'Pending' }));
 
@@ -726,7 +726,7 @@ describe('when a personal customer', () => {
 
       expect(within(dialog).getByRole('heading', { name: 'Filters' })).toBeInTheDocument();
 
-      await userEvent.click(within(dialog).getByRole('combobox'));
+      await userEvent.click(within(dialog).getByRole('combobox', { name: 'Order status' }));
 
       await userEvent.click(screen.getByRole('option', { name: 'Awaiting' }));
 
@@ -1375,7 +1375,7 @@ describe('when a company customer', () => {
 
       const dialog = await screen.findByRole('dialog', { name: 'Filters' });
 
-      await userEvent.click(within(dialog).getByRole('combobox'));
+      await userEvent.click(within(dialog).getByRole('combobox', { name: 'Order status' }));
 
       await userEvent.click(screen.getByRole('option', { name: 'Pending' }));
 
@@ -1481,7 +1481,7 @@ describe('when a company customer', () => {
 
       const dialog = await screen.findByRole('dialog', { name: 'Filters' });
 
-      await userEvent.click(within(dialog).getByRole('combobox'));
+      await userEvent.click(within(dialog).getByRole('combobox', { name: 'Order status' }));
 
       await userEvent.click(screen.getByRole('option', { name: 'Awaiting' }));
 

--- a/apps/storefront/src/pages/order/Order.tsx
+++ b/apps/storefront/src/pages/order/Order.tsx
@@ -313,7 +313,7 @@ function Order({ isCompanyOrder = false }: OrderProps) {
     },
   ] as const satisfies TableColumnItem<ListItem>[];
 
-  const getColumnItems = () => {
+  const getColumnItems = (): TableColumnItem<ListItem>[] => {
     const getNewColumnItems = columnAllItems.filter((item) => {
       const { key } = item;
       if (!isB2BUser && key === 'companyName') return false;
@@ -425,7 +425,7 @@ function Order({ isCompanyOrder = false }: OrderProps) {
         </Box>
 
         <B3Table
-          columnItems={columnItems || []}
+          columnItems={columnItems}
           listItems={data?.edges || []}
           pagination={{ ...pagination, count: data?.totalCount || 0 }}
           onPaginationChange={setPagination}

--- a/apps/storefront/src/pages/order/shared/getOrderStatus.ts
+++ b/apps/storefront/src/pages/order/shared/getOrderStatus.ts
@@ -92,12 +92,6 @@ export const orderStatusTranslationVariables: OrderStatusConfig = {
   'Partially Refunded': 'orders.status.partiallyRefunded',
 };
 
-export const getOrderStatusOptions = () =>
-  Object.keys(orderStatusText).map((code) => ({
-    value: code,
-    label: orderStatusText[code],
-  }));
-
 const getOrderStatus = (code: string | number) => ({
   color: orderStatusColor[code],
   textColor: orderStatusTextColor[code],

--- a/commit-validation.json
+++ b/commit-validation.json
@@ -14,6 +14,7 @@
     "user-management",
     "dashboard",
     "quick-order",
-    "company-hierarchy"
+    "company-hierarchy",
+    "company-orders"
   ]
 }


### PR DESCRIPTION
Jira: [B2BCAT-12](https://bigcommercecloud.atlassian.net/browse/B2BCAT-12)

Note: First commit is a continuation of `B2BCAT-11`. Some missing bits.

## What/Why?
- Include SuperAdmin masquerading tests on mobile
- Improve combobox accessibility, make labels work + use them in the tests
- Add type annotations for `getColumnItems`, remove default value
- Remove unused `getOrderStatusOptions` method

## Rollout/Rollback
Revert

## Testing
This PR is mostly testing, there are some tiny changes but mostly types.

[B2BCAT-12]: https://bigcommercecloud.atlassian.net/browse/B2BCAT-12?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ