### PR TITLE
fix(quotes): B2B-3178 Properly transform quick added products

### DIFF
--- a/apps/storefront/src/pages/quote/components/AddToQuote.tsx
+++ b/apps/storefront/src/pages/quote/components/AddToQuote.tsx
@@ -133,7 +133,7 @@ export default function AddToQuote(props: AddToListProps) {
       customerGroupId,
     });
 
-    const productList = productsSearch.map((product: CustomFieldItems) => {
+    const productList = conversionProductsList(productsSearch).map((product: CustomFieldItems) => {
       const variantProduct =
         variantProducts.find(
           (variantProduct: CustomFieldItems) => variantProduct.productId === product.id,


### PR DESCRIPTION
Jira: [B2B-3178](https://bigcommercecloud.atlassian.net/browse/B2B-3178)

## What/Why?
<!--
  A description about what this pull request implements and its purpose.
  Try to be detailed and describe any technical details to simplify the job
  of the reviewer and the individual on production support.
-->
A bug was reported where quick adding products in a quote stripped the product options (both in the product table and the API payload when submitting a quote). This made the user unable to convert a quote to an order because the API expects the product options.

This PR adds a call to the `conversionProductsList` function when quick adding a product, which properly transforms the product object to what the product table expects.

This fixes the both issues of the product options not showing in the table and the API not receiving the product options when submitting a quote.

## Rollout/Rollback
<!--
Detail how this change will be rolled out. Include reference to any
experiments and how the success will be measured as the experiment is
ramped.

Document rollback procedures. Is rolling back the change as simple as
rolling back an experiment or does it require reverting code? Are there
database migrations that may change our decision to roll forward instead of
back?
-->
Revert and redeploy.

## Testing
<!--
Provide as much information as you can about how you tested and how another
Engineer can test your change. Include screenshots, or test run output
where appropriate.
-->
Before:

https://github.com/user-attachments/assets/ec46f6c8-a6ea-43a5-8310-556f1f55b2fd

After:

https://github.com/user-attachments/assets/46866892-dc29-4e55-a059-23a665cace83



[B2B-3178]: https://bigcommercecloud.atlassian.net/browse/B2B-3178?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ