### PR TITLE
refactor(quotes): B2B-3941 Update product validation logic to separate success, warning, and error states

### DIFF
--- a/apps/storefront/src/pages/QuickOrder/components/QuickOrderFooter.tsx
+++ b/apps/storefront/src/pages/QuickOrder/components/QuickOrderFooter.tsx
@@ -227,19 +227,21 @@ function QuickOrderFooter(props: QuickOrderFooterProps) {
 
   const addToQuote = async (products: CustomFieldItems[]) => {
     if (featureFlags['B2B-3318.move_stock_and_backorder_validation_to_backend']) {
-      const { validProducts, errors } = await validateProducts(products);
+      const { success, warning, error } = await validateProducts(products);
 
-      errors.forEach((error) => {
-        if (error.type === 'network') {
+      error.forEach((err) => {
+        if (err.error.type === 'network') {
           snackbar.error(
             b3Lang('quotes.productValidationFailed', {
-              productName: error.productName,
+              productName: err.product.node?.productName || '',
             }),
           );
         } else {
-          snackbar.error(error.message);
+          snackbar.error(err.error.message);
         }
       });
+
+      const validProducts = [...success, ...warning].map((product) => product.product);
 
       addQuoteDraftProducts(validProducts);
 

--- a/apps/storefront/src/pages/QuoteDraft/index.tsx
+++ b/apps/storefront/src/pages/QuoteDraft/index.tsx
@@ -452,19 +452,21 @@ function QuoteDraft({ setOpenPage }: PageProps) {
 
   const addToQuote = async (products: CustomFieldItems[]) => {
     if (!isEnableProduct && isMoveStockAndBackorderValidationToBackend) {
-      const { validProducts, errors } = await validateProducts(products);
+      const { success, warning, error } = await validateProducts(products);
 
-      errors.forEach((error) => {
-        if (error.type === 'network') {
+      error.forEach((err) => {
+        if (err.error.type === 'network') {
           snackbar.error(
             b3Lang('quotes.productValidationFailed', {
-              productName: error.productName,
+              productName: err.product.node?.productName || '',
             }),
           );
         } else {
-          snackbar.error(error.message);
+          snackbar.error(err.error.message);
         }
       });
+
+      const validProducts = [...success, ...warning].map((product) => product.product);
 
       addQuoteDraftProducts(validProducts);
 

--- a/apps/storefront/src/pages/ShoppingListDetails/components/ShoppingDetailFooter.tsx
+++ b/apps/storefront/src/pages/ShoppingListDetails/components/ShoppingDetailFooter.tsx
@@ -206,19 +206,21 @@ function ShoppingDetailFooter(props: ShoppingDetailFooterProps) {
 
   const addToQuote = async (products: CustomFieldItems[]) => {
     if (featureFlags['B2B-3318.move_stock_and_backorder_validation_to_backend']) {
-      const { validProducts, errors } = await validateProducts(products);
+      const { success, warning, error } = await validateProducts(products);
 
-      errors.forEach((error) => {
-        if (error.type === 'network') {
+      error.forEach((err) => {
+        if (err.error.type === 'network') {
           snackbar.error(
             b3Lang('quotes.productValidationFailed', {
-              productName: error.productName,
+              productName: err.product.node?.productName || '',
             }),
           );
         } else {
-          snackbar.error(error.message);
+          snackbar.error(err.error.message);
         }
       });
+
+      const validProducts = [...success, ...warning].map((product) => product.product);
 
       addQuoteDraftProducts(validProducts);
 


### PR DESCRIPTION
Jira: [B2B-3941](https://bigcommercecloud.atlassian.net/browse/B2B-3941)

## What/Why?
<!--
  A description about what this pull request implements and its purpose.
  Try to be detailed and describe any technical details to simplify the job
  of the reviewer and the individual on production support.
-->
This PR updates the `validateProducts` function to return the list of validated products with their respective validation status. This makes it easier for the consumer of this function to use the products that they care about.

## Rollout/Rollback
<!--
Detail how this change will be rolled out. Include reference to any
experiments and how the success will be measured as the experiment is
ramped.

Document rollback procedures. Is rolling back the change as simple as
rolling back an experiment or does it require reverting code? Are there
database migrations that may change our decision to roll forward instead of
back?
-->
Revert and redeploy.

## Testing
<!--
Provide as much information as you can about how you tested and how another
Engineer can test your change. Include screenshots, or test run output
where appropriate.
-->
Draft quote page:

https://github.com/user-attachments/assets/0aa0bf24-ded7-4a95-bd43-1056c8cd826f

Shopping list page:

https://github.com/user-attachments/assets/90d40ce5-005c-4dd0-8ee3-de4313559077

Quick order (add to quote):

https://github.com/user-attachments/assets/95547287-7859-40fd-9187-940be2f99816

Quick order pad (NP&OOS setting disabled):

https://github.com/user-attachments/assets/4c06b520-dca2-4bf8-b138-4882f5f459df

Quick order page (NP&OOS setting enabled):

https://github.com/user-attachments/assets/e2829512-f266-4337-9824-2010491d5488



[B2B-3941]: https://bigcommercecloud.atlassian.net/browse/B2B-3941?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ