### PR TITLE
test(common): B2B-3774 added infrastructure with b2b-e2e tag to run as a part of deployment requirement

### DIFF
--- a/.infrastructure/regression.tf
+++ b/.infrastructure/regression.tf
@@ -1,0 +1,26 @@
+# Staging regression suite
+
+module "staging_run_suite_staging_b2b_e2e_suite" {
+  source     = "git@github.com:bigcommerce/terraform-services-modules.git//modules/run_regression_suite_from_other_project"
+  project_id = module.service.id
+  target_ids = [
+    module.service.target_ids["staging-us"]
+  ]
+  other_project_name = "functional-tests"
+  other_target_name  = "staging"
+  profile_name       = "staging_b2b_e2e_suite"
+  delay_in_seconds   = 0
+}
+
+# Production regression suite
+
+module "production_require_suite_staging_b2b_e2e_suite" {
+  source     = "git@github.com:bigcommerce/terraform-services-modules.git//modules/require_regression_suite_from_another_project"
+  project_id = module.service.id
+  target_ids = [
+    module.service.target_ids["production-us"]
+  ]
+  other_project_name = "functional-tests"
+  other_target_name  = "staging"
+  profile_name       = "staging_b2b_e2e_suite"
+}


### PR DESCRIPTION
Jira: [B2B-3774](https://bigcommercecloud.atlassian.net/browse/B2B-3774)

## What/Why?
Added b2b-api and b2b-e2e as a part of infrastructure circle CI run 

## Rollout/Rollback
Revert

## Testing
YTD


[B2B-3774]: https://bigcommercecloud.atlassian.net/browse/B2B-3774?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ