### PR TITLE
fix(quotes): B2B-3964 showing TBD only for products with warning or erros

### DIFF
--- a/apps/storefront/src/pages/QuoteDetail/index.test.tsx
+++ b/apps/storefront/src/pages/QuoteDetail/index.test.tsx
@@ -600,4 +600,359 @@ describe('when the user is a B2B customer', () => {
       'https://my-store/cart.php?action=loadInCheckout&id=123&token=1234567889&isFromQuote=Y',
     );
   });
+
+  it('renders TBD instead of price in quote summary if product has an error', async () => {
+    const quote = buildQuoteWith({
+      data: {
+        quote: {
+          id: '272989',
+          quoteNumber: '911911',
+          status: 1,
+          grandTotal: '1000.00',
+          allowCheckout: true,
+          discount: '0.00',
+          displayDiscount: true,
+          shippingMethod: {
+            description: 'Flat rate',
+          },
+          taxTotal: '0.0000',
+          subtotal: '1000.00',
+          shippingTotal: '0.0000',
+          salesRep: '',
+          salesRepEmail: '',
+          productsList: [
+            buildQuoteProductWith({
+              productId: '123',
+              offeredPrice: '1000.00',
+              basePrice: '1000.00',
+            }),
+          ],
+        },
+      },
+    });
+
+    server.use(
+      graphql.query('GetQuoteInfoB2B', () => HttpResponse.json(quote)),
+      graphql.query('SearchProducts', () =>
+        HttpResponse.json({
+          data: {
+            productsSearch: [buildProductSearchWith({ id: 123 })],
+          },
+        }),
+      ),
+      graphql.query('getQuoteExtraFields', () =>
+        HttpResponse.json(buildQuoteExtraFieldsWith('WHATEVER_VALUES')),
+      ),
+      graphql.query('ValidateProduct', () =>
+        HttpResponse.json({
+          data: {
+            validateProduct: {
+              responseType: 'ERROR',
+              message: 'A product with the id of 123 does not have sufficient stock',
+            },
+          },
+        }),
+      ),
+    );
+
+    vitest.mocked(useParams).mockReturnValue({ id: '272989' });
+
+    renderWithProviders(<QuoteDetail />, {
+      preloadedState: {
+        ...preloadedState,
+        global: {
+          ...preloadedState.global,
+          blockPendingQuoteNonPurchasableOOS: {
+            isEnableProduct: false,
+          },
+          featureFlags: {
+            'B2B-3318.move_stock_and_backorder_validation_to_backend': true,
+          },
+        },
+      },
+    });
+
+    await waitForElementToBeRemoved(() => screen.queryByText(/loading/i));
+    expect(
+      await screen.findByText('A product with the id of 123 does not have sufficient stock'),
+    ).toBeInTheDocument();
+    const summaryElement = screen.getByTestId('quote-summary');
+    const withinSummary = within(summaryElement);
+    expect(await withinSummary.findByRole('row', { name: /Original subtotal/ })).toHaveTextContent(
+      /TBD/,
+    );
+    expect(await withinSummary.findByRole('row', { name: /Quoted subtotal/ })).toHaveTextContent(
+      /TBD/,
+    );
+    expect(await withinSummary.findByRole('row', { name: /Shipping/ })).toHaveTextContent(/TBD/);
+    expect(await withinSummary.findByRole('row', { name: /Grand total/ })).toHaveTextContent(/TBD/);
+  });
+
+  it('renders prices in quote summary if product has no errors', async () => {
+    const quote = buildQuoteWith({
+      data: {
+        quote: {
+          id: '272989',
+          quoteNumber: '911911',
+          status: 2,
+          grandTotal: '1000.00',
+          subtotal: '1000.00',
+          discount: '0.00',
+          allowCheckout: true,
+          taxTotal: '0.0000',
+          totalAmount: '1000.00',
+          shippingTotal: '0.00',
+          currency: {
+            token: '$',
+            location: 'left',
+            currencyCode: 'USD',
+            decimalToken: '.',
+            decimalPlaces: 2,
+            thousandsToken: ',',
+            currencyExchangeRate: '1.0000000000',
+          },
+          shippingMethod: {
+            id: '4dcbf24f457dd67d5f89bcf374e0bc9b',
+            cost: 0.0,
+            description: 'Flat rate',
+          },
+          productsList: [
+            buildQuoteProductWith({
+              productId: '123',
+              offeredPrice: '1000.00',
+              basePrice: '1000.00',
+            }),
+          ],
+          salesRep: 'john',
+          salesRepEmail: 'john@email.com',
+          displayDiscount: true,
+        },
+      },
+    });
+
+    server.use(
+      graphql.query('GetQuoteInfoB2B', () => HttpResponse.json(quote)),
+      graphql.query('SearchProducts', () =>
+        HttpResponse.json({
+          data: {
+            productsSearch: [
+              buildProductSearchWith({
+                id: 123,
+                costPrice: '1000',
+                variants: [
+                  {
+                    variant_id: 132,
+                    product_id: 123,
+                    sku: 'test',
+                    option_values: [],
+                    calculated_price: 1000,
+                    image_url: '',
+                    has_price_list: false,
+                    bulk_prices: [],
+                    purchasing_disabled: false,
+                    cost_price: 0,
+                    inventory_level: 2,
+                    bc_calculated_price: {
+                      as_entered: 1000,
+                      tax_inclusive: 1000,
+                      tax_exclusive: 1000,
+                      entered_inclusive: false,
+                    },
+                  },
+                ],
+              }),
+            ],
+          },
+        }),
+      ),
+      graphql.query('getQuoteExtraFields', () =>
+        HttpResponse.json(buildQuoteExtraFieldsWith('WHATEVER_VALUES')),
+      ),
+      graphql.query('ValidateProduct', () =>
+        HttpResponse.json({
+          data: {
+            validateProduct: {
+              responseType: 'SUCCESS',
+              message: 'Product is valid',
+            },
+          },
+        }),
+      ),
+    );
+
+    vitest.mocked(useParams).mockReturnValue({ id: '272989' });
+
+    renderWithProviders(<QuoteDetail />, {
+      preloadedState: {
+        ...preloadedState,
+        global: {
+          ...preloadedState.global,
+          featureFlags: {
+            'B2B-3318.move_stock_and_backorder_validation_to_backend': true,
+          },
+        },
+      },
+    });
+
+    await waitForElementToBeRemoved(() => screen.queryByText(/loading/i));
+    const summaryElement = screen.getByTestId('quote-summary');
+    const withinSummary = within(summaryElement);
+    expect(await withinSummary.findByRole('row', { name: /Original subtotal/ })).toHaveTextContent(
+      /\$1,000.00/,
+    );
+    expect(await withinSummary.findByRole('row', { name: /Discount/ })).toHaveTextContent(/\$0.00/);
+    expect(await withinSummary.findByRole('row', { name: /Quoted subtotal/ })).toHaveTextContent(
+      /\$1,000.00/,
+    );
+    expect(await withinSummary.findByRole('row', { name: /Shipping/ })).toHaveTextContent(/\$0.00/);
+    expect(await withinSummary.findByRole('row', { name: /Tax/ })).toHaveTextContent(/\$0.00/);
+    expect(await withinSummary.findByRole('row', { name: /Grand total/ })).toHaveTextContent(
+      /\$1,000.00/,
+    );
+  });
+
+  it('renders proceed to checkout button when isAutoQuoteEnable is enabled and quote has sales rep revision', async () => {
+    const quote = buildQuoteWith({
+      data: {
+        quote: {
+          id: '123',
+          quoteNumber: '123',
+          status: 2,
+          allowCheckout: true,
+          salesRep: 'John Sales', // sales rep already revised the quote
+          salesRepEmail: 'john.sales@company.com',
+          productsList: [buildQuoteProductWith({ productId: '123' })],
+        },
+      },
+    });
+
+    server.use(
+      graphql.query('GetQuoteInfoB2B', () => HttpResponse.json(quote)),
+      graphql.query('SearchProducts', () =>
+        HttpResponse.json(
+          buildProductSearchResponseWith({
+            data: {
+              productsSearch: [buildProductSearchWith({ id: 123 })],
+            },
+          }),
+        ),
+      ),
+      graphql.query('getQuoteExtraFields', () =>
+        HttpResponse.json(buildQuoteExtraFieldsWith('WHATEVER_VALUES')),
+      ),
+      graphql.query('ValidateProduct', () =>
+        HttpResponse.json({
+          data: {
+            validateProduct: {
+              responseType: 'SUCCESS',
+              message: 'Product is valid',
+            },
+          },
+        }),
+      ),
+    );
+
+    vitest.mocked(useParams).mockReturnValue({ id: '123' });
+
+    const stateWithAutoQuoteDisabled = {
+      ...preloadedState,
+      company: {
+        ...preloadedState.company,
+        permissions: [
+          { code: 'purchase_enable', permissionLevel: 1 },
+          { code: 'checkout_with_quote', permissionLevel: 1 },
+        ],
+      },
+      global: {
+        ...preloadedState.global,
+        featureFlags: {
+          'B2B-3318.move_stock_and_backorder_validation_to_backend': true,
+        },
+        quoteConfig: [
+          {
+            key: 'quote_auto_quoting',
+            value: '1',
+            extraFields: {},
+          },
+        ],
+      },
+    };
+
+    renderWithProviders(<QuoteDetail />, {
+      preloadedState: stateWithAutoQuoteDisabled,
+    });
+
+    await waitForElementToBeRemoved(() => screen.queryByText(/loading/i));
+
+    expect(await screen.findByRole('button', { name: /PROCEED TO CHECKOUT/i })).toBeVisible();
+  });
+
+  it('does not render Proceed to Checkout button when auto quoting is disabled and no sales rep info', async () => {
+    const quote = buildQuoteWith({
+      data: {
+        quote: {
+          id: '14234',
+          quoteNumber: '2342',
+          status: 2,
+          allowCheckout: true,
+          salesRep: '', // No sales rep
+          salesRepEmail: '', // No sales rep email
+          productsList: [buildQuoteProductWith({ productId: '123' })],
+        },
+      },
+    });
+
+    server.use(
+      graphql.query('GetQuoteInfoB2B', () => HttpResponse.json(quote)),
+      graphql.query('SearchProducts', () =>
+        HttpResponse.json(
+          buildProductSearchResponseWith({
+            data: {
+              productsSearch: [buildProductSearchWith({ id: 123 })],
+            },
+          }),
+        ),
+      ),
+      graphql.query('getQuoteExtraFields', () =>
+        HttpResponse.json(buildQuoteExtraFieldsWith('WHATEVER_VALUES')),
+      ),
+      graphql.query('ValidateProduct', () =>
+        HttpResponse.json({
+          data: {
+            validateProduct: {
+              responseType: 'WARNING',
+              message: 'A product with the id of 123 does not have sufficient stock',
+            },
+          },
+        }),
+      ),
+    );
+
+    vitest.mocked(useParams).mockReturnValue({ id: '123' });
+
+    const stateWithAutoQuoteDisabled = {
+      ...preloadedState,
+      global: {
+        ...preloadedState.global,
+        featureFlags: {
+          'B2B-3318.move_stock_and_backorder_validation_to_backend': true,
+        },
+        quoteConfig: [
+          {
+            key: 'quote_auto_quoting',
+            value: '0', // Disable auto quoting
+            extraFields: {},
+          },
+        ],
+      },
+    };
+
+    renderWithProviders(<QuoteDetail />, {
+      preloadedState: stateWithAutoQuoteDisabled,
+    });
+
+    await waitForElementToBeRemoved(() => screen.queryByText(/loading/i));
+
+    expect(screen.queryByRole('button', { name: /PROCEED TO CHECKOUT/i })).not.toBeInTheDocument();
+  });
 });

--- a/apps/storefront/src/pages/quote/components/QuoteDetailSummary.tsx
+++ b/apps/storefront/src/pages/quote/components/QuoteDetailSummary.tsx
@@ -17,7 +17,7 @@ interface QuoteDetailSummaryProps {
   quoteDetailTax: number;
   status: string;
   quoteDetail: CustomFieldItems;
-  isHideQuoteCheckout: boolean;
+  shouldHidePrice: boolean;
 }
 
 export default function QuoteDetailSummary({
@@ -25,7 +25,7 @@ export default function QuoteDetailSummary({
   quoteDetailTax = 0,
   status,
   quoteDetail,
-  isHideQuoteCheckout,
+  shouldHidePrice,
 }: QuoteDetailSummaryProps) {
   const b3Lang = useB3Lang();
   const enteredInclusiveTax = useAppSelector(
@@ -89,7 +89,7 @@ export default function QuoteDetailSummary({
   const shippingAndTax = getShippingAndTax();
 
   const showPrice = (price: string | number): string | number => {
-    if (isHideQuoteCheckout) return b3Lang('quoteDraft.quoteSummary.tbd');
+    if (shouldHidePrice) return b3Lang('quoteDraft.quoteSummary.tbd');
 
     return price;
   };
@@ -97,7 +97,7 @@ export default function QuoteDetailSummary({
   const subtotalPrice = Number(originalSubtotal);
   const quotedSubtotal = Number(originalSubtotal) - Number(discount);
   return (
-    <Card>
+    <Card data-testid="quote-summary">
       <CardContent>
         <Box>
           <Typography variant="h5">{b3Lang('quoteDetail.summary.quoteSummary')}</Typography>
@@ -109,6 +109,7 @@ export default function QuoteDetailSummary({
           >
             {quoteDetail?.displayDiscount && (
               <Grid
+                role="row"
                 container
                 justifyContent="space-between"
                 sx={{
@@ -124,6 +125,7 @@ export default function QuoteDetailSummary({
 
             {!quoteDetail?.salesRepEmail && Number(status) === 1 ? null : (
               <Grid
+                role="row"
                 container
                 justifyContent="space-between"
                 sx={{
@@ -141,6 +143,7 @@ export default function QuoteDetailSummary({
             )}
 
             <Grid
+              role="row"
               container
               justifyContent="space-between"
               sx={{
@@ -168,6 +171,7 @@ export default function QuoteDetailSummary({
             {shippingAndTax && (
               <>
                 <Grid
+                  role="row"
                   container
                   justifyContent="space-between"
                   sx={{
@@ -185,6 +189,7 @@ export default function QuoteDetailSummary({
                   <Typography>{showPrice(shippingAndTax.shippingVal)}</Typography>
                 </Grid>
                 <Grid
+                  role="row"
                   container
                   justifyContent="space-between"
                   sx={{
@@ -198,6 +203,7 @@ export default function QuoteDetailSummary({
             )}
 
             <Grid
+              role="row"
               container
               justifyContent="space-between"
               sx={{

--- a/apps/storefront/src/pages/quote/components/QuoteDetailTable.tsx
+++ b/apps/storefront/src/pages/quote/components/QuoteDetailTable.tsx
@@ -40,7 +40,7 @@ interface ListItemProps {
 interface ShoppingDetailTableProps {
   total: number;
   getQuoteTableDetails: GetRequestList<SearchProps, ProductInfoProps>;
-  isHandleApprove: boolean;
+  quoteReviewedBySalesRep: boolean;
   getTaxRate: (taxClassId: number, variants: any) => number;
   displayDiscount: boolean;
   currency: CurrencyProps;
@@ -98,8 +98,14 @@ const StyledImage = styled('img')(() => ({
 
 function QuoteDetailTable(props: ShoppingDetailTableProps, ref: Ref<unknown>) {
   const b3Lang = useB3Lang();
-  const { total, getQuoteTableDetails, getTaxRate, isHandleApprove, displayDiscount, currency } =
-    props;
+  const {
+    total,
+    getQuoteTableDetails,
+    getTaxRate,
+    quoteReviewedBySalesRep,
+    displayDiscount,
+    currency,
+  } = props;
 
   const isEnableProduct = useAppSelector(
     ({ global }) => global.blockPendingQuoteNonPurchasableOOS.isEnableProduct,
@@ -126,7 +132,7 @@ function QuoteDetailTable(props: ShoppingDetailTableProps, ref: Ref<unknown>) {
 
   const showPrice = (price: string, row: CustomFieldItems): string | number => {
     if (isEnableProduct) {
-      if (isHandleApprove) return price;
+      if (quoteReviewedBySalesRep) return price;
       return getDisplayPrice({
         price,
         productInfo: row,

--- a/apps/storefront/src/pages/quote/components/QuoteSummary.tsx
+++ b/apps/storefront/src/pages/quote/components/QuoteSummary.tsx
@@ -118,8 +118,12 @@ const QuoteSummary = forwardRef((_, ref: Ref<unknown>) => {
                 margin: '4px 0',
               }}
             >
-              <Typography>{b3Lang('quoteDraft.quoteSummary.subTotal')}</Typography>
-              <Typography>{showPrice(priceFormat(quoteSummary.subtotal))}</Typography>
+              <Typography id="quote-draft-subtotal">
+                {b3Lang('quoteDraft.quoteSummary.subTotal')}
+              </Typography>
+              <Typography aria-labelledby="quote-draft-subtotal">
+                {showPrice(priceFormat(quoteSummary.subtotal))}
+              </Typography>
             </Grid>
 
             <Grid
@@ -129,8 +133,12 @@ const QuoteSummary = forwardRef((_, ref: Ref<unknown>) => {
                 margin: '4px 0',
               }}
             >
-              <Typography>{b3Lang('quoteDraft.quoteSummary.shipping')}</Typography>
-              <Typography>{b3Lang('quoteDraft.quoteSummary.tbd')}</Typography>
+              <Typography id="quote-draft-shipping">
+                {b3Lang('quoteDraft.quoteSummary.shipping')}
+              </Typography>
+              <Typography aria-labelledby="quote-draft-shipping">
+                {b3Lang('quoteDraft.quoteSummary.tbd')}
+              </Typography>
             </Grid>
 
             <Grid
@@ -140,8 +148,10 @@ const QuoteSummary = forwardRef((_, ref: Ref<unknown>) => {
                 margin: '4px 0',
               }}
             >
-              <Typography>{b3Lang('quoteDraft.quoteSummary.tax')}</Typography>
-              <Typography>{showPrice(priceFormat(quoteSummary.tax))}</Typography>
+              <Typography id="quote-draft-tax">{b3Lang('quoteDraft.quoteSummary.tax')}</Typography>
+              <Typography aria-labelledby="quote-draft-tax">
+                {showPrice(priceFormat(quoteSummary.tax))}
+              </Typography>
             </Grid>
 
             <Grid
@@ -152,6 +162,7 @@ const QuoteSummary = forwardRef((_, ref: Ref<unknown>) => {
               }}
             >
               <Typography
+                id="quote-draft-grand-total"
                 sx={{
                   fontWeight: 'bold',
                 }}
@@ -159,6 +170,7 @@ const QuoteSummary = forwardRef((_, ref: Ref<unknown>) => {
                 {b3Lang('quoteDraft.quoteSummary.grandTotal')}
               </Typography>
               <Typography
+                aria-labelledby="quote-draft-grand-total"
                 sx={{
                   fontWeight: 'bold',
                 }}

--- a/apps/storefront/src/pages/quote/utils/quoteCheckout.ts
+++ b/apps/storefront/src/pages/quote/utils/quoteCheckout.ts
@@ -9,25 +9,14 @@ import { getSearchVal } from '@/utils/loginInfo';
 
 interface QuoteCheckout {
   role: string | number;
-  hasQuoteValidationErrors: () => boolean;
   location: Location;
   quoteId: string;
   navigate?: NavigateFunction;
 }
 
-export const handleQuoteCheckout = async ({
-  role,
-  hasQuoteValidationErrors,
-  location,
-  quoteId,
-  navigate,
-}: QuoteCheckout) => {
+export const handleQuoteCheckout = async ({ role, location, quoteId, navigate }: QuoteCheckout) => {
   try {
     store.dispatch(setQuoteDetailToCheckoutUrl(''));
-
-    const isHideQuoteCheckout = hasQuoteValidationErrors();
-
-    if (isHideQuoteCheckout) return;
 
     const {
       storefrontProductSettings: { hidePriceFromGuests },


### PR DESCRIPTION
## What/Why?
The quote detail summary is currently showing TBD for all prices even after submission of the quote since we are relying only in the front end flow validations to pass the "showPrice" prop to the quote summary.

When having a purchasable product we should show TBD only on Shipping, only after revision we should see the value of the shipping.

When having out of stock/non purchasable products, we should display TBD on all prices and only render the prices after revision of the quote. 

## Rollout/Rollback
Revert

## Testing

https://github.com/user-attachments/assets/493d2ba0-260c-498f-830f-d176e2a03c33
