### PR TITLE
test(orders): Simplify CompanyOrders/MyOrders data types

### DIFF
--- a/apps/storefront/src/pages/CompanyOrderList/index.mobile.test.tsx
+++ b/apps/storefront/src/pages/CompanyOrderList/index.mobile.test.tsx
@@ -19,19 +19,20 @@ import {
 } from 'tests/test-utils';
 import { when } from 'vitest-when';
 
+import { CompanyStatus, CustomerRole, UserTypes } from '@/types';
+
 import {
   CompanyOrderNode,
   CompanyOrderStatuses,
-  CustomerOrderStatus,
   GetCompanyOrders,
-} from '@/shared/service/b2b/graphql/orders';
-import { CompanyStatus, CustomerRole, UserTypes } from '@/types';
+  OrderStatus,
+} from '../order/orders';
 
 import MyOrders from '.';
 
 const { server } = startMockServer();
 
-const buildOrderStatusWith = builder<CustomerOrderStatus>(() => ({
+const buildOrderStatusWith = builder<OrderStatus>(() => ({
   statusCode: faker.number.int().toString(),
   systemLabel: faker.word.noun(),
   customLabel: faker.word.noun(),
@@ -47,24 +48,9 @@ const buildCompanyOrderNodeWith = builder<CompanyOrderNode>(() => ({
     firstName: faker.person.firstName(),
     lastName: faker.person.lastName(),
     createdAt: getUnixTime(faker.date.past()),
-    updatedAt: getUnixTime(faker.date.recent()),
-    isArchived: faker.datatype.boolean(),
-    isInvoiceOrder: faker.helpers.arrayElement(['A_1', 'A_0']),
     totalIncTax: faker.number.float(),
-    currencyCode: faker.finance.currencyCode(),
-    usdIncTax: faker.number.float(),
-    items: faker.number.int(),
-    userId: faker.number.int(),
     poNumber: faker.number.int().toString(),
-    referenceNumber: faker.number.int().toString(),
     status: faker.word.noun(),
-    customStatus: faker.word.noun(),
-    statusCode: faker.number.int(),
-    ipStatus: faker.helpers.arrayElement(['A_0', 'A_1', 'A_2']),
-    flag: faker.helpers.arrayElement(['A_0', 'A_1', 'A_2', 'A_3']),
-    billingName: faker.person.fullName(),
-    merchantEmail: faker.internet.email(),
-    companyName: faker.company.name(),
     companyInfo: {
       companyName: faker.company.name(),
     },

--- a/apps/storefront/src/pages/CompanyOrderList/index.test.tsx
+++ b/apps/storefront/src/pages/CompanyOrderList/index.test.tsx
@@ -18,19 +18,20 @@ import {
 } from 'tests/test-utils';
 import { when } from 'vitest-when';
 
+import { CompanyStatus, CustomerRole, UserTypes } from '@/types';
+
 import {
   CompanyOrderNode,
   CompanyOrderStatuses,
-  CustomerOrderStatus,
   GetCompanyOrders,
-} from '@/shared/service/b2b/graphql/orders';
-import { CompanyStatus, CustomerRole, UserTypes } from '@/types';
+  OrderStatus,
+} from '../order/orders';
 
 import CompanyOrders from '.';
 
 const { server } = startMockServer();
 
-const buildOrderStatusWith = builder<CustomerOrderStatus>(() => ({
+const buildOrderStatusWith = builder<OrderStatus>(() => ({
   statusCode: faker.number.int().toString(),
   systemLabel: faker.word.noun(),
   customLabel: faker.word.noun(),
@@ -42,24 +43,9 @@ const buildCompanyOrderNodeWith = builder<CompanyOrderNode>(() => ({
     firstName: faker.person.firstName(),
     lastName: faker.person.lastName(),
     createdAt: getUnixTime(faker.date.past()),
-    updatedAt: getUnixTime(faker.date.recent()),
-    isArchived: faker.datatype.boolean(),
-    isInvoiceOrder: faker.helpers.arrayElement(['A_1', 'A_0']),
     totalIncTax: faker.number.float(),
-    currencyCode: faker.finance.currencyCode(),
-    usdIncTax: faker.number.float(),
-    items: faker.number.int(),
-    userId: faker.number.int(),
     poNumber: faker.number.int().toString(),
-    referenceNumber: faker.number.int().toString(),
     status: faker.word.noun(),
-    customStatus: faker.word.noun(),
-    statusCode: faker.number.int(),
-    ipStatus: faker.helpers.arrayElement(['A_0', 'A_1', 'A_2']),
-    flag: faker.helpers.arrayElement(['A_0', 'A_1', 'A_2', 'A_3']),
-    billingName: faker.person.fullName(),
-    merchantEmail: faker.internet.email(),
-    companyName: faker.company.name(),
     companyInfo: {
       companyName: faker.company.name(),
     },

--- a/apps/storefront/src/pages/MyOrders/index.mobile.test.tsx
+++ b/apps/storefront/src/pages/MyOrders/index.mobile.test.tsx
@@ -19,16 +19,17 @@ import {
 } from 'tests/test-utils';
 import { when } from 'vitest-when';
 
+import { CompanyStatus, CustomerRole, UserTypes } from '@/types';
+
 import {
   CompanyOrderNode,
   CompanyOrderStatuses,
   CustomerOrderNode,
   CustomerOrderStatues,
-  CustomerOrderStatus,
   GetCompanyOrders,
   GetCustomerOrders,
-} from '@/shared/service/b2b/graphql/orders';
-import { CompanyStatus, CustomerRole, UserTypes } from '@/types';
+  OrderStatus,
+} from '../order/orders';
 
 import MyOrders from '.';
 
@@ -40,27 +41,13 @@ const buildCustomerOrderNodeWith = builder<CustomerOrderNode>(() => ({
     firstName: faker.person.firstName(),
     lastName: faker.person.lastName(),
     createdAt: getUnixTime(faker.date.past()),
-    updatedAt: getUnixTime(faker.date.recent()),
-    isArchived: faker.datatype.boolean(),
-    isInvoiceOrder: faker.helpers.arrayElement(['A_1', 'A_0']),
     totalIncTax: faker.number.float(),
-    currencyCode: faker.finance.currencyCode(),
-    usdIncTax: faker.number.float(),
-    items: faker.number.int(),
-    userId: faker.number.int(),
     poNumber: faker.number.int().toString(),
-    referenceNumber: faker.number.int().toString(),
     status: faker.word.noun(),
-    customStatus: faker.word.noun(),
-    statusCode: faker.number.int(),
-    ipStatus: faker.helpers.arrayElement(['A_0', 'A_1', 'A_2']),
-    flag: faker.helpers.arrayElement(['A_0', 'A_1', 'A_2', 'A_3']),
-    billingName: faker.person.fullName(),
-    merchantEmail: faker.internet.email(),
   },
 }));
 
-const buildOrderStatusWith = builder<CustomerOrderStatus>(() => ({
+const buildOrderStatusWith = builder<OrderStatus>(() => ({
   statusCode: faker.number.int().toString(),
   systemLabel: faker.word.noun(),
   customLabel: faker.word.noun(),
@@ -648,24 +635,9 @@ const buildCompanyOrderNodeWith = builder<CompanyOrderNode>(() => ({
     firstName: faker.person.firstName(),
     lastName: faker.person.lastName(),
     createdAt: getUnixTime(faker.date.past()),
-    updatedAt: getUnixTime(faker.date.recent()),
-    isArchived: faker.datatype.boolean(),
-    isInvoiceOrder: faker.helpers.arrayElement(['A_1', 'A_0']),
     totalIncTax: faker.number.float(),
-    currencyCode: faker.finance.currencyCode(),
-    usdIncTax: faker.number.float(),
-    items: faker.number.int(),
-    userId: faker.number.int(),
     poNumber: faker.number.int().toString(),
-    referenceNumber: faker.number.int().toString(),
     status: faker.word.noun(),
-    customStatus: faker.word.noun(),
-    statusCode: faker.number.int(),
-    ipStatus: faker.helpers.arrayElement(['A_0', 'A_1', 'A_2']),
-    flag: faker.helpers.arrayElement(['A_0', 'A_1', 'A_2', 'A_3']),
-    billingName: faker.person.fullName(),
-    merchantEmail: faker.internet.email(),
-    companyName: faker.company.name(),
     companyInfo: {
       companyName: faker.company.name(),
     },

--- a/apps/storefront/src/pages/MyOrders/index.test.tsx
+++ b/apps/storefront/src/pages/MyOrders/index.test.tsx
@@ -19,16 +19,17 @@ import {
 } from 'tests/test-utils';
 import { when } from 'vitest-when';
 
+import { CompanyStatus, CustomerRole, UserTypes } from '@/types';
+
 import {
   CompanyOrderNode,
   CompanyOrderStatuses,
   CustomerOrderNode,
   CustomerOrderStatues,
-  CustomerOrderStatus,
   GetCompanyOrders,
   GetCustomerOrders,
-} from '@/shared/service/b2b/graphql/orders';
-import { CompanyStatus, CustomerRole, UserTypes } from '@/types';
+  OrderStatus,
+} from '../order/orders';
 
 import MyOrders from '.';
 
@@ -40,27 +41,13 @@ const buildCustomerOrderNodeWith = builder<CustomerOrderNode>(() => ({
     firstName: faker.person.firstName(),
     lastName: faker.person.lastName(),
     createdAt: getUnixTime(faker.date.past()),
-    updatedAt: getUnixTime(faker.date.recent()),
-    isArchived: faker.datatype.boolean(),
-    isInvoiceOrder: faker.helpers.arrayElement(['A_1', 'A_0']),
     totalIncTax: faker.number.float(),
-    currencyCode: faker.finance.currencyCode(),
-    usdIncTax: faker.number.float(),
-    items: faker.number.int(),
-    userId: faker.number.int(),
     poNumber: faker.number.int().toString(),
-    referenceNumber: faker.number.int().toString(),
     status: faker.word.noun(),
-    customStatus: faker.word.noun(),
-    statusCode: faker.number.int(),
-    ipStatus: faker.helpers.arrayElement(['A_0', 'A_1', 'A_2']),
-    flag: faker.helpers.arrayElement(['A_0', 'A_1', 'A_2', 'A_3']),
-    billingName: faker.person.fullName(),
-    merchantEmail: faker.internet.email(),
   },
 }));
 
-const buildOrderStatusWith = builder<CustomerOrderStatus>(() => ({
+const buildOrderStatusWith = builder<OrderStatus>(() => ({
   statusCode: faker.number.int().toString(),
   systemLabel: faker.word.noun(),
   customLabel: faker.word.noun(),
@@ -794,24 +781,9 @@ const buildCompanyOrderNodeWith = builder<CompanyOrderNode>(() => ({
     firstName: faker.person.firstName(),
     lastName: faker.person.lastName(),
     createdAt: getUnixTime(faker.date.past()),
-    updatedAt: getUnixTime(faker.date.recent()),
-    isArchived: faker.datatype.boolean(),
-    isInvoiceOrder: faker.helpers.arrayElement(['A_1', 'A_0']),
     totalIncTax: faker.number.float(),
-    currencyCode: faker.finance.currencyCode(),
-    usdIncTax: faker.number.float(),
-    items: faker.number.int(),
-    userId: faker.number.int(),
     poNumber: faker.number.int().toString(),
-    referenceNumber: faker.number.int().toString(),
     status: faker.word.noun(),
-    customStatus: faker.word.noun(),
-    statusCode: faker.number.int(),
-    ipStatus: faker.helpers.arrayElement(['A_0', 'A_1', 'A_2']),
-    flag: faker.helpers.arrayElement(['A_0', 'A_1', 'A_2', 'A_3']),
-    billingName: faker.person.fullName(),
-    merchantEmail: faker.internet.email(),
-    companyName: faker.company.name(),
     companyInfo: {
       companyName: faker.company.name(),
     },

--- a/apps/storefront/src/pages/order/orders.ts
+++ b/apps/storefront/src/pages/order/orders.ts
@@ -85,7 +85,7 @@ query ${fn === 'allOrders' ? 'GetAllOrders' : 'GetCustomerOrders'} {
   }
 }`;
 
-export interface CustomerOrderStatus {
+export interface OrderStatus {
   systemLabel: string;
   customLabel: string;
   statusCode: string;
@@ -93,13 +93,13 @@ export interface CustomerOrderStatus {
 
 export interface CustomerOrderStatues {
   data: {
-    bcOrderStatuses: CustomerOrderStatus[];
+    bcOrderStatuses: OrderStatus[];
   };
 }
 
 export interface CompanyOrderStatuses {
   data: {
-    orderStatuses: CustomerOrderStatus[];
+    orderStatuses: OrderStatus[];
   };
 }
 

--- a/apps/storefront/src/types/order.ts
+++ b/apps/storefront/src/types/order.ts
@@ -3,8 +3,3 @@ export interface OrderStatusItem {
   statusCode: string;
   systemLabel: string;
 }
-
-export interface OrderStatusResponse {
-  orderStatuses?: OrderStatusItem[];
-  bcOrderStatuses?: OrderStatusItem[];
-}


### PR DESCRIPTION
Jira: [B2BCAT-39](https://bigcommercecloud.atlassian.net/browse/B2BCAT-39), [B2BCAT-12](https://bigcommercecloud.atlassian.net/browse/B2BCAT-12)

## What/Why?
As part of a previous commit we remove much of the fluff retrieved by
the APIs that wasn't even used as part of the MyOrders page.

We forgot to remove a couple of instances in the tests.
Apply the same changes to the recently merged `CompanyTestHarnesses`.

## Rollout/Rollback
Revert

## Testing
This PR is mainly test files. Passing tests should prove this works as expected.

[B2BCAT-39]: https://bigcommercecloud.atlassian.net/browse/B2BCAT-39?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[B2BCAT-12]: https://bigcommercecloud.atlassian.net/browse/B2BCAT-12?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ