### PR TITLE
fix(shopping-lists): B2B-3782 ensure shopping list id is always int b2c

### DIFF
--- a/apps/storefront/src/pages/PDP/index.b2c.test.tsx
+++ b/apps/storefront/src/pages/PDP/index.b2c.test.tsx
@@ -52,7 +52,7 @@ function FakeProductDataProvider({ productId, quantity, sku, options }: ProductD
 
 const buildCustomerShoppingListNodeWith = builder(() => ({
   node: {
-    id: faker.number.int().toString(),
+    id: faker.number.int(),
     name: faker.lorem.word(),
     description: faker.lorem.sentence(),
     updatedAt: getUnixTime(faker.date.recent()),
@@ -114,7 +114,7 @@ describe('stencil', () => {
     const addItemsToCustomerShoppingList = vi.fn();
 
     const shoppingList = buildCustomerShoppingListNodeWith({
-      node: { id: '992', name: 'Foo Bar Shopping List' },
+      node: { id: 992, name: 'Foo Bar Shopping List' },
     });
 
     server.use(
@@ -143,7 +143,7 @@ describe('stencil', () => {
       .calledWith(
         expect.objectContaining({
           variables: expect.objectContaining({
-            shoppingListId: '992',
+            shoppingListId: 992,
             items: expect.arrayContaining([
               expect.objectContaining({
                 productId: 123,
@@ -202,7 +202,7 @@ describe('stencil', () => {
     const addItemsToCustomerShoppingList = vi.fn();
 
     const shoppingList = buildCustomerShoppingListNodeWith({
-      node: { id: '992', name: 'Foo Bar Shopping List' },
+      node: { id: 992, name: 'Foo Bar Shopping List' },
     });
 
     server.use(
@@ -229,7 +229,7 @@ describe('stencil', () => {
       .calledWith(
         expect.objectContaining({
           variables: expect.objectContaining({
-            shoppingListId: '992',
+            shoppingListId: 992,
             items: expect.arrayContaining([
               expect.objectContaining({
                 productId: 123,
@@ -325,7 +325,7 @@ describe('stencil', () => {
       .calledWith(
         expect.objectContaining({
           variables: expect.objectContaining({
-            shoppingListId: '992',
+            shoppingListId: 992,
             items: expect.arrayContaining([
               expect.objectContaining({
                 productId: 123,
@@ -366,7 +366,7 @@ describe('stencil', () => {
     await userEvent.type(descriptionInput, 'This is a new shopping list');
 
     const shoppingList = buildCustomerShoppingListNodeWith({
-      node: { id: '992', name: 'New Shopping List' },
+      node: { id: 992, name: 'New Shopping List' },
     });
 
     when(getCustomerShoppingLists, { times: 1 })
@@ -390,7 +390,7 @@ describe('stencil', () => {
 
   it('navigates to the shopping list page when the "View Shopping List" button is clicked', async () => {
     const shoppingList = buildCustomerShoppingListNodeWith({
-      node: { id: '992', name: 'Foo Bar Shopping List' },
+      node: { id: 992, name: 'Foo Bar Shopping List' },
     });
 
     server.use(
@@ -579,7 +579,7 @@ describe('other/catalyst', () => {
     const addItemsToCustomerShoppingList = vi.fn();
 
     const shoppingList = buildCustomerShoppingListNodeWith({
-      node: { id: '992', name: 'Foo Bar Shopping List' },
+      node: { id: 992, name: 'Foo Bar Shopping List' },
     });
 
     server.use(
@@ -608,7 +608,7 @@ describe('other/catalyst', () => {
       .calledWith(
         expect.objectContaining({
           variables: expect.objectContaining({
-            shoppingListId: '992',
+            shoppingListId: 992,
             items: expect.arrayContaining([
               expect.objectContaining({
                 productId: 123,
@@ -662,7 +662,7 @@ describe('other/catalyst', () => {
     const addItemsToCustomerShoppingList = vi.fn();
 
     const shoppingList = buildCustomerShoppingListNodeWith({
-      node: { id: '992', name: 'Foo Bar Shopping List' },
+      node: { id: 992, name: 'Foo Bar Shopping List' },
     });
 
     server.use(
@@ -689,7 +689,7 @@ describe('other/catalyst', () => {
       .calledWith(
         expect.objectContaining({
           variables: expect.objectContaining({
-            shoppingListId: '992',
+            shoppingListId: 992,
             items: expect.arrayContaining([
               expect.objectContaining({
                 productId: 123,
@@ -780,7 +780,7 @@ describe('other/catalyst', () => {
       .calledWith(
         expect.objectContaining({
           variables: expect.objectContaining({
-            shoppingListId: '992',
+            shoppingListId: 992,
             items: expect.arrayContaining([
               expect.objectContaining({
                 productId: 123,
@@ -822,7 +822,7 @@ describe('other/catalyst', () => {
     await userEvent.type(descriptionInput, 'This is a new shopping list');
 
     const shoppingList = buildCustomerShoppingListNodeWith({
-      node: { id: '992', name: 'New Shopping List' },
+      node: { id: 992, name: 'New Shopping List' },
     });
 
     when(getCustomerShoppingLists, { times: 1 })
@@ -846,7 +846,7 @@ describe('other/catalyst', () => {
 
   it('navigates to the shopping list page when the "View Shopping List" button is clicked', async () => {
     const shoppingList = buildCustomerShoppingListNodeWith({
-      node: { id: '992', name: 'Foo Bar Shopping List' },
+      node: { id: 992, name: 'Foo Bar Shopping List' },
     });
 
     server.use(

--- a/apps/storefront/src/shared/service/b2b/graphql/shoppingList.ts
+++ b/apps/storefront/src/shared/service/b2b/graphql/shoppingList.ts
@@ -633,7 +633,7 @@ export const addProductToBcShoppingList = (data: CustomFieldItems = {}) =>
   B3Request.graphqlB2B({
     query: addItemsToBcShoppingListQuery,
     variables: {
-      shoppingListId: data.shoppingListId,
+      shoppingListId: Number(data.shoppingListId),
       items: data.items,
     },
   });


### PR DESCRIPTION
Jira: [B2B-3792](https://bigcommercecloud.atlassian.net/browse/B2B-3792)

## What/Why?
https://github.com/bigcommerce/b2b-buyer-portal/pull/580

Same issue described in the PR above that was just merged a few days ago. I just missed to also update the b2c shopping list update query also 🤦🏾 
<!--
  A description about what this pull request implements and its purpose.
  Try to be detailed and describe any technical details to simplify the job
  of the reviewer and the individual on production support.
-->

## Rollout/Rollback
<!--
Detail how this change will be rolled out. Include reference to any
experiments and how the success will be measured as the experiment is
ramped.

Document rollback procedures. Is rolling back the change as simple as
rolling back an experiment or does it require reverting code? Are there
database migrations that may change our decision to roll forward instead of
back?
-->

## Testing
Test adding to shopping list as a b2c user
<!--
Provide as much information as you can about how you tested and how another
Engineer can test your change. Include screenshots, or test run output
where appropriate.
-->
