### PR TITLE
fix(carts): B2B-3701 fix sls to cart success and error messages

### DIFF
--- a/apps/storefront/src/pages/ShoppingListDetails/components/ReAddToCart.test.tsx
+++ b/apps/storefront/src/pages/ShoppingListDetails/components/ReAddToCart.test.tsx
@@ -1,0 +1,307 @@
+import { ReactNode } from 'react';
+import { renderWithProviders, screen } from 'tests/test-utils';
+import { vi } from 'vitest';
+
+import ReAddToCart from './ReAddToCart';
+
+interface TranslationParams {
+  successProducts?: number;
+  quantity?: number;
+}
+
+const mockB3Lang = vi.fn((key: string, params?: TranslationParams) => {
+  const translations: { [key: string]: string } = {
+    'shoppingList.reAddToCart.productsCanCheckout': `${params?.successProducts} products can checkout`,
+    'shoppingList.reAddToCart.productsAddedToCart': `${params?.successProducts} products added to cart`,
+    'shoppingList.reAddToCart.productsCantCheckout': `${params?.quantity} products can't checkout`,
+    'shoppingList.reAddToCart.productsNotAddedToCart': `${params?.quantity} products not added to cart`,
+  };
+  return translations[key] || key;
+});
+
+vi.mock('@/lib/lang', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/lang')>();
+  return {
+    ...actual,
+    useB3Lang: () => mockB3Lang,
+  };
+});
+
+vi.mock('@/hooks', () => ({
+  useMobile: () => [false],
+}));
+
+interface B3QuantityTextFieldProps {
+  onChange?: (value: number | string, isValid: boolean) => void;
+}
+
+vi.mock('@/components', () => ({
+  B3QuantityTextField: ({ onChange }: B3QuantityTextFieldProps) => (
+    <input data-testid="quantity-field" onChange={(e) => onChange?.(e.target.value, true)} />
+  ),
+}));
+
+interface B3DialogProps {
+  children: ReactNode;
+  isOpen: boolean;
+}
+
+vi.mock('@/components/B3Dialog', () => ({
+  default: ({ children, isOpen }: B3DialogProps) =>
+    isOpen ? <div data-testid="dialog">{children}</div> : null,
+}));
+
+interface CustomButtonProps {
+  children: ReactNode;
+  onClick?: () => void;
+}
+
+vi.mock('@/components/button/CustomButton', () => ({
+  default: ({ children, onClick }: CustomButtonProps) => (
+    <button type="button" onClick={onClick}>
+      {children}
+    </button>
+  ),
+}));
+
+interface B3SpinProps {
+  children: ReactNode;
+}
+
+vi.mock('@/components/spin/B3Spin', () => ({
+  default: ({ children }: B3SpinProps) => <div>{children}</div>,
+}));
+
+describe('ReAddToCart - Conditional Alert Rendering', () => {
+  const mockSetValidateFailureProducts = vi.fn();
+  const mockSetValidateSuccessProducts = vi.fn();
+
+  const defaultProps = {
+    shoppingListInfo: { status: 30 },
+    role: 0,
+    allowJuniorPlaceOrder: false,
+    setValidateFailureProducts: mockSetValidateFailureProducts,
+    setValidateSuccessProducts: mockSetValidateSuccessProducts,
+    textAlign: 'left',
+    backendValidationEnabled: false,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('Success Alert conditional rendering', () => {
+    it('should display success alert when successProducts is greater than 0', () => {
+      const products = [
+        {
+          node: {
+            quantity: 2,
+            primaryImage: 'test.jpg',
+            productName: 'Test Product',
+            variantSku: 'SKU123',
+            optionList: '[]',
+            productsSearch: {},
+            basePrice: '10.00',
+          },
+          isValid: true,
+        },
+      ];
+
+      renderWithProviders(
+        <ReAddToCart {...defaultProps} products={products} successProducts={5} />,
+      );
+
+      expect(screen.getByText('5 products added to cart')).toBeInTheDocument();
+    });
+
+    it('should NOT display success alert when successProducts is 0', () => {
+      const products = [
+        {
+          node: {
+            quantity: 2,
+            primaryImage: 'test.jpg',
+            productName: 'Test Product',
+            variantSku: 'SKU123',
+            optionList: '[]',
+            productsSearch: {},
+            basePrice: '10.00',
+          },
+          isValid: true,
+        },
+      ];
+
+      renderWithProviders(
+        <ReAddToCart {...defaultProps} products={products} successProducts={0} />,
+      );
+
+      expect(screen.queryByText(/products added to cart/)).not.toBeInTheDocument();
+    });
+
+    it('should display success alert with checkout message when allowJuniorPlaceOrder is true and successProducts > 0', () => {
+      const products = [
+        {
+          node: {
+            quantity: 2,
+            primaryImage: 'test.jpg',
+            productName: 'Test Product',
+            variantSku: 'SKU123',
+            optionList: '[]',
+            productsSearch: {},
+            basePrice: '10.00',
+          },
+          isValid: true,
+        },
+      ];
+
+      renderWithProviders(
+        <ReAddToCart
+          {...defaultProps}
+          products={products}
+          successProducts={3}
+          allowJuniorPlaceOrder
+        />,
+      );
+
+      expect(screen.getByText('3 products can checkout')).toBeInTheDocument();
+    });
+  });
+
+  describe('Error Alert conditional rendering', () => {
+    it('should display error alert when products array has items', () => {
+      const products = [
+        {
+          node: {
+            quantity: 2,
+            primaryImage: 'test.jpg',
+            productName: 'Test Product',
+            variantSku: 'SKU123',
+            optionList: '[]',
+            productsSearch: {},
+            basePrice: '10.00',
+          },
+          isValid: true,
+        },
+        {
+          node: {
+            quantity: 1,
+            primaryImage: 'test2.jpg',
+            productName: 'Test Product 2',
+            variantSku: 'SKU456',
+            optionList: '[]',
+            productsSearch: {},
+            basePrice: '15.00',
+          },
+          isValid: false,
+        },
+      ];
+
+      renderWithProviders(
+        <ReAddToCart {...defaultProps} products={products} successProducts={0} />,
+      );
+
+      expect(screen.getByText('2 products not added to cart')).toBeInTheDocument();
+    });
+
+    it('should NOT display error alert when products array is empty', () => {
+      renderWithProviders(<ReAddToCart {...defaultProps} products={[]} successProducts={5} />);
+
+      expect(screen.queryByText(/products not added to cart/)).not.toBeInTheDocument();
+      expect(screen.queryByText(/can't checkout/)).not.toBeInTheDocument();
+    });
+
+    it('should display error alert with checkout message when allowJuniorPlaceOrder is true and products exist', () => {
+      const products = [
+        {
+          node: {
+            quantity: 2,
+            primaryImage: 'test.jpg',
+            productName: 'Test Product',
+            variantSku: 'SKU123',
+            optionList: '[]',
+            productsSearch: {},
+            basePrice: '10.00',
+          },
+          isValid: false,
+        },
+      ];
+
+      renderWithProviders(
+        <ReAddToCart
+          {...defaultProps}
+          products={products}
+          successProducts={0}
+          allowJuniorPlaceOrder
+        />,
+      );
+
+      expect(screen.getByText("1 products can't checkout")).toBeInTheDocument();
+    });
+  });
+
+  describe('Combined scenarios', () => {
+    it('should show only success alert when successProducts > 0 and products array is empty', () => {
+      renderWithProviders(<ReAddToCart {...defaultProps} products={[]} successProducts={3} />);
+
+      // When products array is empty, the dialog doesn't open, so no alerts are shown
+      // This test verifies that the success alert conditional rendering is correct,
+      // even though the dialog itself won't be visible with empty products
+      expect(screen.queryByText(/products added to cart/)).not.toBeInTheDocument();
+      expect(screen.queryByText(/not added to cart/)).not.toBeInTheDocument();
+    });
+
+    it('should show only error alert when successProducts is 0 and products array has items', () => {
+      const products = [
+        {
+          node: {
+            quantity: 2,
+            primaryImage: 'test.jpg',
+            productName: 'Test Product',
+            variantSku: 'SKU123',
+            optionList: '[]',
+            productsSearch: {},
+            basePrice: '10.00',
+          },
+          isValid: false,
+        },
+      ];
+
+      renderWithProviders(
+        <ReAddToCart {...defaultProps} products={products} successProducts={0} />,
+      );
+
+      expect(screen.queryByText(/products added to cart/)).not.toBeInTheDocument();
+      expect(screen.getByText('1 products not added to cart')).toBeInTheDocument();
+    });
+
+    it('should show both alerts when successProducts > 0 and products array has items', () => {
+      const products = [
+        {
+          node: {
+            quantity: 2,
+            primaryImage: 'test.jpg',
+            productName: 'Test Product',
+            variantSku: 'SKU123',
+            optionList: '[]',
+            productsSearch: {},
+            basePrice: '10.00',
+          },
+          isValid: false,
+        },
+      ];
+
+      renderWithProviders(
+        <ReAddToCart {...defaultProps} products={products} successProducts={2} />,
+      );
+
+      expect(screen.getByText('2 products added to cart')).toBeInTheDocument();
+      expect(screen.getByText('1 products not added to cart')).toBeInTheDocument();
+    });
+
+    it('should show no alerts when successProducts is 0 and products array is empty', () => {
+      renderWithProviders(<ReAddToCart {...defaultProps} products={[]} successProducts={0} />);
+
+      expect(screen.queryByText(/products added to cart/)).not.toBeInTheDocument();
+      expect(screen.queryByText(/not added to cart/)).not.toBeInTheDocument();
+    });
+  });
+});

--- a/apps/storefront/src/pages/ShoppingListDetails/components/ReAddToCart.tsx
+++ b/apps/storefront/src/pages/ShoppingListDetails/components/ReAddToCart.tsx
@@ -357,15 +357,17 @@ export default function ReAddToCart(props: ShoppingProductsProps) {
             m: '0 0 1rem 0',
           }}
         >
-          <Alert variant="filled" severity="success">
-            {allowJuniorPlaceOrder
-              ? b3Lang('shoppingList.reAddToCart.productsCanCheckout', {
-                  successProducts,
-                })
-              : b3Lang('shoppingList.reAddToCart.productsAddedToCart', {
-                  successProducts,
-                })}
-          </Alert>
+          {successProducts > 0 && (
+            <Alert variant="filled" severity="success">
+              {allowJuniorPlaceOrder
+                ? b3Lang('shoppingList.reAddToCart.productsCanCheckout', {
+                    successProducts,
+                  })
+                : b3Lang('shoppingList.reAddToCart.productsAddedToCart', {
+                    successProducts,
+                  })}
+            </Alert>
+          )}
         </Box>
 
         <Box
@@ -373,15 +375,17 @@ export default function ReAddToCart(props: ShoppingProductsProps) {
             m: '1rem 0',
           }}
         >
-          <Alert variant="filled" severity="error">
-            {allowJuniorPlaceOrder
-              ? b3Lang('shoppingList.reAddToCart.productsCantCheckout', {
-                  quantity: products.length,
-                })
-              : b3Lang('shoppingList.reAddToCart.productsNotAddedToCart', {
-                  quantity: products.length,
-                })}
-          </Alert>
+          {products.length > 0 && (
+            <Alert variant="filled" severity="error">
+              {allowJuniorPlaceOrder
+                ? b3Lang('shoppingList.reAddToCart.productsCantCheckout', {
+                    quantity: products.length,
+                  })
+                : b3Lang('shoppingList.reAddToCart.productsNotAddedToCart', {
+                    quantity: products.length,
+                  })}
+            </Alert>
+          )}
         </Box>
         <B3Spin isSpinning={loading} size={16} isFlex={false}>
           <Box

--- a/apps/storefront/src/pages/ShoppingListDetails/components/ShoppingDetailFooter.test.tsx
+++ b/apps/storefront/src/pages/ShoppingListDetails/components/ShoppingDetailFooter.test.tsx
@@ -1,0 +1,335 @@
+import { SxProps } from '@mui/material';
+import { renderWithProviders, screen, waitFor } from 'tests/test-utils';
+import { vi } from 'vitest';
+
+import type { LineItem } from '@/utils/b3Product/b3Product';
+
+import ShoppingDetailFooter from './ShoppingDetailFooter';
+
+// Mock dependencies
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('react-router-dom')>()),
+  useNavigate: () => mockNavigate,
+}));
+
+const mockB3Lang = vi.fn((key: string) => key);
+vi.mock('@/lib/lang', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/lang')>();
+  return {
+    ...actual,
+    useB3Lang: () => mockB3Lang,
+  };
+});
+
+vi.mock('@/hooks', () => ({
+  useMobile: () => [false],
+  useFeatureFlags: () => ({
+    'B2B-3318.move_stock_and_backorder_validation_to_backend': false,
+  }),
+}));
+
+const mockCreateOrUpdateExistingCart = vi.fn();
+const mockDeleteCart = vi.fn();
+const mockGetCart = vi.fn();
+
+vi.mock('@/utils/cartUtils', () => ({
+  createOrUpdateExistingCart: (lineItems: LineItem[]) => mockCreateOrUpdateExistingCart(lineItems),
+  deleteCartData: vi.fn(),
+  updateCart: vi.fn(),
+}));
+
+vi.mock('@/shared/service/bc/graphql/cart', () => ({
+  deleteCart: (data: Record<string, string>) => mockDeleteCart(data),
+  getCart: (cartId: string) => mockGetCart(cartId),
+}));
+
+interface CustomButtonProps {
+  onClick?: () => void;
+  sx?: SxProps;
+  customLabel?: string;
+  children: React.ReactNode;
+  disabled?: boolean;
+}
+
+vi.mock('@/components/button/CustomButton', () => ({
+  default: ({ children, onClick, disabled }: CustomButtonProps) => (
+    <button type="button" onClick={onClick} disabled={disabled}>
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock('@/utils/b3TriggerCartNumber', () => ({
+  default: vi.fn(),
+}));
+
+vi.mock('@/utils', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/utils')>();
+  return {
+    ...actual,
+    currencyFormat: vi.fn((val: number) => `$${val}`),
+    snackbar: {
+      error: vi.fn(),
+      success: vi.fn(),
+    },
+  };
+});
+
+interface ProductNode {
+  node: Record<string, unknown>;
+}
+
+vi.mock('@/utils/b3Product/shared/config', () => ({
+  addLineItems: vi.fn((items: ProductNode[]) => items),
+  conversionProductsList: vi.fn(),
+}));
+
+vi.mock('js-cookie', () => ({
+  default: {
+    get: vi.fn(() => 'cart-id-123'),
+  },
+}));
+
+describe('ShoppingDetailFooter - setValidateSuccessProducts placement', () => {
+  const mockSetLoading = vi.fn();
+  const mockSetDeleteOpen = vi.fn();
+  const mockSetValidateFailureProducts = vi.fn();
+  const mockSetValidateSuccessProducts = vi.fn();
+
+  const defaultProps = {
+    shoppingListInfo: { status: 30 }, // ShoppingListStatus.Approved
+    allowJuniorPlaceOrder: true,
+    checkedArr: [],
+    selectedSubTotal: 100.0,
+    setLoading: mockSetLoading,
+    setDeleteOpen: mockSetDeleteOpen,
+    setValidateFailureProducts: mockSetValidateFailureProducts,
+    setValidateSuccessProducts: mockSetValidateSuccessProducts,
+    isB2BUser: false, // Set to false to bypass permission checks and ensure buttons render
+    customColor: '#1976d2',
+    isCanEditShoppingList: true,
+    role: 2, // role 2 for submitShoppingListPermission
+    backendValidationEnabled: true,
+  };
+
+  const mockCheckedItems = [
+    {
+      node: {
+        basePrice: '10.00',
+        baseSku: 'BASE-SKU-1',
+        createdAt: 123456789,
+        discount: '0',
+        enteredInclusive: false,
+        id: '1',
+        itemId: 1,
+        optionList: '[]',
+        primaryImage: 'test.jpg',
+        productId: 101,
+        productName: 'Test Product 1',
+        productUrl: '/test-product-1',
+        quantity: 2,
+        tax: '0',
+        updatedAt: 123456790,
+        variantId: 201,
+        variantSku: 'SKU-1',
+        productsSearch: {},
+      },
+    },
+    {
+      node: {
+        basePrice: '15.00',
+        baseSku: 'BASE-SKU-2',
+        createdAt: 123456789,
+        discount: '0',
+        enteredInclusive: false,
+        id: '2',
+        itemId: 2,
+        optionList: '[]',
+        primaryImage: 'test2.jpg',
+        productId: 102,
+        productName: 'Test Product 2',
+        productUrl: '/test-product-2',
+        quantity: 1,
+        tax: '0',
+        updatedAt: 123456790,
+        variantId: 202,
+        variantSku: 'SKU-2',
+        productsSearch: {},
+      },
+    },
+  ];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetCart.mockResolvedValue({ data: { site: { cart: null } } });
+  });
+
+  describe('handleAddToCartBackend - success path', () => {
+    it('should call setValidateSuccessProducts when cart operation succeeds', async () => {
+      mockCreateOrUpdateExistingCart.mockResolvedValue({ errors: null });
+
+      const { user } = renderWithProviders(
+        <ShoppingDetailFooter {...defaultProps} checkedArr={mockCheckedItems} />,
+      );
+
+      const addButton = screen.getByRole('button');
+      await user.click(addButton);
+
+      await waitFor(() => {
+        expect(mockSetValidateSuccessProducts).toHaveBeenCalledWith(
+          expect.arrayContaining([
+            expect.objectContaining({
+              node: expect.objectContaining({
+                variantSku: 'SKU-1',
+              }),
+            }),
+            expect.objectContaining({
+              node: expect.objectContaining({
+                variantSku: 'SKU-2',
+              }),
+            }),
+          ]),
+        );
+      });
+
+      // Verify setValidateFailureProducts was NOT called on success
+      expect(mockSetValidateFailureProducts).not.toHaveBeenCalled();
+    });
+
+    it('should call setValidateSuccessProducts before shouldRedirectCheckout', async () => {
+      const callOrder: string[] = [];
+
+      mockCreateOrUpdateExistingCart.mockResolvedValue({ errors: null });
+      mockSetValidateSuccessProducts.mockImplementation(() => {
+        callOrder.push('setValidateSuccessProducts');
+      });
+
+      // Mock window.location.href to track when redirect happens
+      const originalLocation = window.location;
+      Object.defineProperty(window, 'location', {
+        writable: true,
+        value: { ...originalLocation, href: '' },
+      });
+
+      const { user } = renderWithProviders(
+        <ShoppingDetailFooter {...defaultProps} checkedArr={mockCheckedItems} />,
+      );
+
+      const addButton = screen.getByRole('button');
+      await user.click(addButton);
+
+      await waitFor(() => {
+        expect(mockSetValidateSuccessProducts).toHaveBeenCalled();
+      });
+
+      // Verify setValidateSuccessProducts was called
+      expect(callOrder).toContain('setValidateSuccessProducts');
+
+      // Restore location
+      Object.defineProperty(window, 'location', {
+        writable: true,
+        value: originalLocation,
+      });
+    });
+  });
+
+  describe('handleAddToCartBackend - error path', () => {
+    it('should call setValidateFailureProducts and NOT setValidateSuccessProducts when an error occurs', async () => {
+      const mockError = new Error('Cart creation failed');
+      mockCreateOrUpdateExistingCart.mockRejectedValue(mockError);
+
+      const { user } = renderWithProviders(
+        <ShoppingDetailFooter {...defaultProps} checkedArr={mockCheckedItems} />,
+      );
+
+      const addButton = screen.getByRole('button');
+      await user.click(addButton);
+
+      await waitFor(() => {
+        expect(mockSetValidateFailureProducts).toHaveBeenCalledWith(
+          expect.arrayContaining([
+            expect.objectContaining({
+              node: expect.objectContaining({
+                variantSku: 'SKU-1',
+              }),
+            }),
+          ]),
+        );
+      });
+
+      // Critical test: setValidateSuccessProducts should NOT be called on error
+      expect(mockSetValidateSuccessProducts).not.toHaveBeenCalled();
+    });
+
+    it('should set loading to false even when an error occurs', async () => {
+      const mockError = new Error('Network error');
+      mockCreateOrUpdateExistingCart.mockRejectedValue(mockError);
+
+      const { user } = renderWithProviders(
+        <ShoppingDetailFooter {...defaultProps} checkedArr={mockCheckedItems} />,
+      );
+
+      const addButton = screen.getByRole('button');
+      await user.click(addButton);
+
+      await waitFor(() => {
+        expect(mockSetLoading).toHaveBeenCalledWith(false);
+      });
+    });
+
+    it('should handle non-Error exceptions correctly', async () => {
+      mockCreateOrUpdateExistingCart.mockRejectedValue('String error');
+
+      const { user } = renderWithProviders(
+        <ShoppingDetailFooter {...defaultProps} checkedArr={mockCheckedItems} />,
+      );
+
+      const addButton = screen.getByRole('button');
+      await user.click(addButton);
+
+      await waitFor(() => {
+        expect(mockSetLoading).toHaveBeenCalledWith(false);
+      });
+
+      // setValidateSuccessProducts should still NOT be called
+      expect(mockSetValidateSuccessProducts).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Success vs failure state management', () => {
+    it('should only set success products when operation completes successfully', async () => {
+      mockCreateOrUpdateExistingCart.mockResolvedValue({ errors: null });
+
+      const { user } = renderWithProviders(
+        <ShoppingDetailFooter {...defaultProps} checkedArr={mockCheckedItems} />,
+      );
+
+      const addButton = screen.getByRole('button');
+      await user.click(addButton);
+
+      await waitFor(() => {
+        expect(mockSetValidateSuccessProducts).toHaveBeenCalledTimes(1);
+      });
+
+      expect(mockSetValidateFailureProducts).not.toHaveBeenCalled();
+    });
+
+    it('should only set failure products when operation fails', async () => {
+      mockCreateOrUpdateExistingCart.mockRejectedValue(new Error('Failed'));
+
+      const { user } = renderWithProviders(
+        <ShoppingDetailFooter {...defaultProps} checkedArr={mockCheckedItems} />,
+      );
+
+      const addButton = screen.getByRole('button');
+      await user.click(addButton);
+
+      await waitFor(() => {
+        expect(mockSetValidateFailureProducts).toHaveBeenCalledTimes(1);
+      });
+
+      expect(mockSetValidateSuccessProducts).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/storefront/src/pages/ShoppingListDetails/components/ShoppingDetailFooter.tsx
+++ b/apps/storefront/src/pages/ShoppingListDetails/components/ShoppingDetailFooter.tsx
@@ -322,6 +322,7 @@ function ShoppingDetailFooter(props: ShoppingDetailFooterProps) {
         b3TriggerCartNumber();
       }
       shouldRedirectCheckout();
+      setValidateSuccessProducts(items);
     } catch (e: unknown) {
       if (e instanceof Error) {
         setValidateFailureProducts(items);
@@ -330,7 +331,6 @@ function ShoppingDetailFooter(props: ShoppingDetailFooterProps) {
     } finally {
       setLoading(false);
     }
-    setValidateSuccessProducts(items);
   };
 
   // Add selected product to cart


### PR DESCRIPTION
Jira: [B2B-3701](https://bigcommercecloud.atlassian.net/browse/B2B-3701)

## What/Why?
Users encounter multiple errors when trying to add a product to the cart from a shopping list. One of these errors falsely indicates a successful addition, even when the product cannot be added due to insufficient stock.

This PR fixed a bug where success messages would be permanently rendered wether the operation failed or not.

## Rollout/Rollback
simple revert 

## Testing
Before:
multiple messages, when not even one product was added
<img width="642" height="401" alt="Screenshot 2025-10-03 at 6 53 05 p m" src="https://github.com/user-attachments/assets/af636238-0b4b-4ea8-86e2-481746c5e992" />

After:
Only one error message as when errored, no item is added by back ordering cart rules.

<img width="680" height="594" alt="Screenshot 2025-10-03 at 6 53 48 p m" src="https://github.com/user-attachments/assets/68b61c84-71f3-48fe-a3fe-69b575a6b596" />
