### PR TITLE
fix(quotes): B2B-3773 Update default selector on non-purchasable PDP page

### DIFF
--- a/apps/storefront/src/utils/storefrontConfig.ts
+++ b/apps/storefront/src/utils/storefrontConfig.ts
@@ -266,9 +266,9 @@ const getTemPlateConfig = async (dispatch: any, dispatchGlobal: any) => {
       if (storefrontKey.key === 'quote_on_non_purchasable_product_page') {
         storefrontConfig.extraFields = {
           ...item.extraFields,
-          locationSelector: item.extraFields?.locationSelector || '.add-to-cart-buttons',
+          locationSelector: item.extraFields?.locationSelector || '',
           classSelector: item.extraFields?.classSelector || 'button',
-          customCss: item.extraFields?.customCss || '',
+          customCss: item.extraFields?.customCss || 'margin-top: 0.5rem',
         };
       }
 


### PR DESCRIPTION
Jira: [B2B-3773](https://bigcommercecloud.atlassian.net/browse/B2B-3773)

## What/Why?
<!--
  A description about what this pull request implements and its purpose.
  Try to be detailed and describe any technical details to simplify the job
  of the reviewer and the individual on production support.
-->
On non-purchasable product pages, the add to quote button was getting added to the `.add-to-cart-buttons` element, which is hidden on Cornerstone.

This PR updates the default selector to be blank, so that the add to quote button is instead added as a sibling to `#add-to-cart-wrapper` (the code for this can be seen [here](https://github.com/bigcommerce/b2b-buyer-portal/blob/main/apps/storefront/src/hooks/dom/useMyQuote.ts#L261)).

There will be another PR for this ticket that does some refactoring to the logic that adds the button to the product page.

## Rollout/Rollback
<!--
Detail how this change will be rolled out. Include reference to any
experiments and how the success will be measured as the experiment is
ramped.

Document rollback procedures. Is rolling back the change as simple as
rolling back an experiment or does it require reverting code? Are there
database migrations that may change our decision to roll forward instead of
back?
-->
Revert and redeploy.

## Testing
<!--
Provide as much information as you can about how you tested and how another
Engineer can test your change. Include screenshots, or test run output
where appropriate.
-->
Before:

https://github.com/user-attachments/assets/1e1a42dd-67a6-401f-a7f1-fb19c6ecbe47

After:

https://github.com/user-attachments/assets/ff59b07e-6a4e-4f12-930c-d6e7bc229d5f


[B2B-3773]: https://bigcommercecloud.atlassian.net/browse/B2B-3773?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ