### PR TITLE
fix(quick-order): B2B-3978 filtering out stock error skus

### DIFF
--- a/apps/storefront/src/components/upload/B3Upload.tsx
+++ b/apps/storefront/src/components/upload/B3Upload.tsx
@@ -6,6 +6,7 @@ import { Alert, Box, Link, useTheme } from '@mui/material';
 import Grid from '@mui/material/Unstable_Grid2';
 
 import { useMobile } from '@/hooks/useMobile';
+import { ValidProductItem } from '@/pages/QuickOrder/components/ValidProduct';
 import {
   B2BProductsBulkUploadCSV,
   BcProductsBulkUploadCSV,
@@ -29,8 +30,11 @@ interface B3UploadProps {
   setIsOpen: Dispatch<SetStateAction<boolean>>;
   bulkUploadTitle?: string;
   addBtnText?: string;
-  handleAddToList: (validProduct: CustomFieldItems) => Promise<void>;
-  setProductData?: (product: CustomFieldItems) => void;
+  handleAddToList: (data: {
+    validProduct: ValidProductItem[];
+    stockErrorFile: string;
+  }) => Promise<void>;
+  setProductData?: (products: ValidProductItem[]) => void;
   isLoading?: boolean;
   isToCart?: boolean;
   withModifiers?: boolean;
@@ -216,17 +220,13 @@ export function B3Upload(props: B3UploadProps) {
   const handleConfirmToList = async () => {
     const validProduct = fileDatas?.validProduct || [];
     const stockErrorFile = fileDatas?.stockErrorFile || '';
-    const stockErrorSkus = fileDatas?.stockErrorSkus || [];
     if (validProduct?.length === 0) return;
 
     if (validProduct) {
-      const productsData: CustomFieldItems = {
+      const productsData: { validProduct: ValidProductItem[]; stockErrorFile: string } = {
         validProduct,
+        stockErrorFile,
       };
-
-      if (stockErrorSkus.length > 0) {
-        productsData.stockErrorFile = stockErrorFile;
-      }
 
       await handleAddToList(productsData);
 

--- a/apps/storefront/src/lib/lang/locales/en.json
+++ b/apps/storefront/src/lib/lang/locales/en.json
@@ -290,6 +290,7 @@
   "purchasedProducts.quickOrderPad.bulkUploadCSV": "Bulk upload CSV",
   "purchasedProducts.quickOrderPad.downloadErrorsCSV": "Download error results",
   "purchasedProducts.quickOrderPad.addToCart": "Add to cart",
+  "purchasedProducts.quickOrderPad.otherError": "This product can't be added due to order quantity limits or wrong configuration: {sku}",
   "purchasedProducts.quickAdd.addProductToList": "Add product to list",
   "purchasedProducts.quickAdd.title": "Quick add",
   "purchasedProducts.quickAdd.showMoreRowsButton": "Show more rows",

--- a/apps/storefront/src/pages/QuickOrder/components/ValidProduct.ts
+++ b/apps/storefront/src/pages/QuickOrder/components/ValidProduct.ts
@@ -1,0 +1,84 @@
+/**
+ * Represents the configuration for a modifier.
+ * Includes fields for both Text and Checkbox types found in the data.
+ */
+interface ModifierConfig {
+  default_value?: string;
+  text_characters_limited?: boolean;
+  text_min_length?: number;
+  text_max_length?: number;
+  checkbox_label?: string;
+  checked_by_default?: boolean;
+}
+
+interface PurchasingDisabledInfo {
+  status: boolean;
+  message: string;
+}
+
+interface Adjusters {
+  price: number | null;
+  weight: number | null;
+  image_url: string;
+  purchasing_disabled: PurchasingDisabledInfo;
+}
+
+interface ModifierOptionValue {
+  id: number;
+  option_id: number;
+  label: string;
+  sort_order: number;
+  value_data: {
+    checked_value?: boolean;
+  };
+  is_default: boolean;
+  adjusters: Adjusters;
+}
+
+interface ProductModifier {
+  id: number;
+  product_id: number;
+  name: string;
+  display_name: string;
+  type: 'text' | 'checkbox' | string;
+  required: boolean;
+  sort_order: number;
+  config: ModifierConfig;
+  option_values: ModifierOptionValue[];
+}
+
+interface ProductOption {
+  id: number;
+  label: string;
+  option_id: number;
+  option_display_name: string;
+}
+
+interface ProductDetails {
+  variantSku: string;
+  productId: string;
+  calculatedPrice: number;
+  imageUrl: string;
+  variantId: number;
+  baseSku: string;
+  productName: string;
+  categories: unknown[];
+  option: ProductOption[];
+  minQuantity: number;
+  maxQuantity: number;
+  purchasingDisabled: boolean;
+  isVisible: '0' | '1';
+  isStock: '0' | '1';
+  stock: number;
+  modifiers: ProductModifier[];
+}
+
+/**
+ * The main container type for a single entry in the 'validProduct' array
+ */
+export interface ValidProductItem {
+  products: ProductDetails;
+  sku: string;
+  qty: string;
+  row: number;
+}

--- a/apps/storefront/src/pages/QuickOrder/index.main.test.tsx
+++ b/apps/storefront/src/pages/QuickOrder/index.main.test.tsx
@@ -3272,8 +3272,11 @@ describe('When backend validation feature flag is on', () => {
               validProduct: [
                 buildCSVProductWith({
                   products: {
+                    productId: '1',
+                    variantId: 2,
                     productName: 'Test Product 1',
                     variantSku: 'TEST-SKU-123',
+                    option: [],
                   },
                   qty: '2',
                   row: 1,
@@ -3288,6 +3291,41 @@ describe('When backend validation feature flag is on', () => {
         },
       });
 
+      const productsValidation = vi.fn();
+
+      when(productsValidation)
+        .calledWith({
+          products: expect.arrayContaining([
+            expect.objectContaining({
+              productId: 1,
+              variantId: 2,
+              quantity: 2,
+            }),
+          ]),
+        })
+        .thenReturn({
+          data: {
+            validateProducts: {
+              isValid: true,
+              products: [
+                {
+                  errorCode: 'SUCCESS',
+                  responseType: 'SUCCESS',
+                  message: '',
+                  product: {
+                    productId: 1,
+                    variantId: 2,
+                    quantity: 2,
+                    sku: 'TEST-SKU-123',
+                    availableToSell: 100,
+                    unlimitedBackorder: false,
+                  },
+                },
+              ],
+            },
+          },
+        });
+
       const getCart = vi.fn().mockReturnValue(buildGetCartWith({}));
       const createCartSimple = vi.fn().mockReturnValue({
         data: { cart: { createCart: { cart: { entityId: '12345' } } } },
@@ -3300,6 +3338,9 @@ describe('When backend validation feature flag is on', () => {
         graphql.query('SearchProducts', () => HttpResponse.json(searchProducts())),
         graphql.mutation('ProductUpload', () => HttpResponse.json(csvUpload())),
         graphql.query('getCart', () => HttpResponse.json(getCart())),
+        graphql.query('ValidateProducts', ({ variables }) =>
+          HttpResponse.json(productsValidation(variables)),
+        ),
         graphql.mutation('createCartSimple', () => HttpResponse.json(createCartSimple())),
         graphql.mutation('addCartLineItemsTwo', () =>
           HttpResponse.json(
@@ -3375,6 +3416,8 @@ describe('When backend validation feature flag is on', () => {
                 validProduct: [
                   buildCSVProductWith({
                     products: {
+                      productId: '1',
+                      variantId: 2,
                       productName: 'New Cart Product',
                       variantSku: 'NEW-CART-SKU-123',
                     },
@@ -3412,6 +3455,39 @@ describe('When backend validation feature flag is on', () => {
           }),
         );
 
+        const productsValidation = vi.fn();
+
+        when(productsValidation)
+          .calledWith({
+            products: expect.arrayContaining([
+              expect.objectContaining({
+                productId: 1,
+                variantId: 2,
+                quantity: 3,
+              }),
+            ]),
+          })
+          .thenReturn({
+            data: {
+              validateProducts: {
+                isValid: true,
+                products: [
+                  {
+                    errorCode: 'SUCCESS',
+                    responseType: 'SUCCESS',
+                    message: '',
+                    product: {
+                      productId: 1,
+                      variantId: 2,
+                      sku: 'NEW-CART-SKU-123',
+                      availableToSell: 100,
+                      unlimitedBackorder: false,
+                    },
+                  },
+                ],
+              },
+            },
+          });
         server.use(
           graphql.query('RecentlyOrderedProducts', () =>
             HttpResponse.json(getRecentlyOrderedProducts()),
@@ -3419,6 +3495,9 @@ describe('When backend validation feature flag is on', () => {
           graphql.query('SearchProducts', () => HttpResponse.json(searchProducts())),
           graphql.mutation('ProductUpload', () => HttpResponse.json(csvUpload())),
           graphql.query('getCart', () => HttpResponse.json(getCart())),
+          graphql.query('ValidateProducts', ({ variables }) =>
+            HttpResponse.json(productsValidation(variables)),
+          ),
           graphql.mutation('createCartSimple', () => HttpResponse.json(createCartSimple())),
           graphql.mutation('addCartLineItemsTwo', () => HttpResponse.json(addCartLineItemsTwo())),
         );
@@ -3485,6 +3564,8 @@ describe('When backend validation feature flag is on', () => {
                   products: {
                     productName: 'Failed Cart Product',
                     variantSku: 'FAIL-CART-SKU-123',
+                    productId: '1',
+                    variantId: 2,
                   },
                   qty: '2',
                   row: 1,
@@ -3509,6 +3590,27 @@ describe('When backend validation feature flag is on', () => {
         errors: [{ message: 'Failed to create cart due to server error' }],
       });
 
+      const productsValidation = vi.fn().mockReturnValue({
+        data: {
+          validateProducts: {
+            isValid: true,
+            products: [
+              {
+                errorCode: 'SUCCESS',
+                responseType: 'SUCCESS',
+                message: '',
+                product: {
+                  productId: 1,
+                  variantId: 2,
+                  sku: 'FAIL-CART-SKU-123',
+                  availableToSell: 100,
+                  unlimitedBackorder: false,
+                },
+              },
+            ],
+          },
+        },
+      });
       server.use(
         graphql.query('RecentlyOrderedProducts', () =>
           HttpResponse.json(getRecentlyOrderedProducts()),
@@ -3516,6 +3618,9 @@ describe('When backend validation feature flag is on', () => {
         graphql.query('SearchProducts', () => HttpResponse.json(searchProducts())),
         graphql.mutation('ProductUpload', () => HttpResponse.json(csvUpload())),
         graphql.query('getCart', () => HttpResponse.json(getCart())),
+        graphql.query('ValidateProducts', ({ variables }) =>
+          HttpResponse.json(productsValidation(variables)),
+        ),
         graphql.mutation('createCartSimple', () => HttpResponse.json(createCartSimple())),
       );
 
@@ -3595,6 +3700,41 @@ describe('When backend validation feature flag is on', () => {
         },
       });
 
+      const productsValidation = vi.fn();
+
+      when(productsValidation)
+        .calledWith({
+          products: expect.arrayContaining([
+            expect.objectContaining({
+              productId: 1,
+              variantId: 2,
+              quantity: 1,
+            }),
+          ]),
+        })
+        .thenReturn({
+          data: {
+            validateProducts: {
+              isValid: true,
+              products: [
+                {
+                  errorCode: 'OOS',
+                  responseType: 'ERROR',
+                  message: '',
+                  product: {
+                    productId: 1,
+                    variantId: 2,
+                    quantity: 1,
+                    sku: 'INVALID-SKU-456',
+                    availableToSell: 0,
+                    unlimitedBackorder: false,
+                  },
+                },
+              ],
+            },
+          },
+        });
+
       server.use(
         graphql.query('RecentlyOrderedProducts', () =>
           HttpResponse.json(getRecentlyOrderedProducts()),
@@ -3602,6 +3742,9 @@ describe('When backend validation feature flag is on', () => {
         graphql.query('SearchProducts', () => HttpResponse.json(searchProducts())),
         graphql.mutation('ProductUpload', () => HttpResponse.json(csvUpload())),
         graphql.query('getCart', () => HttpResponse.json(buildGetCartWith({}))),
+        graphql.query('ValidateProducts', ({ variables }) =>
+          HttpResponse.json(productsValidation(variables)),
+        ),
         graphql.mutation('addCartLineItemsTwo', () =>
           HttpResponse.json(
             buildAddCartLineItemsResponseWith({
@@ -3669,6 +3812,8 @@ describe('When backend validation feature flag is on', () => {
                   products: {
                     productName: 'Out of Stock Product',
                     variantSku: 'OOS-SKU-123',
+                    productId: '1',
+                    variantId: 2,
                   },
                   qty: '5',
                   row: 1,
@@ -3701,6 +3846,40 @@ describe('When backend validation feature flag is on', () => {
         ],
       });
 
+      const productsValidation = vi.fn();
+
+      when(productsValidation)
+        .calledWith({
+          products: expect.arrayContaining([
+            expect.objectContaining({
+              productId: 1,
+              variantId: 2,
+              quantity: 5,
+            }),
+          ]),
+        })
+        .thenReturn({
+          data: {
+            validateProducts: {
+              isValid: true,
+              products: [
+                {
+                  errorCode: 'OOS',
+                  responseType: 'ERROR',
+                  message: '',
+                  product: {
+                    productId: 1,
+                    variantId: 2,
+                    sku: 'OOS-SKU-123',
+                    availableToSell: 0,
+                    unlimitedBackorder: false,
+                  },
+                },
+              ],
+            },
+          },
+        });
+
       server.use(
         graphql.query('RecentlyOrderedProducts', () =>
           HttpResponse.json(getRecentlyOrderedProducts()),
@@ -3708,6 +3887,9 @@ describe('When backend validation feature flag is on', () => {
         graphql.query('SearchProducts', () => HttpResponse.json(searchProducts())),
         graphql.mutation('ProductUpload', () => HttpResponse.json(csvUpload())),
         graphql.query('getCart', () => HttpResponse.json(getCart())),
+        graphql.query('ValidateProducts', ({ variables }) =>
+          HttpResponse.json(productsValidation(variables)),
+        ),
         graphql.mutation('createCartSimple', () =>
           HttpResponse.json({
             data: { cart: { createCart: { cart: { entityId: '12345' } } } },
@@ -3769,6 +3951,8 @@ describe('When backend validation feature flag is on', () => {
                   products: {
                     productName: 'Min Quantity Product',
                     variantSku: 'MIN-QTY-SKU-123',
+                    productId: '1',
+                    variantId: 2,
                   },
                   qty: '1',
                   row: 1,
@@ -3800,6 +3984,28 @@ describe('When backend validation feature flag is on', () => {
         ],
       });
 
+      const productsValidation = vi.fn().mockReturnValue({
+        data: {
+          validateProducts: {
+            isValid: true,
+            products: [
+              {
+                errorCode: 'SUCCESS',
+                responseType: 'SUCCESS',
+                message: '',
+                product: {
+                  productId: 1,
+                  variantId: 2,
+                  quantity: 1,
+                  sku: 'MIN-QTY-SKU-123',
+                  availableToSell: 100,
+                  unlimitedBackorder: false,
+                },
+              },
+            ],
+          },
+        },
+      });
       server.use(
         graphql.query('RecentlyOrderedProducts', () =>
           HttpResponse.json(getRecentlyOrderedProducts()),
@@ -3807,6 +4013,9 @@ describe('When backend validation feature flag is on', () => {
         graphql.query('SearchProducts', () => HttpResponse.json(searchProducts())),
         graphql.mutation('ProductUpload', () => HttpResponse.json(csvUpload())),
         graphql.query('getCart', () => HttpResponse.json(getCart())),
+        graphql.query('ValidateProducts', ({ variables }) =>
+          HttpResponse.json(productsValidation(variables)),
+        ),
         graphql.mutation('createCartSimple', () =>
           HttpResponse.json({
             data: { cart: { createCart: { cart: { entityId: '12345' } } } },
@@ -3872,6 +4081,8 @@ describe('When backend validation feature flag is on', () => {
                   products: {
                     productName: 'Error Product',
                     variantSku: 'ERROR-SKU-123',
+                    productId: '1',
+                    variantId: 2,
                   },
                   qty: '1',
                   row: 1,
@@ -3903,6 +4114,31 @@ describe('When backend validation feature flag is on', () => {
         ],
       });
 
+      // return a successful validation response
+      // to test the cart api error message
+      const productsValidation = vi.fn().mockReturnValue({
+        data: {
+          validateProducts: {
+            isValid: true,
+            products: [
+              {
+                errorCode: 'SUCCESS',
+                responseType: 'SUCCESS',
+                message: '',
+                product: {
+                  productId: 1,
+                  variantId: 2,
+                  quantity: 1,
+                  sku: 'ERROR-SKU-123',
+                  availableToSell: 100,
+                  unlimitedBackorder: false,
+                },
+              },
+            ],
+          },
+        },
+      });
+
       server.use(
         graphql.query('RecentlyOrderedProducts', () =>
           HttpResponse.json(getRecentlyOrderedProducts()),
@@ -3910,6 +4146,9 @@ describe('When backend validation feature flag is on', () => {
         graphql.query('SearchProducts', () => HttpResponse.json(searchProducts())),
         graphql.mutation('ProductUpload', () => HttpResponse.json(csvUpload())),
         graphql.query('getCart', () => HttpResponse.json(getCart())),
+        graphql.query('ValidateProducts', ({ variables }) =>
+          HttpResponse.json(productsValidation(variables)),
+        ),
         graphql.mutation('createCartSimple', () =>
           HttpResponse.json({
             data: { cart: { createCart: { cart: { entityId: '12345' } } } },
@@ -3981,6 +4220,8 @@ describe('When backend validation feature flag is on', () => {
                   products: {
                     productName: 'Test Product With Modifiers',
                     variantSku: 'MODIFIER-SKU-123',
+                    productId: '1',
+                    variantId: 2,
                   },
                   qty: '3',
                   row: 1,
@@ -3999,6 +4240,28 @@ describe('When backend validation feature flag is on', () => {
       const createCartSimple = vi.fn().mockReturnValue({
         data: { cart: { createCart: { cart: { entityId: '12345' } } } },
       });
+      const productsValidation = vi.fn().mockReturnValue({
+        data: {
+          validateProducts: {
+            isValid: true,
+            products: [
+              {
+                errorCode: 'SUCCESS',
+                responseType: 'SUCCESS',
+                message: '',
+                product: {
+                  productId: 1,
+                  variantId: 2,
+                  quantity: 3,
+                  sku: 'MODIFIER-SKU-123',
+                  availableToSell: 100,
+                  unlimitedBackorder: false,
+                },
+              },
+            ],
+          },
+        },
+      });
 
       const productUpload = vi.fn();
       when(productUpload)
@@ -4012,6 +4275,9 @@ describe('When backend validation feature flag is on', () => {
         graphql.query('SearchProducts', () => HttpResponse.json(searchProducts())),
         graphql.mutation('ProductUpload', ({ query }) => HttpResponse.json(productUpload(query))),
         graphql.query('getCart', () => HttpResponse.json(getCart())),
+        graphql.query('ValidateProducts', ({ variables }) =>
+          HttpResponse.json(productsValidation(variables)),
+        ),
         graphql.mutation('createCartSimple', () => HttpResponse.json(createCartSimple())),
         graphql.mutation('addCartLineItemsTwo', () =>
           HttpResponse.json(

--- a/apps/storefront/src/shared/service/b2b/graphql/product.ts
+++ b/apps/storefront/src/shared/service/b2b/graphql/product.ts
@@ -109,6 +109,26 @@ const validateProductQuery = `
   }
 `;
 
+const validateProductsQuery = `
+  query ValidateProducts ($products: [ValidateProductInputType]) {
+    validateProducts(products: $products, storeHash: "${storeHash}", channelId: ${channelId}) {
+      isValid
+      products {
+        errorCode
+        responseType
+        message
+        product {
+          productId
+          variantId
+          sku
+          availableToSell
+          unlimitedBackorder
+        }
+      }
+    }
+  }
+`;
+
 const productsBulkUploadCSV = (data: CustomFieldItems) => `mutation ProductUpload {
   productUpload (
     productListData: {
@@ -323,6 +343,25 @@ export interface ValidateProductResponse {
     };
   };
 }
+interface ValidateProductsResponse {
+  data: {
+    validateProducts: {
+      isValid: boolean;
+      products: {
+        errorCode: string;
+        responseType: string;
+        message: string;
+        product: {
+          productId: number;
+          variantId: number;
+          sku: string;
+          availableToSell: number;
+          unlimitedBackorder: boolean;
+        };
+      }[];
+    };
+  };
+}
 
 export const searchProducts = (data: CustomFieldItems = {}) => {
   const { currency_code: currencyCode } = getActiveCurrencyInfo();
@@ -344,12 +383,22 @@ interface ValidateProductVariables {
     optionValue: string;
   }[];
 }
+interface ValidateProductsVariables {
+  products: ValidateProductVariables[];
+}
 
 export const validateProduct = (data: ValidateProductVariables) => {
   return B3Request.graphqlB2B<ValidateProductResponse>({
     query: validateProductQuery,
     variables: data,
   }).then((res) => res.validateProduct);
+};
+
+export const validateProducts = (data: ValidateProductsVariables) => {
+  return B3Request.graphqlB2B<ValidateProductsResponse>({
+    query: validateProductsQuery,
+    variables: data,
+  }).then((res) => res.validateProducts);
 };
 
 export const B2BProductsBulkUploadCSV = (data: CustomFieldItems = {}) =>


### PR DESCRIPTION
Jira: [B2B-3978](https://bigcommercecloud.atlassian.net/browse/B2B-3978)

## What/Why?
<!--
  A description about what this pull request implements and its purpose.
  Try to be detailed and describe any technical details to simplify the job
  of the reviewer and the individual on production support.
-->
Bug: Users can't add valid products to cart and there are no error snackbars anymore

Fix: Calling graphql query `validateProducts` after adding products to the cart by CSV to filter out stock and availability errors before adding the valid products to the cart

## Rollout/Rollback
<!--
Detail how this change will be rolled out. Include reference to any
experiments and how the success will be measured as the experiment is
ramped.

Document rollback procedures. Is rolling back the change as simple as
rolling back an experiment or does it require reverting code? Are there
database migrations that may change our decision to roll forward instead of
back?
-->
Revert. 

## Testing
<!--
Provide as much information as you can about how you tested and how another
Engineer can test your change. Include screenshots, or test run output
where appropriate.
-->
Screen recording working on integration with out of stock products and a non purchasable (back16) product:

https://github.com/user-attachments/assets/0e86cf4b-757b-46b6-8192-cc83dd113044



[B2B-3978]: https://bigcommercecloud.atlassian.net/browse/B2B-3978?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a backend validation step for CSV bulk-add to cart, showing specific errors and adding only validated products.
> 
> - **Quick Order Pad (frontend)**:
>   - Integrates `validateProducts` for CSV bulk-add, mapping validated `SUCCESS` items to cart line items and excluding failures.
>   - Displays granular snackbars for `OOS`, `NON_PURCHASABLE`, and other errors; links to `stockErrorFile` when available.
>   - Refactors types to use `ValidProductItem[]`; updates handlers to accept `{ validProduct, stockErrorFile }`.
> - **Upload Component (`B3Upload`)**:
>   - Updates props/types to pass `ValidProductItem[]` and `stockErrorFile` to parent on confirm.
> - **GraphQL Service**:
>   - Adds `ValidateProducts` query, types, and `validateProducts` helper.
> - **i18n**:
>   - Adds `purchasedProducts.quickOrderPad.otherError` message.
> - **Tests**:
>   - Extensively update/add tests to cover validation flow, error handling, new cart creation, and `withModifiers` flag.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d3ecbd61a6d04869f0e67b4993e9687e46e69fb5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->