### PR TITLE
fix(quotes): B2B-3665 fix: add missing addressId in quote when selecting from saved addresses

### DIFF
--- a/apps/storefront/src/pages/quote/components/AddressItemCard.tsx
+++ b/apps/storefront/src/pages/quote/components/AddressItemCard.tsx
@@ -93,7 +93,7 @@ export function AddressItemCard(props: OrderItemCardProps) {
         <Typography variant="body1">{`${addressInfo.city}, ${addressInfo.state} ${addressInfo.zipCode}, ${addressInfo.country}`}</Typography>
         <Typography variant="body1">{addressInfo.phoneNumber}</Typography>
 
-        <Flex>
+        <Flex theme={theme}>
           <CustomButton
             variant="text"
             onClick={() => {

--- a/apps/storefront/src/pages/quote/components/QuoteAddress.tsx
+++ b/apps/storefront/src/pages/quote/components/QuoteAddress.tsx
@@ -60,6 +60,7 @@ function QuoteAddress(
     getValues,
     formState: { errors },
     setValue,
+    reset,
   } = useForm({
     mode: 'onSubmit',
   });
@@ -106,6 +107,7 @@ function QuoteAddress(
   };
 
   const handleChangeAddress = (address: AddressItemType) => {
+    reset(); // reset the form before setting new values
     const addressItem: any = {
       label: address?.label || '',
       firstName: address?.firstName || '',
@@ -118,6 +120,13 @@ function QuoteAddress(
       state: address?.state || '',
       zipCode: address?.zipCode || '',
       phoneNumber: address?.phoneNumber || '',
+    };
+
+    // selectedAddress temporarily stores the original address to detect changes before submitting the quote.
+    // This field will be removed once address comparison is handled.
+    addressItem.selectedAddress = {
+      ...cloneDeep(addressItem),
+      addressId: Number(address?.id),
     };
 
     Object.keys(addressItem).forEach((item: string) => {


### PR DESCRIPTION
fix(quotes): B2B-3665 fix: add missing addressId in quote when selecting from saved addresses

Jira: [B2B-3665](https://bigcommercecloud.atlassian.net/browse/B2B-3665)

## What/Why?

Missing address Id while submitted a quote.

**Case 1: Company with default shipping and billing address**  
The system correctly passes the addressId to the quote; no changes are needed.

**Case 2: Address selection from the address book**  
When the buyer selects an address via choose from saved, I will pass the addressId to the quote.

**Case 3: User-entered or modified address**  
If the user enters or modifies the address, the addressId will be 0. This functionality is also working correctly; no changes are needed.

## Rollout/Rollback
Revert

## Testing
Added tests to cover the all three scenarios
<img width="602" height="119" alt="Screenshot 2025-10-13 at 3 38 46 pm" src="https://github.com/user-attachments/assets/ecb6a1ca-0a9c-4eb4-b9ef-34499c996b1f" />



[B2B-3665]: https://bigcommercecloud.atlassian.net/browse/B2B-3665?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ