### PR TITLE
fix(quotes): B2B-3790 add missing addressId in quote when selecting from saved or default addresses

### DIFF
--- a/apps/storefront/src/pages/quote/components/QuoteAddress.tsx
+++ b/apps/storefront/src/pages/quote/components/QuoteAddress.tsx
@@ -120,14 +120,11 @@ function QuoteAddress(
       state: address?.state || '',
       zipCode: address?.zipCode || '',
       phoneNumber: address?.phoneNumber || '',
+      addressId: Number(address?.id) || 0,
     };
 
-    // selectedAddress temporarily stores the original address to detect changes before submitting the quote.
-    // This field will be removed once address comparison is handled.
-    addressItem.selectedAddress = {
-      ...cloneDeep(addressItem),
-      addressId: Number(address?.id),
-    };
+    // masterCopy temporarily stores the original address to detect changes and will be removed before submitting the quote.
+    addressItem.masterCopy = cloneDeep(addressItem);
 
     Object.keys(addressItem).forEach((item: string) => {
       if (item === 'company') return;


### PR DESCRIPTION
fix(quotes): B2B-3790 add missing addressId in quote when selecting from saved or default addresses

Jira: [B2B-3790](https://bigcommercecloud.atlassian.net/browse/B2B-3790)

## What/Why?
When a company has a default shipping or billing address, the quote creation flow automatically populates those fields with the default address and its corresponding addressId.

However, if the buyer manually edits any of the prefilled address fields (without selecting a new one from the saved addresses), the system still sends the default addressId in the quote submission.

This creates a broken relationship between the actual modified address and the original saved address — the modified address should no longer be linked to the default one.

## Rollout/Rollback
Revert

## Testing
<img width="736" height="164" alt="Screenshot 2025-10-16 at 2 24 12 pm" src="https://github.com/user-attachments/assets/69cf83f8-5443-4bc3-bdfd-266866cef441" />

## Demo
https://drive.google.com/file/d/1MI9mBIdS6x_pePnQ--Ktwhbvt7bPy_I9/view?usp=sharing

## Notes
Extension to [this PR](https://github.com/bigcommerce/b2b-buyer-portal/pull/575)




[B2B-3790]: https://bigcommercecloud.atlassian.net/browse/B2B-3790?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ