### PR TITLE
fix(common): B2BCAT-21 Ignore ImmutableStateInvariantMiddleware warnings in production

### DIFF
--- a/apps/storefront/tests/setup-test-environment.ts
+++ b/apps/storefront/tests/setup-test-environment.ts
@@ -35,9 +35,17 @@ afterEach(() => {
 });
 
 failOnConsole({
-  silenceMessage: (message) => {
-    // TODO: This warns in production, will have to be fixed in the future.
-    return message.includes('The value provided to Autocomplete is invalid.');
+  silenceMessage: (message: string) => {
+    // TODO: These warn in production, will have to be fixed in the future.
+    if (message.includes('ImmutableStateInvariantMiddleware')) {
+      return true;
+    }
+
+    if (message.includes('The value provided to Autocomplete is invalid.')) {
+      return true;
+    }
+
+    return false;
   },
   shouldFailOnLog: true,
   shouldFailOnWarn: true,


### PR DESCRIPTION
Jira: [B2BCAT-21](https://bigcommercecloud.atlassian.net/browse/B2BCAT-21)

## What/Why?
Add an ignore for `ImmutableStateInvariantMiddleware` to the `failOnConsole` tool.
This warning needs fixing, but it is probably all too messy atm to try and debug it.

## Rollout/Rollback
Revert

## Testing
This PR should not fail its tests

[B2BCAT-21]: https://bigcommercecloud.atlassian.net/browse/B2BCAT-21?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ