### PR TITLE
fix(headless): B2B-3440 callback registered fix

### DIFF
--- a/apps/storefront/src/pages/Registered/index.tsx
+++ b/apps/storefront/src/pages/Registered/index.tsx
@@ -244,8 +244,8 @@ function Registered(props: PageProps) {
             : LOGIN_LANDING_LOCATIONS.BUYER_PORTAL;
 
           window.b2b.callbacks.dispatchEvent('on-registered', {
-            email: customer.emailAddress,
-            password: customer.password,
+            email,
+            password,
             landingLoginLocation,
           });
           window.location.hash = '';


### PR DESCRIPTION
Jira: [B2B-3440](https://bigcommercecloud.atlassian.net/browse/B2B-3440)

## What/Why?
Reverting changes made in #306 for a merchant that is soon to launch a Catalyst B2B sf. 

Catalyst merchant identified a bug where registered users wont be logged in automatically. This is due to sending incorrect params to the 'on-registered' callback event. 

The correct params are the ones send in the handleFinish function, the change made in #306 sends what the customer login mutation responds and it does not contain the password, that's why the catalyst integration broke.

## Rollout/Rollback
Revert

## Testing
Before (user is redirected to home and is not auth in catalyst):

https://github.com/user-attachments/assets/75631d9c-4982-4a92-b223-ddd50d898819


After:

https://github.com/user-attachments/assets/4d9059aa-2b0c-4dac-b2ab-21220f649d80



[B2B-3440]: https://bigcommercecloud.atlassian.net/browse/B2B-3440?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ