### PR TITLE
feat(orders): B2B-3250 allow download digital products files

### DIFF
--- a/apps/storefront/src/components/B3ProductList.tsx
+++ b/apps/storefront/src/components/B3ProductList.tsx
@@ -1,6 +1,6 @@
 import { ChangeEvent, KeyboardEvent, ReactElement, useEffect, useState } from 'react';
 import styled from '@emotion/styled';
-import { Box, Checkbox, FormControlLabel, TextField, Typography } from '@mui/material';
+import { Box, Button, Checkbox, FormControlLabel, TextField, Typography } from '@mui/material';
 import noop from 'lodash-es/noop';
 
 import { PRODUCT_DEFAULT_IMAGE } from '@/constants';
@@ -124,6 +124,7 @@ interface ProductProps<T> {
   canToProduct?: boolean;
   textAlign?: string;
   type?: string;
+  getCurrentProductUrls?: (productId: number | undefined) => void;
 }
 
 export default function B3ProductList<T>(props: ProductProps<T>) {
@@ -142,6 +143,7 @@ export default function B3ProductList<T>(props: ProductProps<T>) {
     textAlign = 'left',
     money,
     type,
+    getCurrentProductUrls,
   } = props;
 
   const [list, setList] = useState<ProductItem[]>([]);
@@ -402,6 +404,20 @@ export default function B3ProductList<T>(props: ProductProps<T>) {
                 <Typography variant="body1" color="#616161">
                   {product.sku}
                 </Typography>
+                {product.type === 'digital' &&
+                  product.downloadFileUrls &&
+                  product.downloadFileUrls.length > 0 && (
+                    <Button
+                      sx={{
+                        m: '0 0 0 -8px',
+                        minWidth: 0,
+                      }}
+                      variant="text"
+                      onClick={() => getCurrentProductUrls?.(product.product_id)}
+                    >
+                      {b3Lang('orderDetail.digitalProducts.viewFiles')}
+                    </Button>
+                  )}
                 {(product.product_options || []).map((option) => (
                   <ProductOptionText
                     key={`${option.option_id}`}

--- a/apps/storefront/src/lib/lang/locales/en.json
+++ b/apps/storefront/src/lib/lang/locales/en.json
@@ -126,7 +126,6 @@
   "global.B2BAutoCompleteCheckbox.input.label": "Company",
   "global.B2BSwitchCompanyModal.title": "Switch company",
   "global.B2BSwitchCompanyModal.confirm.button": "Switch company",
-
   "dashboard.company": "Company",
   "dashboard.admin": "Admin",
   "dashboard.email": "Email",
@@ -139,7 +138,6 @@
   "dashboard.masqueradeModal.message": "This action will empty your shopping cart. Do you want to continue?",
   "dashboard.masqueradeModal.actions.cancel": "Cancel",
   "dashboard.masqueradeModal.actions.continue": "Continue",
-
   "orders.order": "Order",
   "orders.poReference": "PO / Reference",
   "orders.grandTotal": "Grand total",
@@ -164,7 +162,6 @@
   "orders.status.manualVerificationRequired": "Manual Verification Required",
   "orders.status.disputed": "Disputed",
   "orders.status.partiallyRefunded": "Partially Refunded",
-
   "invoice.exportCsvText": "Export all as CSV",
   "invoice.exportSelectedAsCsv": "Export selected as CSV",
   "invoice.exportFilteredAsCsv": "Export filtered as CSV",
@@ -206,7 +203,6 @@
   "invoice.filterStatus.partiallyPaid": "Partially paid",
   "invoice.filterStatus.paid": "Paid",
   "invoice.filterStatus.overdue": "Overdue",
-
   "quotes.dateCreated": "Date created",
   "quotes.status": "Status",
   "quotes.updated": "Updated",
@@ -235,7 +231,6 @@
   "quotes.quoteItemCard.expirationDate": "Expiration date",
   "quotes.quoteItemCard.subtotal": "Subtotal",
   "quotes.quoteItemCard.view": "VIEW",
-
   "shoppingLists.createNew": "Create new",
   "shoppingLists.deleteSuccess": "The shopping list was successfully deleted",
   "shoppingLists.deleteShoppingList": "Delete shopping list",
@@ -259,7 +254,6 @@
   "shoppingLists.card.lastActivity": "Last activity:",
   "shoppingLists.card.view": "View",
   "shoppingLists.viewShoppingList": "View shopping list",
-
   "purchasedProducts.product": "Product",
   "purchasedProducts.price": "Price",
   "purchasedProducts.qty": "Qty",
@@ -327,7 +321,6 @@
   "purchasedProducts.error.selectOneItem": "Please select at least one item",
   "purchasedProducts.error.fillCorrectQuantity": "Please fill in the correct quantity",
   "purchasedProducts.error.failedApplication": "Application failed, please contact the merchant.",
-
   "orderDetail.orderId": "Order #{orderId}",
   "orderDetail.purchaseOrderNumber": ", {purchaseOrderNumber}",
   "orderDetail.backToOrders": "Back to orders",
@@ -382,7 +375,11 @@
   "orderDetail.anotherCompany.tips": "This order is related to another company. To reorder, add to a shopping list, or perform other actions, you need to switch to that company.",
   "orderDetail.switchCompany.title": "Switch company",
   "orderDetail.switchCompany.content.tipsText": "To continue you have to switch company. Switching to a different company will refresh your shopping cart.",
-
+  "orderDetail.digitalProducts.download": "Download",
+  "orderDetail.digitalProducts.filesToDownload": "Files to download",
+  "orderDetail.digitalProducts.viewFiles": "View files",
+  "orderDetail.digitalProducts.close": "Close",
+  "orderDetail.digitalProducts.fileNotAvailable": "The file is not available for download. Please contact support.",
   "addresses.noPermissionToAdd": "You do not have permission to add new address, please contact store owner",
   "addresses.noPermissionToEdit": "You do not have permission to edit address, please contact store owner",
   "addresses.noPermissionToDelete": "You do not have permission to delete address, please contact store owner",
@@ -425,7 +422,6 @@
   "addresses.editAddress.state": "State",
   "addresses.editAddress.zipCode": "Zip Code",
   "addresses.editAddress.phoneNumber": "Phone number",
-
   "shoppingList.shoppingListStatusUpdated": "Shopping list status updated successfully",
   "shoppingList.productRemoved": "Product removed from your shopping list",
   "shoppingList.addToShoppingList.productsAdded": "Products were added to your shopping list",
@@ -505,7 +501,6 @@
   "shoppingList.addItemNotes.cancel": "cancel",
   "shoppingList.addItemNotes.save": "save",
   "shoppingList.addItemNotes.placeholder": "Add notes to products",
-
   "userManagement.addUser": "Add new user",
   "userManagement.deleteUserSuccessfully": "User deleted successfully",
   "userManagement.deleteUser": "Delete user",
@@ -526,7 +521,6 @@
   "userManagement.userRole.admin": "Admin",
   "userManagement.userRole.seniorBuyer": "Senior buyer",
   "userManagement.userRole.juniorBuyer": "Junior buyer",
-
   "quoteDraft.addQuoteInfo": "Please add quote info before submitting",
   "quoteDraft.submit": "Please add quote products before submitting",
   "quoteDraft.submit.errorTip": "There are some products in the quote that are out of stock or unavailable for purchase. Please remove the product or modify the quantity of the product.",
@@ -601,7 +595,6 @@
   "quoteDraft.quoteTable.unavailable.tip": "Not available for purchase",
   "quoteDraft.productPageToQuote.outOfStock": "{name} Out of stock. In stock: {qty}",
   "quoteDraft.productPageToQuote.unavailable": "Not available for purchase",
-
   "accountSettings.notification.detailsUpdated": "Your account details have been updated.",
   "accountSettings.notification.emailExists": "Email already exists",
   "accountSettings.notification.updateEmailPassword": "Please type in your current password to update your email address.",
@@ -624,7 +617,6 @@
   "accountSettings.form.lastName": "Last name",
   "accountSettings.form.email": "Email",
   "accountSettings.form.phoneNumber": "Phone number",
-
   "quoteDetail.uploadedByCustomer": "Uploaded by customer: {createdBy}",
   "quoteDetail.uploadedBySalesRep": "Uploaded by sales rep: {createdBy}",
   "quoteDetail.submittedQuote": "Your quote was submitted. You can always find the quote using this link.",
@@ -668,7 +660,6 @@
   "quoteDetail.tableCard.total": "Total:",
   "quoteDetail.tableCard.qty": "Qty: {quantity}",
   "quoteDetail.termsAndConditions": "Terms and conditions",
-
   "register.title.registerComplete": "Application submitted",
   "register.title.registerCompleteWarning": "Application has been submitted",
   "register.title.accountCreated": "Registration complete!",
@@ -683,7 +674,6 @@
   "register.label.companyAttachments": "Company attachments",
   "register.emailValidate.alreadyExitsBC": "The email address {email} is already in use. Please enter a different one.",
   "register.registeredSingleCheckBox.label": "Email me special promotions and updates",
-
   "login.button.signIn": "Sign In",
   "login.button.signInUppercase": "SIGN IN",
   "login.button.createAccount": "CREATE ACCOUNT",
@@ -700,19 +690,15 @@
   "login.registerLogo": "register Logo",
   "login.loginText.quoteDetailToCheckoutUrl": "Please log in to purchase this quote",
   "login.loginText.missingCaptcha": "The captcha you entered is incorrect. Please try again.",
-
   "pdp.notification.productsAdded": "Products were added to your shopping list",
   "pdp.notification.viewShoppingList": "view shopping list",
   "pdp.addToShoppingList": "Add to shopping list",
   "pdp.cartToQuote.error.notFound": "Cart not found",
   "pdp.cartToQuote.error.empty": "No products in the cart.",
-
   "forgotPassword.resetPassword": "Reset password",
   "forgotPassword.requestEmail": "Fill in your email below to request a new password. An email will be sent to the address below containing a link to verify your email address.",
   "forgotPassword.resetPasswordBtn": "Reset Password",
-
   "registeredbctob2b.title": "Business Account Application",
-
   "payment.errorInvoiceCantBeBlank": "The invoice cannot be blank",
   "payment.errorOpenBalanceIsIncorrect": "The invoice openBalance code or value is incorrect",
   "payment.invoiceDoesNotExist": "Invoice does not exist",
@@ -731,7 +717,6 @@
   "payment.invoiceNumber": "Invoice#",
   "payment.amountPaid": "Amount paid",
   "payment.okButton": "Ok",
-
   "companyHierarchy.table.name": "Name",
   "companyHierarchy.dialog.title": "Switch company",
   "companyHierarchy.dialog.content": "Switching to a different company will refresh your shopping cart. Do you want to continue?",

--- a/apps/storefront/src/pages/OrderDetail/components/DownloadDigitalProductsDialog/DownloadDigitalProductsDialog.tsx
+++ b/apps/storefront/src/pages/OrderDetail/components/DownloadDigitalProductsDialog/DownloadDigitalProductsDialog.tsx
@@ -1,0 +1,96 @@
+import { InsertDriveFileOutlined } from '@mui/icons-material';
+import { Box, Button, Typography, useTheme } from '@mui/material';
+
+import B3Dialog from '@/components/B3Dialog';
+import { useB3Lang } from '@/lib/lang';
+import { ProductItem } from '@/types';
+import { snackbar } from '@/utils';
+
+import { handleDownleoadDigitalFile } from './handleDownloadDigitalFile';
+
+interface DownloadDigitalProductsDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  product?: ProductItem;
+}
+
+function DownloadDigitalProductsDialog({
+  isOpen,
+  onClose,
+  product,
+}: DownloadDigitalProductsDialogProps) {
+  const theme = useTheme();
+  const b3Lang = useB3Lang();
+  const primaryColor = theme.palette.primary.main;
+
+  const onClick = async (fileUrl: string) => {
+    try {
+      await handleDownleoadDigitalFile(fileUrl);
+    } catch {
+      snackbar.error(b3Lang('orderDetail.digitalProducts.fileNotAvailable'));
+    }
+  };
+
+  return (
+    <B3Dialog
+      isOpen={isOpen}
+      fullWidth
+      handleLeftClick={onClose}
+      title={b3Lang('orderDetail.digitalProducts.filesToDownload')}
+      leftSizeBtn={b3Lang('orderDetail.digitalProducts.close')}
+      maxWidth="md"
+      showRightBtn={false}
+    >
+      {product?.downloadFileUrls?.map((fileUrl: string, index: number) => {
+        const key = `${product?.product_id}-${index}`;
+        return (
+          <Box
+            key={key}
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              padding: '8px 0',
+              margin: '15px 0 15px 0',
+              borderWidth: '1px',
+              borderStyle: 'solid',
+              borderColor: primaryColor,
+              borderRadius: '10px',
+              p: 2,
+            }}
+          >
+            <Box sx={{ display: 'flex' }}>
+              <InsertDriveFileOutlined
+                sx={{
+                  color: primaryColor,
+                  fontSize: '40px',
+                }}
+              />
+              <Typography
+                sx={{
+                  color: primaryColor,
+                  fontSize: '14px',
+                  alignSelf: 'center',
+                }}
+              >
+                {`${product?.name} ${index + 1}`}
+              </Typography>
+            </Box>
+            <Button
+              onClick={() => onClick(fileUrl)}
+              sx={{
+                color: primaryColor,
+                textDecoration: 'none',
+                fontSize: '14px',
+              }}
+            >
+              {b3Lang('orderDetail.digitalProducts.download')}
+            </Button>
+          </Box>
+        );
+      })}
+    </B3Dialog>
+  );
+}
+
+export default DownloadDigitalProductsDialog;

--- a/apps/storefront/src/pages/OrderDetail/components/DownloadDigitalProductsDialog/handleDownloadDigitalFile.ts
+++ b/apps/storefront/src/pages/OrderDetail/components/DownloadDigitalProductsDialog/handleDownloadDigitalFile.ts
@@ -1,0 +1,31 @@
+const getFileNameFromResponseHeader = (headers: Headers): string => {
+  const disposition = headers.get('content-disposition');
+  const dispositionParams = disposition?.split(';') ?? [];
+
+  const filenameParam = dispositionParams.find((param) => param.trim().startsWith('filename='));
+  if (filenameParam) {
+    return JSON.parse(filenameParam.split('=')[1]);
+  }
+  return '';
+};
+
+const handleBlobDownload = (blob: Blob, filename: string) => {
+  const tempLink = document.createElement('a');
+  tempLink.style.display = 'none';
+  tempLink.href = URL.createObjectURL(blob);
+  tempLink.setAttribute('download', filename);
+  document.body.appendChild(tempLink);
+  tempLink.click();
+};
+
+export const handleDownleoadDigitalFile = async (fileUrl: string) => {
+  const res = await fetch(fileUrl);
+  const blob = await res.blob();
+
+  if (blob.type === 'text/html') {
+    throw new Error();
+  }
+
+  const filename = getFileNameFromResponseHeader(res.headers);
+  handleBlobDownload(blob, filename);
+};

--- a/apps/storefront/src/pages/OrderDetail/components/OrderBilling.tsx
+++ b/apps/storefront/src/pages/OrderDetail/components/OrderBilling.tsx
@@ -1,12 +1,15 @@
-import { useContext } from 'react';
+import { useContext, useEffect, useState } from 'react';
 import { Box, Card, CardContent, Stack, Typography } from '@mui/material';
 
 import { B3ProductList } from '@/components';
 import { useMobile } from '@/hooks';
 import { useB3Lang } from '@/lib/lang';
 
-import { OrderBillings } from '../../../types';
+import { Address, OrderProductItem } from '../../../types';
 import { OrderDetailsContext } from '../context/OrderDetailsContext';
+
+import DownloadDigitalProductsDialog from './DownloadDigitalProductsDialog/DownloadDigitalProductsDialog';
+import { getDigitalDownloadElements } from './getDigitalDownloadElements';
 
 type OrderBillingProps = {
   isCurrentCompany: boolean;
@@ -14,16 +17,53 @@ type OrderBillingProps = {
 
 export default function OrderBilling({ isCurrentCompany }: OrderBillingProps) {
   const {
-    state: { billings = [], addressLabelPermission, orderId, money },
+    state: { billingAddress, digitalProducts = [], addressLabelPermission, orderId, money },
   } = useContext(OrderDetailsContext);
 
   const [isMobile] = useMobile();
 
   const b3Lang = useB3Lang();
 
-  const getFullName = (billing: OrderBillings) => {
-    const { billingAddress } = billing;
+  const [digitalProductsWithUrl, setDigitalProductsWithUrl] = useState<OrderProductItem[]>([]);
+  const [currentDigitalProduct, setCurrentDigitalProduct] = useState<OrderProductItem>();
 
+  useEffect(() => {
+    const getDigitalProductsInformation = async (id: number | string) => {
+      const elements = await getDigitalDownloadElements(id);
+
+      if (!elements.length) {
+        return;
+      }
+
+      const digitalProductsData = elements.map((item) => item.node);
+
+      const digitalProductsUrls = digitalProducts.map((product: OrderProductItem) => {
+        const fileUrls =
+          digitalProductsData.find(({ productEntityId }) => productEntityId === product.product_id)
+            ?.downloadFileUrls || [];
+
+        return {
+          ...product,
+          downloadFileUrls: fileUrls,
+        };
+      });
+
+      setDigitalProductsWithUrl(digitalProductsUrls);
+    };
+
+    if (orderId) {
+      getDigitalProductsInformation(orderId);
+    }
+  }, [digitalProducts, orderId]);
+
+  const getCurrentProductUrls = (productId: number | undefined) => {
+    const currentProduct = digitalProductsWithUrl?.find(
+      (product) => product.product_id === productId,
+    );
+    setCurrentDigitalProduct(currentProduct);
+  };
+
+  const getFullName = (billingAddress: Address) => {
     if (billingAddress) {
       const { first_name: firstName, last_name: lastName } = billingAddress;
 
@@ -33,9 +73,7 @@ export default function OrderBilling({ isCurrentCompany }: OrderBillingProps) {
     return '';
   };
 
-  const getFullAddress = (billing: OrderBillings) => {
-    const { billingAddress } = billing;
-
+  const getFullAddress = (billingAddress: Address) => {
     if (billingAddress) {
       const { street_1: street1, city, state, zip, country } = billingAddress;
 
@@ -55,65 +93,69 @@ export default function OrderBilling({ isCurrentCompany }: OrderBillingProps) {
     return company.substring(index + 1, company.length);
   };
 
-  const hasDigitalProducts = billings.some((billing) => billing.digitalProducts.length > 0);
-
-  if (!hasDigitalProducts) {
+  if (!billingAddress) {
     return null;
   }
 
   return (
     <Stack spacing={2}>
-      {billings.map((billingItem: OrderBillings) => (
-        <Card key={`billing-${orderId}`}>
-          <CardContent>
-            <Box
+      <Card key={`billing-${orderId}`}>
+        <CardContent>
+          <Box
+            sx={{
+              wordBreak: 'break-word',
+              color: 'rgba(0, 0, 0, 0.87)',
+            }}
+          >
+            <Typography
+              variant="h6"
               sx={{
-                wordBreak: 'break-word',
-                color: 'rgba(0, 0, 0, 0.87)',
+                fontSize: '24px',
+                fontWeight: '400',
               }}
             >
-              <Typography
-                variant="h6"
-                sx={{
-                  fontSize: '24px',
-                  fontWeight: '400',
-                }}
-              >
-                {getFullName(billingItem)}
-                {' – '}
-                {getCompanyName(billingItem.billingAddress.company || '')}
-              </Typography>
-              <Typography
-                variant="h6"
-                sx={{
-                  fontSize: '24px',
-                  fontWeight: '400',
-                }}
-              >
-                {getFullAddress(billingItem)}
-              </Typography>
-            </Box>
-
-            <Box
+              {getFullName(billingAddress)}
+              {' – '}
+              {getCompanyName(billingAddress.company || '')}
+            </Typography>
+            <Typography
+              variant="h6"
               sx={{
-                margin: '20px 0 2px',
+                fontSize: '24px',
+                fontWeight: '400',
               }}
             >
-              <Typography variant="body1" sx={{ fontWeight: 'bold', color: '#313440' }}>
-                {b3Lang('orderDetail.billing.digitalProducts')}
-              </Typography>
-            </Box>
+              {getFullAddress(billingAddress)}
+            </Typography>
+          </Box>
 
-            <B3ProductList
-              products={billingItem.digitalProducts}
-              totalText="Total"
-              canToProduct={isCurrentCompany}
-              textAlign={isMobile ? 'left' : 'right'}
-              money={money}
-            />
-          </CardContent>
-        </Card>
-      ))}
+          <Box
+            sx={{
+              margin: '20px 0 2px',
+            }}
+          >
+            <Typography variant="body1" sx={{ fontWeight: 'bold', color: '#313440' }}>
+              {b3Lang('orderDetail.billing.digitalProducts')}
+            </Typography>
+          </Box>
+
+          <B3ProductList
+            products={
+              digitalProductsWithUrl.length ? digitalProductsWithUrl : digitalProducts || []
+            }
+            totalText="Total"
+            canToProduct={isCurrentCompany}
+            textAlign={isMobile ? 'left' : 'right'}
+            money={money}
+            getCurrentProductUrls={getCurrentProductUrls}
+          />
+        </CardContent>
+        <DownloadDigitalProductsDialog
+          isOpen={!!currentDigitalProduct}
+          onClose={() => setCurrentDigitalProduct(undefined)}
+          product={currentDigitalProduct}
+        />
+      </Card>
     </Stack>
   );
 }

--- a/apps/storefront/src/pages/OrderDetail/components/getDigitalDownloadElements.ts
+++ b/apps/storefront/src/pages/OrderDetail/components/getDigitalDownloadElements.ts
@@ -1,0 +1,59 @@
+import B3Request from '@/shared/service/request/b3Fetch';
+
+type DigitalProductNode = {
+  downloadFileUrls: string[];
+  downloadPageUrl: string;
+  name: string;
+  productEntityId: number;
+};
+
+type DigitalProduct = {
+  node: DigitalProductNode;
+};
+
+export type DigitalDownloadElementsResponse = {
+  data: {
+    site: {
+      order: {
+        consignments: {
+          downloads: Array<{
+            lineItems: {
+              edges: DigitalProduct[];
+            };
+          }>;
+        };
+      };
+    };
+  };
+};
+
+const getDigitalDownloadLinks = `
+  query GetDigitalDownloadLinks($orderId: Int!) {
+    site {
+      order(filter: {entityId: $orderId}) {
+        consignments {
+          downloads {           
+            lineItems {
+              edges {
+                node {
+                  name
+                  downloadPageUrl
+                  downloadFileUrls
+                  productEntityId
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+export const getDigitalDownloadElements = (orderId: number | string): Promise<DigitalProduct[]> =>
+  B3Request.graphqlBCProxy({
+    query: getDigitalDownloadLinks,
+    variables: { orderId },
+  }).then((res) => {
+    return res.data.site.order.consignments.downloads[0]?.lineItems.edges || [];
+  });

--- a/apps/storefront/src/pages/OrderDetail/context/OrderDetailsContext.tsx
+++ b/apps/storefront/src/pages/OrderDetail/context/OrderDetailsContext.tsx
@@ -1,6 +1,7 @@
 import { createContext, Dispatch, ReactNode, useMemo, useReducer } from 'react';
 
 import {
+  Address,
   CompanyInfoTypes,
   MoneyFormat,
   OrderBillings,
@@ -37,6 +38,8 @@ export interface OrderDetailsState {
   orderIsDigital?: boolean;
   companyInfo?: CompanyInfoTypes;
   customerId?: number;
+  digitalProducts?: OrderProductItem[];
+  billingAddress?: Address;
 }
 interface OrderDetailsAction {
   type: string;
@@ -101,6 +104,21 @@ const initState = {
     companyZipCode: '',
     phoneNumber: '',
     bcId: '',
+  },
+  digitalProducts: [],
+  billingAddress: {
+    city: '',
+    company: '',
+    country: '',
+    country_iso2: '',
+    email: '',
+    first_name: '',
+    last_name: '',
+    phone: '',
+    state: '',
+    street_1: '',
+    street_2: '',
+    zip: '',
   },
 };
 

--- a/apps/storefront/src/pages/OrderDetail/index.tsx
+++ b/apps/storefront/src/pages/OrderDetail/index.tsx
@@ -33,8 +33,6 @@ import {
   OrderShipping,
 } from './components';
 
-const convertBCOrderDetails = convertB2BOrderDetails;
-
 interface LocationState {
   isCompanyOrder: boolean;
 }
@@ -67,7 +65,15 @@ function OrderDetail() {
   } = useContext(GlobalContext);
 
   const {
-    state: { poNumber, status = '', customStatus, orderSummary, orderStatus = [], products },
+    state: {
+      poNumber,
+      status = '',
+      customStatus,
+      orderSummary,
+      orderStatus = [],
+      products,
+      digitalProducts,
+    },
     state: detailsData,
     dispatch,
   } = useContext(OrderDetailsContext);
@@ -124,9 +130,7 @@ function OrderDetail() {
 
             setIsCurrentCompany(Number(companyInfo.companyId) === Number(currentCompanyId));
 
-            const data = isB2BUser
-              ? convertB2BOrderDetails(newOrder, b3Lang)
-              : convertBCOrderDetails(newOrder, b3Lang);
+            const data = convertB2BOrderDetails(newOrder, b3Lang);
             dispatch({
               type: 'all',
               payload: data,
@@ -353,8 +357,7 @@ function OrderDetail() {
             <Stack spacing={3}>
               <OrderShipping isCurrentCompany={isCurrentCompany} />
               {/* Digital Order Display */}
-              <OrderBilling isCurrentCompany={isCurrentCompany} />
-
+              {!!digitalProducts?.length && <OrderBilling isCurrentCompany={isCurrentCompany} />}
               <OrderHistory />
             </Stack>
           </Grid>

--- a/apps/storefront/src/pages/OrderDetail/shared/B2BOrderData.ts
+++ b/apps/storefront/src/pages/OrderDetail/shared/B2BOrderData.ts
@@ -194,9 +194,15 @@ const handleProductQuantity = (data: B2BOrderData) => {
   return newProducts;
 };
 
+const getDigitalProducts = (products: OrderProductItem[]) => {
+  return products.filter((product) => product.type === 'digital');
+};
+
 const convertB2BOrderDetails = (data: B2BOrderData, b3Lang: LangFormatFunction) => ({
   shippings: getOrderShipping(data),
   billings: getOrderBilling(data),
+  digitalProducts: getDigitalProducts(data.products),
+  billingAddress: data.billingAddress || {},
   history: data.orderHistoryEvent || [],
   poNumber: data.poNumber || '',
   status: data.status,

--- a/apps/storefront/src/types/orderDetail.ts
+++ b/apps/storefront/src/types/orderDetail.ts
@@ -194,6 +194,7 @@ export interface B2BOrderData {
   dateShipped: string;
   defaultCurrencyCode: string;
   defaultCurrencyId: number;
+  digitalProducts: OrderProductItem[];
   discountAmount: string;
   ebayOrderId: string;
   firstName: string;

--- a/apps/storefront/src/types/products.ts
+++ b/apps/storefront/src/types/products.ts
@@ -56,6 +56,9 @@ export interface ProductItem {
   inventoryLevel?: number;
   isPriceHidden?: boolean;
   applied_discounts?: AppliedDiscount[];
+  type?: string;
+  product_id?: number;
+  downloadFileUrls?: string[];
 }
 
 interface OptionValue {

--- a/apps/storefront/src/types/shoppingList.ts
+++ b/apps/storefront/src/types/shoppingList.ts
@@ -38,7 +38,6 @@ export interface ShoppingListProductItem extends ProductItem {
   orderQuantityMaximum?: number;
   orderQuantityMinimum?: number;
   variantId?: number | string;
-  type?: string;
 }
 
 export interface ShoppingListAddProductOption {


### PR DESCRIPTION
## What/Why?
Currently the buyer portal does not allow users to download their order's product digital files from the portal, so in order to allow users to download files of digital products from the buyer portal we need to get the downloadUrls provided and offer them a new UI to access the files.

The api currently does not return information related to the max amount limit of order's digital files so I'm addoing a couple of utils to find if the response blob is a type text/html to handle the display of the error for the users.

## Rollout/Rollback
Revert PR

## Testing

https://github.com/user-attachments/assets/68e48cc9-bb8c-4943-9c12-3d1ade323ab1

