### PR TITLE
docs(common): B2B-3452 removing required /assets route in env variable

### DIFF
--- a/docs/headless.md
+++ b/docs/headless.md
@@ -57,10 +57,11 @@ Building your buyer portal application requires you to run the `yarn build` comm
 Make sure that you have configured the following `.env` values correctly before building:
 
 - `VITE_IS_LOCAL_ENVIRONMENT`: Set this to `FALSE`
-- `VITE_ASSETS_ABSOLUTE_PATH`: Set this to the URL where the assets folder is hosted. **Note that this needs to be the absolute URL to the `/assets` folder location where the build will be served from in production.** Also please include the trailing `/`.
-- `VITE_DISABLE_BUILD_HASH`: Set this to `TRUE` if you want to disable the hash in the build files. This is useful if you want to avoid updating the file names in your headless app everytime you deploy or if you are using a CDN that does not support cache busting with hashes.
+- `VITE_ASSETS_ABSOLUTE_PATH`: Set this to the URL where the assets folder is hosted. Also please include the trailing `/`.
 
-  For example, if you deploy the contents of the `dist` folder built by running `yarn build` and hosted it at https://my.custom.cdn/generated/b2b, the value you should put is https://my.custom.cdn/generated/b2b/assets/.
+  For example, if you deploy the contents of the `dist` folder built by running `yarn build` and hosted it at https://my.custom.cdn/generated/b2b, the value you should put is https://my.custom.cdn/generated/b2b/.
+
+- `VITE_DISABLE_BUILD_HASH`: Set this to `TRUE` if you want to disable the hash in the build files. This is useful if you want to avoid updating the file names in your headless app on each deployment and you would like to have a stable reference.
 
 Environment variables have been updated so you can run your UI directly into production storefronts.
 

--- a/docs/stencil.md
+++ b/docs/stencil.md
@@ -74,9 +74,11 @@ Building your buyer portal application requires you to run the `yarn build` comm
 
 Make sure that you have configured the following `.env` values correctly before building:
 - `VITE_IS_LOCAL_ENVIRONMENT`: Set this to `FALSE`
-- `VITE_ASSETS_ABSOLUTE_PATH`: Set this to the URL where the assets folder is hosted. **Note that this needs to be the absolute URL to the `/assets` folder location where the build will be served from in production.** Also please include the trailing `/`.
+- `VITE_ASSETS_ABSOLUTE_PATH`: Set this to the URL where the assets folder is hosted. Also please include the trailing `/`.
 
-  For example, if you deploy the contents of the `dist` folder built by running `yarn build` and hosted it at https://my.custom.cdn/generated/b2b, the value you should put is https://my.custom.cdn/generated/b2b/assets/.
+  For example, if you deploy the contents of the `dist` folder built by running `yarn build` and hosted it at https://my.custom.cdn/generated/b2b, the value you should put is https://my.custom.cdn/generated/b2b/.
+
+- `VITE_DISABLE_BUILD_HASH`: Set this to `TRUE` if you want to disable the hash in the build files. This is useful if you want to avoid updating the file names in your headless app on each deployment and you would like to have a stable reference. 
 
 Once you have uploaded the contents of the `dist` folder to your hosting provider, you need to update your scripts in your BigCommerce storefront that points to the newly uploaded files.
 


### PR DESCRIPTION
Jira: [B2B-3452](https://bigcommercecloud.atlassian.net/browse/B2B-3452)

## What/Why?
Removing all references to the `/assets` route for the VITE_ASSETS_ABSOLUTE_PATH from the documentation since we no longer need this in our build process.

## Rollout/Rollback
Revert

## Testing
Build success:
<img width="1128" height="467" alt="Screenshot 2025-09-03 at 5 15 08 p m" src="https://github.com/user-attachments/assets/620f58e9-6cd8-4941-935c-2e8124e9a87c" />

Deployed build:
https://test-store-w2.mybigcommerce.com/

[B2B-3452]: https://bigcommercecloud.atlassian.net/browse/B2B-3452?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ