### PR TITLE
test(invoices): B2BCAT-13 Ensure View payment history is always available in the test

### DIFF
--- a/apps/storefront/src/pages/Invoice/index.test.tsx
+++ b/apps/storefront/src/pages/Invoice/index.test.tsx
@@ -994,6 +994,7 @@ describe('when using the action menu', () => {
                     node: {
                       id: '3344',
                       invoiceNumber: '3322',
+                      status: InvoiceStatusCode.PartiallyPaid,
                     },
                   }),
                 ],


### PR DESCRIPTION
Jira: [B2BCAT-13](https://bigcommercecloud.atlassian.net/browse/B2BCAT-13)

## What/Why?

Invoices with status = Open do not show the view payment history link, this is causing some flakiness in the test. This commit hardcodes the status to PartiallyPaid to ensure it always shows.


## Rollout/Rollback
Revert 🤷 

## Testing
Running the flaky test 20 times in a row:

### Before:
<img width="809" height="505" alt="image" src="https://github.com/user-attachments/assets/fac8612e-9c2d-4767-978f-abd304d7cad2" />

### After:
<img width="639" height="518" alt="image" src="https://github.com/user-attachments/assets/6100cfaf-fac4-4d82-afba-b5a2508ff5ac" />


[B2BCAT-13]: https://bigcommercecloud.atlassian.net/browse/B2BCAT-13?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ