### PR TITLE
feat(quotes): B2B-3554 getting available to sell and unlimited backorder values from backend

### DIFF
--- a/apps/storefront/src/hooks/dom/utils.test.ts
+++ b/apps/storefront/src/hooks/dom/utils.test.ts
@@ -185,6 +185,8 @@ const buildSearchB2BProductWith = builder<SearchB2BProduct>(() => ({
   productUrl: faker.internet.url(),
   taxClassId: faker.number.int({ min: 1 }),
   isPriceHidden: faker.datatype.boolean(),
+  availableToSell: faker.number.int({ min: 1 }),
+  unlimitedBackorder: faker.datatype.boolean(),
 }));
 
 const buildValidateProductWith = builder<ValidateProduct>(() => ({

--- a/apps/storefront/src/pages/QuickOrder/index.main.test.tsx
+++ b/apps/storefront/src/pages/QuickOrder/index.main.test.tsx
@@ -185,6 +185,8 @@ const buildSearchProductWith = builder<SearchProduct>(() => ({
   productUrl: faker.internet.url(),
   taxClassId: faker.number.int(),
   isPriceHidden: faker.datatype.boolean(),
+  availableToSell: faker.number.int({ min: 0, max: 20 }),
+  unlimitedBackorder: faker.datatype.boolean(),
 }));
 
 const buildGetRecentlyOrderedProductsWith = builder<RecentlyOrderedProductsResponse>(() => {

--- a/apps/storefront/src/pages/QuickOrder/index.quickpad.test.tsx
+++ b/apps/storefront/src/pages/QuickOrder/index.quickpad.test.tsx
@@ -151,6 +151,8 @@ const buildSearchProductWith = builder<SearchProduct>(() => ({
   productUrl: faker.internet.url(),
   taxClassId: faker.number.int(),
   isPriceHidden: faker.datatype.boolean(),
+  availableToSell: faker.number.int({ min: 0, max: 20 }),
+  unlimitedBackorder: faker.datatype.boolean(),
 }));
 
 const buildGetCartWith = builder<GetCart>(() => {

--- a/apps/storefront/src/pages/QuoteDraft/index.test.tsx
+++ b/apps/storefront/src/pages/QuoteDraft/index.test.tsx
@@ -282,6 +282,8 @@ const buildSearchProductWith = builder<SearchProduct>(() => ({
   productUrl: faker.internet.url(),
   taxClassId: faker.number.int(),
   isPriceHidden: faker.datatype.boolean(),
+  availableToSell: faker.number.int({ min: 0, max: 20 }),
+  unlimitedBackorder: faker.datatype.boolean(),
 }));
 
 const buildVariantInfoWith = builder<VariantInfo>(() => ({
@@ -1282,6 +1284,63 @@ describe('when the user is a B2B customer', () => {
       const productTable = await screen.findByRole('table');
 
       expect(within(productTable).queryByText('Insufficient stock')).not.toBeInTheDocument();
+    });
+
+    it('does show stock warning in the product table if inventory tracking is enabled and quantity exceeds stock', async () => {
+      const alabama = { stateName: 'Alabama', stateCode: 'AL' };
+      const usa = { id: '226', countryName: 'United States', countryCode: 'US', states: [alabama] };
+
+      server.use(
+        graphql.query('Countries', () => HttpResponse.json({ data: { countries: [usa] } })),
+        graphql.query('Addresses', () =>
+          HttpResponse.json({ data: { addresses: { totalCount: 0, edges: [] } } }),
+        ),
+        graphql.query('getQuoteExtraFields', () =>
+          HttpResponse.json({ data: { quoteExtraFieldsConfig: [] } }),
+        ),
+      );
+
+      const product = buildDraftQuoteItemWith({
+        node: {
+          quantity: 10,
+          variantSku: 'LC-123',
+          productsSearch: buildProductWith({
+            inventoryLevel: 10,
+            inventoryTracking: 'product',
+            variants: [
+              buildVariantWith({ inventory_level: 10, purchasing_disabled: false, sku: 'LC-123' }),
+            ],
+            availableToSell: 5,
+            unlimitedBackorder: false,
+          }),
+        },
+      });
+
+      const quoteInfo = buildQuoteInfoStateWith({
+        draftQuoteInfo: {
+          // email is checked on save and must match the company.customer in state for the save to succeed
+          contactInfo: { email: customerEmail },
+          billingAddress: noAddress,
+          shippingAddress: noAddress,
+        },
+        draftQuoteList: [product],
+      });
+
+      renderWithProviders(<QuoteDraft setOpenPage={vi.fn()} />, {
+        preloadedState: {
+          ...preloadedState,
+          quoteInfo,
+          global: buildGlobalStateWith({
+            blockPendingQuoteNonPurchasableOOS: { isEnableProduct: false },
+            featureFlags,
+          }),
+        },
+      });
+
+      const productTable = await screen.findByRole('table');
+
+      expect(within(productTable).getByText('Insufficient stock')).toBeInTheDocument();
+      expect(within(productTable).getByText('In stock: 5')).toBeInTheDocument();
     });
 
     it('creates successfully a new quote when submitting the draft quote and gets redirected to quote detail', async () => {

--- a/apps/storefront/src/pages/ShoppingListDetails/components/ReAddToCart.tsx
+++ b/apps/storefront/src/pages/ShoppingListDetails/components/ReAddToCart.tsx
@@ -433,7 +433,7 @@ export default function ReAddToCart(props: ShoppingProductsProps) {
                 </Flex>
               )}
               {products.map((product: ProductsProps, index: number) => {
-                const { isStock, maxQuantity, minQuantity, stock } = product;
+                const { isStock, maxQuantity, minQuantity, stock, node } = product;
 
                 const {
                   quantity = 1,
@@ -498,8 +498,8 @@ export default function ReAddToCart(props: ShoppingProductsProps) {
                     <FlexItem {...itemStyle.default} textAlignLocation={textAlign}>
                       <B3QuantityTextField
                         isStock={isStock}
-                        maxQuantity={maxQuantity}
-                        minQuantity={minQuantity}
+                        maxQuantity={maxQuantity || node.productsSearch?.orderQuantityMaximum}
+                        minQuantity={minQuantity || node.productsSearch?.orderQuantityMinimum}
                         stock={stock}
                         value={quantity}
                         onChange={(value, isValid) => {

--- a/apps/storefront/src/pages/ShoppingListDetails/components/ShoppingDetailFooter.tsx
+++ b/apps/storefront/src/pages/ShoppingListDetails/components/ShoppingDetailFooter.tsx
@@ -298,8 +298,20 @@ function ShoppingDetailFooter(props: ShoppingDetailFooterProps) {
     const items = checkedArr.map(({ node }: ProductsProps) => {
       return { node };
     });
+
+    let updatedItems = [];
     try {
       const skus = items.map(({ node }: ProductsProps) => node.variantSku);
+
+      updatedItems = items.map((item: ProductsProps) => {
+        return {
+          ...item,
+          isStock: item?.node?.productsSearch?.inventoryTracking === 'none' ? '0' : '1',
+          minQuantity: item?.node?.productsSearch?.orderQuantityMinimum,
+          maxQuantity: item?.node?.productsSearch?.orderQuantityMaximum,
+          stock: item?.node?.productsSearch?.availableToSell,
+        };
+      });
 
       if (skus.length === 0) {
         snackbar.error(
@@ -324,12 +336,13 @@ function ShoppingDetailFooter(props: ShoppingDetailFooterProps) {
       shouldRedirectCheckout();
     } catch (e: unknown) {
       if (e instanceof Error) {
-        setValidateFailureProducts(items);
+        setValidateFailureProducts(updatedItems);
         snackbar.error(e.message);
       }
     } finally {
       setLoading(false);
     }
+
     setValidateSuccessProducts(items);
   };
 

--- a/apps/storefront/src/pages/ShoppingListDetails/index.test.tsx
+++ b/apps/storefront/src/pages/ShoppingListDetails/index.test.tsx
@@ -230,6 +230,8 @@ const buildSearchB2BProductWith = builder<SearchB2BProduct>(() => ({
   productUrl: faker.internet.url(),
   taxClassId: faker.number.int(),
   isPriceHidden: faker.datatype.boolean(),
+  availableToSell: faker.number.int(),
+  unlimitedBackorder: faker.datatype.boolean(),
 }));
 
 const buildSearchProductsResponseWith = builder<SearchProductsResponse>(() => ({
@@ -1837,6 +1839,8 @@ describe('when backend validation is enabled', () => {
           ],
         }),
       ],
+      availableToSell: 1,
+      inventoryTracking: 'product',
     });
 
     const searchProductsQuerySpy = vi.fn();
@@ -1899,6 +1903,8 @@ describe('when backend validation is enabled', () => {
     await screen.findByText('Lovely socks, out of stock');
     await screen.findByText('1 product(s) were not added to cart, please change the quantity');
 
+    await screen.findByText('1 in stock');
+
     spy.mockRestore();
   });
 
@@ -1956,6 +1962,10 @@ describe('when backend validation is enabled', () => {
           ],
         }),
       ],
+      orderQuantityMaximum: 6,
+      orderQuantityMinimum: 3,
+      availableToSell: 10,
+      inventoryTracking: 'product',
     });
 
     const searchProductsQuerySpy = vi.fn();
@@ -2025,6 +2035,8 @@ describe('when backend validation is enabled', () => {
     );
     await screen.findByText('1 product(s) were not added to cart, please change the quantity');
 
+    await screen.findByText('Min is 3');
+
     spy.mockRestore();
   });
 
@@ -2056,7 +2068,7 @@ describe('when backend validation is enabled', () => {
         basePrice: '49.00',
         tax: '0.00',
         discount: '0.00',
-        quantity: 4,
+        quantity: 7,
         optionList: JSON.stringify([
           { valueLabel: 'color', valueText: 'red' },
           { valueLabel: 'size', valueText: 'large' },
@@ -2082,6 +2094,10 @@ describe('when backend validation is enabled', () => {
           ],
         }),
       ],
+      orderQuantityMaximum: 6,
+      orderQuantityMinimum: 3,
+      availableToSell: 10,
+      inventoryTracking: 'product',
     });
 
     const searchProductsQuerySpy = vi.fn();
@@ -2134,7 +2150,7 @@ describe('when backend validation is enabled', () => {
     const row = screen.getByRole('row', { name: /Lovely socks/ });
 
     expect(within(row).getByText('Lovely socks')).toBeInTheDocument();
-    expect(within(row).getByRole('cell', { name: '4' })).toBeInTheDocument();
+    expect(within(row).getByRole('cell', { name: '7' })).toBeInTheDocument();
 
     const checkbox = within(row).getByRole('checkbox');
 
@@ -2147,6 +2163,131 @@ describe('when backend validation is enabled', () => {
     await userEvent.click(screen.getByRole('menuitem', { name: /Add selected to cart/ }));
 
     await screen.findByText('1 product(s) were not added to cart, please change the quantity');
+
+    await screen.findByText('Max is 6');
+
+    spy.mockRestore();
+  });
+
+  it('it renders out of stock message on exceeded product inventory', async () => {
+    vitest.mocked(useParams).mockReturnValue({ id: '272989' });
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const getVariantInfoBySkus = vi.fn();
+
+    const variantInfo = buildVariantInfoWith({
+      variantSku: 'LVLY-SK-123',
+      minQuantity: 0,
+      purchasingDisabled: '0',
+      isStock: '1',
+      stock: 1,
+    });
+
+    when(getVariantInfoBySkus)
+      .calledWith(expect.stringContaining('variantSkus: ["LVLY-SK-123"]'))
+      .thenDo(() => buildVariantInfoResponseWith({ data: { variantSku: [variantInfo] } }));
+
+    const lovelySocksProductEdge = buildShoppingListProductEdgeWith({
+      node: {
+        productName: 'Lovely socks',
+        productId: 73737,
+        variantSku: 'LVLY-SK-123',
+        productNote: 'Decorative wool socks',
+        primaryImage: 'https://example.com/socks.jpg',
+        basePrice: '49.00',
+        tax: '0.00',
+        discount: '0.00',
+        quantity: 2,
+        optionList: JSON.stringify([
+          { valueLabel: 'color', valueText: 'red' },
+          { valueLabel: 'size', valueText: 'large' },
+        ]),
+      },
+    });
+
+    const shoppingListResponse = buildShoppingListGraphQLResponseWith({
+      data: {
+        shoppingList: { products: { totalCount: 1, edges: [lovelySocksProductEdge] }, status: 0 },
+      },
+    });
+
+    const lovelySocksSearchProduct = buildSearchB2BProductWith({
+      id: lovelySocksProductEdge.node.productId,
+      name: lovelySocksProductEdge.node.productName,
+      isPriceHidden: false,
+      optionsV3: [
+        buildSearchB2BProductV3OptionWith({
+          display_name: 'Size',
+          option_values: [
+            buildSearchB2BProductV3OptionValueWith({ label: 'large', is_default: true }),
+          ],
+        }),
+      ],
+      availableToSell: 0,
+      inventoryTracking: 'product',
+    });
+
+    const searchProductsQuerySpy = vi.fn();
+    server.use(
+      graphql.query('B2BShoppingListDetails', async () => HttpResponse.json(shoppingListResponse)),
+      graphql.query('SearchProducts', ({ query }) => {
+        searchProductsQuerySpy(query);
+
+        return HttpResponse.json(
+          buildSearchProductsResponseWith({ data: { productsSearch: [lovelySocksSearchProduct] } }),
+        );
+      }),
+      graphql.query('GetVariantInfoBySkus', ({ query }) =>
+        HttpResponse.json(getVariantInfoBySkus(query)),
+      ),
+      graphql.query('getCart', () =>
+        HttpResponse.json<GetCart>({ data: { site: { cart: null } } }),
+      ),
+      graphql.mutation('createCartSimple', () =>
+        HttpResponse.json({
+          data: { cart: { createCart: null } },
+          errors: [{ message: 'Lovely socks, out of stock' }],
+        }),
+      ),
+    );
+
+    renderWithProviders(<ShoppingListDetailsContent setOpenPage={() => {}} />, {
+      preloadedState: {
+        company: b2bCompanyWithShoppingListPermissions,
+        global: buildGlobalStateWith({
+          featureFlags: {
+            'B2B-3318.move_stock_and_backorder_validation_to_backend': true,
+          },
+        }),
+      },
+      initialGlobalContext: { productQuoteEnabled: true, shoppingListEnabled: true },
+    });
+
+    await waitForElementToBeRemoved(() => screen.queryByText(/loading/i));
+
+    expect(searchProductsQuerySpy).toHaveBeenCalledWith(
+      expect.stringContaining('productIds: [73737]'),
+    );
+
+    const row = screen.getByRole('row', { name: /Lovely socks/ });
+
+    expect(within(row).getByText('Lovely socks')).toBeInTheDocument();
+    expect(within(row).getByRole('cell', { name: '2' })).toBeInTheDocument();
+
+    const checkbox = within(row).getByRole('checkbox');
+
+    await userEvent.click(checkbox);
+
+    expect(within(row).getByRole('checkbox')).toBeChecked();
+
+    await userEvent.click(screen.getByRole('button', { name: /Add selected to/ }));
+
+    await userEvent.click(screen.getByRole('menuitem', { name: /Add selected to cart/ }));
+
+    await screen.findByText('Lovely socks, out of stock');
+    await screen.findByText('1 product(s) were not added to cart, please change the quantity');
+
+    await screen.findByText('Out of stock');
 
     spy.mockRestore();
   });

--- a/apps/storefront/src/pages/quote/components/QuoteTable.tsx
+++ b/apps/storefront/src/pages/quote/components/QuoteTable.tsx
@@ -217,6 +217,7 @@ function QuoteTable(props: ShoppingDetailTableProps) {
           selectOptions: row.optionList,
         };
         const productFields = getProductOptionsFields(product, {});
+        const isInventoryTrackingEnabled = product.inventoryTracking !== 'none';
 
         const optionList = JSON.parse(row.optionList);
         const optionsValue: CustomFieldItems[] = productFields.filter((item) => item.valueText);
@@ -249,6 +250,14 @@ function QuoteTable(props: ShoppingDetailTableProps) {
             } else {
               warningMessage = b3Lang('quoteDraft.quoteTable.unavailable.tip');
             }
+          }
+        } else if (!product.unlimitedBackorder) {
+          const productStock = isInventoryTrackingEnabled ? product.availableToSell : row.quantity;
+          if (isInventoryTrackingEnabled && productStock <= row.quantity) {
+            warningMessage = b3Lang('quoteDraft.quoteTable.outOfStock.tip');
+            warningDetails = b3Lang('quoteDraft.quoteTable.oosNumber.tip', {
+              qty: productStock,
+            });
           }
         }
 

--- a/apps/storefront/src/shared/service/b2b/graphql/product.ts
+++ b/apps/storefront/src/shared/service/b2b/graphql/product.ts
@@ -79,6 +79,8 @@ const getSearchProductsQuery = (data: CustomFieldItems) => `
       productUrl,
       taxClassId,
       isPriceHidden,
+      availableToSell,
+      unlimitedBackorder,
     }
   }
 `;
@@ -282,6 +284,8 @@ export interface SearchProductsResponse {
       productUrl: string;
       taxClassId: number;
       isPriceHidden: boolean;
+      availableToSell: number | null;
+      unlimitedBackorder: boolean | null;
     }>;
   };
 }


### PR DESCRIPTION
## What/Why?

- I'm using the new availableToSell and umlimitedBackorder keys from searchProducts to update the soft validations strings in the QuoteTable and shopping list errored panel. Validations cover the different scenarios such as Min and Max quantity values for each product, if is out of stock and display the value of stock in case the user is setting a bigger quantity of the current stock value.
- I also updated the current warning stock message in the QuoteTable to use the availableToSell key so is compatible with backordered products.

## Rollout/Rollback
Revert

## Testing
WIP