### PR TITLE
fix(quotes): B2B-3531 fix for product variants showing $ symbol in quote details page 

### DIFF
--- a/apps/storefront/src/pages/quote/components/QuoteDetailTable.tsx
+++ b/apps/storefront/src/pages/quote/components/QuoteDetailTable.tsx
@@ -189,7 +189,7 @@ function QuoteDetailTable(props: ShoppingDetailTableProps, ref: Ref<unknown>) {
                           }}
                           key={`${option.optionId}_${option.optionName}_${option.optionLabel}`}
                         >
-                          ${option.optionName}: ${option.optionLabel}
+                          {option.optionName}: {option.optionLabel}
                         </Typography>
                       ),
                   )}


### PR DESCRIPTION
Jira: [B2B-3531](https://bigcommercecloud.atlassian.net/browse/B2B-3531)

## What/Why?
$ symbol showing in front of product variants and values in account details page

## Rollout/Rollback
Revert

## Demo
<img width="624" height="285" alt="Screenshot 2025-09-25 at 4 13 16 pm" src="https://github.com/user-attachments/assets/9d287303-e3b7-4141-b4fb-74ecacabf635" />

Note: Code was removed in this [commit](https://github.com/bigcommerce/b2b-buyer-portal/commit/a5ec5e96671cafd128b9c727009b0894270c9cf9)

[B2B-3531]: https://bigcommercecloud.atlassian.net/browse/B2B-3531?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ