### PR TITLE
fix(shopping-lists): B2B-3708 updated bulk csv query to use variables

### DIFF
--- a/apps/storefront/src/pages/OrderDetail/index.test.tsx
+++ b/apps/storefront/src/pages/OrderDetail/index.test.tsx
@@ -1694,22 +1694,39 @@ describe('when a personal customer visits an order', () => {
           ),
         ),
         graphql.query('SearchProducts', () => HttpResponse.json({ data: { productsSearch: [] } })),
-        graphql.mutation('AddItemsToCustomerShoppingList', ({ query }) =>
-          HttpResponse.json(addItemsToCustomerShoppingList(query)),
+        graphql.mutation('AddItemsToCustomerShoppingList', ({ variables }) =>
+          HttpResponse.json(addItemsToCustomerShoppingList({ variables })),
         ),
       );
 
       when(addItemsToCustomerShoppingList)
         .calledWith(
-          stringContainingAll(
-            'productId: 123,',
-            'variantId: 456,',
-            'quantity: 2,',
-            '{optionId: "attribute[22]", optionValue: "bar" },',
-            'shoppingListId: 992,',
-          ),
+          expect.objectContaining({
+            variables: expect.objectContaining({
+              shoppingListId: 992,
+              items: expect.arrayContaining([
+                expect.objectContaining({
+                  productId: 123,
+                  variantId: 456,
+                  quantity: 2,
+                  optionList: expect.arrayContaining([
+                    expect.objectContaining({
+                      optionId: 'attribute[22]',
+                      optionValue: 'bar',
+                    }),
+                  ]),
+                }),
+              ]),
+            }),
+          }),
         )
-        .thenReturn({});
+        .thenReturn({
+          data: {
+            customerShoppingListsItemsCreate: {
+              shoppingListsItems: [],
+            },
+          },
+        });
 
       server.use(
         graphql.query('GetCustomerOrderStatuses', () =>
@@ -1724,26 +1741,6 @@ describe('when a personal customer visits an order', () => {
               data: { customerOrder: { products: [screamCanister, laughCanister] } },
             }),
           ),
-        ),
-
-        graphql.query('CustomerShoppingLists', () =>
-          HttpResponse.json(
-            buildCustomerShoppingListResponseWith({
-              data: { customerShoppingLists: { totalCount: 1, edges: [shoppingList] } },
-            }),
-          ),
-        ),
-        graphql.query('SearchProducts', () =>
-          HttpResponse.json({
-            data: {
-              productsSearch: [
-                { optionsV3: [{ id: 114, option_values: [{ id: 103 }, { id: 104 }] }] },
-              ],
-            },
-          }),
-        ),
-        graphql.mutation('AddItemsToCustomerShoppingList', ({ query }) =>
-          HttpResponse.json(addItemsToCustomerShoppingList(query)),
         ),
       );
 
@@ -1796,15 +1793,33 @@ describe('when a personal customer visits an order', () => {
 
       when(addItemsToCustomerShoppingList)
         .calledWith(
-          stringContainingAll(
-            'productId: 123,',
-            'variantId: 456,',
-            'quantity: 2,',
-            '{optionId: "attribute[22]", optionValue: "bar" },',
-            'shoppingListId: 992,',
-          ),
+          expect.objectContaining({
+            variables: expect.objectContaining({
+              shoppingListId: 992,
+              items: expect.arrayContaining([
+                expect.objectContaining({
+                  productId: 123,
+                  variantId: 456,
+                  quantity: 2,
+                  optionList: expect.arrayContaining([
+                    expect.objectContaining({
+                      optionId: 'attribute[22]',
+                      optionValue: 'bar',
+                    }),
+                  ]),
+                }),
+              ]),
+            }),
+          }),
         )
-        .thenReturn({});
+        .thenReturn({
+          data: {
+            customerShoppingListsItemsCreate: {
+              shoppingListsItems: [],
+            },
+          },
+        });
+
       const createCustomerShoppingList = vi.fn();
 
       server.use(
@@ -1825,8 +1840,8 @@ describe('when a personal customer visits an order', () => {
           HttpResponse.json(getCustomerShoppingLists(query)),
         ),
         graphql.query('SearchProducts', () => HttpResponse.json({ data: { productsSearch: [] } })),
-        graphql.mutation('AddItemsToCustomerShoppingList', ({ query }) =>
-          HttpResponse.json(addItemsToCustomerShoppingList(query)),
+        graphql.mutation('AddItemsToCustomerShoppingList', ({ variables }) =>
+          HttpResponse.json(addItemsToCustomerShoppingList({ variables })),
         ),
         graphql.mutation('CreateCustomerShoppingList', ({ variables }) =>
           HttpResponse.json(createCustomerShoppingList(variables)),
@@ -1920,22 +1935,39 @@ describe('when a personal customer visits an order', () => {
           ),
         ),
         graphql.query('SearchProducts', () => HttpResponse.json({ data: { productsSearch: [] } })),
-        graphql.mutation('AddItemsToCustomerShoppingList', ({ query }) =>
-          HttpResponse.json(addItemsToCustomerShoppingList(query)),
+        graphql.mutation('AddItemsToCustomerShoppingList', ({ variables }) =>
+          HttpResponse.json(addItemsToCustomerShoppingList({ variables })),
         ),
       );
 
       when(addItemsToCustomerShoppingList)
         .calledWith(
-          stringContainingAll(
-            'productId: 123,',
-            'variantId: 456,',
-            'quantity: 2,',
-            '{optionId: "attribute[22]", optionValue: "bar" },',
-            'shoppingListId: 992,',
-          ),
+          expect.objectContaining({
+            variables: expect.objectContaining({
+              shoppingListId: 992,
+              items: expect.arrayContaining([
+                expect.objectContaining({
+                  productId: 123,
+                  variantId: 456,
+                  quantity: 2,
+                  optionList: expect.arrayContaining([
+                    expect.objectContaining({
+                      optionId: 'attribute[22]',
+                      optionValue: 'bar',
+                    }),
+                  ]),
+                }),
+              ]),
+            }),
+          }),
         )
-        .thenReturn({});
+        .thenReturn({
+          data: {
+            customerShoppingListsItemsCreate: {
+              shoppingListsItems: [],
+            },
+          },
+        });
 
       server.use(
         graphql.query('GetCustomerOrderStatuses', () =>
@@ -1950,17 +1982,6 @@ describe('when a personal customer visits an order', () => {
               data: { customerOrder: { products: [screamCanister, laughCanister] } },
             }),
           ),
-        ),
-        graphql.query('CustomerShoppingLists', () =>
-          HttpResponse.json(
-            buildCustomerShoppingListResponseWith({
-              data: { customerShoppingLists: { totalCount: 1, edges: [shoppingList] } },
-            }),
-          ),
-        ),
-        graphql.query('SearchProducts', () => HttpResponse.json({ data: { productsSearch: [] } })),
-        graphql.mutation('AddItemsToCustomerShoppingList', ({ query }) =>
-          HttpResponse.json(addItemsToCustomerShoppingList(query)),
         ),
       );
 
@@ -2030,26 +2051,40 @@ describe('when a personal customer visits an order', () => {
           ),
         ),
         graphql.query('SearchProducts', () => HttpResponse.json({ data: { productsSearch: [] } })),
-        graphql.mutation('AddItemsToCustomerShoppingList', ({ query }) =>
-          HttpResponse.json(addItemsToCustomerShoppingList(query)),
+        graphql.mutation('AddItemsToCustomerShoppingList', ({ query, variables }) =>
+          HttpResponse.json(addItemsToCustomerShoppingList({ query, variables })),
         ),
       );
 
       when(addItemsToCustomerShoppingList)
         .calledWith(
-          stringContainingAll(
-            'productId: 123,',
-            'variantId: 456,',
-            'quantity: 1,',
-
-            'productId: 789,',
-            'variantId: 1011,',
-            'quantity: 2,',
-
-            'shoppingListId: 992,',
-          ),
+          expect.objectContaining({
+            variables: expect.objectContaining({
+              shoppingListId: 992,
+              items: expect.arrayContaining([
+                expect.objectContaining({
+                  productId: 123,
+                  variantId: 456,
+                  quantity: 1,
+                  optionList: [],
+                }),
+                expect.objectContaining({
+                  productId: 789,
+                  variantId: 1011,
+                  quantity: 2,
+                  optionList: [],
+                }),
+              ]),
+            }),
+          }),
         )
-        .thenReturn({});
+        .thenReturn({
+          data: {
+            customerShoppingListsItemsCreate: {
+              shoppingListsItems: [],
+            },
+          },
+        });
 
       server.use(
         graphql.query('GetCustomerOrderStatuses', () =>
@@ -2064,18 +2099,6 @@ describe('when a personal customer visits an order', () => {
               data: { customerOrder: { products: [screamCanister, laughCanister] } },
             }),
           ),
-        ),
-
-        graphql.query('CustomerShoppingLists', () =>
-          HttpResponse.json(
-            buildCustomerShoppingListResponseWith({
-              data: { customerShoppingLists: { totalCount: 1, edges: [shoppingList] } },
-            }),
-          ),
-        ),
-        graphql.query('SearchProducts', () => HttpResponse.json({ data: { productsSearch: [] } })),
-        graphql.mutation('AddItemsToCustomerShoppingList', ({ query }) =>
-          HttpResponse.json(addItemsToCustomerShoppingList(query)),
         ),
       );
 

--- a/apps/storefront/src/pages/PDP/index.b2b.test.tsx
+++ b/apps/storefront/src/pages/PDP/index.b2b.test.tsx
@@ -159,21 +159,38 @@ describe('stencil', () => {
           },
         }),
       ),
-      graphql.mutation('AddItemsToShoppingList', ({ query }) =>
-        HttpResponse.json(addItemsToShoppingList(query)),
+      graphql.mutation('AddItemsToShoppingList', ({ variables }) =>
+        HttpResponse.json(addItemsToShoppingList({ variables })),
       ),
     );
 
     when(addItemsToShoppingList)
       .calledWith(
-        stringContainingAll(
-          'productId: 123,',
-          'quantity: 2,',
-          '{optionId: "attribute[114]", optionValue: "104" }',
-          'shoppingListId: 992,',
-        ),
+        expect.objectContaining({
+          variables: expect.objectContaining({
+            shoppingListId: '992',
+            items: expect.arrayContaining([
+              expect.objectContaining({
+                productId: 123,
+                quantity: 2,
+                optionList: expect.arrayContaining([
+                  expect.objectContaining({
+                    optionId: 'attribute[114]',
+                    optionValue: '104',
+                  }),
+                ]),
+              }),
+            ]),
+          }),
+        }),
       )
-      .thenReturn({});
+      .thenReturn({
+        data: {
+          shoppingListItemsCreate: {
+            shoppingListsItems: [],
+          },
+        },
+      });
 
     const shoppingListClickNode = screen.getByRole('link', { name: 'Shopping List Click Node' });
 
@@ -228,22 +245,39 @@ describe('stencil', () => {
           },
         }),
       ),
-      graphql.mutation('AddItemsToShoppingList', ({ query }) =>
-        HttpResponse.json(addItemsToShoppingList(query)),
+      graphql.mutation('AddItemsToShoppingList', ({ variables }) =>
+        HttpResponse.json(addItemsToShoppingList({ variables })),
       ),
     );
 
     when(addItemsToShoppingList)
       .calledWith(
-        stringContainingAll(
-          'productId: 123,',
-          'variantId: 333,', // this time it includes the variant ID
-          'quantity: 2,',
-          '{optionId: "attribute[114]", optionValue: "104" }',
-          'shoppingListId: 992,',
-        ),
+        expect.objectContaining({
+          variables: expect.objectContaining({
+            shoppingListId: '992',
+            items: expect.arrayContaining([
+              expect.objectContaining({
+                productId: 123,
+                variantId: 333, // this time it includes the variant ID
+                quantity: 2,
+                optionList: expect.arrayContaining([
+                  expect.objectContaining({
+                    optionId: 'attribute[114]',
+                    optionValue: '104',
+                  }),
+                ]),
+              }),
+            ]),
+          }),
+        }),
       )
-      .thenReturn({});
+      .thenReturn({
+        data: {
+          shoppingListItemsCreate: {
+            shoppingListsItems: [],
+          },
+        },
+      });
 
     const shoppingListClickNode = screen.getByRole('link', { name: 'Shopping List Click Node' });
 
@@ -281,8 +315,8 @@ describe('stencil', () => {
         HttpResponse.json(createShoppingList(variables)),
       ),
       graphql.query('SearchProducts', ({ query }) => HttpResponse.json(searchProducts(query))),
-      graphql.mutation('AddItemsToShoppingList', ({ query }) =>
-        HttpResponse.json(addItemsToShoppingList(query)),
+      graphql.mutation('AddItemsToShoppingList', ({ variables }) =>
+        HttpResponse.json(addItemsToShoppingList({ variables })),
       ),
     );
 
@@ -319,14 +353,26 @@ describe('stencil', () => {
 
     when(addItemsToShoppingList)
       .calledWith(
-        stringContainingAll(
-          'productId: 123,',
-          'quantity: 1,',
-          'optionList: [],',
-          'shoppingListId: 992,',
-        ),
+        expect.objectContaining({
+          variables: expect.objectContaining({
+            shoppingListId: '992',
+            items: expect.arrayContaining([
+              expect.objectContaining({
+                productId: 123,
+                quantity: 1,
+                optionList: [],
+              }),
+            ]),
+          }),
+        }),
       )
-      .thenReturn({});
+      .thenReturn({
+        data: {
+          shoppingListItemsCreate: {
+            shoppingListsItems: [],
+          },
+        },
+      });
 
     render(<FakeProductDataProvider productId="123" sku="SKU-123" quantity="1" options={{}} />);
 
@@ -588,21 +634,38 @@ describe('other/catalyst', () => {
           },
         }),
       ),
-      graphql.mutation('AddItemsToShoppingList', ({ query }) =>
-        HttpResponse.json(addItemsToShoppingList(query)),
+      graphql.mutation('AddItemsToShoppingList', ({ variables }) =>
+        HttpResponse.json(addItemsToShoppingList({ variables })),
       ),
     );
 
     when(addItemsToShoppingList)
       .calledWith(
-        stringContainingAll(
-          'productId: 123,',
-          'quantity: 2,',
-          '{optionId: "attribute[114]", optionValue: "104" }',
-          'shoppingListId: 992,',
-        ),
+        expect.objectContaining({
+          variables: expect.objectContaining({
+            shoppingListId: '992',
+            items: expect.arrayContaining([
+              expect.objectContaining({
+                productId: 123,
+                quantity: 2,
+                optionList: expect.arrayContaining([
+                  expect.objectContaining({
+                    optionId: 'attribute[114]',
+                    optionValue: '104',
+                  }),
+                ]),
+              }),
+            ]),
+          }),
+        }),
       )
-      .thenReturn({});
+      .thenReturn({
+        data: {
+          shoppingListsItemsCreate: {
+            shoppingListsItems: [],
+          },
+        },
+      });
 
     renderWithProviders(<PDP />, { preloadedState });
 
@@ -652,22 +715,39 @@ describe('other/catalyst', () => {
           },
         }),
       ),
-      graphql.mutation('AddItemsToShoppingList', ({ query }) =>
-        HttpResponse.json(addItemsToShoppingList(query)),
-      ),
+      graphql.mutation('AddItemsToShoppingList', ({ variables }) => {
+        return HttpResponse.json(addItemsToShoppingList({ variables }));
+      }),
     );
 
     when(addItemsToShoppingList)
       .calledWith(
-        stringContainingAll(
-          'productId: 123,',
-          'variantId: 333,', // this time it includes the variant ID
-          'quantity: 2,',
-          '{optionId: "attribute[114]", optionValue: "104" }',
-          'shoppingListId: 992,',
-        ),
+        expect.objectContaining({
+          variables: expect.objectContaining({
+            shoppingListId: '992',
+            items: expect.arrayContaining([
+              expect.objectContaining({
+                productId: 123,
+                variantId: 333, // this time it includes the variant ID
+                quantity: 2,
+                optionList: expect.arrayContaining([
+                  expect.objectContaining({
+                    optionId: 'attribute[114]',
+                    optionValue: '104',
+                  }),
+                ]),
+              }),
+            ]),
+          }),
+        }),
       )
-      .thenReturn({});
+      .thenReturn({
+        data: {
+          shoppingListsItemsCreate: {
+            shoppingListsItems: [],
+          },
+        },
+      });
 
     renderWithProviders(<PDP />, { preloadedState });
 
@@ -719,21 +799,38 @@ describe('other/catalyst', () => {
           },
         }),
       ),
-      graphql.mutation('AddItemsToShoppingList', ({ query }) =>
-        HttpResponse.json(addItemsToShoppingList(query)),
+      graphql.mutation('AddItemsToShoppingList', ({ variables }) =>
+        HttpResponse.json(addItemsToShoppingList({ variables })),
       ),
     );
 
     when(addItemsToShoppingList)
       .calledWith(
-        stringContainingAll(
-          'productId: 123,',
-          'quantity: 2,',
-          '{optionId: "attribute[114]", optionValue: "104" }',
-          'shoppingListId: 992,',
-        ),
+        expect.objectContaining({
+          variables: expect.objectContaining({
+            shoppingListId: '992',
+            items: expect.arrayContaining([
+              expect.objectContaining({
+                productId: 123,
+                quantity: 2,
+                optionList: expect.arrayContaining([
+                  expect.objectContaining({
+                    optionId: 'attribute[114]',
+                    optionValue: '104',
+                  }),
+                ]),
+              }),
+            ]),
+          }),
+        }),
       )
-      .thenReturn({});
+      .thenReturn({
+        data: {
+          shoppingListsItemsCreate: {
+            shoppingListsItems: [],
+          },
+        },
+      });
 
     renderWithProviders(<PDP />, { preloadedState });
 
@@ -766,8 +863,8 @@ describe('other/catalyst', () => {
         HttpResponse.json(createShoppingList(variables)),
       ),
       graphql.query('SearchProducts', ({ query }) => HttpResponse.json(searchProducts(query))),
-      graphql.mutation('AddItemsToShoppingList', ({ query }) =>
-        HttpResponse.json(addItemsToShoppingList(query)),
+      graphql.mutation('AddItemsToShoppingList', ({ variables }) =>
+        HttpResponse.json(addItemsToShoppingList({ variables })),
       ),
     );
 
@@ -804,14 +901,26 @@ describe('other/catalyst', () => {
 
     when(addItemsToShoppingList)
       .calledWith(
-        stringContainingAll(
-          'productId: 123,',
-          'quantity: 1,',
-          'optionList: [],',
-          'shoppingListId: 992,',
-        ),
+        expect.objectContaining({
+          variables: expect.objectContaining({
+            shoppingListId: '992',
+            items: expect.arrayContaining([
+              expect.objectContaining({
+                productId: 123,
+                quantity: 1,
+                optionList: [],
+              }),
+            ]),
+          }),
+        }),
       )
-      .thenReturn({});
+      .thenReturn({
+        data: {
+          shoppingListsItemsCreate: {
+            shoppingListsItems: [],
+          },
+        },
+      });
 
     set(window, 'b2b.utils.shoppingList.itemFromCurrentPage', [
       {

--- a/apps/storefront/src/pages/PDP/index.b2c.test.tsx
+++ b/apps/storefront/src/pages/PDP/index.b2c.test.tsx
@@ -134,21 +134,38 @@ describe('stencil', () => {
           },
         }),
       ),
-      graphql.mutation('AddItemsToCustomerShoppingList', ({ query }) =>
-        HttpResponse.json(addItemsToCustomerShoppingList(query)),
-      ),
+      graphql.mutation('AddItemsToCustomerShoppingList', ({ variables }) => {
+        return HttpResponse.json(addItemsToCustomerShoppingList({ variables }));
+      }),
     );
 
     when(addItemsToCustomerShoppingList)
       .calledWith(
-        stringContainingAll(
-          'productId: 123,',
-          'quantity: 2,',
-          '{optionId: "attribute[114]", optionValue: "104" }',
-          'shoppingListId: 992,',
-        ),
+        expect.objectContaining({
+          variables: expect.objectContaining({
+            shoppingListId: '992',
+            items: expect.arrayContaining([
+              expect.objectContaining({
+                productId: 123,
+                quantity: 2,
+                optionList: expect.arrayContaining([
+                  expect.objectContaining({
+                    optionId: 'attribute[114]',
+                    optionValue: '104',
+                  }),
+                ]),
+              }),
+            ]),
+          }),
+        }),
       )
-      .thenReturn({});
+      .thenReturn({
+        data: {
+          customerShoppingListsItemsCreate: {
+            shoppingListsItems: [],
+          },
+        },
+      });
 
     const shoppingListClickNode = screen.getByRole('link', { name: 'Shopping List Click Node' });
 
@@ -203,22 +220,39 @@ describe('stencil', () => {
           },
         }),
       ),
-      graphql.mutation('AddItemsToCustomerShoppingList', ({ query }) =>
-        HttpResponse.json(addItemsToCustomerShoppingList(query)),
+      graphql.mutation('AddItemsToCustomerShoppingList', ({ variables }) =>
+        HttpResponse.json(addItemsToCustomerShoppingList({ variables })),
       ),
     );
 
     when(addItemsToCustomerShoppingList)
       .calledWith(
-        stringContainingAll(
-          'productId: 123,',
-          'variantId: 333,', // this time it includes the variant ID
-          'quantity: 2,',
-          '{optionId: "attribute[114]", optionValue: "104" }',
-          'shoppingListId: 992,',
-        ),
+        expect.objectContaining({
+          variables: expect.objectContaining({
+            shoppingListId: '992',
+            items: expect.arrayContaining([
+              expect.objectContaining({
+                productId: 123,
+                variantId: 333,
+                quantity: 2,
+                optionList: expect.arrayContaining([
+                  expect.objectContaining({
+                    optionId: 'attribute[114]',
+                    optionValue: '104',
+                  }),
+                ]),
+              }),
+            ]),
+          }),
+        }),
       )
-      .thenReturn({});
+      .thenReturn({
+        data: {
+          customerShoppingListsItemsCreate: {
+            shoppingListsItems: [],
+          },
+        },
+      });
 
     const shoppingListClickNode = screen.getByRole('link', { name: 'Shopping List Click Node' });
 
@@ -256,8 +290,8 @@ describe('stencil', () => {
         HttpResponse.json(createCustomerShoppingList(variables)),
       ),
       graphql.query('SearchProducts', ({ query }) => HttpResponse.json(searchProducts(query))),
-      graphql.mutation('AddItemsToCustomerShoppingList', ({ query }) =>
-        HttpResponse.json(addItemsToCustomerShoppingList(query)),
+      graphql.mutation('AddItemsToCustomerShoppingList', ({ variables }) =>
+        HttpResponse.json(addItemsToCustomerShoppingList({ variables })),
       ),
     );
 
@@ -289,14 +323,26 @@ describe('stencil', () => {
 
     when(addItemsToCustomerShoppingList)
       .calledWith(
-        stringContainingAll(
-          'productId: 123,',
-          'quantity: 1,',
-          'optionList: [],',
-          'shoppingListId: 992,',
-        ),
+        expect.objectContaining({
+          variables: expect.objectContaining({
+            shoppingListId: '992',
+            items: expect.arrayContaining([
+              expect.objectContaining({
+                productId: 123,
+                quantity: 1,
+                optionList: [],
+              }),
+            ]),
+          }),
+        }),
       )
-      .thenReturn({});
+      .thenReturn({
+        data: {
+          customerShoppingListsItemsCreate: {
+            shoppingListsItems: [],
+          },
+        },
+      });
 
     render(<FakeProductDataProvider productId="123" sku="SKU-123" quantity="1" options={{}} />);
 
@@ -553,21 +599,38 @@ describe('other/catalyst', () => {
           },
         }),
       ),
-      graphql.mutation('AddItemsToCustomerShoppingList', ({ query }) =>
-        HttpResponse.json(addItemsToCustomerShoppingList(query)),
+      graphql.mutation('AddItemsToCustomerShoppingList', ({ variables }) =>
+        HttpResponse.json(addItemsToCustomerShoppingList({ variables })),
       ),
     );
 
     when(addItemsToCustomerShoppingList)
       .calledWith(
-        stringContainingAll(
-          'productId: 123,',
-          'quantity: 2,',
-          '{optionId: "attribute[114]", optionValue: "104" }',
-          'shoppingListId: 992,',
-        ),
+        expect.objectContaining({
+          variables: expect.objectContaining({
+            shoppingListId: '992',
+            items: expect.arrayContaining([
+              expect.objectContaining({
+                productId: 123,
+                quantity: 2,
+                optionList: expect.arrayContaining([
+                  expect.objectContaining({
+                    optionId: 'attribute[114]',
+                    optionValue: '104',
+                  }),
+                ]),
+              }),
+            ]),
+          }),
+        }),
       )
-      .thenReturn({});
+      .thenReturn({
+        data: {
+          customerShoppingListsItemsCreate: {
+            shoppingListsItems: [],
+          },
+        },
+      });
 
     renderWithProviders(<PDP />, { preloadedState });
 
@@ -617,22 +680,39 @@ describe('other/catalyst', () => {
           },
         }),
       ),
-      graphql.mutation('AddItemsToCustomerShoppingList', ({ query }) =>
-        HttpResponse.json(addItemsToCustomerShoppingList(query)),
+      graphql.mutation('AddItemsToCustomerShoppingList', ({ variables }) =>
+        HttpResponse.json(addItemsToCustomerShoppingList({ variables })),
       ),
     );
 
     when(addItemsToCustomerShoppingList)
       .calledWith(
-        stringContainingAll(
-          'productId: 123,',
-          'variantId: 333,', // this time it includes the variant ID
-          'quantity: 2,',
-          '{optionId: "attribute[114]", optionValue: "104" }',
-          'shoppingListId: 992,',
-        ),
+        expect.objectContaining({
+          variables: expect.objectContaining({
+            shoppingListId: '992',
+            items: expect.arrayContaining([
+              expect.objectContaining({
+                productId: 123,
+                variantId: 333,
+                quantity: 2,
+                optionList: expect.arrayContaining([
+                  expect.objectContaining({
+                    optionId: 'attribute[114]',
+                    optionValue: '104',
+                  }),
+                ]),
+              }),
+            ]),
+          }),
+        }),
       )
-      .thenReturn({});
+      .thenReturn({
+        data: {
+          customerShoppingListsItemsCreate: {
+            shoppingListsItems: [],
+          },
+        },
+      });
 
     renderWithProviders(<PDP />, { preloadedState });
 
@@ -665,8 +745,8 @@ describe('other/catalyst', () => {
         HttpResponse.json(createCustomerShoppingList(variables)),
       ),
       graphql.query('SearchProducts', ({ query }) => HttpResponse.json(searchProducts(query))),
-      graphql.mutation('AddItemsToCustomerShoppingList', ({ query }) =>
-        HttpResponse.json(addItemsToCustomerShoppingList(query)),
+      graphql.mutation('AddItemsToCustomerShoppingList', ({ variables }) =>
+        HttpResponse.json(addItemsToCustomerShoppingList({ variables })),
       ),
     );
 
@@ -698,14 +778,26 @@ describe('other/catalyst', () => {
 
     when(addItemsToCustomerShoppingList)
       .calledWith(
-        stringContainingAll(
-          'productId: 123,',
-          'quantity: 1,',
-          'optionList: [],',
-          'shoppingListId: 992,',
-        ),
+        expect.objectContaining({
+          variables: expect.objectContaining({
+            shoppingListId: '992',
+            items: expect.arrayContaining([
+              expect.objectContaining({
+                productId: 123,
+                quantity: 1,
+                optionList: [],
+              }),
+            ]),
+          }),
+        }),
       )
-      .thenReturn({});
+      .thenReturn({
+        data: {
+          customerShoppingListsItemsCreate: {
+            shoppingListsItems: [],
+          },
+        },
+      });
 
     set(window, 'b2b.utils.shoppingList.itemFromCurrentPage', [
       {

--- a/apps/storefront/src/shared/service/b2b/graphql/shoppingList.ts
+++ b/apps/storefront/src/shared/service/b2b/graphql/shoppingList.ts
@@ -1,5 +1,5 @@
 import { ShoppingListStatus } from '@/types/shoppingList';
-import { convertArrayToGraphql, convertObjectToGraphql } from '@/utils';
+import { convertObjectToGraphql } from '@/utils';
 
 import B3Request from '../../request/b3Fetch';
 
@@ -303,32 +303,34 @@ const getShoppingListDetails = (data: CustomFieldItems) => `
   }
 `;
 
-const addItemsToShoppingList = (data: CustomFieldItems) => `mutation AddItemsToShoppingList {
-  shoppingListsItemsCreate(
-    shoppingListId: ${data.shoppingListId},
-    items: ${convertArrayToGraphql(data.items || [])}
-  ) {
-    shoppingListsItems {
-      id,
-      createdAt,
-      updatedAt,
-      productId,
-      variantId,
-      quantity,
-      productName,
-      optionList,
-      itemId,
-      baseSku,
-      variantSku,
-      basePrice,
-      discount,
-      tax,
-      enteredInclusive,
-      productUrl,
-      primaryImage,
+const addItemsToShoppingListQuery = `
+  mutation AddItemsToShoppingList($shoppingListId: Int!, $items: [ShoppingListsItemsInputType!]!) {
+    shoppingListsItemsCreate(
+      shoppingListId: $shoppingListId,
+      items: $items
+    ) {
+      shoppingListsItems {
+        id,
+        createdAt,
+        updatedAt,
+        productId,
+        variantId,
+        quantity,
+        productName,
+        optionList,
+        itemId,
+        baseSku,
+        variantSku,
+        basePrice,
+        discount,
+        tax,
+        enteredInclusive,
+        productUrl,
+        primaryImage,
+      }
     }
   }
-}`;
+`;
 
 const deleteShoppingListItem = (data: CustomFieldItems) => `mutation {
   shoppingListsItemsDelete(
@@ -450,34 +452,34 @@ const getCustomerShoppingListDetails = (data: CustomFieldItems) => `{
   }
 }`;
 
-const addItemsToBcShoppingList = (
-  data: CustomFieldItems,
-) => `mutation AddItemsToCustomerShoppingList {
-  customerShoppingListsItemsCreate (
-    shoppingListId: ${data.shoppingListId},
-    items: ${convertArrayToGraphql(data.items || [])}
-  ) {
-    shoppingListsItems {
-      id,
-      createdAt,
-      updatedAt,
-      productId,
-      variantId,
-      quantity,
-      productName,
-      optionList,
-      itemId,
-      baseSku,
-      variantSku,
-      basePrice,
-      discount,
-      tax,
-      enteredInclusive,
-      productUrl,
-      primaryImage,
+const addItemsToBcShoppingListQuery = `
+    mutation AddItemsToCustomerShoppingList($shoppingListId: Int!, $items: [ShoppingListsItemsInputType!]!) {
+      customerShoppingListsItemsCreate(
+        shoppingListId: $shoppingListId,
+        items: $items
+      ) {
+        shoppingListsItems {
+          id,
+          createdAt,
+          updatedAt,
+          productId,
+          variantId,
+          quantity,
+          productName,
+          optionList,
+          itemId,
+          baseSku,
+          variantSku,
+          basePrice,
+          discount,
+          tax,
+          enteredInclusive,
+          productUrl,
+          primaryImage,
+        }
+      }
     }
-  }
-}`;
+  `;
 
 const updateCustomerShoppingListsItem = (data: CustomFieldItems) => `mutation {
   customerShoppingListsItemsUpdate (
@@ -575,7 +577,11 @@ export const getB2BShoppingListDetails = (data: CustomFieldItems = {}) =>
 
 export const addProductToShoppingList = (data: CustomFieldItems = {}) =>
   B3Request.graphqlB2B({
-    query: addItemsToShoppingList(data),
+    query: addItemsToShoppingListQuery,
+    variables: {
+      shoppingListId: data.shoppingListId,
+      items: data.items,
+    },
   });
 
 export const updateB2BShoppingListsItem = (data: CustomFieldItems = {}) =>
@@ -625,7 +631,11 @@ export const getBcShoppingListDetails = (data: CustomFieldItems = {}) =>
 
 export const addProductToBcShoppingList = (data: CustomFieldItems = {}) =>
   B3Request.graphqlB2B({
-    query: addItemsToBcShoppingList(data),
+    query: addItemsToBcShoppingListQuery,
+    variables: {
+      shoppingListId: data.shoppingListId,
+      items: data.items,
+    },
   });
 
 export const updateBcShoppingListsItem = (data: CustomFieldItems = {}) =>


### PR DESCRIPTION
Jira: [B2B-3708](https://bigcommercecloud.atlassian.net/browse/B2B-3708)

## What/Why?
getting hit with the `Document contains more than 4500 tokens` GraphQL error when attempting to bulk upload a 200 SKU CSV to their shopping list. 

The issue was caused by GraphQL variables being embedded directly into the query string instead of being passed separately as proper GraphQL variables.
<!--
  A description about what this pull request implements and its purpose.
  Try to be detailed and describe any technical details to simplify the job
  of the reviewer and the individual on production support.
-->

## Rollout/Rollback
simple revert and redeploy
<!--
Detail how this change will be rolled out. Include reference to any
experiments and how the success will be measured as the experiment is
ramped.

Document rollback procedures. Is rolling back the change as simple as
rolling back an experiment or does it require reverting code? Are there
database migrations that may change our decision to roll forward instead of
back?
-->

## Testing
### Before query with 200 sku's ~4500 tokens

https://github.com/user-attachments/assets/10b0ad6e-6638-48a9-9ba9-58893f844aec

### After query with 200 sku's ~350 tokens

https://github.com/user-attachments/assets/983e2032-0640-4cb7-9426-5984f2e3c230


<!--
Provide as much information as you can about how you tested and how another
Engineer can test your change. Include screenshots, or test run output
where appropriate.
-->


[B2B-3708]: https://bigcommercecloud.atlassian.net/browse/B2B-3708?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ