### PR TITLE
fix(quick-order): B2B-3941 Treat validation warnings as errors when adding to cart

### DIFF
--- a/apps/storefront/src/pages/QuickOrder/components/QuickAdd.tsx
+++ b/apps/storefront/src/pages/QuickOrder/components/QuickAdd.tsx
@@ -335,7 +335,9 @@ export default function QuickAdd(props: AddToListContentProps) {
 
     const productsToValidate = mapCatalogToValidationPayload(variantInfoList, skuValue);
 
-    const { validProducts, errors } = await validateProducts(productsToValidate);
+    // When adding products to a cart, warnings need to be treated as errors.
+    // We are doing this in the frontend for now, but it will be moved to the backend in the future.
+    const { validProducts, errors } = await validateProducts(productsToValidate, 'cart');
 
     const productItems = mergeValidatedWithCatalog(validProducts, variantInfoList);
 


### PR DESCRIPTION
Jira: [B2B-3941](https://bigcommercecloud.atlassian.net/browse/B2B-3941)

## What/Why?
<!--
  A description about what this pull request implements and its purpose.
  Try to be detailed and describe any technical details to simplify the job
  of the reviewer and the individual on production support.
-->
When the non-purchasable & out of stock setting is enabled, validation warnings are treated as successful. As a result, when trying to add multiple products to a cart, the request to the cart API included non-purchasable/out of stock products, causing it to fail and preventing any requested products from being added.

This PR fixes this by modifying the `validateProducts` function to accept an optional `destination` string. When the string is set to `quote` (the default), we continue to treat warnings as successful (which is the desired behavior for quotes). When it's set to `cart`, we treat warnings as errors, ensuring that non-purchasable/out of stock products are filtered out from cart API request.

## Rollout/Rollback
<!--
Detail how this change will be rolled out. Include reference to any
experiments and how the success will be measured as the experiment is
ramped.

Document rollback procedures. Is rolling back the change as simple as
rolling back an experiment or does it require reverting code? Are there
database migrations that may change our decision to roll forward instead of
back?
-->
Revert and redeploy.

## Testing
<!--
Provide as much information as you can about how you tested and how another
Engineer can test your change. Include screenshots, or test run output
where appropriate.
-->
Added new unit tests.

Before:

https://github.com/user-attachments/assets/45532cda-2396-4c72-a8f0-1c535c070ee2

After:

https://github.com/user-attachments/assets/49a8e002-4223-46d5-90cd-1d37a270c997

Products with validation warnings still get added to quotes:

https://github.com/user-attachments/assets/77d333d7-5afa-4f64-bfe3-21582aaa71c0



[B2B-3941]: https://bigcommercecloud.atlassian.net/browse/B2B-3941?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ