### PR TITLE
docs(addresses): B2BCAT-5 Rename `addressType` to `type` to avoid collisions

### DIFF
--- a/rfc/graphql-schema/additionalTypeDefs/byPage/addresses.ts
+++ b/rfc/graphql-schema/additionalTypeDefs/byPage/addresses.ts
@@ -27,7 +27,7 @@ export default /* GraphQL */ `
 
     label: String!
 
-    addressType: AddressType!
+    type: AddressType!
   }
 
   type CompanyAddressEdge {


### PR DESCRIPTION


Jira: [B2BCAT-5](https://bigcommercecloud.atlassian.net/browse/B2BCAT-5)

## What/Why?
The current address already includes an `addressType` field, renaming this one to `type`.

## Rollout/Rollback
Revert

## Testing
n/a

[B2BCAT-5]: https://bigcommercecloud.atlassian.net/browse/B2BCAT-5?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ