### PR TITLE
fix(shopping-lists): B2B-3301 Fixed selection resetting when updating quantity, notes, or options in the table

### DIFF
--- a/apps/storefront/src/components/table/B3PaginationTable.tsx
+++ b/apps/storefront/src/components/table/B3PaginationTable.tsx
@@ -28,6 +28,10 @@ export interface TablePagination {
   first: number;
 }
 
+export interface TableRefreshConfig {
+  keepCheckedItems?: boolean;
+}
+
 interface GetRequestListResult<T extends object> {
   edges: PossibleNodeWrapper<T>[];
   totalCount: number;
@@ -171,7 +175,7 @@ function PaginationTable<GetRequestListParams, Row extends object>(
   );
 
   const fetchList = useCallback(
-    async (b3Pagination?: TablePagination, isRefresh?: boolean) => {
+    async (b3Pagination?: TablePagination, isRefresh?: boolean, config?: TableRefreshConfig) => {
       try {
         if (cache?.current && isEqual(cache.current, searchParams) && !isRefresh && !b3Pagination) {
           return;
@@ -204,7 +208,7 @@ function PaginationTable<GetRequestListParams, Row extends object>(
 
         cacheList(edges);
 
-        if (!isSelectOtherPageCheckbox) setSelectCheckbox([]);
+        if (!isSelectOtherPageCheckbox && config?.keepCheckedItems !== true) setSelectCheckbox([]);
 
         if (!b3Pagination) {
           setPagination({
@@ -231,9 +235,12 @@ function PaginationTable<GetRequestListParams, Row extends object>(
     ],
   );
 
-  const refresh = useCallback(() => {
-    fetchList(pagination, true);
-  }, [fetchList, pagination]);
+  const refresh = useCallback(
+    (config?: TableRefreshConfig) => {
+      fetchList(pagination, true, config);
+    },
+    [fetchList, pagination],
+  );
 
   useEffect(() => {
     const isChangeCompany =

--- a/apps/storefront/src/pages/ShoppingListDetails/components/ShoppingDetailTable.tsx
+++ b/apps/storefront/src/pages/ShoppingListDetails/components/ShoppingDetailTable.tsx
@@ -13,7 +13,11 @@ import { Delete, Edit, StickyNote2 } from '@mui/icons-material';
 import { Box, Grid, styled, TextField, Typography } from '@mui/material';
 import cloneDeep from 'lodash-es/cloneDeep';
 
-import { B3PaginationTable, GetRequestList } from '@/components/table/B3PaginationTable';
+import {
+  B3PaginationTable,
+  GetRequestList,
+  TableRefreshConfig,
+} from '@/components/table/B3PaginationTable';
 import { TableColumnItem } from '@/components/table/B3Table';
 import { PRODUCT_DEFAULT_IMAGE } from '@/constants';
 import { useMobile, useSort } from '@/hooks';
@@ -90,7 +94,7 @@ interface PaginationTableRefProps extends HTMLInputElement {
   getList: () => void;
   setList: (items?: ListItemProps[]) => void;
   getSelectedValue: () => void;
-  refresh: () => void;
+  refresh: (type?: TableRefreshConfig) => void;
 }
 
 const StyledShoppingListTableContainer = styled('div')(() => ({
@@ -223,8 +227,8 @@ function ShoppingDetailTable(props: ShoppingDetailTableProps, ref: Ref<unknown>)
     paginationTableRef.current?.setList([...newListItems]);
   };
 
-  const initSearch = () => {
-    paginationTableRef.current?.refresh();
+  const initSearch = (type?: TableRefreshConfig) => {
+    paginationTableRef.current?.refresh(type);
   };
 
   useImperativeHandle(ref, () => ({
@@ -273,7 +277,7 @@ function ShoppingDetailTable(props: ShoppingDetailTableProps, ref: Ref<unknown>)
       setSelectedOptionsOpen(false);
       setEditProductItemId('');
       snackbar.success(b3Lang('shoppingList.table.productUpdated'));
-      initSearch();
+      initSearch({ keepCheckedItems: true });
     } finally {
       setIsRequestLoading(false);
     }
@@ -328,7 +332,7 @@ function ShoppingDetailTable(props: ShoppingDetailTableProps, ref: Ref<unknown>)
       await handleUpdateShoppingListItem(itemId);
       snackbar.success(b3Lang('shoppingList.table.quantityUpdated'));
       setQtyNotChangeFlag(true);
-      initSearch();
+      initSearch({ keepCheckedItems: true });
     } finally {
       setIsRequestLoading(false);
     }
@@ -366,7 +370,7 @@ function ShoppingDetailTable(props: ShoppingDetailTableProps, ref: Ref<unknown>)
       handleCancelAddNotesClick();
       await handleUpdateShoppingListItem(addNoteItemId);
       snackbar.success(b3Lang('shoppingList.table.productNotesUpdated'));
-      initSearch();
+      initSearch({ keepCheckedItems: true });
     } finally {
       setIsRequestLoading(false);
     }

--- a/apps/storefront/src/pages/ShoppingListDetails/index.tsx
+++ b/apps/storefront/src/pages/ShoppingListDetails/index.tsx
@@ -271,7 +271,7 @@ function ShoppingListDetails({ setOpenPage }: PageProps) {
 
   const getShoppingListDetails = async (params: SearchProps) => {
     const shoppingListDetailInfo = await getShoppingList(params);
-
+    setIsRequestLoading(true);
     const {
       products: { edges, totalCount },
     } = shoppingListDetailInfo;
@@ -282,7 +282,7 @@ function ShoppingListDetails({ setOpenPage }: PageProps) {
 
     if (isB2BUser) setCustomerInfo(shoppingListDetailInfo.customerInfo);
     setShoppingListInfo(shoppingListDetailInfo);
-
+    setIsRequestLoading(false);
     if (!listProducts) {
       return {
         edges: [],


### PR DESCRIPTION
## What/Why?
Context - Fixed selection resetting when updating quantity, notes, or options in the table

Bug - https://bigcommercecloud.atlassian.net/browse/B2B-3301

Changes:
Added `PRESERVE_SELECTION`  to the B3PaginationTable to avoid setting the selection during the internal table refresh

## Demo
https://www.loom.com/share/d22c496131d2428fbb05d7638353a0f6

## Testing
Added for B3PaginationTable as most logic of this PR was sitting here

## Previous PR (Declined because of fork)
https://github.com/bigcommerce/b2b-buyer-portal/pull/463
