### PR TITLE
feat(catalyst): B2B-2626 native catalyst notifications

### DIFF
--- a/apps/storefront/src/components/B3Tip.tsx
+++ b/apps/storefront/src/components/B3Tip.tsx
@@ -2,6 +2,7 @@ import { Alert, Box, Snackbar } from '@mui/material';
 
 import useMobile from '@/hooks/useMobile';
 import { MsgsProps, TipMessagesProps } from '@/shared/dynamicallyVariable/context/config';
+
 import TipBody from './TipBody';
 
 interface B3TipProps extends TipMessagesProps {
@@ -35,10 +36,7 @@ function MessageAlert({
       severity={msg.type}
       onClose={() => msg.isClose && onClose(msg.id)}
     >
-      <TipBody
-        action={msg.action}
-        message={msg.msg}
-      />
+      <TipBody action={msg.action} message={msg.msg} />
     </Alert>
   );
 }

--- a/apps/storefront/src/components/B3Tip.tsx
+++ b/apps/storefront/src/components/B3Tip.tsx
@@ -34,7 +34,7 @@ function MessageAlert({
       variant="filled"
       key={msg.id}
       severity={msg.type}
-      onClose={() => msg.isClose && onClose(msg.id)}
+      onClose={() => onClose(msg.id)}
     >
       <TipBody action={msg.action} message={msg.msg} description={msg.description} />
     </Alert>

--- a/apps/storefront/src/components/B3Tip.tsx
+++ b/apps/storefront/src/components/B3Tip.tsx
@@ -1,7 +1,8 @@
-import { Alert, AlertTitle, Box, Snackbar } from '@mui/material';
+import { Alert, Box, Snackbar } from '@mui/material';
 
 import useMobile from '@/hooks/useMobile';
 import { MsgsProps, TipMessagesProps } from '@/shared/dynamicallyVariable/context/config';
+import TipBody from './TipBody';
 
 interface B3TipProps extends TipMessagesProps {
   handleItemClose: (id: number | string) => void;
@@ -15,8 +16,6 @@ function MessageAlert({
   msg: MsgsProps;
   onClose: (id: string | number) => void;
 }) {
-  const Body = msg.jsx ? msg.jsx : () => <span>{msg.msg}</span>;
-
   return (
     <Alert
       sx={{
@@ -36,8 +35,10 @@ function MessageAlert({
       severity={msg.type}
       onClose={() => msg.isClose && onClose(msg.id)}
     >
-      {msg.title && <AlertTitle>{msg.title}</AlertTitle>}
-      <Body />
+      <TipBody
+        action={msg.action}
+        message={msg.msg}
+      />
     </Alert>
   );
 }

--- a/apps/storefront/src/components/B3Tip.tsx
+++ b/apps/storefront/src/components/B3Tip.tsx
@@ -36,7 +36,7 @@ function MessageAlert({
       severity={msg.type}
       onClose={() => msg.isClose && onClose(msg.id)}
     >
-      <TipBody action={msg.action} message={msg.msg} />
+      <TipBody action={msg.action} message={msg.msg} description={msg.description} />
     </Alert>
   );
 }

--- a/apps/storefront/src/components/B3Tip.tsx
+++ b/apps/storefront/src/components/B3Tip.tsx
@@ -21,7 +21,7 @@ function MessageAlert({
       sx={{
         alignItems: 'center',
         '& button[title="Close"]': {
-          display: msg.isClose ? 'block' : 'none',
+          display: 'block',
         },
         mb: '5px',
 

--- a/apps/storefront/src/components/HeadlessController/index.tsx
+++ b/apps/storefront/src/components/HeadlessController/index.tsx
@@ -1,5 +1,6 @@
 import { useContext, useEffect, useRef } from 'react';
 import { setElementsListenersConfig } from '@b3/global-b3';
+import { useB3Lang } from '@b3/lang';
 import Cookies from 'js-cookie';
 
 import { HeadlessRoutes } from '@/constants';
@@ -77,6 +78,7 @@ const Manager = new CallbackManager();
 export default function HeadlessController({ setOpenPage }: HeadlessControllerProps) {
   const storeDispatch = useAppDispatch();
   const store = useAppStore();
+  const b3Lang = useB3Lang();
 
   const { state: globalState } = useContext(GlobalContext);
   const isB2BUser = useAppSelector(isB2BUserSelector);
@@ -92,7 +94,10 @@ export default function HeadlessController({ setOpenPage }: HeadlessControllerPr
   const {
     state: { addQuoteBtn, shoppingListBtn, addToAllQuoteBtn },
   } = useContext(CustomStyleContext);
-  const { addToQuoteFromCart, addToQuoteFromCookie } = addProductsFromCartToQuote(setOpenPage);
+  const { addToQuoteFromCart, addToQuoteFromCookie } = addProductsFromCartToQuote(
+    setOpenPage,
+    b3Lang,
+  );
 
   const {
     registerEnabled,
@@ -160,7 +165,7 @@ export default function HeadlessController({ setOpenPage }: HeadlessControllerPr
               sku: await getSku(item),
             };
 
-            return addProductsToDraftQuote([productWithSku], setOpenPage);
+            return addProductsToDraftQuote([productWithSku], setOpenPage, b3Lang);
           },
           addProductsFromCart: addToQuoteFromCookie,
           addProductsFromCartId: addToQuoteFromCart,
@@ -172,7 +177,7 @@ export default function HeadlessController({ setOpenPage }: HeadlessControllerPr
               })),
             );
 
-            return addProductsToDraftQuote(products, setOpenPage);
+            return addProductsToDraftQuote(products, setOpenPage, b3Lang);
           },
           getQuoteConfigs: () => quoteConfig,
           getCurrent: () => ({ productList }),

--- a/apps/storefront/src/components/TipBody.test.tsx
+++ b/apps/storefront/src/components/TipBody.test.tsx
@@ -1,0 +1,45 @@
+import { describe, it, vi, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import TipBody from './TipBody';
+
+describe('TipBody', () => {
+    it('renders the message', () => {
+        render(<TipBody message="Hello world" />);
+        expect(screen.getByText('Hello world')).toBeInTheDocument();
+    });
+
+    it('renders the description if provided', () => {
+        render(<TipBody message="Tip" description="This is a description" />);
+        expect(screen.getByText('This is a description')).toBeInTheDocument();
+    });
+
+    it('does not render the description if not provided', () => {
+        render(<TipBody message="Tip" />);
+        expect(screen.queryByText('This is a description')).not.toBeInTheDocument();
+    });
+
+    it('renders the action button if action is provided', () => {
+        const action = { label: 'Click me', onClick: vi.fn() };
+        render(<TipBody message="Tip" action={action} />);
+        expect(screen.getByRole('button', { name: 'Click me' })).toBeInTheDocument();
+    });
+
+    it('does not render the action button if action is not provided', () => {
+        render(<TipBody message="Tip" />);
+        expect(screen.queryByRole('button')).not.toBeInTheDocument();
+    });
+
+    it('calls action.onClick when the button is clicked', async () => {
+        const onClick = vi.fn();
+        const action = { label: 'Do it', onClick };
+        render(<TipBody message="Tip" action={action} />);
+        await userEvent.click(screen.getByRole('button', { name: 'Do it' }));
+        expect(onClick).toHaveBeenCalledTimes(1);
+    });
+
+    it('renders message as ReactNode', () => {
+        render(<TipBody message={<span data-testid="custom-node">Custom</span>} />);
+        expect(screen.getByTestId('custom-node')).toBeInTheDocument();
+    });
+});

--- a/apps/storefront/src/components/TipBody.test.tsx
+++ b/apps/storefront/src/components/TipBody.test.tsx
@@ -1,45 +1,46 @@
-import { describe, it, vi, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
 import TipBody from './TipBody';
 
 describe('TipBody', () => {
-    it('renders the message', () => {
-        render(<TipBody message="Hello world" />);
-        expect(screen.getByText('Hello world')).toBeInTheDocument();
-    });
+  it('renders the message', () => {
+    render(<TipBody message="Hello world" />);
+    expect(screen.getByText('Hello world')).toBeInTheDocument();
+  });
 
-    it('renders the description if provided', () => {
-        render(<TipBody message="Tip" description="This is a description" />);
-        expect(screen.getByText('This is a description')).toBeInTheDocument();
-    });
+  it('renders the description if provided', () => {
+    render(<TipBody message="Tip" description="This is a description" />);
+    expect(screen.getByText('This is a description')).toBeInTheDocument();
+  });
 
-    it('does not render the description if not provided', () => {
-        render(<TipBody message="Tip" />);
-        expect(screen.queryByText('This is a description')).not.toBeInTheDocument();
-    });
+  it('does not render the description if not provided', () => {
+    render(<TipBody message="Tip" />);
+    expect(screen.queryByText('This is a description')).not.toBeInTheDocument();
+  });
 
-    it('renders the action button if action is provided', () => {
-        const action = { label: 'Click me', onClick: vi.fn() };
-        render(<TipBody message="Tip" action={action} />);
-        expect(screen.getByRole('button', { name: 'Click me' })).toBeInTheDocument();
-    });
+  it('renders the action button if action is provided', () => {
+    const action = { label: 'Click me', onClick: vi.fn() };
+    render(<TipBody message="Tip" action={action} />);
+    expect(screen.getByRole('button', { name: 'Click me' })).toBeInTheDocument();
+  });
 
-    it('does not render the action button if action is not provided', () => {
-        render(<TipBody message="Tip" />);
-        expect(screen.queryByRole('button')).not.toBeInTheDocument();
-    });
+  it('does not render the action button if action is not provided', () => {
+    render(<TipBody message="Tip" />);
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
 
-    it('calls action.onClick when the button is clicked', async () => {
-        const onClick = vi.fn();
-        const action = { label: 'Do it', onClick };
-        render(<TipBody message="Tip" action={action} />);
-        await userEvent.click(screen.getByRole('button', { name: 'Do it' }));
-        expect(onClick).toHaveBeenCalledTimes(1);
-    });
+  it('calls action.onClick when the button is clicked', async () => {
+    const onClick = vi.fn();
+    const action = { label: 'Do it', onClick };
+    render(<TipBody message="Tip" action={action} />);
+    await userEvent.click(screen.getByRole('button', { name: 'Do it' }));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
 
-    it('renders message as ReactNode', () => {
-        render(<TipBody message={<span data-testid="custom-node">Custom</span>} />);
-        expect(screen.getByTestId('custom-node')).toBeInTheDocument();
-    });
+  it('renders message as ReactNode', () => {
+    render(<TipBody message={<span data-testid="custom-node">Custom</span>} />);
+    expect(screen.getByTestId('custom-node')).toBeInTheDocument();
+  });
 });

--- a/apps/storefront/src/components/TipBody.tsx
+++ b/apps/storefront/src/components/TipBody.tsx
@@ -1,0 +1,43 @@
+import { ReactNode } from 'react';
+import { Box, Button } from '@mui/material';
+
+interface TipBodyProps {
+  action?: {
+    label: string;
+    onClick: () => void;
+  };
+  message: ReactNode;
+}
+
+export default function TipBody(props: TipBodyProps) {
+  const { action, message } = props;
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+      }}
+    >
+      <Box
+        sx={{
+          mr: '15px',
+        }}
+      >
+        {message}
+      </Box>
+      {action && (
+        <Button
+          onClick={action.onClick}
+          variant="text"
+          sx={{
+            color: '#ffffff',
+            padding: 0,
+          }}
+        >
+          {action.label}
+        </Button>
+      )}
+    </Box>
+  );
+}

--- a/apps/storefront/src/components/TipBody.tsx
+++ b/apps/storefront/src/components/TipBody.tsx
@@ -7,10 +7,11 @@ interface TipBodyProps {
     onClick: () => void;
   };
   message: ReactNode;
+  description?: string;
 }
 
 export default function TipBody(props: TipBodyProps) {
-  const { action, message } = props;
+  const { action, message, description } = props;
 
   return (
     <Box
@@ -25,6 +26,15 @@ export default function TipBody(props: TipBodyProps) {
         }}
       >
         {message}
+        {description && (
+          <p
+            style={{
+              margin: 0,
+            }}
+          >
+            {description}
+          </p>
+        )}
       </Box>
       {action && (
         <Button

--- a/apps/storefront/src/hooks/dom/useCartToQuote.ts
+++ b/apps/storefront/src/hooks/dom/useCartToQuote.ts
@@ -84,9 +84,6 @@ const useCartToQuote = ({ setOpenPage, cartQuoteEnabled }: MutationObserverProps
       if (checkIsInPage(CART_URL)) {
         globalSnackbar.warning(
           'Your account is pending approval. Ordering will be enabled after account approval',
-          {
-            isClose: true,
-          },
         );
       }
 

--- a/apps/storefront/src/hooks/dom/useCartToQuote.ts
+++ b/apps/storefront/src/hooks/dom/useCartToQuote.ts
@@ -33,7 +33,10 @@ interface IsShowBlockPendingAccountOrderCreationTipProps {
 
 const useCartToQuote = ({ setOpenPage, cartQuoteEnabled }: MutationObserverProps) => {
   const b3Lang = useB3Lang();
-  const { addToQuoteFromCookie: addToQuote, addLoading } = addProductsFromCartToQuote(setOpenPage);
+  const { addToQuoteFromCookie: addToQuote, addLoading } = addProductsFromCartToQuote(
+    setOpenPage,
+    b3Lang,
+  );
 
   const translationVarName = 'global.customStyles.addToAllQuoteBtn';
   const defaultButtonText = 'Add All To Quote';

--- a/apps/storefront/src/hooks/dom/utils.ts
+++ b/apps/storefront/src/hooks/dom/utils.ts
@@ -1,7 +1,6 @@
 import config from '@b3/global-b3';
 import { LangFormatFunction } from '@b3/lang';
 
-import B3AddToQuoteTip from '@/components/B3AddToQuoteTip';
 import { type SetOpenPage } from '@/pages/SetOpenPage';
 import { searchProducts } from '@/shared/service/b2b';
 import { getCart } from '@/shared/service/bc/graphql/cart';
@@ -168,6 +167,7 @@ const getCartProducts = (lineItems: LineItemsProps) =>
 const addProductsToDraftQuote = async (
   products: LineItem[],
   setOpenPage: SetOpenPage,
+  b3Lang: LangFormatFunction,
   cartId?: string,
 ) => {
   // filter out products without SKU or variantId
@@ -209,34 +209,21 @@ const addProductsToDraftQuote = async (
     // Save the shopping cart id, used to clear the shopping cart after submitting the quote
     if (cartId) B3LStorage.set('cartToQuoteId', cartId);
 
-    globalSnackbar.success('', {
-      jsx: () =>
-        B3AddToQuoteTip({
-          gotoQuoteDraft: () => gotoQuoteDraft(setOpenPage),
-          msg: 'Product was added to your quote.',
-        }),
+    globalSnackbar.success(b3Lang('quoteDraft.notification.productPlural'), {
+      action: {
+        onClick: () => gotoQuoteDraft(setOpenPage),
+        label: b3Lang('quoteDraft.notification.openQuote'),
+      },
       isClose: true,
     });
-    return;
   }
-
-  globalSnackbar.error('', {
-    jsx: () =>
-      B3AddToQuoteTip({
-        gotoQuoteDraft: () => gotoQuoteDraft(setOpenPage),
-        msg: 'The quantity of each product in Quote is 1-1000000.',
-      }),
-    isClose: true,
-  });
 };
 
-const addProductsFromCartToQuote = (setOpenPage: SetOpenPage) => {
+const addProductsFromCartToQuote = (setOpenPage: SetOpenPage, b3Lang: LangFormatFunction) => {
   const addToQuote = async (cartInfoWithOptions: CartInfoProps | any) => {
     try {
       if (!cartInfoWithOptions.data.site.cart) {
-        globalSnackbar.error('No products in Cart.', {
-          isClose: true,
-        });
+        globalSnackbar.error(b3Lang('pdp.cartToQuote.error.notFound'));
         return;
       }
 
@@ -245,15 +232,11 @@ const addProductsFromCartToQuote = (setOpenPage: SetOpenPage) => {
       const { cartProductsList, noSkuProducts } = getCartProducts(lineItems);
 
       if (noSkuProducts.length > 0) {
-        globalSnackbar.error('Can not add products without SKU.', {
-          isClose: true,
-        });
+        globalSnackbar.error(b3Lang('quoteDraft.notification.cantAddProductsNoSku'));
       }
 
       if (cartProductsList.length === 0) {
-        globalSnackbar.error('No products being added.', {
-          isClose: true,
-        });
+        globalSnackbar.error(b3Lang('pdp.cartToQuote.error.empty'));
       }
       if (noSkuProducts.length === cartProductsList.length) return;
 
@@ -294,9 +277,7 @@ const addProductFromProductPageToQuote = (
       const form = productView.querySelector('form[data-cart-item-add]') as HTMLFormElement;
 
       if (!sku) {
-        globalSnackbar.error('Can not add products without SKU.', {
-          isClose: true,
-        });
+        globalSnackbar.error(b3Lang('quoteDraft.notification.cantAddProductsNoSku'));
 
         return;
       }
@@ -322,9 +303,7 @@ const addProductFromProductPageToQuote = (
 
       const { isValid, message } = isAllRequiredOptionFilled(allOptions, optionList);
       if (!isValid) {
-        globalSnackbar.error(message, {
-          isClose: true,
-        });
+        globalSnackbar.error(message);
         return;
       }
 
@@ -372,27 +351,23 @@ const addProductFromProductPageToQuote = (
       const isSuccess = validProductQty(newProducts);
       if (quoteListitem && isSuccess) {
         await addQuoteDraftProduce(quoteListitem, qty, optionList || []);
-        globalSnackbar.success('', {
-          jsx: () =>
-            B3AddToQuoteTip({
-              gotoQuoteDraft: () => gotoQuoteDraft(setOpenPage),
-              msg: 'global.notification.addProductSingular',
-            }),
+        globalSnackbar.success(b3Lang('global.notification.addProductSingular'), {
+          action: {
+            onClick: () => gotoQuoteDraft(setOpenPage),
+            label: b3Lang('quoteDraft.notification.openQuote'),
+          },
           isClose: true,
         });
       } else if (!isSuccess) {
-        globalSnackbar.error('', {
-          jsx: () =>
-            B3AddToQuoteTip({
-              gotoQuoteDraft: () => gotoQuoteDraft(setOpenPage),
-              msg: 'global.notification.maximumPurchaseExceed',
-            }),
+        globalSnackbar.error(b3Lang('global.notification.maximumPurchaseExceed'), {
+          action: {
+            onClick: () => gotoQuoteDraft(setOpenPage),
+            label: b3Lang('quoteDraft.notification.openQuote'),
+          },
           isClose: true,
         });
       } else {
-        globalSnackbar.error('Price error', {
-          isClose: true,
-        });
+        globalSnackbar.error('Price error');
       }
     } catch (e) {
       b2bLogger.error(e);

--- a/apps/storefront/src/hooks/dom/utils.ts
+++ b/apps/storefront/src/hooks/dom/utils.ts
@@ -214,7 +214,6 @@ const addProductsToDraftQuote = async (
         onClick: () => gotoQuoteDraft(setOpenPage),
         label: b3Lang('quoteDraft.notification.openQuote'),
       },
-      isClose: true,
     });
   }
 };
@@ -356,7 +355,6 @@ const addProductFromProductPageToQuote = (
             onClick: () => gotoQuoteDraft(setOpenPage),
             label: b3Lang('quoteDraft.notification.openQuote'),
           },
-          isClose: true,
         });
       } else if (!isSuccess) {
         globalSnackbar.error(b3Lang('global.notification.maximumPurchaseExceed'), {
@@ -364,7 +362,6 @@ const addProductFromProductPageToQuote = (
             onClick: () => gotoQuoteDraft(setOpenPage),
             label: b3Lang('quoteDraft.notification.openQuote'),
           },
-          isClose: true,
         });
       } else {
         globalSnackbar.error('Price error');

--- a/apps/storefront/src/index.d.ts
+++ b/apps/storefront/src/index.d.ts
@@ -20,6 +20,24 @@ type ChannelPlatform =
   | 'wordpress'
   | 'custom';
 
+type Position =
+  | 'top-left'
+  | 'top-right'
+  | 'bottom-left'
+  | 'bottom-right'
+  | 'top-center'
+  | 'bottom-center';
+
+interface ToastOptions {
+  action?: {
+    label: string;
+    onClick: () => void;
+  };
+  description?: string;
+  position?: Position;
+  dismissLabel?: string;
+}
+
 declare interface Window {
   tipDispatch: import('@/shared/global/context/config.ts').DispatchProps;
   globalTipDispatch: any;
@@ -31,6 +49,14 @@ declare interface Window {
       environment: import('@/types/global').Environment;
       disable_logout_button?: boolean;
       cart_url?: string;
+    };
+  };
+  catalyst: {
+    toast: {
+      error: (message: string, options?: ToastOptions) => void;
+      success: (message: string, options?: ToastOptions) => void;
+      info: (message: string, options?: ToastOptions) => void;
+      warning: (message: string, options?: ToastOptions) => void;
     };
   };
   b2b: {

--- a/apps/storefront/src/index.d.ts
+++ b/apps/storefront/src/index.d.ts
@@ -51,7 +51,7 @@ declare interface Window {
       cart_url?: string;
     };
   };
-  catalyst: {
+  catalyst?: {
     toast: {
       error: (message: string, options?: ToastOptions) => void;
       success: (message: string, options?: ToastOptions) => void;

--- a/apps/storefront/src/pages/Invoice/components/B3Pulldown.tsx
+++ b/apps/storefront/src/pages/Invoice/components/B3Pulldown.tsx
@@ -107,9 +107,7 @@ function B3Pulldown({
     };
 
     if (openBalance.value === '.' || Number(openBalance.value) === 0) {
-      snackbar.error('The payment amount entered has an invalid value.', {
-        isClose: true,
-      });
+      snackbar.error('The payment amount entered has an invalid value.');
 
       return;
     }

--- a/apps/storefront/src/pages/Invoice/components/InvoiceFooter.tsx
+++ b/apps/storefront/src/pages/Invoice/components/InvoiceFooter.tsx
@@ -61,9 +61,7 @@ function InvoiceFooter(props: InvoiceFooterProps) {
         (item: CustomFieldItems) => item.amount === '.' || Number(item.amount) === 0,
       );
       if (badItem) {
-        snackbar.error(b3Lang('invoice.footer.invalidNameError'), {
-          isClose: true,
-        });
+        snackbar.error(b3Lang('invoice.footer.invalidNameError'));
 
         return;
       }

--- a/apps/storefront/src/pages/OrderDetail/components/OrderDialog.tsx
+++ b/apps/storefront/src/pages/OrderDetail/components/OrderDialog.tsx
@@ -250,20 +250,14 @@ export default function OrderDialog({
         });
         b3TriggerCartNumber();
       } else if (res.errors) {
-        snackbar.error(res.errors[0].message, {
-          isClose: true,
-        });
+        snackbar.error(res.errors[0].message);
       }
     } catch (err) {
       if (err instanceof Error) {
-        snackbar.error(err.message, {
-          isClose: true,
-        });
+        snackbar.error(err.message);
       } else if (typeof err === 'object' && err !== null && 'detail' in err) {
         const customError = err as { detail: string };
-        snackbar.error(customError.detail, {
-          isClose: true,
-        });
+        snackbar.error(customError.detail);
       }
     } finally {
       setIsRequestLoading(false);

--- a/apps/storefront/src/pages/OrderDetail/components/OrderDialog.tsx
+++ b/apps/storefront/src/pages/OrderDetail/components/OrderDialog.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useState } from 'react';
 import { FieldValues, useForm } from 'react-hook-form';
+import { useNavigate } from 'react-router-dom';
 import { useB3Lang } from '@b3/lang';
 import { Box, Typography } from '@mui/material';
 import Cookies from 'js-cookie';
 
-import { B3CustomForm, successTip } from '@/components';
+import { B3CustomForm } from '@/components';
 import B3Dialog from '@/components/B3Dialog';
 import { CART_URL } from '@/constants';
 import { useMobile } from '@/hooks';
@@ -17,6 +18,7 @@ import {
 import { isB2BUserSelector, useAppSelector } from '@/store';
 import { BigCommerceStorefrontAPIBaseURL, snackbar } from '@/utils';
 import b2bLogger from '@/utils/b3Logger';
+import { handleTipLink } from '@/utils/b3Tip';
 import b3TriggerCartNumber from '@/utils/b3TriggerCartNumber';
 import { callCart } from '@/utils/cartUtils';
 
@@ -73,6 +75,7 @@ export default function OrderDialog({
   itemKey,
   orderId,
 }: OrderDialogProps) {
+  const navigate = useNavigate();
   const isB2BUser = useAppSelector(isB2BUserSelector);
   const [isOpenCreateShopping, setOpenCreateShopping] = useState(false);
   const [openShoppingList, setOpenShoppingList] = useState(false);
@@ -233,15 +236,17 @@ export default function OrderDialog({
 
       if (status) {
         setOpen(false);
-        snackbar.success('', {
-          jsx: successTip({
-            message: b3Lang('orderDetail.reorder.productsAdded'),
-            link: CART_URL,
-            linkText: b3Lang('orderDetail.viewCart'),
-            isOutLink: true,
-            isCustomEvent: true,
-          }),
-          isClose: true,
+        snackbar.success(b3Lang('orderDetail.reorder.productsAdded'), {
+          action: {
+            label: b3Lang('orderDetail.reorder.viewCart'),
+            onClick: () => {
+              handleTipLink(CART_URL, {
+                isCustomEvent: true,
+                isOutLink: true,
+                navigate,
+              });
+            },
+          },
         });
         b3TriggerCartNumber();
       } else if (res.errors) {
@@ -330,13 +335,15 @@ export default function OrderDialog({
         items: params,
       });
 
-      snackbar.success('', {
-        jsx: successTip({
-          message: b3Lang('orderDetail.addToShoppingList.productsAdded'),
-          link: `/shoppingList/${id}`,
-          linkText: b3Lang('orderDetail.viewShoppingList'),
-        }),
-        isClose: true,
+      snackbar.success(b3Lang('orderDetail.addToShoppingList.productsAdded'), {
+        action: {
+          label: b3Lang('orderDetail.viewShoppingList'),
+          onClick: () => {
+            handleTipLink(`/shoppingList/${id}`, {
+              navigate,
+            });
+          },
+        },
       });
 
       setOpenShoppingList(false);

--- a/apps/storefront/src/pages/OrderDetail/components/OrderDialog.tsx
+++ b/apps/storefront/src/pages/OrderDetail/components/OrderDialog.tsx
@@ -18,7 +18,6 @@ import {
 import { isB2BUserSelector, useAppSelector } from '@/store';
 import { BigCommerceStorefrontAPIBaseURL, snackbar } from '@/utils';
 import b2bLogger from '@/utils/b3Logger';
-import { handleTipLink } from '@/utils/b3Tip';
 import b3TriggerCartNumber from '@/utils/b3TriggerCartNumber';
 import { callCart } from '@/utils/cartUtils';
 
@@ -240,11 +239,9 @@ export default function OrderDialog({
           action: {
             label: b3Lang('orderDetail.reorder.viewCart'),
             onClick: () => {
-              handleTipLink(CART_URL, {
-                isCustomEvent: true,
-                isOutLink: true,
-                navigate,
-              });
+              if (window.b2b.callbacks.dispatchEvent('on-click-cart-button')) {
+                window.location.href = CART_URL;
+              }
             },
           },
         });
@@ -333,9 +330,7 @@ export default function OrderDialog({
         action: {
           label: b3Lang('orderDetail.viewShoppingList'),
           onClick: () => {
-            handleTipLink(`/shoppingList/${id}`, {
-              navigate,
-            });
+            navigate(`/shoppingList/${id}`);
           },
         },
       });

--- a/apps/storefront/src/pages/PDP/addProductsToShoppingListErrorHandler.ts
+++ b/apps/storefront/src/pages/PDP/addProductsToShoppingListErrorHandler.ts
@@ -3,7 +3,5 @@ import { globalSnackbar, ValidationError } from '@/utils';
 export const addProductsToShoppingListErrorHandler = (error: Error) => {
   const message =
     error instanceof ValidationError ? error.message : 'Something went wrong. Please try again.';
-  globalSnackbar.error(message, {
-    isClose: true,
-  });
+  globalSnackbar.error(message);
 };

--- a/apps/storefront/src/pages/PDP/index.test.tsx
+++ b/apps/storefront/src/pages/PDP/index.test.tsx
@@ -233,9 +233,7 @@ describe('when a product without a required variant is added to a shopping list'
     await userEvent.click(screen.getByText('Test Shopping List 1'));
     await userEvent.click(screen.getByText('OK'));
 
-    expect(globalSnackbar.error).toHaveBeenCalledWith('Please fill out product options first.', {
-      isClose: true,
-    });
+    expect(globalSnackbar.error).toHaveBeenCalledWith('Please fill out product options first.');
 
     expect(globalSnackbar.success).not.toHaveBeenCalled();
     expect(window.scrollTo).toHaveBeenCalledWith(0, 0);
@@ -565,9 +563,7 @@ describe('when an unexpected error occurred during adding a product to shopping 
     await userEvent.click(screen.getByText('Test Shopping List 1'));
     await userEvent.click(screen.getByText('OK'));
 
-    expect(globalSnackbar.error).toHaveBeenCalledWith('Something went wrong. Please try again.', {
-      isClose: true,
-    });
+    expect(globalSnackbar.error).toHaveBeenCalledWith('Something went wrong. Please try again.');
     expect(window.scrollTo).toHaveBeenCalledWith(0, 0);
   });
 });

--- a/apps/storefront/src/pages/PDP/useAddedToShoppingListAlert.tsx
+++ b/apps/storefront/src/pages/PDP/useAddedToShoppingListAlert.tsx
@@ -1,5 +1,4 @@
 import { useB3Lang } from '@b3/lang';
-import { Box, Button } from '@mui/material';
 
 import { useAppSelector } from '@/store';
 import { globalSnackbar } from '@/utils';
@@ -18,34 +17,11 @@ export function useAddedToShoppingListAlert() {
     });
 
   return (id: string) => {
-    globalSnackbar.success('Products were added to your shopping list', {
-      jsx: () => (
-        <Box
-          sx={{
-            display: 'flex',
-            alignItems: 'center',
-          }}
-        >
-          <Box
-            sx={{
-              mr: '15px',
-            }}
-          >
-            {b3Lang('pdp.notification.productsAdded')}
-          </Box>
-          <Button
-            onClick={() => gotoShoppingDetail(id)}
-            variant="text"
-            sx={{
-              color: '#ffffff',
-              padding: 0,
-            }}
-          >
-            {b3Lang('pdp.notification.viewShoppingList')}
-          </Button>
-        </Box>
-      ),
-      isClose: true,
+    globalSnackbar.success(b3Lang('shoppingList.addToShoppingList.productsAdded'), {
+      action: {
+        label: b3Lang('pdp.notification.viewShoppingList'),
+        onClick: () => gotoShoppingDetail(id),
+      },
     });
   };
 }

--- a/apps/storefront/src/pages/QuickOrder/components/QuickAdd.tsx
+++ b/apps/storefront/src/pages/QuickOrder/components/QuickAdd.tsx
@@ -313,9 +313,6 @@ export default function QuickAdd(props: AddToListContentProps) {
             b3Lang('purchasedProducts.quickAdd.notFoundSku', {
               notFoundSku: notFoundSku.join(','),
             }),
-            {
-              isClose: true,
-            },
           );
         }
 
@@ -325,9 +322,6 @@ export default function QuickAdd(props: AddToListContentProps) {
             b3Lang('purchasedProducts.quickAdd.notPurchaseableSku', {
               notPurchaseSku: notPurchaseSku.join(','),
             }),
-            {
-              isClose: true,
-            },
           );
         }
 
@@ -344,9 +338,6 @@ export default function QuickAdd(props: AddToListContentProps) {
             b3Lang('purchasedProducts.quickAdd.insufficientStockSku', {
               stockSku: stockSku.join(','),
             }),
-            {
-              isClose: true,
-            },
           );
         }
 
@@ -365,9 +356,6 @@ export default function QuickAdd(props: AddToListContentProps) {
                 limit,
                 sku,
               }),
-              {
-                isClose: true,
-              },
             );
           });
         }

--- a/apps/storefront/src/pages/QuickOrder/components/QuickOrderFooter.tsx
+++ b/apps/storefront/src/pages/QuickOrder/components/QuickOrderFooter.tsx
@@ -4,7 +4,6 @@ import { useB3Lang } from '@b3/lang';
 import { ArrowDropDown } from '@mui/icons-material';
 import {
   Box,
-  Button,
   Grid,
   Menu,
   MenuItem,
@@ -421,33 +420,6 @@ function QuickOrderFooter(props: QuickOrderFooterProps) {
     navigate(`/shoppingList/${id}`);
   };
 
-  const tip = (id: string | number) => (
-    <Box
-      sx={{
-        display: 'flex',
-        alignItems: 'center',
-      }}
-    >
-      <Box
-        sx={{
-          mr: '15px',
-        }}
-      >
-        {b3Lang('purchasedProducts.footer.productsAddedToShoppingList')}
-      </Box>
-      <Button
-        onClick={() => gotoShoppingDetail(id)}
-        variant="text"
-        sx={{
-          color: '#ffffff',
-          padding: 0,
-        }}
-      >
-        view shopping list
-      </Button>
-    </Box>
-  );
-
   const handleShoppingClose = (isTrue?: boolean) => {
     if (isTrue) {
       setOpenShoppingList(false);
@@ -511,8 +483,10 @@ function QuickOrderFooter(props: QuickOrderFooterProps) {
       });
 
       snackbar.success(b3Lang('purchasedProducts.footer.productsAddedToShoppingList'), {
-        jsx: () => tip(shoppingListId),
-        isClose: true,
+        action: {
+          label: b3Lang('pdp.notification.viewShoppingList'),
+          onClick: () => gotoShoppingDetail(shoppingListId),
+        },
       });
       handleShoppingClose(true);
     } catch (err) {

--- a/apps/storefront/src/pages/QuickOrder/components/QuickOrderFooter.tsx
+++ b/apps/storefront/src/pages/QuickOrder/components/QuickOrderFooter.tsx
@@ -233,13 +233,9 @@ function QuickOrderFooter(props: QuickOrderFooterProps) {
           },
         });
       } else if (res && res.errors) {
-        snackbar.error(res.errors[0].message, {
-          isClose: true,
-        });
+        snackbar.error(res.errors[0].message);
       } else {
-        snackbar.error('Error has occurred', {
-          isClose: true,
-        });
+        snackbar.error('Error has occurred');
       }
     } finally {
       b3TriggerCartNumber();
@@ -287,9 +283,7 @@ function QuickOrderFooter(props: QuickOrderFooterProps) {
         return !variantSku;
       });
       if (noSkuProducts.length > 0) {
-        snackbar.error(b3Lang('purchasedProducts.footer.cantAddProductsNoSku'), {
-          isClose: true,
-        });
+        snackbar.error(b3Lang('purchasedProducts.footer.cantAddProductsNoSku'));
       }
       if (noSkuProducts.length === checkedArr.length) return;
 

--- a/apps/storefront/src/pages/QuickOrder/components/QuickOrderFooter.tsx
+++ b/apps/storefront/src/pages/QuickOrder/components/QuickOrderFooter.tsx
@@ -24,7 +24,6 @@ import {
   validProductQty,
 } from '@/utils/b3Product/b3Product';
 import { conversionProductsList } from '@/utils/b3Product/shared/config';
-import { handleTipLink } from '@/utils/b3Tip';
 import b3TriggerCartNumber from '@/utils/b3TriggerCartNumber';
 import { callCart } from '@/utils/cartUtils';
 
@@ -224,11 +223,9 @@ function QuickOrderFooter(props: QuickOrderFooterProps) {
           action: {
             label: b3Lang('purchasedProducts.footer.viewCart'),
             onClick: () => {
-              handleTipLink(CART_URL, {
-                isCustomEvent: true,
-                isOutLink: true,
-                navigate,
-              });
+              if (window.b2b.callbacks.dispatchEvent('on-click-cart-button')) {
+                window.location.href = CART_URL;
+              }
             },
           },
         });
@@ -376,9 +373,7 @@ function QuickOrderFooter(props: QuickOrderFooterProps) {
           action: {
             label: b3Lang('purchasedProducts.footer.viewQuote'),
             onClick: () => {
-              handleTipLink('/quoteDraft', {
-                navigate,
-              });
+              navigate('/quoteDraft');
             },
           },
         });
@@ -387,9 +382,7 @@ function QuickOrderFooter(props: QuickOrderFooterProps) {
           action: {
             label: b3Lang('purchasedProducts.footer.viewQuote'),
             onClick: () => {
-              handleTipLink('/quoteDraft', {
-                navigate,
-              });
+              navigate('/quoteDraft');
             },
           },
         });

--- a/apps/storefront/src/pages/QuickOrder/components/QuickOrderFooter.tsx
+++ b/apps/storefront/src/pages/QuickOrder/components/QuickOrderFooter.tsx
@@ -2,15 +2,7 @@ import { Dispatch, SetStateAction, useContext, useEffect, useRef, useState } fro
 import { useNavigate } from 'react-router-dom';
 import { useB3Lang } from '@b3/lang';
 import { ArrowDropDown } from '@mui/icons-material';
-import {
-  Box,
-  Grid,
-  Menu,
-  MenuItem,
-  SxProps,
-  Typography,
-  useMediaQuery,
-} from '@mui/material';
+import { Box, Grid, Menu, MenuItem, SxProps, Typography, useMediaQuery } from '@mui/material';
 import { v1 as uuid } from 'uuid';
 
 import CustomButton from '@/components/button/CustomButton';

--- a/apps/storefront/src/pages/QuickOrder/components/QuickOrderFooter.tsx
+++ b/apps/storefront/src/pages/QuickOrder/components/QuickOrderFooter.tsx
@@ -14,7 +14,6 @@ import {
 } from '@mui/material';
 import { v1 as uuid } from 'uuid';
 
-import { successTip } from '@/components';
 import CustomButton from '@/components/button/CustomButton';
 import { CART_URL, PRODUCT_DEFAULT_IMAGE } from '@/constants';
 import { useMobile } from '@/hooks';
@@ -34,6 +33,7 @@ import {
   validProductQty,
 } from '@/utils/b3Product/b3Product';
 import { conversionProductsList } from '@/utils/b3Product/shared/config';
+import { handleTipLink } from '@/utils/b3Tip';
 import b3TriggerCartNumber from '@/utils/b3TriggerCartNumber';
 import { callCart } from '@/utils/cartUtils';
 
@@ -229,15 +229,17 @@ function QuickOrderFooter(props: QuickOrderFooterProps) {
       const res = await callCart(lineItems);
 
       if (res && !res.errors) {
-        snackbar.success('', {
-          jsx: successTip({
-            message: b3Lang('purchasedProducts.footer.productsAdded'),
-            link: CART_URL,
-            linkText: b3Lang('purchasedProducts.footer.viewCart'),
-            isOutLink: true,
-            isCustomEvent: true,
-          }),
-          isClose: true,
+        snackbar.success(b3Lang('purchasedProducts.footer.productsAdded'), {
+          action: {
+            label: b3Lang('purchasedProducts.footer.viewCart'),
+            onClick: () => {
+              handleTipLink(CART_URL, {
+                isCustomEvent: true,
+                isOutLink: true,
+                navigate,
+              });
+            },
+          },
         });
       } else if (res && res.errors) {
         snackbar.error(res.errors[0].message, {
@@ -377,15 +379,7 @@ function QuickOrderFooter(props: QuickOrderFooterProps) {
       isSuccess = validProductQty(newProducts);
 
       if (!isFondVariant) {
-        snackbar.error('', {
-          jsx: successTip({
-            message: errorMessage,
-            link: '',
-            linkText: '',
-            isOutLink: false,
-          }),
-          isClose: true,
-        });
+        snackbar.error(errorMessage);
 
         return;
       }
@@ -393,24 +387,26 @@ function QuickOrderFooter(props: QuickOrderFooterProps) {
       if (isSuccess) {
         await calculateProductListPrice(newProducts, '2');
         addQuoteDraftProducts(newProducts);
-        snackbar.success('', {
-          jsx: successTip({
-            message: b3Lang('purchasedProducts.footer.productsAddedToQuote'),
-            link: '/quoteDraft',
-            linkText: b3Lang('purchasedProducts.footer.viewQuote'),
-            isOutLink: false,
-          }),
-          isClose: true,
+        snackbar.success(b3Lang('purchasedProducts.footer.productsAddedToQuote'), {
+          action: {
+            label: b3Lang('purchasedProducts.footer.viewQuote'),
+            onClick: () => {
+              handleTipLink('/quoteDraft', {
+                navigate,
+              });
+            },
+          },
         });
       } else {
-        snackbar.error('', {
-          jsx: successTip({
-            message: b3Lang('purchasedProducts.footer.productsLimit'),
-            link: '/quoteDraft',
-            linkText: b3Lang('purchasedProducts.footer.viewQuote'),
-            isOutLink: false,
-          }),
-          isClose: true,
+        snackbar.error(b3Lang('purchasedProducts.footer.productsLimit'), {
+          action: {
+            label: b3Lang('purchasedProducts.footer.viewQuote'),
+            onClick: () => {
+              handleTipLink('/quoteDraft', {
+                navigate,
+              });
+            },
+          },
         });
       }
     } catch (e) {

--- a/apps/storefront/src/pages/QuickOrder/components/QuickOrderPad.tsx
+++ b/apps/storefront/src/pages/QuickOrder/components/QuickOrderPad.tsx
@@ -219,7 +219,9 @@ export default function QuickOrderPad() {
           {
             action: {
               label: b3Lang('purchasedProducts.quickOrderPad.downloadErrorsCSV'),
-              onClick: () => (window.location.href = stockErrorFile),
+              onClick: () => {
+                window.location.href = stockErrorFile;
+              },
             },
           },
         );

--- a/apps/storefront/src/pages/QuickOrder/components/QuickOrderPad.tsx
+++ b/apps/storefront/src/pages/QuickOrder/components/QuickOrderPad.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useB3Lang } from '@b3/lang';
 import { UploadFile as UploadFileIcon } from '@mui/icons-material';
-import { Box, Card, CardContent, Divider, Link, Typography } from '@mui/material';
+import { Box, Card, CardContent, Divider, Typography } from '@mui/material';
 
 import { B3Upload } from '@/components';
 import CustomButton from '@/components/button/CustomButton';
@@ -81,51 +81,6 @@ export default function QuickOrderPad() {
 
     return res;
   };
-
-  const limitProductTips = (data: CustomFieldItems) => (
-    <>
-      <p
-        style={{
-          margin: 0,
-        }}
-      >
-        {b3Lang('purchasedProducts.quickOrderPad.notEnoughStock', {
-          variantSku: data.variantSku,
-        })}
-      </p>
-      <p
-        style={{
-          margin: 0,
-        }}
-      >
-        {b3Lang('purchasedProducts.quickOrderPad.availableAmount', {
-          availableAmount: data.AvailableAmount,
-        })}
-      </p>
-    </>
-  );
-
-  const outOfStockProductTips = (outOfStock: string[], fileErrorsCSV: string) => (
-    <>
-      <p
-        style={{
-          margin: 0,
-        }}
-      >
-        {b3Lang('purchasedProducts.quickOrderPad.outOfStockSku', {
-          outOfStock: outOfStock.join(','),
-        })}
-      </p>
-      <Link
-        href={fileErrorsCSV}
-        sx={{
-          color: '#FFFFFF',
-        }}
-      >
-        {b3Lang('purchasedProducts.quickOrderPad.downloadErrorsCSV')}
-      </Link>
-    </>
-  );
 
   const getValidProducts = (products: CustomFieldItems) => {
     const notPurchaseSku: string[] = [];
@@ -232,9 +187,16 @@ export default function QuickOrderPad() {
 
       if (limitProduct.length > 0) {
         limitProduct.forEach((data: CustomFieldItems) => {
-          snackbar.warning('', {
-            jsx: () => limitProductTips(data),
-          });
+          snackbar.warning(
+            b3Lang('purchasedProducts.quickOrderPad.notEnoughStock', {
+              variantSku: data.variantSku,
+            }),
+            {
+              description: b3Lang('purchasedProducts.quickOrderPad.availableAmount', {
+                availableAmount: data.AvailableAmount,
+              }),
+            },
+          );
         });
       }
 
@@ -250,10 +212,17 @@ export default function QuickOrderPad() {
       }
 
       if (outOfStock.length > 0 && stockErrorFile) {
-        snackbar.error('', {
-          jsx: () => outOfStockProductTips(outOfStock, stockErrorFile),
-          isClose: true,
-        });
+        snackbar.error(
+          b3Lang('purchasedProducts.quickOrderPad.outOfStockSku', {
+            outOfStock: outOfStock.join(','),
+          }),
+          {
+            action: {
+              label: b3Lang('purchasedProducts.quickOrderPad.downloadErrorsCSV'),
+              onClick: () => (window.location.href = stockErrorFile),
+            },
+          },
+        );
       }
 
       if (minLimitQuantity.length > 0) {

--- a/apps/storefront/src/pages/QuickOrder/components/QuickOrderPad.tsx
+++ b/apps/storefront/src/pages/QuickOrder/components/QuickOrderPad.tsx
@@ -49,9 +49,7 @@ export default function QuickOrderPad() {
         },
       });
     } else {
-      snackbar.error('Error has occurred', {
-        isClose: true,
-      });
+      snackbar.error('Error has occurred');
     }
   };
 
@@ -59,9 +57,7 @@ export default function QuickOrderPad() {
     const res = await callCart(products);
 
     if (res && res.errors) {
-      snackbar.error(res.errors[0].message, {
-        isClose: true,
-      });
+      snackbar.error(res.errors[0].message);
     } else {
       snackbar.success(b3Lang('purchasedProducts.quickOrderPad.productsAdded'), {
         action: {
@@ -205,9 +201,6 @@ export default function QuickOrderPad() {
           b3Lang('purchasedProducts.quickOrderPad.notPurchaseableSku', {
             notPurchaseSku: notPurchaseSku.join(','),
           }),
-          {
-            isClose: true,
-          },
         );
       }
 
@@ -234,9 +227,6 @@ export default function QuickOrderPad() {
               minQuantity: data.minQuantity,
               sku: data.variantSku,
             }),
-            {
-              isClose: true,
-            },
           );
         });
       }
@@ -248,9 +238,6 @@ export default function QuickOrderPad() {
               maxQuantity: data.maxQuantity,
               sku: data.variantSku,
             }),
-            {
-              isClose: true,
-            },
           );
         });
       }

--- a/apps/storefront/src/pages/QuickOrder/components/QuickOrderPad.tsx
+++ b/apps/storefront/src/pages/QuickOrder/components/QuickOrderPad.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { useB3Lang } from '@b3/lang';
 import { UploadFile as UploadFileIcon } from '@mui/icons-material';
 import { Box, Card, CardContent, Divider, Link, Typography } from '@mui/material';
 
-import { B3Upload, successTip } from '@/components';
+import { B3Upload } from '@/components';
 import CustomButton from '@/components/button/CustomButton';
 import { CART_URL } from '@/constants';
 import { useBlockPendingAccountViewPrice } from '@/hooks';
@@ -11,6 +12,7 @@ import useMobile from '@/hooks/useMobile';
 import { useAppSelector } from '@/store';
 import { snackbar } from '@/utils';
 import b2bLogger from '@/utils/b3Logger';
+import { handleTipLink } from '@/utils/b3Tip';
 import b3TriggerCartNumber from '@/utils/b3TriggerCartNumber';
 import { callCart } from '@/utils/cartUtils';
 
@@ -20,6 +22,7 @@ import QuickAdd from './QuickAdd';
 import SearchProduct from './SearchProduct';
 
 export default function QuickOrderPad() {
+  const navigate = useNavigate();
   const [isMobile] = useMobile();
   const b3Lang = useB3Lang();
 
@@ -33,15 +36,17 @@ export default function QuickOrderPad() {
 
   const getSnackbarMessage = (res: any) => {
     if (res && !res.errors) {
-      snackbar.success('', {
-        jsx: successTip({
-          message: b3Lang('purchasedProducts.quickOrderPad.productsAdded'),
-          link: CART_URL,
-          linkText: b3Lang('purchasedProducts.quickOrderPad.viewCart'),
-          isOutLink: true,
-          isCustomEvent: true,
-        }),
-        isClose: true,
+      snackbar.success(b3Lang('purchasedProducts.quickOrderPad.productsAdded'), {
+        action: {
+          label: b3Lang('purchasedProducts.quickOrderPad.viewCart'),
+          onClick: () => {
+            handleTipLink(CART_URL, {
+              isCustomEvent: true,
+              isOutLink: true,
+              navigate,
+            });
+          },
+        },
       });
     } else {
       snackbar.error('Error has occurred', {
@@ -58,15 +63,17 @@ export default function QuickOrderPad() {
         isClose: true,
       });
     } else {
-      snackbar.success('', {
-        jsx: successTip({
-          message: b3Lang('purchasedProducts.quickOrderPad.productsAdded'),
-          link: CART_URL,
-          linkText: b3Lang('purchasedProducts.quickOrderPad.viewCart'),
-          isOutLink: true,
-          isCustomEvent: true,
-        }),
-        isClose: true,
+      snackbar.success(b3Lang('purchasedProducts.quickOrderPad.productsAdded'), {
+        action: {
+          label: b3Lang('purchasedProducts.quickOrderPad.viewCart'),
+          onClick: () => {
+            handleTipLink(CART_URL, {
+              isCustomEvent: true,
+              isOutLink: true,
+              navigate,
+            });
+          },
+        },
       });
     }
 

--- a/apps/storefront/src/pages/QuickOrder/components/QuickOrderPad.tsx
+++ b/apps/storefront/src/pages/QuickOrder/components/QuickOrderPad.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
 import { useB3Lang } from '@b3/lang';
 import { UploadFile as UploadFileIcon } from '@mui/icons-material';
 import { Box, Card, CardContent, Divider, Typography } from '@mui/material';
@@ -12,7 +11,6 @@ import useMobile from '@/hooks/useMobile';
 import { useAppSelector } from '@/store';
 import { snackbar } from '@/utils';
 import b2bLogger from '@/utils/b3Logger';
-import { handleTipLink } from '@/utils/b3Tip';
 import b3TriggerCartNumber from '@/utils/b3TriggerCartNumber';
 import { callCart } from '@/utils/cartUtils';
 
@@ -22,7 +20,6 @@ import QuickAdd from './QuickAdd';
 import SearchProduct from './SearchProduct';
 
 export default function QuickOrderPad() {
-  const navigate = useNavigate();
   const [isMobile] = useMobile();
   const b3Lang = useB3Lang();
 
@@ -40,11 +37,9 @@ export default function QuickOrderPad() {
         action: {
           label: b3Lang('purchasedProducts.quickOrderPad.viewCart'),
           onClick: () => {
-            handleTipLink(CART_URL, {
-              isCustomEvent: true,
-              isOutLink: true,
-              navigate,
-            });
+            if (window.b2b.callbacks.dispatchEvent('on-click-cart-button')) {
+              window.location.href = CART_URL;
+            }
           },
         },
       });
@@ -63,11 +58,9 @@ export default function QuickOrderPad() {
         action: {
           label: b3Lang('purchasedProducts.quickOrderPad.viewCart'),
           onClick: () => {
-            handleTipLink(CART_URL, {
-              isCustomEvent: true,
-              isOutLink: true,
-              navigate,
-            });
+            if (window.b2b.callbacks.dispatchEvent('on-click-cart-button')) {
+              window.location.href = CART_URL;
+            }
           },
         },
       });

--- a/apps/storefront/src/pages/QuickOrder/utils.ts
+++ b/apps/storefront/src/pages/QuickOrder/utils.ts
@@ -67,9 +67,6 @@ export const handleVerifyProduct = (products: CustomFieldItems, b3Lang: LangForm
       b3Lang('purchasedProducts.quickOrderPad.insufficientStockSku', {
         sku: productSku,
       }),
-      {
-        isClose: true,
-      },
     );
 
     return {
@@ -84,9 +81,6 @@ export const handleVerifyProduct = (products: CustomFieldItems, b3Lang: LangForm
         minQuantity: orderQuantityMinimum,
         sku: productSku,
       }),
-      {
-        isClose: true,
-      },
     );
 
     return {
@@ -101,9 +95,6 @@ export const handleVerifyProduct = (products: CustomFieldItems, b3Lang: LangForm
         maxQuantity: orderQuantityMaximum,
         sku: productSku,
       }),
-      {
-        isClose: true,
-      },
     );
 
     return {

--- a/apps/storefront/src/pages/QuoteDetail/index.tsx
+++ b/apps/storefront/src/pages/QuoteDetail/index.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import { useB3Lang } from '@b3/lang';
-import { Box, Button, Grid } from '@mui/material';
+import { Box, Grid } from '@mui/material';
 import copy from 'copy-to-clipboard';
 import { get } from 'lodash-es';
 
@@ -517,51 +517,29 @@ function QuoteDetail() {
     const { state } = location;
 
     if (!state) return;
-    const tip = () => (
-      <Box
-        sx={{
-          display: 'flex',
-          alignItems: 'center',
-        }}
-      >
-        <Box
-          sx={{
-            mr: '15px',
-          }}
-        >
-          {Number(role) === 100
-            ? b3Lang('quoteDetail.submittedQuote')
-            : b3Lang('quoteDetail.quoteSubmitted')}
-        </Box>
-        <Button
-          onClick={() => {
-            if (Number(role) === 100) {
-              copy(window.location.href);
-              snackbar.success(b3Lang('quoteDetail.copySuccessful'));
-            } else {
-              navigate('/quotes');
-            }
-          }}
-          variant="text"
-          sx={{
-            color: '#ffffff',
-            textAlign: 'left',
-            padding: 0,
-          }}
-        >
-          {Number(role) === 100
-            ? b3Lang('quoteDetail.copyQuoteLink')
-            : b3Lang('quoteDetail.reviewAllQuotes')}
-        </Button>
-      </Box>
-    );
 
     setTimeout(() => {
-      snackbar.success('', {
-        jsx: () => tip(),
-        isClose: true,
-        duration: 30000,
-      });
+      snackbar.success(
+        Number(role) === 100
+          ? b3Lang('quoteDetail.submittedQuote')
+          : b3Lang('quoteDetail.quoteSubmitted'),
+        {
+          action: {
+            label:
+              Number(role) === 100
+                ? b3Lang('quoteDetail.copyQuoteLink')
+                : b3Lang('quoteDetail.reviewAllQuotes'),
+            onClick: () => {
+              if (Number(role) === 100) {
+                copy(window.location.href);
+                snackbar.success(b3Lang('quoteDetail.copySuccessful'));
+              } else {
+                navigate('/quotes');
+              }
+            },
+          },
+        },
+      );
     }, 10);
     location.state = null;
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/apps/storefront/src/pages/ShoppingListDetails/components/AddToShoppingList.tsx
+++ b/apps/storefront/src/pages/ShoppingListDetails/components/AddToShoppingList.tsx
@@ -61,14 +61,12 @@ export default function AddToShoppingList(props: AddToListProps) {
         items,
       });
 
-      snackbar.success(b3Lang('shoppingList.addToShoppingList.productsAdded'), {
-        isClose: true,
-      });
+      snackbar.success(b3Lang('shoppingList.addToShoppingList.productsAdded'));
 
       return res;
     } catch (e: any) {
       if (e.message.length > 0) {
-        snackbar.error(e.message, { isClose: true });
+        snackbar.error(e.message);
       }
     }
     return true;
@@ -93,9 +91,7 @@ export default function AddToShoppingList(props: AddToListProps) {
       items,
     });
 
-    snackbar.success(b3Lang('shoppingList.addToShoppingList.productsAdded'), {
-      isClose: true,
-    });
+    snackbar.success(b3Lang('shoppingList.addToShoppingList.productsAdded'));
 
     return res;
   };
@@ -183,9 +179,6 @@ export default function AddToShoppingList(props: AddToListProps) {
           b3Lang('shoppingList.addToShoppingList.skuNotAddable', {
             notAddAble: notAddAble.join(', '),
           }),
-          {
-            isClose: true,
-          },
         );
       }
 
@@ -194,9 +187,6 @@ export default function AddToShoppingList(props: AddToListProps) {
           b3Lang('shoppingList.addToShoppingList.skuNotPurchasable', {
             notPurchaseSku: notPurchaseSku.join(', '),
           }),
-          {
-            isClose: true,
-          },
         );
       }
 

--- a/apps/storefront/src/pages/ShoppingListDetails/components/QuickAdd.tsx
+++ b/apps/storefront/src/pages/ShoppingListDetails/components/QuickAdd.tsx
@@ -333,9 +333,6 @@ export default function QuickAdd(props: AddToListContentProps) {
             b3Lang('shoppingList.quickAdd.skuNotFound', {
               notFoundSku: notFoundSku.join(', '),
             }),
-            {
-              isClose: true,
-            },
           );
         }
 
@@ -345,9 +342,6 @@ export default function QuickAdd(props: AddToListContentProps) {
             b3Lang('shoppingList.quickAdd.skuNotPurchasable', {
               notPurchaseSku: notPurchaseSku.join(', '),
             }),
-            {
-              isClose: true,
-            },
           );
         }
 
@@ -357,9 +351,6 @@ export default function QuickAdd(props: AddToListContentProps) {
             b3Lang('shoppingList.quickAdd.skuNotAddable', {
               notAddAble: notAddAble.join(', '),
             }),
-            {
-              isClose: true,
-            },
           );
         }
 
@@ -372,9 +363,6 @@ export default function QuickAdd(props: AddToListContentProps) {
             b3Lang('shoppingList.quickAdd.skuLimitQuantity', {
               numberLimit: numberLimit.join(', '),
             }),
-            {
-              isClose: true,
-            },
           );
         }
 

--- a/apps/storefront/src/pages/ShoppingListDetails/components/ReAddToCart.tsx
+++ b/apps/storefront/src/pages/ShoppingListDetails/components/ReAddToCart.tsx
@@ -254,9 +254,7 @@ export default function ReAddToCart(props: ShoppingProductsProps) {
       }
 
       if (res.errors) {
-        snackbar.error(res.message, {
-          isClose: true,
-        });
+        snackbar.error(res.message);
       }
 
       b3TriggerCartNumber();

--- a/apps/storefront/src/pages/ShoppingListDetails/components/ReAddToCart.tsx
+++ b/apps/storefront/src/pages/ShoppingListDetails/components/ReAddToCart.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { useB3Lang } from '@b3/lang';
 import styled from '@emotion/styled';
 import { Delete } from '@mui/icons-material';
 import { Alert, Box, Grid, Typography } from '@mui/material';
 
-import { B3QuantityTextField, successTip } from '@/components';
+import { B3QuantityTextField } from '@/components';
 import B3Dialog from '@/components/B3Dialog';
 import CustomButton from '@/components/button/CustomButton';
 import B3Spin from '@/components/spin/B3Spin';
@@ -19,6 +20,7 @@ import {
   getProductOptionsFields,
   ProductsProps,
 } from '@/utils/b3Product/shared/config';
+import { handleTipLink } from '@/utils/b3Tip';
 import b3TriggerCartNumber from '@/utils/b3TriggerCartNumber';
 import { callCart } from '@/utils/cartUtils';
 
@@ -167,6 +169,7 @@ export default function ReAddToCart(props: ShoppingProductsProps) {
 
   const { submitShoppingListPermission } = useAppSelector(rolePermissionSelector);
 
+  const navigate = useNavigate();
   const b3Lang = useB3Lang();
   const [isOpen, setOpen] = useState<boolean>(false);
   const [loading, setLoading] = useState<boolean>(false);
@@ -234,15 +237,17 @@ export default function ReAddToCart(props: ShoppingProductsProps) {
         ) {
           window.location.href = CHECKOUT_URL;
         } else {
-          snackbar.success('', {
-            jsx: successTip({
-              message: b3Lang('shoppingList.reAddToCart.productsAdded'),
-              link: CART_URL,
-              linkText: b3Lang('shoppingList.reAddToCart.viewCart'),
-              isOutLink: true,
-              isCustomEvent: true,
-            }),
-            isClose: true,
+          snackbar.success(b3Lang('shoppingList.reAddToCart.productsAdded'), {
+            action: {
+              label: b3Lang('shoppingList.reAddToCart.viewCart'),
+              onClick: () => {
+                handleTipLink(CART_URL, {
+                  isCustomEvent: true,
+                  isOutLink: true,
+                  navigate,
+                });
+              },
+            },
           });
           b3TriggerCartNumber();
         }

--- a/apps/storefront/src/pages/ShoppingListDetails/components/ReAddToCart.tsx
+++ b/apps/storefront/src/pages/ShoppingListDetails/components/ReAddToCart.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
 import { useB3Lang } from '@b3/lang';
 import styled from '@emotion/styled';
 import { Delete } from '@mui/icons-material';
@@ -20,7 +19,6 @@ import {
   getProductOptionsFields,
   ProductsProps,
 } from '@/utils/b3Product/shared/config';
-import { handleTipLink } from '@/utils/b3Tip';
 import b3TriggerCartNumber from '@/utils/b3TriggerCartNumber';
 import { callCart } from '@/utils/cartUtils';
 
@@ -169,7 +167,6 @@ export default function ReAddToCart(props: ShoppingProductsProps) {
 
   const { submitShoppingListPermission } = useAppSelector(rolePermissionSelector);
 
-  const navigate = useNavigate();
   const b3Lang = useB3Lang();
   const [isOpen, setOpen] = useState<boolean>(false);
   const [loading, setLoading] = useState<boolean>(false);
@@ -241,11 +238,9 @@ export default function ReAddToCart(props: ShoppingProductsProps) {
             action: {
               label: b3Lang('shoppingList.reAddToCart.viewCart'),
               onClick: () => {
-                handleTipLink(CART_URL, {
-                  isCustomEvent: true,
-                  isOutLink: true,
-                  navigate,
-                });
+                if (window.b2b.callbacks.dispatchEvent('on-click-cart-button')) {
+                  window.location.href = CART_URL;
+                }
               },
             },
           });

--- a/apps/storefront/src/pages/ShoppingListDetails/components/ShoppingDetailFooter.tsx
+++ b/apps/storefront/src/pages/ShoppingListDetails/components/ShoppingDetailFooter.tsx
@@ -1,11 +1,11 @@
 import { useContext, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { useB3Lang } from '@b3/lang';
 import { ArrowDropDown, Delete } from '@mui/icons-material';
 import { Box, Grid, Menu, MenuItem, Typography } from '@mui/material';
 import Cookies from 'js-cookie';
 import { v1 as uuid } from 'uuid';
 
-import { successTip } from '@/components';
 import CustomButton from '@/components/button/CustomButton';
 import { CART_URL, CHECKOUT_URL, PRODUCT_DEFAULT_IMAGE } from '@/constants';
 import { useMobile } from '@/hooks';
@@ -30,6 +30,7 @@ import {
   conversionProductsList,
   ProductsProps,
 } from '@/utils/b3Product/shared/config';
+import { handleTipLink } from '@/utils/b3Tip';
 import b3TriggerCartNumber from '@/utils/b3TriggerCartNumber';
 import { callCart, deleteCartData, updateCart } from '@/utils/cartUtils';
 
@@ -76,6 +77,7 @@ interface ListItemProps {
 function ShoppingDetailFooter(props: ShoppingDetailFooterProps) {
   const [isMobile] = useMobile();
   const b3Lang = useB3Lang();
+  const navigate = useNavigate();
 
   const {
     state: { productQuoteEnabled = false },
@@ -273,15 +275,17 @@ function ShoppingDetailFooter(props: ShoppingDetailFooterProps) {
           ) {
             window.location.href = CHECKOUT_URL;
           } else {
-            snackbar.success('', {
-              jsx: successTip({
-                message: b3Lang('shoppingList.footer.productsAddedToCart'),
-                link: CART_URL,
-                linkText: b3Lang('shoppingList.footer.viewCart'),
-                isOutLink: true,
-                isCustomEvent: true,
-              }),
-              isClose: true,
+            snackbar.success(b3Lang('shoppingList.footer.productsAddedToCart'), {
+              action: {
+                label: b3Lang('shoppingList.reAddToCart.viewCart'),
+                onClick: () => {
+                  handleTipLink(CART_URL, {
+                    isCustomEvent: true,
+                    isOutLink: true,
+                    navigate,
+                  });
+                },
+              },
             });
             b3TriggerCartNumber();
           }
@@ -421,15 +425,7 @@ function ShoppingDetailFooter(props: ShoppingDetailFooterProps) {
       isSuccess = validProductQty(newProducts);
 
       if (!isFondVariant) {
-        snackbar.error('', {
-          jsx: successTip({
-            message: errorMessage,
-            link: '',
-            linkText: '',
-            isOutLink: false,
-          }),
-          isClose: true,
-        });
+        snackbar.error(errorMessage);
 
         return;
       }
@@ -437,24 +433,26 @@ function ShoppingDetailFooter(props: ShoppingDetailFooterProps) {
       if (isSuccess) {
         await calculateProductListPrice(newProducts, '2');
         addQuoteDraftProducts(newProducts);
-        snackbar.success('', {
-          jsx: successTip({
-            message: b3Lang('shoppingList.footer.productsAddedToQuote'),
-            link: '/quoteDraft',
-            linkText: b3Lang('shoppingList.footer.viewQuote'),
-            isOutLink: false,
-          }),
-          isClose: true,
+        snackbar.success(b3Lang('shoppingList.footer.productsAddedToQuote'), {
+          action: {
+            label: b3Lang('shoppingList.footer.viewQuote'),
+            onClick: () => {
+              handleTipLink('/quoteDraft', {
+                navigate,
+              });
+            },
+          },
         });
       } else {
-        snackbar.error('', {
-          jsx: successTip({
-            message: b3Lang('shoppingList.footer.productsLimit'),
-            link: '/quoteDraft',
-            linkText: b3Lang('shoppingList.footer.viewQuote'),
-            isOutLink: false,
-          }),
-          isClose: true,
+        snackbar.error(b3Lang('shoppingList.footer.productsLimit'), {
+          action: {
+            label: b3Lang('shoppingList.footer.viewQuote'),
+            onClick: () => {
+              handleTipLink('/quoteDraft', {
+                navigate,
+              });
+            },
+          },
         });
       }
     } catch (e) {

--- a/apps/storefront/src/pages/ShoppingListDetails/components/ShoppingDetailFooter.tsx
+++ b/apps/storefront/src/pages/ShoppingListDetails/components/ShoppingDetailFooter.tsx
@@ -221,9 +221,6 @@ function ShoppingDetailFooter(props: ShoppingDetailFooterProps) {
           b3Lang('shoppingList.footer.unavailableProducts', {
             skus: cantPurchase.slice(0, -1),
           }),
-          {
-            isClose: true,
-          },
         );
         return;
       }
@@ -233,9 +230,6 @@ function ShoppingDetailFooter(props: ShoppingDetailFooterProps) {
           allowJuniorPlaceOrder
             ? b3Lang('shoppingList.footer.selectItemsToCheckout')
             : b3Lang('shoppingList.footer.selectItemsToAddToCart'),
-          {
-            isClose: true,
-          },
         );
         return;
       }
@@ -264,9 +258,7 @@ function ShoppingDetailFooter(props: ShoppingDetailFooterProps) {
           b3TriggerCartNumber();
         }
         if (res && res.errors) {
-          snackbar.error(res.errors[0].message, {
-            isClose: true,
-          });
+          snackbar.error(res.errors[0].message);
         } else if (validateFailureArr.length === 0) {
           if (
             allowJuniorPlaceOrder &&
@@ -343,9 +335,7 @@ function ShoppingDetailFooter(props: ShoppingDetailFooterProps) {
         return !variantSku;
       });
       if (noSkuProducts.length > 0) {
-        snackbar.error(b3Lang('shoppingList.footer.cantAddProductsNoSku'), {
-          isClose: true,
-        });
+        snackbar.error(b3Lang('shoppingList.footer.cantAddProductsNoSku'));
       }
       if (noSkuProducts.length === checkedArr.length) return;
 

--- a/apps/storefront/src/pages/ShoppingListDetails/components/ShoppingDetailFooter.tsx
+++ b/apps/storefront/src/pages/ShoppingListDetails/components/ShoppingDetailFooter.tsx
@@ -30,7 +30,6 @@ import {
   conversionProductsList,
   ProductsProps,
 } from '@/utils/b3Product/shared/config';
-import { handleTipLink } from '@/utils/b3Tip';
 import b3TriggerCartNumber from '@/utils/b3TriggerCartNumber';
 import { callCart, deleteCartData, updateCart } from '@/utils/cartUtils';
 
@@ -271,11 +270,9 @@ function ShoppingDetailFooter(props: ShoppingDetailFooterProps) {
               action: {
                 label: b3Lang('shoppingList.reAddToCart.viewCart'),
                 onClick: () => {
-                  handleTipLink(CART_URL, {
-                    isCustomEvent: true,
-                    isOutLink: true,
-                    navigate,
-                  });
+                  if (window.b2b.callbacks.dispatchEvent('on-click-cart-button')) {
+                    window.location.href = CART_URL;
+                  }
                 },
               },
             });
@@ -427,9 +424,7 @@ function ShoppingDetailFooter(props: ShoppingDetailFooterProps) {
           action: {
             label: b3Lang('shoppingList.footer.viewQuote'),
             onClick: () => {
-              handleTipLink('/quoteDraft', {
-                navigate,
-              });
+              navigate('/quoteDraft');
             },
           },
         });
@@ -438,9 +433,7 @@ function ShoppingDetailFooter(props: ShoppingDetailFooterProps) {
           action: {
             label: b3Lang('shoppingList.footer.viewQuote'),
             onClick: () => {
-              handleTipLink('/quoteDraft', {
-                navigate,
-              });
+              navigate('/quoteDraft');
             },
           },
         });

--- a/apps/storefront/src/pages/ShoppingListDetails/index.tsx
+++ b/apps/storefront/src/pages/ShoppingListDetails/index.tsx
@@ -317,9 +317,7 @@ function ShoppingListDetails({ setOpenPage }: PageProps) {
         });
       }
 
-      snackbar.success(b3Lang('shoppingList.shoppingListStatusUpdated'), {
-        isClose: true,
-      });
+      snackbar.success(b3Lang('shoppingList.shoppingListStatusUpdated'));
       tableRef.current?.initSearch();
     } finally {
       setIsRequestLoading(false);

--- a/apps/storefront/src/pages/quote/components/AddToQuote.tsx
+++ b/apps/storefront/src/pages/quote/components/AddToQuote.tsx
@@ -108,18 +108,14 @@ export default function AddToQuote(props: AddToListProps) {
       return !(sku || variantSku);
     });
     if (noSkuProducts.length > 0) {
-      snackbar.error(b3Lang('quoteDraft.notification.cantAddProductsNoSku'), {
-        isClose: true,
-      });
+      snackbar.error(b3Lang('quoteDraft.notification.cantAddProductsNoSku'));
     }
 
     if (noSkuProducts.length === products.length) return [];
 
     addToQuote(newProducts);
 
-    snackbar.success(b3Lang('quoteDraft.notification.productSingular'), {
-      isClose: true,
-    });
+    snackbar.success(b3Lang('quoteDraft.notification.productSingular'));
 
     return products;
   };
@@ -155,9 +151,7 @@ export default function AddToQuote(props: AddToListProps) {
 
     addToQuote(newProducts);
 
-    snackbar.success(b3Lang('quoteDraft.notification.productPlural'), {
-      isClose: true,
-    });
+    snackbar.success(b3Lang('quoteDraft.notification.productPlural'));
 
     return variantProducts;
   };
@@ -243,9 +237,7 @@ export default function AddToQuote(props: AddToListProps) {
         await calculateProductListPrice(newProducts, '2');
 
         addQuoteDraftProducts(newProducts);
-        snackbar.success(b3Lang('quoteDraft.notification.productPlural'), {
-          isClose: true,
-        });
+        snackbar.success(b3Lang('quoteDraft.notification.productPlural'));
         updateList();
         setIsOpenBulkLoadCSV(false);
       } else {

--- a/apps/storefront/src/shared/dynamicallyVariable/context/config.ts
+++ b/apps/storefront/src/shared/dynamicallyVariable/context/config.ts
@@ -4,6 +4,7 @@ export type AlertTip = 'error' | 'info' | 'success' | 'warning';
 export interface MsgsProps {
   title?: string;
   msg?: string;
+  description?: string;
   id: string | number;
   type: AlertTip;
   isClose?: boolean;

--- a/apps/storefront/src/shared/dynamicallyVariable/context/config.ts
+++ b/apps/storefront/src/shared/dynamicallyVariable/context/config.ts
@@ -1,16 +1,19 @@
-import { Dispatch, ReactElement, ReactNode } from 'react';
+import { Dispatch, ReactNode } from 'react';
 
 export type AlertTip = 'error' | 'info' | 'success' | 'warning';
 export interface MsgsProps {
   title?: string;
   msg?: string;
-  jsx?: () => ReactElement;
   id: string | number;
   type: AlertTip;
   isClose?: boolean;
   vertical?: 'top' | 'bottom';
   horizontal?: 'left' | 'right' | 'center';
   time: number;
+  action?: {
+    label: string;
+    onClick: () => void;
+  };
 }
 export interface TipMessagesProps {
   msgs?: Array<MsgsProps> | [];

--- a/apps/storefront/src/shared/dynamicallyVariable/context/config.ts
+++ b/apps/storefront/src/shared/dynamicallyVariable/context/config.ts
@@ -7,9 +7,6 @@ export interface MsgsProps {
   description?: string;
   id: string | number;
   type: AlertTip;
-  isClose?: boolean;
-  vertical?: 'top' | 'bottom';
-  horizontal?: 'left' | 'right' | 'center';
   time: number;
   action?: {
     label: string;

--- a/apps/storefront/src/shared/dynamicallyVariable/context/config.ts
+++ b/apps/storefront/src/shared/dynamicallyVariable/context/config.ts
@@ -2,7 +2,6 @@ import { Dispatch, ReactNode } from 'react';
 
 export type AlertTip = 'error' | 'info' | 'success' | 'warning';
 export interface MsgsProps {
-  title?: string;
   msg?: string;
   description?: string;
   id: string | number;

--- a/apps/storefront/src/utils/b3Tip.ts
+++ b/apps/storefront/src/utils/b3Tip.ts
@@ -2,6 +2,19 @@ import { ReactElement } from 'react';
 import { v1 as uuid } from 'uuid';
 
 import { AlertTip, MsgsProps } from '@/shared/dynamicallyVariable/context/config';
+import { platform } from './basicConfig';
+
+type Position = 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right' | 'top-center' | 'bottom-center';
+
+interface ToastOptions {
+  action?: {
+    label: string;
+    onClick: () => void;
+  };
+  description?: string;
+  position?: Position;
+  dismissLabel?: string;
+}
 
 interface SnackbarItemProps {
   duration?: number;
@@ -11,7 +24,7 @@ interface SnackbarItemProps {
 
 const getLocalHandler = (variant: AlertTip) => {
   return (message: string, options?: SnackbarItemProps) => {
-    const msgs: Array<MsgsProps> = [
+    const msgs = [
       {
         isClose: options?.isClose || false,
         id: uuid(),
@@ -34,7 +47,32 @@ const getLocalHandler = (variant: AlertTip) => {
   };
 };
 
-export const snackbar = {
+const getNewLocalHandler = (variant: AlertTip) => {
+  return (message: string, options?: Pick<ToastOptions, 'action' | 'description'> & SnackbarItemProps) => {
+    const msgs: Array<MsgsProps> = [
+      {
+        id: uuid(),
+        type: variant,
+        msg: message || `${variant} without any info.`,
+        action: options?.action,
+        isClose: options?.isClose || false,
+        time: 5000,
+      },
+    ];
+
+    window.tipDispatch?.({
+      type: 'tip',
+      payload: {
+        tipMessage: {
+          autoHideDuration: options?.duration || 5000,
+          msgs,
+        },
+      },
+    });
+  }
+}
+
+export const snackbar = platform === 'catalyst' ? window.catalyst.toast : {
   error: getLocalHandler('error'),
   success: getLocalHandler('success'),
   info: getLocalHandler('info'),
@@ -66,7 +104,32 @@ const getGlobalHandler = (variant: AlertTip) => {
   };
 };
 
-export const globalSnackbar = {
+const getNewGlobalHandler = (variant: AlertTip) => {
+  return (message: string, options?: Pick<ToastOptions, 'action' | 'description'> & SnackbarItemProps) => {
+    const msgs = [
+      {
+        id: uuid(),
+        type: variant,
+        msg: message || `${variant} without any info.`,
+        action: options?.action,
+        isClose: options?.isClose || false,
+        time: 5000,
+      },
+    ];
+
+    window.globalTipDispatch({
+      type: 'globalTip',
+      payload: {
+        globalTipMessage: {
+          autoHideDuration: options?.duration || 5000,
+          msgs,
+        },
+      },
+    })
+  }
+};
+
+export const globalSnackbar = platform === 'catalyst' ? window.catalyst.toast : {
   error: getGlobalHandler('error'),
   success: getGlobalHandler('success'),
   info: getGlobalHandler('info'),

--- a/apps/storefront/src/utils/b3Tip.ts
+++ b/apps/storefront/src/utils/b3Tip.ts
@@ -1,10 +1,18 @@
 import { ReactElement } from 'react';
+import { NavigateFunction } from 'react-router-dom';
 import { v1 as uuid } from 'uuid';
 
 import { AlertTip, MsgsProps } from '@/shared/dynamicallyVariable/context/config';
+
 import { platform } from './basicConfig';
 
-type Position = 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right' | 'top-center' | 'bottom-center';
+type Position =
+  | 'top-left'
+  | 'top-right'
+  | 'bottom-left'
+  | 'bottom-right'
+  | 'top-center'
+  | 'bottom-center';
 
 interface ToastOptions {
   action?: {
@@ -48,7 +56,10 @@ const getLocalHandler = (variant: AlertTip) => {
 };
 
 const getNewLocalHandler = (variant: AlertTip) => {
-  return (message: string, options?: Pick<ToastOptions, 'action' | 'description'> & SnackbarItemProps) => {
+  return (
+    message: string,
+    options?: Pick<ToastOptions, 'action' | 'description'> & SnackbarItemProps,
+  ) => {
     const msgs: Array<MsgsProps> = [
       {
         id: uuid(),
@@ -69,15 +80,18 @@ const getNewLocalHandler = (variant: AlertTip) => {
         },
       },
     });
-  }
-}
-
-export const snackbar = platform === 'catalyst' ? window.catalyst.toast : {
-  error: getLocalHandler('error'),
-  success: getLocalHandler('success'),
-  info: getLocalHandler('info'),
-  warning: getLocalHandler('warning'),
+  };
 };
+
+export const snackbar =
+  platform === 'catalyst'
+    ? window.catalyst.toast
+    : {
+        error: getLocalHandler('error'),
+        success: getLocalHandler('success'),
+        info: getLocalHandler('info'),
+        warning: getLocalHandler('warning'),
+      };
 
 const getGlobalHandler = (variant: AlertTip) => {
   return (message: string, options?: SnackbarItemProps) => {
@@ -105,7 +119,10 @@ const getGlobalHandler = (variant: AlertTip) => {
 };
 
 const getNewGlobalHandler = (variant: AlertTip) => {
-  return (message: string, options?: Pick<ToastOptions, 'action' | 'description'> & SnackbarItemProps) => {
+  return (
+    message: string,
+    options?: Pick<ToastOptions, 'action' | 'description'> & SnackbarItemProps,
+  ) => {
     const msgs = [
       {
         id: uuid(),
@@ -125,13 +142,38 @@ const getNewGlobalHandler = (variant: AlertTip) => {
           msgs,
         },
       },
-    })
-  }
+    });
+  };
 };
 
-export const globalSnackbar = platform === 'catalyst' ? window.catalyst.toast : {
-  error: getGlobalHandler('error'),
-  success: getGlobalHandler('success'),
-  info: getGlobalHandler('info'),
-  warning: getGlobalHandler('warning'),
+export const globalSnackbar =
+  platform === 'catalyst'
+    ? window.catalyst.toast
+    : {
+        error: getGlobalHandler('error'),
+        success: getGlobalHandler('success'),
+        info: getGlobalHandler('info'),
+        warning: getGlobalHandler('warning'),
+      };
+
+interface LinkOptions {
+  isCustomEvent?: boolean;
+  isOutLink?: boolean;
+  navigate: NavigateFunction;
+}
+
+export const handleTipLink = (
+  link: string,
+  { isCustomEvent, isOutLink, navigate }: LinkOptions,
+) => {
+  if (isCustomEvent) {
+    if (!window.b2b.callbacks.dispatchEvent('on-click-cart-button')) {
+      return;
+    }
+  }
+  if (isOutLink) {
+    window.location.href = link;
+  } else {
+    navigate(link);
+  }
 };

--- a/apps/storefront/src/utils/b3Tip.ts
+++ b/apps/storefront/src/utils/b3Tip.ts
@@ -1,4 +1,3 @@
-import { NavigateFunction } from 'react-router-dom';
 import { v1 as uuid } from 'uuid';
 
 import { AlertTip, MsgsProps } from '@/shared/dynamicallyVariable/context/config';
@@ -73,26 +72,4 @@ export const globalSnackbar = window.catalyst?.toast || {
   success: getGlobalHandler('success'),
   info: getGlobalHandler('info'),
   warning: getGlobalHandler('warning'),
-};
-
-interface LinkOptions {
-  isCustomEvent?: boolean;
-  isOutLink?: boolean;
-  navigate: NavigateFunction;
-}
-
-export const handleTipLink = (
-  link: string,
-  { isCustomEvent, isOutLink, navigate }: LinkOptions,
-) => {
-  if (isCustomEvent) {
-    if (!window.b2b.callbacks.dispatchEvent('on-click-cart-button')) {
-      return;
-    }
-  }
-  if (isOutLink) {
-    window.location.href = link;
-  } else {
-    navigate(link);
-  }
 };

--- a/apps/storefront/src/utils/b3Tip.ts
+++ b/apps/storefront/src/utils/b3Tip.ts
@@ -31,31 +31,6 @@ interface SnackbarItemProps {
 }
 
 const getLocalHandler = (variant: AlertTip) => {
-  return (message: string, options?: SnackbarItemProps) => {
-    const msgs = [
-      {
-        isClose: options?.isClose || false,
-        id: uuid(),
-        type: variant,
-        msg: message || `${variant} without any info.`,
-        jsx: options?.jsx,
-        time: 5000,
-      },
-    ];
-
-    window.tipDispatch?.({
-      type: 'tip',
-      payload: {
-        tipMessage: {
-          autoHideDuration: options?.duration || 5000,
-          msgs,
-        },
-      },
-    });
-  };
-};
-
-const getNewLocalHandler = (variant: AlertTip) => {
   return (
     message: string,
     options?: Pick<ToastOptions, 'action' | 'description'> & SnackbarItemProps,
@@ -95,31 +70,6 @@ export const snackbar =
       };
 
 const getGlobalHandler = (variant: AlertTip) => {
-  return (message: string, options?: SnackbarItemProps) => {
-    const msgs = [
-      {
-        isClose: options?.isClose || false,
-        id: uuid(),
-        type: variant,
-        msg: message || `${variant} without any info.`,
-        jsx: options?.jsx,
-        time: 5000,
-      },
-    ];
-
-    window.globalTipDispatch({
-      type: 'globalTip',
-      payload: {
-        globalTipMessage: {
-          autoHideDuration: options?.duration || 5000,
-          msgs,
-        },
-      },
-    });
-  };
-};
-
-const getNewGlobalHandler = (variant: AlertTip) => {
   return (
     message: string,
     options?: Pick<ToastOptions, 'action' | 'description'> & SnackbarItemProps,

--- a/apps/storefront/src/utils/b3Tip.ts
+++ b/apps/storefront/src/utils/b3Tip.ts
@@ -68,6 +68,7 @@ const getNewLocalHandler = (variant: AlertTip) => {
         action: options?.action,
         isClose: options?.isClose || false,
         time: 5000,
+        description: options?.description,
       },
     ];
 
@@ -131,6 +132,7 @@ const getNewGlobalHandler = (variant: AlertTip) => {
         action: options?.action,
         isClose: options?.isClose || false,
         time: 5000,
+        description: options?.description,
       },
     ];
 

--- a/apps/storefront/src/utils/b3Tip.ts
+++ b/apps/storefront/src/utils/b3Tip.ts
@@ -1,18 +1,7 @@
-import { ReactElement } from 'react';
 import { NavigateFunction } from 'react-router-dom';
 import { v1 as uuid } from 'uuid';
 
 import { AlertTip, MsgsProps } from '@/shared/dynamicallyVariable/context/config';
-
-import { platform } from './basicConfig';
-
-type Position =
-  | 'top-left'
-  | 'top-right'
-  | 'bottom-left'
-  | 'bottom-right'
-  | 'top-center'
-  | 'bottom-center';
 
 interface ToastOptions {
   action?: {
@@ -20,28 +9,16 @@ interface ToastOptions {
     onClick: () => void;
   };
   description?: string;
-  position?: Position;
-  dismissLabel?: string;
-}
-
-interface SnackbarItemProps {
-  duration?: number;
-  jsx?: () => ReactElement;
-  isClose?: boolean;
 }
 
 const getLocalHandler = (variant: AlertTip) => {
-  return (
-    message: string,
-    options?: Pick<ToastOptions, 'action' | 'description'> & SnackbarItemProps,
-  ) => {
+  return (message: string, options?: ToastOptions) => {
     const msgs: Array<MsgsProps> = [
       {
         id: uuid(),
         type: variant,
         msg: message || `${variant} without any info.`,
         action: options?.action,
-        isClose: options?.isClose || false,
         time: 5000,
         description: options?.description,
       },
@@ -51,7 +28,7 @@ const getLocalHandler = (variant: AlertTip) => {
       type: 'tip',
       payload: {
         tipMessage: {
-          autoHideDuration: options?.duration || 5000,
+          autoHideDuration: 5000,
           msgs,
         },
       },
@@ -59,28 +36,21 @@ const getLocalHandler = (variant: AlertTip) => {
   };
 };
 
-export const snackbar =
-  platform === 'catalyst'
-    ? window.catalyst.toast
-    : {
-        error: getLocalHandler('error'),
-        success: getLocalHandler('success'),
-        info: getLocalHandler('info'),
-        warning: getLocalHandler('warning'),
-      };
+export const snackbar = window.catalyst.toast || {
+  error: getLocalHandler('error'),
+  success: getLocalHandler('success'),
+  info: getLocalHandler('info'),
+  warning: getLocalHandler('warning'),
+};
 
 const getGlobalHandler = (variant: AlertTip) => {
-  return (
-    message: string,
-    options?: Pick<ToastOptions, 'action' | 'description'> & SnackbarItemProps,
-  ) => {
+  return (message: string, options?: ToastOptions) => {
     const msgs = [
       {
         id: uuid(),
         type: variant,
         msg: message || `${variant} without any info.`,
         action: options?.action,
-        isClose: options?.isClose || false,
         time: 5000,
         description: options?.description,
       },
@@ -90,7 +60,7 @@ const getGlobalHandler = (variant: AlertTip) => {
       type: 'globalTip',
       payload: {
         globalTipMessage: {
-          autoHideDuration: options?.duration || 5000,
+          autoHideDuration: 5000,
           msgs,
         },
       },
@@ -98,15 +68,12 @@ const getGlobalHandler = (variant: AlertTip) => {
   };
 };
 
-export const globalSnackbar =
-  platform === 'catalyst'
-    ? window.catalyst.toast
-    : {
-        error: getGlobalHandler('error'),
-        success: getGlobalHandler('success'),
-        info: getGlobalHandler('info'),
-        warning: getGlobalHandler('warning'),
-      };
+export const globalSnackbar = window.catalyst?.toast || {
+  error: getGlobalHandler('error'),
+  success: getGlobalHandler('success'),
+  info: getGlobalHandler('info'),
+  warning: getGlobalHandler('warning'),
+};
 
 interface LinkOptions {
   isCustomEvent?: boolean;

--- a/apps/storefront/src/utils/b3Tip.ts
+++ b/apps/storefront/src/utils/b3Tip.ts
@@ -36,7 +36,7 @@ const getLocalHandler = (variant: AlertTip) => {
   };
 };
 
-export const snackbar = window.catalyst.toast || {
+export const snackbar = window.catalyst?.toast || {
   error: getLocalHandler('error'),
   success: getLocalHandler('success'),
   info: getLocalHandler('info'),

--- a/packages/lang/locales/en.json
+++ b/packages/lang/locales/en.json
@@ -700,6 +700,9 @@
   "pdp.notification.productsAdded": "Products were added to your shopping list",
   "pdp.notification.viewShoppingList": "view shopping list",
   "pdp.addToShoppingList": "Add to shopping list",
+  "pdp.cartToQuote.error.notFound": "Cart not found",
+  "pdp.cartToQuote.error.empty": "No products in the cart.",
+
 
   "forgotPassword.resetPassword": "Reset password",
   "forgotPassword.requestEmail": "Fill in your email below to request a new password. An email will be sent to the address below containing a link to verify your email address.",


### PR DESCRIPTION
## Please read this PR commit by commit.
## Reference catalyst PR https://github.com/bigcommerce/catalyst/pull/2499

Jira: [B2B-2626](https://bigcommercecloud.atlassian.net/browse/B2B-2626)

## What/Why?
This PR refactors our toast system to make it simpler and adaptable to our new Catalyst storefront plus other headless integrations. 
 
Some extra cleanup was made within our types as we introduced a TipBody to remove the jsx prop supplied to several custom notifications. 

We could not consolidate global notifs and local notifs in this PR since stencil has a custom behavior where notifications dispatched inside an iframe cannot be visible in the stencil page. We could do something like this:

```js
snackbar.success('', { type: 'global' }) // add a type prop for global/local
```

But we think this is out of the scope of this PR as its getting big. 

## Rollout/Rollback
Revert

## Testing

https://github.com/user-attachments/assets/0360d8de-77d4-4e84-832a-568a88d2bfb8



[B2B-2626]: https://bigcommercecloud.atlassian.net/browse/B2B-2626?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ