### PR TITLE
fix(orders): B2B-3691 use searchproduct information to create line items object

### DIFF
--- a/apps/storefront/src/pages/ShoppingListDetails/components/ShoppingDetailFooter.tsx
+++ b/apps/storefront/src/pages/ShoppingListDetails/components/ShoppingDetailFooter.tsx
@@ -313,7 +313,6 @@ function ShoppingDetailFooter(props: ShoppingDetailFooterProps) {
       const lineItems = addLineItems(items);
       const deleteCartObject = deleteCartData(items);
       const cartInfo = await getCart();
-
       if (allowJuniorPlaceOrder && cartInfo.data.site.cart) {
         await deleteCart(deleteCartObject);
         await updateCart(cartInfo, lineItems);


### PR DESCRIPTION
## What/Why?
In our new backendValidation function we were not using the current functionality that transforms the lineItems object to the one required by the cart create query. So I'm reusing the implementation and using it in both front end and backend validation functions. Since the lineitems optionList was not prepared for the query it was causing errores when adding a purchased product to the cart.

## Rollout/Rollback
Revert

## Testing

https://github.com/user-attachments/assets/e3c619e4-79e7-43f6-b176-dae19ae3c92d
