### PR TITLE
fix(quotes): B2B-3763 fix cant add np&oos product to quote

### DIFF
--- a/apps/storefront/src/pages/ShoppingListDetails/components/QuickAdd.tsx
+++ b/apps/storefront/src/pages/ShoppingListDetails/components/QuickAdd.tsx
@@ -21,7 +21,7 @@ interface AddToListContentProps {
   level?: number;
   buttonText?: string;
   buttonLoading?: boolean;
-  type?: string;
+  type: 'shoppingList' | 'quoteDraft';
 }
 
 export default function QuickAdd(props: AddToListContentProps) {
@@ -35,6 +35,9 @@ export default function QuickAdd(props: AddToListContentProps) {
     type,
   } = props;
 
+  const allowAddNonPurchasableProduct = useAppSelector(
+    ({ global }) => global.blockPendingQuoteNonPurchasableOOS.isEnableProduct || false,
+  );
   const companyStatus = useAppSelector(({ company }) => company.companyInfo.status);
   const draftQuoteList = useAppSelector(({ quoteInfo }) => quoteInfo.draftQuoteList);
 
@@ -163,7 +166,7 @@ export default function QuickAdd(props: AddToListContentProps) {
 
         const quantity = (skuValue[sku] as number) || 0;
 
-        if (purchasingDisabled === '1' && type !== 'shoppingList') {
+        if (purchasingDisabled === '1' && !allowAddNonPurchasableProduct && type === 'quoteDraft') {
           notPurchaseSku.push(sku);
           return;
         }
@@ -256,7 +259,7 @@ export default function QuickAdd(props: AddToListContentProps) {
         numberLimit,
       };
     },
-    [draftQuoteList, type],
+    [allowAddNonPurchasableProduct, draftQuoteList, type],
   );
 
   const showErrors = (

--- a/apps/storefront/src/pages/ShoppingListDetails/index.quickadd.test.tsx
+++ b/apps/storefront/src/pages/ShoppingListDetails/index.quickadd.test.tsx
@@ -169,17 +169,23 @@ const storeInfoWithDateFormat = buildStoreInfoStateWith({ timeFormat: { display:
 const preloadedState = { company: approvedB2BCompany, storeInfo: storeInfoWithDateFormat };
 
 it('renders the quick add section', () => {
-  renderWithProviders(<QuickAdd updateList={vi.fn()} quickAddToList={vi.fn()} />, {
-    preloadedState,
-  });
+  renderWithProviders(
+    <QuickAdd updateList={vi.fn()} quickAddToList={vi.fn()} type="quoteDraft" />,
+    {
+      preloadedState,
+    },
+  );
 
   expect(screen.getByText('Quick add')).toBeInTheDocument();
 });
 
 it('increases the number of input rows when clicking -show more rows- button', async () => {
-  renderWithProviders(<QuickAdd updateList={vi.fn()} quickAddToList={vi.fn()} />, {
-    preloadedState,
-  });
+  renderWithProviders(
+    <QuickAdd updateList={vi.fn()} quickAddToList={vi.fn()} type="shoppingList" />,
+    {
+      preloadedState,
+    },
+  );
 
   const showMoreRowsButton = screen.getByRole('button', { name: 'Show more rows' });
 
@@ -214,9 +220,12 @@ it('calls "quickAddToList" with the skus and the quantities when clicking on the
 
   const quickAddToList = vi.fn();
 
-  renderWithProviders(<QuickAdd updateList={vi.fn()} quickAddToList={quickAddToList} />, {
-    preloadedState,
-  });
+  renderWithProviders(
+    <QuickAdd updateList={vi.fn()} quickAddToList={quickAddToList} type="shoppingList" />,
+    {
+      preloadedState,
+    },
+  );
 
   const [skuInput] = screen.getAllByRole('textbox', { name: 'SKU#' });
   const [qtyInput] = screen.getAllByRole('spinbutton', { name: 'Qty' });
@@ -258,9 +267,12 @@ it('only clears inputs that were passed to "quickAddToList", keeps the rest', as
 
   const quickAddToList = vi.fn();
 
-  renderWithProviders(<QuickAdd updateList={vi.fn()} quickAddToList={quickAddToList} />, {
-    preloadedState,
-  });
+  renderWithProviders(
+    <QuickAdd updateList={vi.fn()} quickAddToList={quickAddToList} type="shoppingList" />,
+    {
+      preloadedState,
+    },
+  );
 
   const [firstInput, secondSkuInput] = screen.getAllByRole('textbox', { name: 'SKU#' });
   const [firstQtyInput, secondQtyInput] = screen.getAllByRole('spinbutton', { name: 'Qty' });
@@ -295,9 +307,12 @@ it('submits the form when pressing enter on either of the inputs', async () => {
     graphql.query('GetVariantInfoBySkus', () => HttpResponse.json({ data: { variantSku: [] } })),
   );
 
-  renderWithProviders(<QuickAdd updateList={vi.fn()} quickAddToList={vi.fn()} />, {
-    preloadedState,
-  });
+  renderWithProviders(
+    <QuickAdd updateList={vi.fn()} quickAddToList={vi.fn()} type="shoppingList" />,
+    {
+      preloadedState,
+    },
+  );
 
   const [skuInput] = screen.getAllByRole('textbox', { name: 'SKU#' });
   const [qtyInput] = screen.getAllByRole('spinbutton', { name: 'Qty' });
@@ -343,9 +358,12 @@ describe('when there is a problem with some of the skus', () => {
       ),
     );
 
-    renderWithProviders(<QuickAdd updateList={vi.fn()} quickAddToList={vi.fn()} />, {
-      preloadedState,
-    });
+    renderWithProviders(
+      <QuickAdd updateList={vi.fn()} quickAddToList={vi.fn()} type="quoteDraft" />,
+      {
+        preloadedState,
+      },
+    );
 
     const [skuInput] = screen.getAllByRole('textbox', { name: 'SKU#' });
     const [qtyInput] = screen.getAllByRole('spinbutton', { name: 'Qty' });
@@ -384,9 +402,12 @@ describe('when there is a problem with some of the skus', () => {
       ),
     );
 
-    renderWithProviders(<QuickAdd updateList={vi.fn()} quickAddToList={vi.fn()} />, {
-      preloadedState,
-    });
+    renderWithProviders(
+      <QuickAdd updateList={vi.fn()} quickAddToList={vi.fn()} type="quoteDraft" />,
+      {
+        preloadedState,
+      },
+    );
 
     const [skuInput] = screen.getAllByRole('textbox', { name: 'SKU#' });
     const [qtyInput] = screen.getAllByRole('spinbutton', { name: 'Qty' });
@@ -426,9 +447,12 @@ describe('when the sku has a required modifier', () => {
       ),
     );
 
-    renderWithProviders(<QuickAdd updateList={vi.fn()} quickAddToList={vi.fn()} />, {
-      preloadedState,
-    });
+    renderWithProviders(
+      <QuickAdd updateList={vi.fn()} quickAddToList={vi.fn()} type="quoteDraft" />,
+      {
+        preloadedState,
+      },
+    );
 
     const [skuInput] = screen.getAllByRole('textbox', { name: 'SKU#' });
     const [qtyInput] = screen.getAllByRole('spinbutton', { name: 'Qty' });
@@ -473,14 +497,17 @@ describe('when an existing sky on the draft quote is over the quantity limit', (
       ),
     );
 
-    renderWithProviders(<QuickAdd updateList={vi.fn()} quickAddToList={vi.fn()} />, {
-      preloadedState: {
-        ...preloadedState,
-        quoteInfo: buildQuoteInfoStateWith({
-          draftQuoteList: [draftItemOverLimit],
-        }),
+    renderWithProviders(
+      <QuickAdd updateList={vi.fn()} quickAddToList={vi.fn()} type="quoteDraft" />,
+      {
+        preloadedState: {
+          ...preloadedState,
+          quoteInfo: buildQuoteInfoStateWith({
+            draftQuoteList: [draftItemOverLimit],
+          }),
+        },
       },
-    });
+    );
 
     const [skuInput] = screen.getAllByRole('textbox', { name: 'SKU#' });
     const [qtyInput] = screen.getAllByRole('spinbutton', { name: 'Qty' });
@@ -500,9 +527,12 @@ describe('when an existing sky on the draft quote is over the quantity limit', (
 
 describe('when some data is missing in the form', async () => {
   it('shows an error message when sku or quantity are not provided', async () => {
-    renderWithProviders(<QuickAdd updateList={vi.fn()} quickAddToList={vi.fn()} />, {
-      preloadedState,
-    });
+    renderWithProviders(
+      <QuickAdd updateList={vi.fn()} quickAddToList={vi.fn()} type="shoppingList" />,
+      {
+        preloadedState,
+      },
+    );
 
     const [firstSkuInput, secondSkuInput] = screen.getAllByRole('textbox', { name: 'SKU#' });
     const [firstQtyInput, secondQtyInput] = screen.getAllByRole('spinbutton', { name: 'Qty' });
@@ -528,9 +558,12 @@ describe('when some data is missing in the form', async () => {
   });
 
   it('shows an error message when quantity is negative', async () => {
-    renderWithProviders(<QuickAdd updateList={vi.fn()} quickAddToList={vi.fn()} />, {
-      preloadedState,
-    });
+    renderWithProviders(
+      <QuickAdd updateList={vi.fn()} quickAddToList={vi.fn()} type="shoppingList" />,
+      {
+        preloadedState,
+      },
+    );
 
     const [skuInput] = screen.getAllByRole('textbox', { name: 'SKU#' });
     const [qtyInput] = screen.getAllByRole('spinbutton', { name: 'Qty' });

--- a/apps/storefront/src/pages/quote/components/AddToQuote.tsx
+++ b/apps/storefront/src/pages/quote/components/AddToQuote.tsx
@@ -278,6 +278,7 @@ export default function AddToQuote(props: AddToListProps) {
           <QuickAdd
             updateList={updateList}
             quickAddToList={quickAddToList}
+            type="quoteDraft"
             level={1}
             buttonText={b3Lang('quoteDraft.button.addProductsToAddToQuote')}
           />


### PR DESCRIPTION
Jira: [B2B-3763](https://bigcommercecloud.atlassian.net/browse/B2B-3763 )

## What/Why?
<!--
  A description about what this pull request implements and its purpose.
  Try to be detailed and describe any technical details to simplify the job
  of the reviewer and the individual on production support.
-->
 "Add to Quote" form in the Draft Quote UI fails to add non-purchasable and out-of-stock (np&oos) product to a quote even if the setting is one.

Issue stemmed from the QuickAdd component L166 where we don't consider this setting in the following block:
```js
        if (purchasingDisabled === '1' && type !== 'shoppingList') {
```
## Rollout/Rollback
Revert this change

## Testing
<!--
Provide as much information as you can about how you tested and how another
Engineer can test your change. Include screenshots, or test run output
where appropriate.
-->

https://github.com/user-attachments/assets/30b2fb2a-1c54-412b-b589-cff2ae2ae8d2





[B2B-3763]: https://bigcommercecloud.atlassian.net/browse/B2B-3763?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ