### PR TITLE
refactor(quick-order): B2B-3941 Separate add to cart functions

### DIFF
--- a/apps/storefront/src/pages/QuickOrder/components/ChooseOptionsDialog.tsx
+++ b/apps/storefront/src/pages/QuickOrder/components/ChooseOptionsDialog.tsx
@@ -79,7 +79,7 @@ interface ChooseOptionsDialogProps {
   isOpen: boolean;
   product?: ShoppingListProductItem;
   onCancel: () => void;
-  onConfirm: (products: CustomFieldItems[]) => void;
+  onConfirm: (product: CustomFieldItems) => Promise<void>;
   isLoading: boolean;
   setIsLoading: Dispatch<SetStateAction<boolean>>;
 }
@@ -450,16 +450,14 @@ export default function ChooseOptionsDialog(props: ChooseOptionsDialogProps) {
         return;
       }
 
-      onConfirm([
-        {
-          ...product,
-          newSelectOptionList: optionList,
-          productId: product?.id,
-          quantity: parseInt(quantity.toString(), 10) || 1,
-          variantId: parseInt(variantId.toString(), 10) || 1,
-          additionalProducts,
-        },
-      ]);
+      onConfirm({
+        ...product,
+        newSelectOptionList: optionList,
+        productId: product?.id,
+        quantity: parseInt(quantity.toString(), 10) || 1,
+        variantId: parseInt(variantId.toString(), 10) || 1,
+        additionalProducts,
+      });
     })();
   };
 

--- a/apps/storefront/src/pages/QuickOrder/components/ProductListDialog.tsx
+++ b/apps/storefront/src/pages/QuickOrder/components/ProductListDialog.tsx
@@ -70,7 +70,7 @@ interface ProductListDialogProps {
   onSearchTextChange: (e: ChangeEvent<HTMLInputElement>) => void;
   onSearch: () => void;
   onProductQuantityChange: (id: number, newQuantity: number) => void;
-  onAddToListClick: (products: CustomFieldItems[]) => void;
+  onAddToListClick: (product: CustomFieldItems) => Promise<void>;
   onChooseOptionsClick: (id: number) => void;
 }
 
@@ -133,14 +133,12 @@ export default function ProductListDialog(props: ProductListDialogProps) {
         variantId = product.variants[0].variant_id;
       }
 
-      onAddToListClick([
-        {
-          ...product,
-          newSelectOptionList: [],
-          quantity: parseInt(product.quantity.toString(), 10) || 1,
-          variantId,
-        },
-      ]);
+      onAddToListClick({
+        ...product,
+        newSelectOptionList: [],
+        quantity: parseInt(product.quantity.toString(), 10) || 1,
+        variantId,
+      });
     }
   };
 

--- a/apps/storefront/src/pages/QuickOrder/components/QuickOrderPad.tsx
+++ b/apps/storefront/src/pages/QuickOrder/components/QuickOrderPad.tsx
@@ -51,8 +51,8 @@ export default function QuickOrderPad() {
     }
   };
 
-  const quickAddToList = async (products: CustomFieldItems[]) => {
-    const res = await createOrUpdateExistingCart(products);
+  const addSingleProductToCart = async (product: CustomFieldItems) => {
+    const res = await createOrUpdateExistingCart([product]);
 
     if (res && res.errors) {
       snackbar.error(res.errors[0].message);
@@ -70,8 +70,6 @@ export default function QuickOrderPad() {
     }
 
     b3TriggerCartNumber();
-
-    return res;
   };
 
   const getValidProducts = (products: CustomFieldItems) => {
@@ -301,28 +299,23 @@ export default function QuickOrderPad() {
     }
   };
 
-  const handleQuickSearchAddCart = async (productData: CustomFieldItems[]) => {
-    const currentProducts = productData.map((item) => {
-      return {
-        node: {
-          ...item,
-          productsSearch: item,
-        },
-      };
-    });
-    const isPassVerify = await addCartProductToVerify(
-      currentProducts as CustomFieldItems[],
-      b3Lang,
-    );
+  const handleQuickSearchAddCart = async (product: CustomFieldItems) => {
+    const currentProduct: CustomFieldItems = {
+      node: {
+        ...product,
+        productsSearch: product,
+      },
+    };
+
+    const isPassVerify = await addCartProductToVerify([currentProduct], b3Lang);
+
     try {
       if (isPassVerify) {
-        await quickAddToList(productData);
+        await addSingleProductToCart(product);
       }
     } catch (error) {
       b2bLogger.error(error);
     }
-
-    return productData;
   };
 
   const handleOpenUploadDiag = () => {
@@ -333,9 +326,9 @@ export default function QuickOrderPad() {
     }
   };
 
-  const handleBackendQuickSearchAddToCart = async (productData: CustomFieldItems[]) => {
+  const handleBackendQuickSearchAddToCart = async (product: CustomFieldItems) => {
     try {
-      await quickAddToList(productData);
+      await addSingleProductToCart(product);
     } catch (e: unknown) {
       if (e instanceof Error) {
         snackbar.error(e.message);
@@ -371,7 +364,7 @@ export default function QuickOrderPad() {
 
           <Divider />
 
-          <QuickAdd quickAddToList={quickAddToList} />
+          <QuickAdd />
 
           <Divider />
 

--- a/apps/storefront/src/pages/QuickOrder/components/SearchProduct.tsx
+++ b/apps/storefront/src/pages/QuickOrder/components/SearchProduct.tsx
@@ -18,7 +18,7 @@ import ChooseOptionsDialog from './ChooseOptionsDialog';
 import ProductListDialog from './ProductListDialog';
 
 interface SearchProductProps {
-  addToList: (products: CustomFieldItems[]) => void;
+  addToList: (product: CustomFieldItems) => Promise<void>;
 }
 
 export default function SearchProduct({ addToList }: SearchProductProps) {
@@ -105,18 +105,14 @@ export default function SearchProduct({ addToList }: SearchProductProps) {
     setProductList([...productList]);
   };
 
-  const handleAddToListClick = async (products: CustomFieldItems[]) => {
+  const handleAddToListClick = async (product: CustomFieldItems) => {
     try {
       setIsLoading(true);
-      await calculateProductListPrice(products);
-      await addToList(products);
+      await calculateProductListPrice([product]);
+      await addToList(product);
     } finally {
       setIsLoading(false);
     }
-  };
-
-  const handleProductListAddToList = async (products: CustomFieldItems[]) => {
-    await handleAddToListClick(products);
   };
 
   const handleChangeOptionsClick = (productId: number) => {
@@ -135,11 +131,11 @@ export default function SearchProduct({ addToList }: SearchProductProps) {
     setProductListOpen(true);
   };
 
-  const handleChooseOptionsDialogConfirm = async (products: CustomFieldItems[]) => {
+  const handleChooseOptionsDialogConfirm = async (product: CustomFieldItems) => {
     try {
       setIsLoading(true);
-      await calculateProductListPrice(products);
-      await handleAddToListClick(products);
+      await calculateProductListPrice([product]);
+      await handleAddToListClick(product);
       setChooseOptionsOpen(false);
       setProductListOpen(true);
     } catch (error) {
@@ -207,7 +203,7 @@ export default function SearchProduct({ addToList }: SearchProductProps) {
         onCancel={handleProductListDialogCancel}
         onProductQuantityChange={handleProductQuantityChange}
         onChooseOptionsClick={handleChangeOptionsClick}
-        onAddToListClick={handleProductListAddToList}
+        onAddToListClick={handleAddToListClick}
       />
 
       <ChooseOptionsDialog


### PR DESCRIPTION
Jira: [B2B-3941](https://bigcommercecloud.atlassian.net/browse/B2B-3941)

## What/Why?
<!--
  A description about what this pull request implements and its purpose.
  Try to be detailed and describe any technical details to simplify the job
  of the reviewer and the individual on production support.
-->
This PR separates the quick order add to cart functions into two:
- Adding a single product to a cart (which is handled via search in the quick order pad)
- Adding multiple products to a cart (handled by the quick add/csv upload in the quick order pad)

This allowed me to move the function that adds multiple products to a cart into the `QuickAdd` component, which will enable me to call the new shared validate/add to cart function easily once it's created.

## Rollout/Rollback
<!--
Detail how this change will be rolled out. Include reference to any
experiments and how the success will be measured as the experiment is
ramped.

Document rollback procedures. Is rolling back the change as simple as
rolling back an experiment or does it require reverting code? Are there
database migrations that may change our decision to roll forward instead of
back?
-->
Revert and redeploy.

## Testing
<!--
Provide as much information as you can about how you tested and how another
Engineer can test your change. Include screenshots, or test run output
where appropriate.
-->

https://github.com/user-attachments/assets/be4d62f2-9797-479c-8ebe-362a568ca18d



[B2B-3941]: https://bigcommercecloud.atlassian.net/browse/B2B-3941?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ