### PR TITLE
fix(orders): B2B-3942 lift reorder checkbox state to parent

### DIFF
--- a/apps/storefront/src/pages/OrderDetail/components/OrderCheckboxProduct.tsx
+++ b/apps/storefront/src/pages/OrderDetail/components/OrderCheckboxProduct.tsx
@@ -25,6 +25,7 @@ interface OrderCheckboxProductProps {
   products: EditableProductItem[];
   getProductQuantity?: (item: EditableProductItem) => number;
   onProductChange?: (products: EditableProductItem[]) => void;
+  checkedArr?: number[];
   setCheckedArr?: (items: number[]) => void;
   setReturnArr?: (items: ReturnListProps[]) => void;
   textAlign?: string;
@@ -36,6 +37,7 @@ export default function OrderCheckboxProduct(props: OrderCheckboxProductProps) {
     products,
     getProductQuantity = (item) => item.editQuantity,
     onProductChange = () => {},
+    checkedArr = [],
     setCheckedArr = () => {},
     setReturnArr = () => {},
     textAlign = 'left',
@@ -45,8 +47,6 @@ export default function OrderCheckboxProduct(props: OrderCheckboxProductProps) {
   const b3Lang = useB3Lang();
 
   const [isMobile] = useMobile();
-
-  const [list, setList] = useState<number[]>([]);
 
   const [returnList, setReturnList] = useState<ReturnListProps[]>([]);
 
@@ -60,9 +60,8 @@ export default function OrderCheckboxProduct(props: OrderCheckboxProductProps) {
   const itemStyle = isMobile ? mobileItemStyle : defaultItemStyle;
 
   const handleSelectAllChange = () => {
-    const newList = [...list];
-    if (newList.length === products.length) {
-      setList([]);
+    if (checkedArr.length === products.length) {
+      setCheckedArr([]);
       setReturnList([]);
     } else {
       const variantIds = products.map((item) => item.variant_id);
@@ -74,13 +73,13 @@ export default function OrderCheckboxProduct(props: OrderCheckboxProductProps) {
         };
       });
 
-      setList(variantIds);
+      setCheckedArr(variantIds);
       setReturnList(returnIds);
     }
   };
 
   const handleSelectChange = (variantId: number, returnId: number, returnQty: number) => {
-    const newList = [...list];
+    const newList = [...checkedArr];
     const newReturnList = [...returnList];
     const index = newList.findIndex((item) => item === variantId);
     const returnIndex = newReturnList.findIndex((item) => item.returnId === returnId);
@@ -94,11 +93,11 @@ export default function OrderCheckboxProduct(props: OrderCheckboxProductProps) {
         returnQty,
       });
     }
-    setList(newList);
+    setCheckedArr(newList);
     setReturnList(newReturnList);
   };
 
-  const isChecked = (variantId: number) => list.includes(variantId);
+  const isChecked = (variantId: number) => checkedArr.includes(variantId);
 
   const handleProductQuantityChange =
     (product: EditableProductItem) => (e: ChangeEvent<HTMLInputElement>) => {
@@ -141,12 +140,6 @@ export default function OrderCheckboxProduct(props: OrderCheckboxProductProps) {
   };
 
   useEffect(() => {
-    setCheckedArr(list);
-    // Disabling this line as this dispatcher does not need to be in the dep array
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [list]);
-
-  useEffect(() => {
     setReturnArr(returnList);
     // Disabling this line as this dispatcher does not need to be in the dep array
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -156,7 +149,10 @@ export default function OrderCheckboxProduct(props: OrderCheckboxProductProps) {
     <Box>
       {!isMobile && (
         <Flex isHeader isMobile={isMobile}>
-          <Checkbox checked={list.length === products.length} onChange={handleSelectAllChange} />
+          <Checkbox
+            checked={checkedArr.length === products.length}
+            onChange={handleSelectAllChange}
+          />
           <FlexItem>
             <ProductHead>{b3Lang('orderDetail.reorder.product')}</ProductHead>
           </FlexItem>
@@ -176,7 +172,10 @@ export default function OrderCheckboxProduct(props: OrderCheckboxProductProps) {
         <FormControlLabel
           label="Select all products"
           control={
-            <Checkbox checked={list.length === products.length} onChange={handleSelectAllChange} />
+            <Checkbox
+              checked={checkedArr.length === products.length}
+              onChange={handleSelectAllChange}
+            />
           }
           sx={{
             paddingLeft: '0.6rem',

--- a/apps/storefront/src/pages/OrderDetail/components/OrderDialog.tsx
+++ b/apps/storefront/src/pages/OrderDetail/components/OrderDialog.tsx
@@ -358,6 +358,7 @@ export default function OrderDialog({
         editQuantity: item.quantity,
       })),
     );
+    setCheckedArr([]);
 
     const getVariantInfoByList = async () => {
       const visibleProducts = products.filter((item: OrderProductItem) => item?.isVisible);
@@ -407,6 +408,7 @@ export default function OrderDialog({
           <OrderCheckboxProduct
             products={editableProducts}
             onProductChange={handleProductChange}
+            checkedArr={checkedArr}
             setCheckedArr={setCheckedArr}
             setReturnArr={setReturnArr}
             textAlign={isMobile ? 'left' : 'right'}


### PR DESCRIPTION
Jira: [B2B-3942](https://bigcommercecloud.atlassian.net/browse/B2B-3942)

## What/Why?
Backend validation needs to uncheck any reorder items that were successfully added to the cart. To do that reliably, the checkbox state has to live in the parent (`OrderDialog`) instead of inside `OrderCheckboxProduct`. 

This PR just lifts that state so the parent can eventually handle the success case and drive the checkboxes accordingly.

Note: This lays some of the groundwork for a later PR where we actually do the unchecking on success
<!--
  A description about what this pull request implements and its purpose.
  Try to be detailed and describe any technical details to simplify the job
  of the reviewer and the individual on production support.
-->

## Rollout/Rollback
revert and redeploy
<!--
Detail how this change will be rolled out. Include reference to any
experiments and how the success will be measured as the experiment is
ramped.

Document rollback procedures. Is rolling back the change as simple as
rolling back an experiment or does it require reverting code? Are there
database migrations that may change our decision to roll forward instead of
back?
-->

## Testing
Should be no change in behavior with checkbox functionality

https://github.com/user-attachments/assets/31323e23-2283-4e64-bbbe-944c738b6171


<!--
Provide as much information as you can about how you tested and how another
Engineer can test your change. Include screenshots, or test run output
where appropriate.
-->


[B2B-3942]: https://bigcommercecloud.atlassian.net/browse/B2B-3942?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ