### PR TITLE
feat(register): B2B-3501 Honour `?redirectTo=check-out after registration (second try)

### DIFF
--- a/apps/storefront/src/App.tsx
+++ b/apps/storefront/src/App.tsx
@@ -120,7 +120,7 @@ export default function App() {
   // open storefront
   useSetOpen(isOpen, openUrl, params);
 
-  const { pathname, href, search } = window.location;
+  const { pathname, search } = window.location;
 
   const loginAndRegister = () => {
     dispatch({
@@ -130,7 +130,7 @@ export default function App() {
       },
     });
 
-    if (pathname.includes('login.php') && !href.includes('change_password')) {
+    if (pathname.includes('login.php') && !search.includes('change_password')) {
       dispatch({
         type: 'common',
         payload: {
@@ -202,7 +202,7 @@ export default function App() {
       }
 
       // background login enter judgment and refresh
-      if (!href.includes('checkout') && !(customerId && !window.location.hash)) {
+      if (!pathname.includes('checkout') && !(customerId && !window.location.hash)) {
         await gotoAllowedAppPage(Number(userInfo.role), gotoPage);
       } else {
         showPageMask(false);

--- a/apps/storefront/src/constants/index.ts
+++ b/apps/storefront/src/constants/index.ts
@@ -107,6 +107,7 @@ export const PAGES_SUBSIDIARIES_PERMISSION_KEYS = [
 ] as const;
 
 export const LOGIN_LANDING_LOCATIONS = {
-  HOME: '1',
   BUYER_PORTAL: '0',
+  HOME: '1',
+  CHECKOUT: '2',
 };

--- a/apps/storefront/src/pages/Registered/index.tsx
+++ b/apps/storefront/src/pages/Registered/index.tsx
@@ -1,5 +1,5 @@
 import { useContext, useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import { Box, ImageListItem } from '@mui/material';
 
 import b2bLogo from '@/assets/b2bLogo.png';
@@ -46,6 +46,8 @@ function Registered(props: PageProps) {
   const navigate = useNavigate();
 
   const IframeDocument = useAppSelector(themeFrameSelector);
+  const loginLandingLocation = useAppSelector(({ global }) => global.loginLandingLocation);
+  const [params] = useSearchParams();
 
   const { isCheckout, isCloseGotoBCHome, logo, registerEnabled } = useContext(GlobalContext).state;
 
@@ -236,21 +238,24 @@ function Registered(props: PageProps) {
 
         clearRegisterInfo();
 
-        const isLoginLandLocation = loginJump(navigate);
-
         if (platform === 'catalyst') {
-          const landingLoginLocation = isLoginLandLocation
-            ? LOGIN_LANDING_LOCATIONS.HOME
-            : LOGIN_LANDING_LOCATIONS.BUYER_PORTAL;
+          const landingLoginLocation =
+            params.get('redirectTo') === 'check-out'
+              ? LOGIN_LANDING_LOCATIONS.CHECKOUT
+              : loginLandingLocation;
 
           window.b2b.callbacks.dispatchEvent('on-registered', {
             email,
             password,
             landingLoginLocation,
           });
+
           window.location.hash = '';
+
           return;
         }
+
+        const isLoginLandLocation = loginJump(navigate);
 
         if (!isLoginLandLocation) return;
 

--- a/apps/storefront/src/shared/routes/index.tsx
+++ b/apps/storefront/src/shared/routes/index.tsx
@@ -159,7 +159,7 @@ const gotoAllowedAppPage = async (
     b2bLogger.error(err);
   }
 
-  let url = hash.split('#')[1] || '';
+  let url = hash.substring(1);
 
   if ((!url && role !== CustomerRole.GUEST && pathname.includes('account.php')) || isAccountEnter) {
     let isB2BUser = false;
@@ -186,9 +186,10 @@ const gotoAllowedAppPage = async (
         break;
     }
   }
+  const [realPath] = url.split('?');
 
   const flag = routes.some((item: RouteItem) => {
-    if (matchPath(item.path, url) || isInvoicePage()) {
+    if (matchPath(item.path, realPath) || isInvoicePage()) {
       return item.permissions.includes(Number(role));
     }
     return false;
@@ -198,7 +199,7 @@ const gotoAllowedAppPage = async (
     if (url.includes('/login?') || url.includes('payment')) {
       return true;
     }
-    return matchPath(item.path, url);
+    return matchPath(item.path, realPath);
   });
   if (flag || isFirstLevelFlag) gotoPage(url);
 };

--- a/commit-validation.json
+++ b/commit-validation.json
@@ -17,6 +17,7 @@
     "company-hierarchy",
     "company-orders",
     "invoices",
-    "invoice-payment"
+    "invoice-payment",
+    "register"
   ]
 }


### PR DESCRIPTION


Jira: [B2B-3501](https://bigcommercecloud.atlassian.net/browse/B2B-3501)

## What/Why?
This commit redirects the user back to checkout when the `redirectTo=check-out` param is present.

This enhances the flow where a user click "create account" in checkout, as it takes them back to where they were after registration.

As part of this same change, we've tighten the detection of certain scenarios, making sure we avoid certain false~positives when detecting checkout/change_password/etc.

This is the second attempt at trying to honour the `redirectTo` query param in buyer portal to redirect users back to checkout.

In the previous attempt, the pathname was set to `/` even if there was no original hash in the url, this caused a `/#/` to always show.

This commit minimised the amount of change to `routes/index.tsx` but ensures the query param is usable.

## Rollout/Rollback
Revert

## Testing

https://github.com/user-attachments/assets/6cd57ae1-9616-43d7-aa4a-93475760d683




# No `#/` gets added.

https://github.com/user-attachments/assets/d4cb0bde-84d5-4806-8da5-b69e61139c5c




[B2B-3501]: https://bigcommercecloud.atlassian.net/browse/B2B-3501?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ