### PR TITLE
fix(quotes): B2B-3474 clean sku for pdp add to quote

### DIFF
--- a/apps/storefront/src/hooks/dom/utils.ts
+++ b/apps/storefront/src/hooks/dom/utils.ts
@@ -236,7 +236,9 @@ const addProductFromProductPageToQuote = (
       const productId = (productView.querySelector('input[name=product_id]') as CustomFieldItems)
         ?.value;
       const qty = (productView.querySelector('[name="qty[]"]') as CustomFieldItems)?.value ?? 1;
-      const sku = (productView.querySelector('[data-product-sku]')?.innerHTML ?? '').trim();
+      const sku = featureFlags['B2B-3474.get_sku_from_pdp_with_text_content']
+        ? (productView.querySelector('[data-product-sku]')?.textContent ?? '').trim()
+        : (productView.querySelector('[data-product-sku]')?.innerHTML ?? '').trim();
       const form = productView.querySelector('form[data-cart-item-add]') as HTMLFormElement;
 
       if (!sku) {

--- a/apps/storefront/src/utils/featureFlags.ts
+++ b/apps/storefront/src/utils/featureFlags.ts
@@ -11,6 +11,10 @@ export const featureFlags = [
     key: 'B2B-3857.move_tax_display_settings_to_bc_storefront_graph',
     name: 'moveTaxDisplaySettingsToBCStorefrontGraph',
   },
+  {
+    key: 'B2B-3474.get_sku_from_pdp_with_text_content',
+    name: 'getSkuFromPdpWithTextContent',
+  },
 ] as const;
 
 export type FeatureFlagKey = (typeof featureFlags)[number]['key'];


### PR DESCRIPTION
Jira: [B2B-3474](https://bigcommercecloud.atlassian.net/browse/B2B-3474)

## What/Why?
<!--
  A description about what this pull request implements and its purpose.
  Try to be detailed and describe any technical details to simplify the job
  of the reviewer and the individual on production support.
-->

Fixing a bug where items with an SKU string including an "&" symbol could not be added to quote. This fix replaces `innerHtml` for `textContent` in order to correctly read strings without html encodings.

## Rollout/Rollback
<!--
Detail how this change will be rolled out. Include reference to any
experiments and how the success will be measured as the experiment is
ramped.

Document rollback procedures. Is rolling back the change as simple as
rolling back an experiment or does it require reverting code? Are there
database migrations that may change our decision to roll forward instead of
back?
-->
Feature is behind ff `B2B-3474.get_sku_from_pdp_with_text_content`.

## Testing
<!--
Provide as much information as you can about how you tested and how another
Engineer can test your change. Include screenshots, or test run output
where appropriate.
-->
Added unit tests for this fix.

Before:

https://github.com/user-attachments/assets/bc49dc55-a624-45f6-bc74-a8285b1c9eca

After


https://github.com/user-attachments/assets/28576c45-5010-4ccd-8f1b-9be16128ee3b



[B2B-3474]: https://bigcommercecloud.atlassian.net/browse/B2B-3474?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ