### PR TITLE
fix(shopping-lists): B2B-3845 Warning about invalid props being passed to html components

### DIFF
--- a/apps/storefront/src/pages/ShoppingListDetails/components/ReAddToCart.tsx
+++ b/apps/storefront/src/pages/ShoppingListDetails/components/ReAddToCart.tsx
@@ -84,7 +84,9 @@ const Flex = styled('div')<FlexProps>(({ isHeader, isMobile }) => {
   };
 });
 
-const FlexItem = styled(Box)(
+const FlexItem = styled(Box, {
+  shouldForwardProp: (prop) => prop !== 'textAlignLocation',
+})(
   ({
     width,
     padding = '0',

--- a/apps/storefront/src/pages/ShoppingListDetails/index.test.tsx
+++ b/apps/storefront/src/pages/ShoppingListDetails/index.test.tsx
@@ -805,7 +805,6 @@ describe("when a product's quantity is increased", () => {
 
   it('should keep checkbox selection even after the product Qty update', async () => {
     vitest.mocked(useParams).mockReturnValue({ id: '272989' });
-    vi.spyOn(console, 'error').mockImplementation(() => {});
 
     const twoLovelyBoots = buildShoppingListProductEdgeWith({
       node: { productName: 'Lovely boots', quantity: 2, basePrice: '49.00' },
@@ -840,7 +839,7 @@ describe("when a product's quantity is increased", () => {
     await waitForElementToBeRemoved(() => screen.queryByText(/loading/i));
 
     const rowOfLovelyBoots = screen.getByRole('row', { name: /Lovely boots/ });
-    within(rowOfLovelyBoots).getByRole('checkbox').click();
+    await userEvent.click(within(rowOfLovelyBoots).getByRole('checkbox'));
 
     getShoppingList.mockReturnValueOnce(
       buildShoppingListGraphQLResponseWith({
@@ -856,7 +855,7 @@ describe("when a product's quantity is increased", () => {
       initialSelectionEnd: Infinity,
     });
     expect(getShoppingList).toHaveBeenCalledTimes(2);
-    quantityInput.blur();
+    await userEvent.tab();
 
     await waitFor(() => {
       expect(getShoppingList).toHaveBeenCalledTimes(3);
@@ -964,7 +963,6 @@ describe('when the shopping list is ready for approval', () => {
 describe('when shopping list products verify inventory into add to cart', () => {
   it('errors on exceed product inventory', async () => {
     vitest.mocked(useParams).mockReturnValue({ id: '272989' });
-    vi.spyOn(console, 'error').mockImplementation(() => {});
 
     const variantInfo = buildVariantInfoWith({
       variantSku: 'LVLY-SK-123',
@@ -1065,7 +1063,6 @@ describe('when shopping list products verify inventory into add to cart', () => 
 
   it('errors on min quantity not reached', async () => {
     vitest.mocked(useParams).mockReturnValue({ id: '272989' });
-    vi.spyOn(console, 'error').mockImplementation(() => {});
 
     const variantInfo = buildVariantInfoWith({
       variantSku: 'LVLY-SK-123',
@@ -1166,7 +1163,6 @@ describe('when shopping list products verify inventory into add to cart', () => 
 
   it('errors on max quantity exceed', async () => {
     vitest.mocked(useParams).mockReturnValue({ id: '272989' });
-    vi.spyOn(console, 'error').mockImplementation(() => {});
 
     const variantInfo = buildVariantInfoWith({
       variantSku: 'LVLY-SK-123',
@@ -1273,7 +1269,6 @@ describe('when shopping list products verify inventory into add to cart', () => 
 describe('Add to quote', () => {
   it('add shopping list to draft quote', async () => {
     vitest.mocked(useParams).mockReturnValue({ id: '272989' });
-    // const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
     const searchProductsQuerySpy = vi.fn();
 
@@ -1801,7 +1796,7 @@ describe('when backend validation is enabled', () => {
 
   it('errors on exceed product inventory', async () => {
     vitest.mocked(useParams).mockReturnValue({ id: '272989' });
-    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementationOnce(() => {});
 
     const variantInfo = buildVariantInfoWith({ variantSku: 'LVLY-SK-123' });
 
@@ -1903,7 +1898,7 @@ describe('when backend validation is enabled', () => {
 
   it('respects unlimited backorder stock', async () => {
     vitest.mocked(useParams).mockReturnValue({ id: '272989' });
-    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementationOnce(() => {});
 
     const variantInfo = buildVariantInfoWith({ variantSku: 'LVLY-SK-123' });
 
@@ -2014,7 +2009,7 @@ describe('when backend validation is enabled', () => {
 
   it('errors on min quantity not reached', async () => {
     vitest.mocked(useParams).mockReturnValue({ id: '272989' });
-    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementationOnce(() => {});
 
     const variantInfo = buildVariantInfoWith({ variantSku: 'LVLY-SK-123' });
 
@@ -2116,7 +2111,7 @@ describe('when backend validation is enabled', () => {
 
   it('errors on max quantity exceed', async () => {
     vitest.mocked(useParams).mockReturnValue({ id: '272989' });
-    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementationOnce(() => {});
 
     const variantInfo = buildVariantInfoWith({ variantSku: 'LVLY-SK-123' });
 
@@ -2318,7 +2313,6 @@ describe('when backend validation is enabled', () => {
 
   it('shows only the most recent error for the product added to the cart', async () => {
     vi.mocked(useParams).mockReturnValue({ id: '272989' });
-    vi.spyOn(console, 'error').mockImplementation(() => {});
 
     const variantInfo = buildVariantInfoWith({
       variantSku: 'LVLY-SK-123',
@@ -2481,7 +2475,6 @@ describe('when backend validation is enabled', () => {
 
   it('succeeds adding to cart when initial add works (no validation needed)', async () => {
     vi.mocked(useParams).mockReturnValue({ id: '272989' });
-    vi.spyOn(console, 'error').mockImplementation(() => {});
 
     set(window, 'b2b.callbacks.dispatchEvent', vi.fn());
 
@@ -2547,7 +2540,6 @@ describe('when backend validation is enabled', () => {
 
   it('adds valid products to cart while showing failed products in dialog', async () => {
     vi.mocked(useParams).mockReturnValue({ id: '272989' });
-    vi.spyOn(console, 'error').mockImplementation(() => {});
 
     set(window, 'b2b.callbacks.dispatchEvent', vi.fn());
 
@@ -2682,7 +2674,6 @@ describe('when backend validation is enabled', () => {
 
   it('shows all products as failed when all validation fails', async () => {
     vi.mocked(useParams).mockReturnValue({ id: '272989' });
-    vi.spyOn(console, 'error').mockImplementation(() => {});
 
     const product1 = buildShoppingListProductEdgeWith({
       node: {
@@ -2779,7 +2770,6 @@ describe('when backend validation is enabled', () => {
 
   it('treats products with WARNING validation response as failures', async () => {
     vi.mocked(useParams).mockReturnValue({ id: '272989' });
-    vi.spyOn(console, 'error').mockImplementation(() => {});
 
     const warningProduct = buildShoppingListProductEdgeWith({
       node: {
@@ -2859,7 +2849,7 @@ describe('when backend validation is enabled', () => {
 
   it('shows all products as failed when second cart add fails after validation', async () => {
     vi.mocked(useParams).mockReturnValue({ id: '272989' });
-    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementationOnce(() => {});
 
     const product = buildShoppingListProductEdgeWith({
       node: {
@@ -2942,7 +2932,7 @@ describe('when backend validation is enabled', () => {
 
   it('does not validate products on network error and shows all products as failed', async () => {
     vi.mocked(useParams).mockReturnValue({ id: '272989' });
-    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementationOnce(() => {});
 
     const product = buildShoppingListProductEdgeWith({
       node: {


### PR DESCRIPTION
Jira: [B2B-3845](https://bigcommercecloud.atlassian.net/browse/B2B-3845)

## What/Why?
Fix warning about invalid props being passed to html components.

Avoid passing invalid props through styled components directly to HTML components, doing so will trigger a WARNING.

We do that using a filter for `@emotion/styled`

## Rollout/Rollback
Revert

## Testing

### Before:

<img width="2037" height="772" alt="image" src="https://github.com/user-attachments/assets/4ecc1e72-9670-4acf-8b48-685873b73003" />

### After:

<img width="2027" height="797" alt="image" src="https://github.com/user-attachments/assets/7263c4f9-f148-4a73-907f-1bb92df693aa" />

These warnings show up in the console in the browser and in some tests sometimes.


[B2B-3845]: https://bigcommercecloud.atlassian.net/browse/B2B-3845?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Addresses console warnings about invalid props reaching DOM elements.
> 
> - Adds `shouldForwardProp` to styled `FlexItem` to prevent forwarding `textAlignLocation` to the underlying HTML element in `ReAddToCart.tsx`
> - Test cleanup/stability: replace direct element interactions with `userEvent` (`click`, `tab`) and reduce broad `console.error` stubs (use `mockImplementationOnce` or remove) across `index.test.tsx`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a7e4c7ed154a7ea6c22d5272128dbd1652213669. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->