### PR TITLE
fix(quotes): B2B-3325 Remove validation warning snackbar on PDP

### DIFF
--- a/apps/storefront/src/hooks/dom/utils.test.ts
+++ b/apps/storefront/src/hooks/dom/utils.test.ts
@@ -664,7 +664,7 @@ describe('addProductFromProductPageToQuote', () => {
       expect(addQuoteDraftProduce).not.toHaveBeenCalled();
     });
 
-    it('adds product and shows warning when validateProduct returns a warning', async () => {
+    it('adds product successfully when validateProduct returns a warning', async () => {
       createDOM({ productId: 123, qty: 1, sku: 'SKU123' });
 
       when(searchProduct)
@@ -705,7 +705,6 @@ describe('addProductFromProductPageToQuote', () => {
       );
       await addToQuote();
 
-      expect(globalSnackbar.warning).toHaveBeenCalledWith('test');
       expect(addQuoteDraftProduce).toHaveBeenCalled();
     });
 

--- a/apps/storefront/src/hooks/dom/utils.ts
+++ b/apps/storefront/src/hooks/dom/utils.ts
@@ -292,10 +292,6 @@ const addProductFromProductPageToQuote = (
 
           return;
         }
-
-        if (responseType === 'WARNING') {
-          globalSnackbar.warning(message);
-        }
       } else if (!isEnableProduct) {
         const currentProduct = getVariantInfoOOSAndPurchase({
           ...productsSearch[0],


### PR DESCRIPTION
Jira: [B2B-3325](https://bigcommercecloud.atlassian.net/browse/B2B-3325)

## What/Why?
<!--
  A description about what this pull request implements and its purpose.
  Try to be detailed and describe any technical details to simplify the job
  of the reviewer and the individual on production support.
-->
This PR removes the warning snackbar message from the product validation endpoint. We should just add the product to the quote successfully without showing warnings to the buyer. This change is gated behind the backordering feature flag.

## Rollout/Rollback
<!--
Detail how this change will be rolled out. Include reference to any
experiments and how the success will be measured as the experiment is
ramped.

Document rollback procedures. Is rolling back the change as simple as
rolling back an experiment or does it require reverting code? Are there
database migrations that may change our decision to roll forward instead of
back?
-->
Revert and redeploy.

## Testing
<!--
Provide as much information as you can about how you tested and how another
Engineer can test your change. Include screenshots, or test run output
where appropriate.
-->
Before:

https://github.com/user-attachments/assets/d9aaed4d-a89e-4af7-bb62-59d137ac5f9d

After:

https://github.com/user-attachments/assets/98cc46d1-00c1-40c5-9187-ba91b9beb016



[B2B-3325]: https://bigcommercecloud.atlassian.net/browse/B2B-3325?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ