### PR TITLE
fix(orders): B2B-3691 adding test case for successful cart creation when backend validation is enabled and product variant

### DIFF
--- a/apps/storefront/src/shared/service/b2b/graphql/quickOrder.ts
+++ b/apps/storefront/src/shared/service/b2b/graphql/quickOrder.ts
@@ -5,7 +5,7 @@ interface OptionSelection {
   value_id: number;
 }
 
-interface OptionList {
+export interface OptionList {
   id: number;
   option_id: number;
   order_product_id: number;


### PR DESCRIPTION
## What/Why?
Adding test case to cover scenario when we are creating a cart successfully from a purchased product with variants. This was covered for the front end validations scenario but it was missing when using the new backend validations feature flag.

## Rollout/Rollback
Revert

## Testing
<img width="866" height="705" alt="image" src="https://github.com/user-attachments/assets/c039572a-e444-411e-b8fe-cfda5f4c3367" />

