### PR TITLE
feat(quotes): B2B-3746 fix backordering validation to include variant checking

### DIFF
--- a/apps/storefront/src/pages/QuoteDraft/index.test.tsx
+++ b/apps/storefront/src/pages/QuoteDraft/index.test.tsx
@@ -1286,14 +1286,13 @@ describe('when the user is a B2B customer', () => {
     expect(within(productTable).getByText('Insufficient stock')).toBeInTheDocument();
   });
 
-  it('should show stock warning for variant with insufficient stock when NP&OOS is disabled', async () => {
+  it('show stock warning for variant with insufficient stock when NP&OOS is disabled', async () => {
     const product = buildDraftQuoteItemWith({
       node: {
         quantity: 100,
         variantSku: 'ABCBLK',
         productsSearch: buildProductWith({
           inventoryTracking: 'variant',
-          unlimitedBackorder: false,
           availableToSell: 10,
           variants: [
             buildVariantWith({
@@ -1301,7 +1300,6 @@ describe('when the user is a B2B customer', () => {
               available_to_sell: 10,
               purchasing_disabled: false,
               sku: 'ABCBLK',
-              unlimited_backorder: true,
             }),
           ],
         }),

--- a/apps/storefront/src/pages/quote/components/QuoteTable.tsx
+++ b/apps/storefront/src/pages/quote/components/QuoteTable.tsx
@@ -251,10 +251,10 @@ function QuoteTable(props: ShoppingDetailTableProps) {
               warningMessage = b3Lang('quoteDraft.quoteTable.unavailable.tip');
             }
           }
-        } else {
+        } else if (isInventoryTrackingEnabled) {
           let hasUnlimitedBackorder = product.unlimitedBackorder;
 
-          if (isInventoryTrackingEnabled && product.inventoryTracking === 'variant') {
+          if (product.inventoryTracking === 'variant') {
             const currentVariant = product.variants.find(
               (variant: CustomFieldItems) => variant.sku === row.variantSku,
             );
@@ -262,11 +262,9 @@ function QuoteTable(props: ShoppingDetailTableProps) {
           }
 
           if (!hasUnlimitedBackorder) {
-            const availableStock = isInventoryTrackingEnabled
-              ? product.availableToSell
-              : row.quantity;
+            const availableStock = product.availableToSell;
 
-            if (isInventoryTrackingEnabled && availableStock < row.quantity) {
+            if (availableStock < row.quantity) {
               warningMessage = b3Lang('quoteDraft.quoteTable.outOfStock.tip');
               warningDetails = b3Lang('quoteDraft.quoteTable.oosNumber.tip', {
                 qty: availableStock,


### PR DESCRIPTION
Jira: [B2B-3746](https://bigcommercecloud.atlassian.net/browse/B2B-3746)

## What/Why?
Products with variants and unlimited backorder limits were incorrectly showing stock level warnings in the draft quote UI, even when the variant had unlimited backorder enabled.

This is because the stock warning logic was only checking product-level unlimitedBackorder settings but not variant-level unlimited backorder settings when inventoryTracking was set to variant
<!--
  A description about what this pull request implements and its purpose.
  Try to be detailed and describe any technical details to simplify the job
  of the reviewer and the individual on production support.
-->

## Rollout/Rollback
revert and redeploy
<!--
Detail how this change will be rolled out. Include reference to any
experiments and how the success will be measured as the experiment is
ramped.

Document rollback procedures. Is rolling back the change as simple as
rolling back an experiment or does it require reverting code? Are there
database migrations that may change our decision to roll forward instead of
back?
-->

## Testing

### Before

https://github.com/user-attachments/assets/6cfb1e4d-8710-4f6a-8c11-9fe2799a468e


### After

https://github.com/user-attachments/assets/aa116a1b-4ba6-42f5-8a59-fd5e23a86a89


<!--
Provide as much information as you can about how you tested and how another
Engineer can test your change. Include screenshots, or test run output
where appropriate.
-->


[B2B-3746]: https://bigcommercecloud.atlassian.net/browse/B2B-3746?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ