### PR TITLE
chore(common): B2B-3803 Reduce number of chunks

### DIFF
--- a/apps/storefront/src/index.d.ts
+++ b/apps/storefront/src/index.d.ts
@@ -46,7 +46,7 @@ declare interface Window {
       channel_id: number;
       store_hash: string;
       platform: ChannelPlatform;
-      environment: import('@/types/global').Environment;
+      environment: string;
       disable_logout_button?: boolean;
       cart_url?: string;
     };

--- a/apps/storefront/src/main.ts
+++ b/apps/storefront/src/main.ts
@@ -1,11 +1,26 @@
-import { Environment, EnvSpecificConfig } from '@/types';
+import { bindLinks, initApp, requestIdleCallbackFunction, unbindLinks } from './load-functions';
 
-// TODO: update the following to BC cdn when migration is completed
-const ENVIRONMENT_CDN_BASE_PATH: EnvSpecificConfig<string> = {
-  local: '/',
-  integration: 'https://microapps.integration.zone/b2b-buyer-portal/',
-  staging: 'https://microapps.staging.zone/b2b-buyer-portal/',
-  production: 'https://microapps.bigcommerce.com/b2b-buyer-portal/',
+export enum Environment {
+  Production = 'production',
+  Staging = 'staging',
+  Integration = 'integration',
+  Local = 'local',
+}
+
+const getBasePath = (env: string = Environment.Production): string => {
+  if (env === Environment.Production) {
+    return 'https://microapps.bigcommerce.com/b2b-buyer-portal/';
+  }
+
+  if (env === Environment.Staging) {
+    return 'https://microapps.staging.zone/b2b-buyer-portal/';
+  }
+
+  if (env === Environment.Integration) {
+    return 'https://microapps.integration.zone/b2b-buyer-portal/';
+  }
+
+  return '/';
 };
 
 window.b2b = {
@@ -14,16 +29,13 @@ window.b2b = {
     // this function is called at runtime and intentionally references `window.B3`
     // so that the same runtime files can dynamically choose the cdn base url location
     // based on environment it is deployed to
-    const environment: Environment = window.B3?.setting?.environment ?? Environment.Production;
-    return `${ENVIRONMENT_CDN_BASE_PATH[environment]}${filename}`;
+    const basePath = getBasePath(window.B3?.setting?.environment);
+
+    return `${basePath}${filename}`;
   },
 };
 
 (async function bootstrap() {
-  const { bindLinks, initApp, requestIdleCallbackFunction, unbindLinks } = await import(
-    './load-functions'
-  );
-
   // check if the accessed url contains a hashtag
   if (window.location.hash.startsWith('#/')) {
     initApp();

--- a/apps/storefront/src/shared/service/request/base.ts
+++ b/apps/storefront/src/shared/service/request/base.ts
@@ -19,16 +19,32 @@ const ENVIRONMENT_B2B_APP_CLIENT_ID: EnvSpecificConfig<string> = {
 const DEFAULT_ENVIRONMENT =
   import.meta.env.VITE_IS_LOCAL_ENVIRONMENT === 'TRUE' ? Environment.Local : Environment.Production;
 
+function isEnvironment(value?: string): value is Environment {
+  if (!value) {
+    return false;
+  }
+
+  return Object.values<string>(Environment).includes(value);
+}
+
+const getEnvironment = (environment?: Environment): Environment => {
+  if (environment) {
+    return environment;
+  }
+
+  if (isEnvironment(window.B3?.setting?.environment)) {
+    return window.B3.setting.environment;
+  }
+
+  return DEFAULT_ENVIRONMENT;
+};
+
 export function getAPIBaseURL(environment?: Environment) {
-  return ENVIRONMENT_B2B_API_URL[
-    environment ?? window.B3?.setting?.environment ?? DEFAULT_ENVIRONMENT
-  ];
+  return ENVIRONMENT_B2B_API_URL[getEnvironment(environment)];
 }
 
 export function getAppClientId(environment?: Environment) {
-  return ENVIRONMENT_B2B_APP_CLIENT_ID[
-    environment ?? window.B3?.setting?.environment ?? DEFAULT_ENVIRONMENT
-  ];
+  return ENVIRONMENT_B2B_APP_CLIENT_ID[getEnvironment(environment)];
 }
 
 enum RequestType {

--- a/apps/storefront/vite.config.ts
+++ b/apps/storefront/vite.config.ts
@@ -106,6 +106,15 @@ export default defineConfig(({ mode }): UserConfig & Pick<ViteUserConfig, 'test'
             dropzone: ['react-dropzone'],
             eCache: ['@emotion/cache'],
           },
+          chunkFileNames(chunk) {
+            if (chunk.name === 'index' && chunk.facadeModuleId) {
+              const folderName = path.basename(path.dirname(chunk.facadeModuleId));
+
+              return `chunks/${folderName}.[hash].js`;
+            }
+
+            return `chunks/[name].[hash].js`;
+          },
         },
         onwarn(warning, warn) {
           if (warning.code === 'MODULE_LEVEL_DIRECTIVE') {


### PR DESCRIPTION
Jira: [B2B-3803](https://bigcommercecloud.atlassian.net/browse/B2B-3803)

## What/Why?
- Combine the `load-functions` bundle into the main entry file.
- Do not trust window.B3.settings.environment`
- Give chunks proper names/move them to the `chunks/` folder

We want to avoid chaining http requests when loading the buyer portal, current flow looks like:

- `index` -> `load-functions` -> `app`

after this change:


- `index` -> `app`

## Rollout/Rollback
Revert

## Testing

### Before:
<img width="824" height="730" alt="image" src="https://github.com/user-attachments/assets/9dd32ffd-2c89-4b9e-946b-af1181d8ff10" />


### After:
<img width="729" height="667" alt="image" src="https://github.com/user-attachments/assets/373948d6-52cd-4f6c-96af-d54216bcd40d" />


[B2B-3803]: https://bigcommercecloud.atlassian.net/browse/B2B-3803?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ