### PR TITLE
fix(shopping-lists): B2B-3782 ensure shopping list id is always int

### DIFF
--- a/apps/storefront/src/pages/PDP/index.b2b.test.tsx
+++ b/apps/storefront/src/pages/PDP/index.b2b.test.tsx
@@ -32,7 +32,7 @@ beforeEach(() => {
 
 const buildShoppingListNodeWith = builder(() => ({
   node: {
-    id: faker.number.int().toString(),
+    id: faker.number.int(),
     name: faker.lorem.word(),
     description: faker.lorem.sentence(),
     customerInfo: {
@@ -117,7 +117,7 @@ describe('stencil', () => {
     const addItemsToShoppingList = vi.fn();
 
     const shoppingList = buildShoppingListNodeWith({
-      node: { id: '992', name: 'Foo Bar Shopping List' },
+      node: { id: 992, name: 'Foo Bar Shopping List' },
     });
 
     server.use(
@@ -146,7 +146,7 @@ describe('stencil', () => {
       .calledWith(
         expect.objectContaining({
           variables: expect.objectContaining({
-            shoppingListId: '992',
+            shoppingListId: 992,
             items: expect.arrayContaining([
               expect.objectContaining({
                 productId: 123,
@@ -205,7 +205,7 @@ describe('stencil', () => {
     const addItemsToShoppingList = vi.fn();
 
     const shoppingList = buildShoppingListNodeWith({
-      node: { id: '992', name: 'Foo Bar Shopping List' },
+      node: { id: 992, name: 'Foo Bar Shopping List' },
     });
 
     server.use(
@@ -232,7 +232,7 @@ describe('stencil', () => {
       .calledWith(
         expect.objectContaining({
           variables: expect.objectContaining({
-            shoppingListId: '992',
+            shoppingListId: 992,
             items: expect.arrayContaining([
               expect.objectContaining({
                 productId: 123,
@@ -333,7 +333,7 @@ describe('stencil', () => {
       .calledWith(
         expect.objectContaining({
           variables: expect.objectContaining({
-            shoppingListId: '992',
+            shoppingListId: 992,
             items: expect.arrayContaining([
               expect.objectContaining({
                 productId: 123,
@@ -374,7 +374,7 @@ describe('stencil', () => {
     await userEvent.type(descriptionInput, 'This is a new shopping list');
 
     const shoppingList = buildShoppingListNodeWith({
-      node: { id: '992', name: 'New Shopping List' },
+      node: { id: 992, name: 'New Shopping List' },
     });
 
     when(getCompanyShoppingLists, { times: 1 })
@@ -398,7 +398,7 @@ describe('stencil', () => {
 
   it('navigates to the shopping list page when the "View Shopping List" button is clicked', async () => {
     const shoppingList = buildShoppingListNodeWith({
-      node: { id: '992', name: 'Foo Bar Shopping List' },
+      node: { id: 992, name: 'Foo Bar Shopping List' },
     });
 
     server.use(
@@ -462,7 +462,7 @@ describe('stencil', () => {
       );
 
       const shoppingList = buildShoppingListNodeWith({
-        node: { id: '992', name: 'Foo Bar Shopping List' },
+        node: { id: 992, name: 'Foo Bar Shopping List' },
       });
 
       server.use(
@@ -516,7 +516,7 @@ describe('stencil', () => {
       );
 
       const shoppingList = buildShoppingListNodeWith({
-        node: { id: '992', name: 'Foo Bar Shopping List' },
+        node: { id: 992, name: 'Foo Bar Shopping List' },
       });
 
       server.use(
@@ -592,7 +592,7 @@ describe('other/catalyst', () => {
     const addItemsToShoppingList = vi.fn();
 
     const shoppingList = buildShoppingListNodeWith({
-      node: { id: '992', name: 'Foo Bar Shopping List' },
+      node: { id: 992, name: 'Foo Bar Shopping List' },
     });
 
     server.use(
@@ -621,7 +621,7 @@ describe('other/catalyst', () => {
       .calledWith(
         expect.objectContaining({
           variables: expect.objectContaining({
-            shoppingListId: '992',
+            shoppingListId: 992,
             items: expect.arrayContaining([
               expect.objectContaining({
                 productId: 123,
@@ -675,7 +675,7 @@ describe('other/catalyst', () => {
     const addItemsToShoppingList = vi.fn();
 
     const shoppingList = buildShoppingListNodeWith({
-      node: { id: '992', name: 'Foo Bar Shopping List' },
+      node: { id: 992, name: 'Foo Bar Shopping List' },
     });
 
     server.use(
@@ -702,7 +702,7 @@ describe('other/catalyst', () => {
       .calledWith(
         expect.objectContaining({
           variables: expect.objectContaining({
-            shoppingListId: '992',
+            shoppingListId: 992,
             items: expect.arrayContaining([
               expect.objectContaining({
                 productId: 123,
@@ -757,7 +757,7 @@ describe('other/catalyst', () => {
     const addItemsToShoppingList = vi.fn();
 
     const shoppingList = buildShoppingListNodeWith({
-      node: { id: '992', name: 'Foo Bar Shopping List' },
+      node: { id: 992, name: 'Foo Bar Shopping List' },
     });
 
     server.use(
@@ -786,7 +786,7 @@ describe('other/catalyst', () => {
       .calledWith(
         expect.objectContaining({
           variables: expect.objectContaining({
-            shoppingListId: '992',
+            shoppingListId: 992,
             items: expect.arrayContaining([
               expect.objectContaining({
                 productId: 123,
@@ -881,7 +881,7 @@ describe('other/catalyst', () => {
       .calledWith(
         expect.objectContaining({
           variables: expect.objectContaining({
-            shoppingListId: '992',
+            shoppingListId: 992,
             items: expect.arrayContaining([
               expect.objectContaining({
                 productId: 123,
@@ -923,7 +923,7 @@ describe('other/catalyst', () => {
     await userEvent.type(descriptionInput, 'This is a new shopping list');
 
     const shoppingList = buildShoppingListNodeWith({
-      node: { id: '992', name: 'New Shopping List' },
+      node: { id: 992, name: 'New Shopping List' },
     });
 
     when(getCompanyShoppingLists, { times: 1 })
@@ -947,7 +947,7 @@ describe('other/catalyst', () => {
 
   it('navigates to the shopping list page when the "View Shopping List" button is clicked', async () => {
     const shoppingList = buildShoppingListNodeWith({
-      node: { id: '992', name: 'Foo Bar Shopping List' },
+      node: { id: 992, name: 'Foo Bar Shopping List' },
     });
 
     server.use(
@@ -1004,7 +1004,7 @@ describe('other/catalyst', () => {
       ]);
 
       const shoppingList = buildShoppingListNodeWith({
-        node: { id: '992', name: 'Foo Bar Shopping List' },
+        node: { id: 992, name: 'Foo Bar Shopping List' },
       });
 
       server.use(
@@ -1053,7 +1053,7 @@ describe('other/catalyst', () => {
       ]);
 
       const shoppingList = buildShoppingListNodeWith({
-        node: { id: '992', name: 'Foo Bar Shopping List' },
+        node: { id: 992, name: 'Foo Bar Shopping List' },
       });
 
       server.use(

--- a/apps/storefront/src/shared/service/b2b/graphql/shoppingList.ts
+++ b/apps/storefront/src/shared/service/b2b/graphql/shoppingList.ts
@@ -579,7 +579,7 @@ export const addProductToShoppingList = (data: CustomFieldItems = {}) =>
   B3Request.graphqlB2B({
     query: addItemsToShoppingListQuery,
     variables: {
-      shoppingListId: data.shoppingListId,
+      shoppingListId: Number(data.shoppingListId),
       items: data.items,
     },
   });


### PR DESCRIPTION
Jira: [B2B-3782](https://bigcommercecloud.atlassian.net/browse/B2B-3782)

## What/Why?
After converting the `addItemsToShoppingListQuery` to use GraphQL variables instead of string interpolation, the mutation now enforces strict typing `($shoppingListId: Int!)`. However, the `shoppingListId` is being passed as a string from the product page, causing a type mismatch.

https://github.com/bigcommerce/b2b-buyer-portal/pull/573
<!--
  A description about what this pull request implements and its purpose.
  Try to be detailed and describe any technical details to simplify the job
  of the reviewer and the individual on production support.
-->

## Rollout/Rollback
revert and redeploy
<!--
Detail how this change will be rolled out. Include reference to any
experiments and how the success will be measured as the experiment is
ramped.

Document rollback procedures. Is rolling back the change as simple as
rolling back an experiment or does it require reverting code? Are there
database migrations that may change our decision to roll forward instead of
back?
-->

## Testing
### Before

https://github.com/user-attachments/assets/be616fa2-0aa3-439f-be67-04a57374a7a1

### After

https://github.com/user-attachments/assets/42a8e5e0-55d0-4911-9ee2-77b24ffeed5a

<!--
Provide as much information as you can about how you tested and how another
Engineer can test your change. Include screenshots, or test run output
where appropriate.
-->


[B2B-3782]: https://bigcommercecloud.atlassian.net/browse/B2B-3782?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
