### PR TITLE
fix(quick-order): B2B-3978 passing withModifiers to bulk upload csv

### DIFF
--- a/apps/storefront/src/pages/QuickOrder/components/QuickOrderPad.tsx
+++ b/apps/storefront/src/pages/QuickOrder/components/QuickOrderPad.tsx
@@ -32,6 +32,8 @@ export default function QuickOrderPad() {
   const featureFlags = useFeatureFlags();
   const backendValidationEnabled =
     featureFlags['B2B-3318.move_stock_and_backorder_validation_to_backend'] ?? false;
+  const passWithModifiersToProductUpload =
+    featureFlags['B2B-3978.pass_with_modifiers_to_product_upload'] ?? false;
 
   const companyStatus = useAppSelector(({ company }) => company.companyInfo.status);
 
@@ -386,6 +388,7 @@ export default function QuickOrderPad() {
         addBtnText={addBtnText}
         isLoading={isLoading}
         isToCart
+        withModifiers={passWithModifiersToProductUpload}
       />
     </Card>
   );

--- a/apps/storefront/src/utils/featureFlags.ts
+++ b/apps/storefront/src/utils/featureFlags.ts
@@ -15,6 +15,10 @@ export const featureFlags = [
     key: 'B2B-3474.get_sku_from_pdp_with_text_content',
     name: 'getSkuFromPdpWithTextContent',
   },
+  {
+    key: 'B2B-3978.pass_with_modifiers_to_product_upload',
+    name: 'passWithModifiersToProductUpload',
+  },
 ] as const;
 
 export type FeatureFlagKey = (typeof featureFlags)[number]['key'];


### PR DESCRIPTION
Jira: [B2B-3978](https://bigcommercecloud.atlassian.net/browse/B2B-3978)

## What/Why?
<!--
  A description about what this pull request implements and its purpose.
  Try to be detailed and describe any technical details to simplify the job
  of the reviewer and the individual on production support.
-->
Fixing a bug where passing an SKU of a product with required modifiers would break the CSV upload in quick order form by not rendering the error report due to an unknown error. The reason being not passing the `withModifiers` flag. 

This flag is used by the api to validate modifiers for every single product. 

## Rollout/Rollback
<!--
Detail how this change will be rolled out. Include reference to any
experiments and how the success will be measured as the experiment is
ramped.

Document rollback procedures. Is rolling back the change as simple as
rolling back an experiment or does it require reverting code? Are there
database migrations that may change our decision to roll forward instead of
back?
-->
This fix is under the feature flag `B2B-3978.pass_with_modifiers_to_product_upload`

## Testing
<!--
Provide as much information as you can about how you tested and how another
Engineer can test your change. Include screenshots, or test run output
where appropriate.
-->
Before:
Error has no product name, no error report snackbar is shown.
https://github.com/user-attachments/assets/4cc267d2-f489-409a-8ccd-a05fe28a4d28

After:

https://github.com/user-attachments/assets/2531eeaa-9a4f-4b88-bf8c-8556eebdbb1c




[B2B-3978]: https://bigcommercecloud.atlassian.net/browse/B2B-3978?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ