### PR TITLE
fix(common): B2B-3719 fix blank page rendering after ending masquerade

### DIFF
--- a/apps/storefront/src/components/layout/B3FallbackRoute.tsx
+++ b/apps/storefront/src/components/layout/B3FallbackRoute.tsx
@@ -1,0 +1,26 @@
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import { SetOpenPage } from '@/pages/SetOpenPage';
+
+interface RedirectFallbackProps {
+  path?: string;
+  setOpenPage: SetOpenPage;
+}
+
+export function RedirectFallback({ path, setOpenPage }: RedirectFallbackProps) {
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    // Strategy 1: Use first available route
+    if (path) {
+      navigate(path, { replace: true });
+      return;
+    }
+
+    // Strategy 2: Close the B2B app if no routes available
+    setOpenPage({ isOpen: false });
+  }, [path, navigate, setOpenPage]);
+
+  return null; // This component doesn't render anything
+}

--- a/apps/storefront/src/components/layout/B3RenderRouter.tsx
+++ b/apps/storefront/src/components/layout/B3RenderRouter.tsx
@@ -11,6 +11,8 @@ import { channelId } from '@/utils';
 
 import Loading from '../loading/Loading';
 
+import { RedirectFallback } from './B3FallbackRoute';
+
 const B3Layout = lazy(() => import('@/components/layout/B3Layout'));
 
 const B3LayoutTip = lazy(() => import('@/components/layout/B3LayoutTip'));
@@ -24,7 +26,7 @@ interface B3RenderRouterProps {
 export default function B3RenderRouter(props: B3RenderRouterProps) {
   const { setOpenPage, openUrl, isOpen } = props;
   const { state: globalState } = useContext(GlobalContext);
-  const newRoutes = () => getAllowedRoutes(globalState);
+  const routes = getAllowedRoutes(globalState);
   const location = useLocation();
   const navigate = useNavigate();
   const dispatch = useAppDispatch();
@@ -69,12 +71,16 @@ export default function B3RenderRouter(props: B3RenderRouterProps) {
             </B3Layout>
           }
         >
-          {newRoutes().map((route: RouteItem) => {
+          {routes.map((route: RouteItem) => {
             const { path, component: Component } = route;
             return (
               <Route key={path} path={path} element={<Component setOpenPage={setOpenPage} />} />
             );
           })}
+          <Route
+            path="*"
+            element={<RedirectFallback path={routes[0]?.path} setOpenPage={setOpenPage} />}
+          />
         </Route>
         {firstLevelRouting.map((route: RouteFirstLevelItem) => {
           const { isProvider, path, component: Component } = route;


### PR DESCRIPTION
Jira: [B2B-3719](https://bigcommercecloud.atlassian.net/browse/B2B-3719)

## What/Why?
Fixed the blank page rendering after the masquerade 

This pull request adds a fallback routing strategy to the B3 router in the storefront application. The main change is the introduction of a new `B3FallbackRoute` component, which handles cases where no matching route is found by either redirecting to the first available route or closing the B2B app if no routes are available.

**Routing improvements:**

* Added new `B3FallbackRoute` component in `B3FallbackRoute.tsx` to handle unmatched routes by redirecting to the first available route or closing the app if none exist.
* Integrated `B3FallbackRoute` into the B3 router by adding a catch-all route (`path="*"`) in `B3RenderRouter.tsx`.

## Rollout/Rollback
Revert 

## Testing / QA
https://drive.google.com/file/d/1ZZnlE_xX-rGYTKBn7JxQm7GqzTGk2Aql/view?usp=drive_link


[B2B-3719]: https://bigcommercecloud.atlassian.net/browse/B2B-3719?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ