### PR TITLE
build(common): B2BCAT-87 Use corepack to install yarn in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,24 +1,52 @@
-aliases:
-  - &node_executor
-      executor:
-        name: node/node
-        node-version: "22.16"
-
 version: 2.1
+
+executors:
+  node:
+    docker:
+      - image: cimg/node:22.16
 
 orbs:
   ci: bigcommerce/internal@volatile
-  node: bigcommerce/internal-node@volatile
   security: bigcommerce/internal-security@volatile
   test-coverage-reporter: bigcommerce/internal-test-coverage-reporter@volatile
 
+commands:
+  install-dependencies:
+    steps:
+      - restore_cache:
+          keys:
+            - node-modules-cache-i1-{{ checksum "package.json" }}
+
+      - run:
+          name: Enable corepack
+          command: |
+            mkdir -p /tmp/bc/bin
+            mkdir -p /tmp/bc/caches/corepack
+            mkdir -p /tmp/bc/caches/yarn
+            export COREPACK_HOME=/tmp/bc/caches/corepack
+            echo 'export PATH=/tmp/bc/bin:$PATH' >> $BASH_ENV
+            corepack enable yarn --install-directory /tmp/bc/bin
+            hash -r
+            yarn config set cache-folder /tmp/bc/caches/yarn
+
+      - run:
+          name: Installing dependencies
+          command: |
+            yarn install --immutable
+
+      - save_cache:
+          name: Saving node_modules cache
+          key: node-modules-cache-i1-{{ checksum "package.json" }}
+          paths:
+            - /tmp/bc/caches
+
 jobs:
   test:
-    <<: *node_executor
+    executor: node
     resource_class: medium+
     steps:
       - ci/pre-setup
-      - node/yarn-install
+      - install-dependencies
       - test-coverage-reporter/install
       - run:
           name: "Run unit tests for core package"
@@ -35,21 +63,21 @@ jobs:
           path: ./apps/storefront/coverage/lcov-report
 
   lint:
-    <<: *node_executor
+    executor: node
     resource_class: medium+
     steps:
       - ci/pre-setup
-      - node/yarn-install
+      - install-dependencies
       - run:
-          name: "Run lint"
+          name: 'Run lint'
           command: yarn run lint
 
   build_and_push:
-    <<: *node_executor
+    executor: node
     resource_class: medium+
     steps:
       - ci/pre-setup
-      - node/yarn-install
+      - install-dependencies
       - ci/gcloud_login
       - run:
           name: "Build distribution files"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "apps/*",
     "packages/*"
   ],
-  "packageManager": "yarn@1.22.22",
+  "packageManager": "yarn@1.22.22+sha256.c17d3797fb9a9115bf375e31bfd30058cac6bc9c3b8807a3d8cb2094794b51ca",
   "scripts": {
     "build": "turbo run build",
     "build:production": "turbo run build",


### PR DESCRIPTION
Jira: [B2BCAT-87](https://bigcommercecloud.atlassian.net/browse/B2BCAT-87)

## What/Why?
Use corepack to install yarn in CircleCI + standard CircleCI Image

## Rollout/Rollback
Revert

## Testing
This is the issue we are trying to solve:

<img width="1040" height="441" alt="image" src="https://github.com/user-attachments/assets/ccd14e9d-774e-46d5-b7d1-db350f818ca4" />


Builds are faster, and they pass 🤷 

[B2BCAT-87]: https://bigcommercecloud.atlassian.net/browse/B2BCAT-87?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ