### PR TITLE
feat(register): B2B-3501 Rename redirectTo=checkout to redirectTo=check-out

### DIFF
--- a/apps/storefront/src/pages/Registered/index.tsx
+++ b/apps/storefront/src/pages/Registered/index.tsx
@@ -240,7 +240,7 @@ function Registered(props: PageProps) {
 
         if (platform === 'catalyst') {
           const landingLoginLocation =
-            params.get('redirectTo') === 'checkout'
+            params.get('redirectTo') === 'check-out'
               ? LOGIN_LANDING_LOCATIONS.CHECKOUT
               : loginLandingLocation;
 


### PR DESCRIPTION
Jira: [B2B-3501](https://bigcommercecloud.atlassian.net/browse/B2B-3501)

## What/Why?
There's a conflict with old versions of the buyer portal, where `checkout` in the url will close the buyer portal instead of opening the registration page.

## Rollout/Rollback
Revert

## Testing
Sibling:
 - https://github.com/b3bc-external/b2b-checkout-app/pull/387
