### PR TITLE
fix(common): B2B-3719 read hash at event time

### DIFF
--- a/apps/storefront/src/App.tsx
+++ b/apps/storefront/src/App.tsx
@@ -335,9 +335,12 @@ export default function App() {
   }, [isOpen]);
 
   useEffect(() => {
-    const { hash = '' } = window.location;
-
-    const handleHashChange = () => (!hash || hash === '#/') && setOpenPage({ isOpen: false });
+    const handleHashChange = () => {
+      const { hash } = window.location;
+      if (!hash || hash === '#/') {
+        setOpenPage({ isOpen: false });
+      }
+    };
 
     window.addEventListener('hashchange', handleHashChange);
 


### PR DESCRIPTION
Jira: [3719](https://bigcommercecloud.atlassian.net/browse/B2B-3719)

## What/Why?
<!--
  A description about what this pull request implements and its purpose.
  Try to be detailed and describe any technical details to simplify the job
  of the reviewer and the individual on production support.
-->

We changed the hashchange handler in `apps/storefront/src/App.tsx`. The old code captured the hash at mount, so after ending masquerade it compared against a stale value and closed the overlay, causing a blank page. The new handler reads `window.location.hash` at event time and only closes when the current hash is empty or `#/`. This ensures the app frame stays open and the router correctly shows `/dashboard` after ending masquerade.

## Rollout/Rollback
<!--
Detail how this change will be rolled out. Include reference to any
experiments and how the success will be measured as the experiment is
ramped.

Document rollback procedures. Is rolling back the change as simple as
rolling back an experiment or does it require reverting code? Are there
database migrations that may change our decision to roll forward instead of
back?
-->
Rollback

## Testing
<!--
Provide as much information as you can about how you tested and how another
Engineer can test your change. Include screenshots, or test run output
where appropriate.
-->
Tested on integration and can no longer see blank page.