### PR TITLE
refactor(register): B2B-3803 Remove use of a global `RegisterProvider`

### DIFF
--- a/apps/storefront/src/components/layout/B3RenderRouter.tsx
+++ b/apps/storefront/src/components/layout/B3RenderRouter.tsx
@@ -1,10 +1,9 @@
 import { lazy, Suspense, useContext, useEffect } from 'react';
 import { Outlet, Route, Routes, useLocation, useNavigate } from 'react-router-dom';
 
-import { RegisteredProvider } from '@/pages/Registered/context/RegisteredContext';
 import { type SetOpenPage } from '@/pages/SetOpenPage';
 import { GlobalContext } from '@/shared/global';
-import { RouteFirstLevelItem, RouteItem } from '@/shared/routeList';
+import { RouteItem } from '@/shared/routeList';
 import { firstLevelRouting, getAllowedRoutes } from '@/shared/routes';
 import { getPageTranslations, useAppDispatch } from '@/store';
 import { channelId } from '@/utils';
@@ -82,23 +81,9 @@ export default function B3RenderRouter(props: B3RenderRouterProps) {
             element={<RedirectFallback path={routes[0]?.path} setOpenPage={setOpenPage} />}
           />
         </Route>
-        {firstLevelRouting.map((route: RouteFirstLevelItem) => {
-          const { isProvider, path, component: Component } = route;
-          if (isProvider) {
-            return (
-              <Route
-                key={path}
-                path={path}
-                element={
-                  <RegisteredProvider>
-                    <Component setOpenPage={setOpenPage} />
-                  </RegisteredProvider>
-                }
-              />
-            );
-          }
-          return <Route key={path} path={path} element={<Component setOpenPage={setOpenPage} />} />;
-        })}
+        {firstLevelRouting.map(({ path, component: Component }) => (
+          <Route key={path} path={path} element={<Component setOpenPage={setOpenPage} />} />
+        ))}
       </Routes>
     </Suspense>
   );

--- a/apps/storefront/src/pages/Registered/index.tsx
+++ b/apps/storefront/src/pages/Registered/index.tsx
@@ -23,7 +23,7 @@ import { getStoreConfigs } from '@/utils/storefrontConfig';
 import { loginCheckout, LoginConfig } from '../Login/config';
 import { type PageProps } from '../PageProps';
 
-import { RegisteredContext } from './context/RegisteredContext';
+import { RegisteredContext, RegisteredProvider } from './context/RegisteredContext';
 import {
   AccountFormFieldsItems,
   b2bAddressRequiredFields,
@@ -339,4 +339,10 @@ function Registered(props: PageProps) {
   );
 }
 
-export default Registered;
+export default function RegisterPage(props: PageProps) {
+  return (
+    <RegisteredProvider>
+      <Registered {...props} />
+    </RegisteredProvider>
+  );
+}

--- a/apps/storefront/src/pages/RegisteredBCToB2B/index.tsx
+++ b/apps/storefront/src/pages/RegisteredBCToB2B/index.tsx
@@ -38,7 +38,7 @@ import {
   State,
   toHump,
 } from '../Registered/config';
-import { RegisteredContext } from '../Registered/context/RegisteredContext';
+import { RegisteredContext, RegisteredProvider } from '../Registered/context/RegisteredContext';
 import RegisteredFinish from '../Registered/RegisteredFinish';
 import {
   InformationFourLabels,
@@ -67,7 +67,7 @@ const StyledRegisterContent = styled(Box)({
   },
 });
 
-export default function RegisteredBCToB2B(props: PageProps) {
+function RegisteredBCToB2B(props: PageProps) {
   const [errorMessage, setErrorMessage] = useState('');
   const [showFinishPage, setShowFinishPage] = useState<boolean>(false);
 
@@ -745,5 +745,13 @@ export default function RegisteredBCToB2B(props: PageProps) {
         </B3Spin>
       </RegisteredContainer>
     </B3Card>
+  );
+}
+
+export default function RegisteredBCToB2BPage(props: PageProps) {
+  return (
+    <RegisteredProvider>
+      <RegisteredBCToB2B {...props} />
+    </RegisteredProvider>
   );
 }

--- a/apps/storefront/src/shared/routeList.ts
+++ b/apps/storefront/src/shared/routeList.ts
@@ -16,7 +16,7 @@ export interface BuyerPortalRoute {
   isMenuItem?: boolean;
 }
 
-interface RouteItemBasic extends BuyerPortalRoute {
+export interface RouteItemBasic extends BuyerPortalRoute {
   component: FC<PageProps> | LazyExoticComponent<(props: PageProps) => ReactElement>;
   permissions: number[]; // 0: admin, 1: senior buyer, 2: junior buyer, 3: salesRep, 4: salesRep-【Not represented】, 99: bc user, 100: guest
 }
@@ -29,10 +29,6 @@ export interface RouteItem extends RouteItemBasic {
   idLang: string;
   permissionCodes?: string;
   subsidiariesCompanyKey?: (typeof PAGES_SUBSIDIARIES_PERMISSION_KEYS)[number]['key'];
-}
-
-export interface RouteFirstLevelItem extends RouteItemBasic {
-  isProvider: boolean;
 }
 
 const {

--- a/apps/storefront/src/shared/routes/index.tsx
+++ b/apps/storefront/src/shared/routes/index.tsx
@@ -13,8 +13,8 @@ import { GlobalState } from '../global/context/config';
 import {
   BuyerPortalRoute,
   getAllowedRoutesWithoutComponent,
-  RouteFirstLevelItem,
   RouteItem,
+  RouteItemBasic,
   routeList,
 } from '../routeList';
 
@@ -72,55 +72,48 @@ function addComponentToRoutes(routes: BuyerPortalRoute[]): RouteItem[] {
 
 const routes: RouteItem[] = addComponentToRoutes(routeList);
 
-const firstLevelRouting: RouteFirstLevelItem[] = [
+const firstLevelRouting: RouteItemBasic[] = [
   {
     path: '/',
     name: '',
     component: HomePage,
     permissions: allLegacyPermission,
-    isProvider: false,
   },
   {
     path: '/register',
     name: 'register',
     component: Registered,
     permissions: allLegacyPermission,
-    isProvider: true,
   },
   {
     path: '/login',
     name: 'Login',
     component: Login,
     permissions: allLegacyPermission,
-    isProvider: false,
   },
   {
     path: '/pdp',
     name: 'pdp',
     component: PDP,
     permissions: allLegacyPermission,
-    isProvider: false,
   },
   {
     path: '/forgotPassword',
     name: 'forgotPassword',
     component: ForgotPassword,
     permissions: allLegacyPermission,
-    isProvider: false,
   },
   {
     path: '/registeredbctob2b',
     name: 'registeredbctob2b',
     component: RegisteredBCToB2B,
     permissions: allLegacyPermission,
-    isProvider: true,
   },
   {
     path: '/payment/:id',
     name: 'payment',
     component: InvoicePayment,
     permissions: allLegacyPermission,
-    isProvider: false,
   },
 ];
 
@@ -195,7 +188,7 @@ const gotoAllowedAppPage = async (
     return false;
   });
 
-  const isFirstLevelFlag = firstLevelRouting.some((item: RouteFirstLevelItem) => {
+  const isFirstLevelFlag = firstLevelRouting.some((item: RouteItemBasic) => {
     if (url.includes('/login?') || url.includes('payment')) {
       return true;
     }


### PR DESCRIPTION
Jira: [B2B-3803](https://bigcommercecloud.atlassian.net/browse/B2B-3803)

## What/Why?
This provider is only used in two pages, Register and RegisteredBCToB2B. There's no reason to make this global as it is only used to avoid passing props down.

This decouples routeList.ts / routes/index.ts from the internals of the Register/RegisteredBCToB2B pages.

## Rollout/Rollback
Revert

## Testing

https://github.com/user-attachments/assets/dab361c4-9c7b-4e7c-a5eb-d6e438966f78



[B2B-3803]: https://bigcommercecloud.atlassian.net/browse/B2B-3803?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ