### PR TITLE
fix(orders): B2B-3942 preserve input shape in validateProducts

### DIFF
--- a/apps/storefront/src/pages/QuickOrder/components/QuickAdd.tsx
+++ b/apps/storefront/src/pages/QuickOrder/components/QuickAdd.tsx
@@ -328,7 +328,9 @@ export default function QuickAdd() {
     productItems: CustomFieldItems[];
     passSku: string[];
     notFoundSkus: string[];
-    validationErrors: (ValidatedProductWarning | ValidatedProductError)[];
+    validationErrors: Array<
+      ValidatedProductWarning<CustomFieldItems> | ValidatedProductError<CustomFieldItems>
+    >;
   }> => {
     const notFoundSkus = filterInputSkusForNotFoundProducts(skus, variantInfoList);
 

--- a/apps/storefront/src/utils/validateProducts.test.ts
+++ b/apps/storefront/src/utils/validateProducts.test.ts
@@ -1,0 +1,139 @@
+import { graphql, HttpResponse, startMockServer } from 'tests/test-utils';
+import { expect, it, vi } from 'vitest';
+import { when } from 'vitest-when';
+
+import { validateProducts } from './validateProducts';
+
+const { server } = startMockServer();
+
+it('standardizes products and preserves the original payload', async () => {
+  const validateProduct = vi.fn();
+
+  when(validateProduct)
+    .calledWith({
+      productId: 1,
+      variantId: 3,
+      quantity: 2,
+      productOptions: [{ optionId: 5, optionValue: 'Red' }],
+    })
+    .thenReturn({ data: { validateProduct: { responseType: 'SUCCESS', message: '' } } });
+
+  when(validateProduct)
+    .calledWith({
+      productId: 10,
+      variantId: 12,
+      quantity: 4,
+      productOptions: [{ optionId: 6, optionValue: 'Blue' }],
+    })
+    .thenReturn({ data: { validateProduct: { responseType: 'SUCCESS', message: '' } } });
+
+  when(validateProduct)
+    .calledWith({
+      productId: 20,
+      variantId: 21,
+      quantity: 5,
+      productOptions: [{ optionId: 7, optionValue: 'Green' }],
+    })
+    .thenReturn({ data: { validateProduct: { responseType: 'SUCCESS', message: '' } } });
+
+  server.use(
+    graphql.query('ValidateProduct', ({ variables }) =>
+      HttpResponse.json(validateProduct(variables)),
+    ),
+  );
+
+  const graphQlNodeProduct = {
+    node: {
+      productId: 1,
+      quantity: 2,
+      extraInfo: 'bar',
+      productsSearch: {
+        variantId: 3,
+        newSelectOptionList: [{ optionId: 'attribute[5]', optionValue: 'Red' }],
+      },
+    },
+  };
+
+  const productWithProductsSearch = {
+    productId: 10,
+    variantId: 11,
+    quantity: 4,
+    someMoreInfo: 'baz',
+    productsSearch: {
+      variantId: 12,
+      selectedOptions: [{ optionId: 'attribute[6]', optionValue: 'Blue' }],
+    },
+  };
+
+  const plainProduct = {
+    productId: 20,
+    variantId: 21,
+    quantity: 5,
+    otherInfo: 'qux',
+    productOptions: [{ optionId: 'attribute[7]', optionValue: 'Green' }],
+  };
+
+  const result = await validateProducts([
+    graphQlNodeProduct,
+    productWithProductsSearch,
+    plainProduct,
+  ]);
+
+  expect(result).toEqual({
+    success: [
+      { status: 'success', product: graphQlNodeProduct },
+      { status: 'success', product: productWithProductsSearch },
+      { status: 'success', product: plainProduct },
+    ],
+    warning: [],
+    error: [],
+  });
+});
+
+it('groups products by their validation status', async () => {
+  const validateProduct = vi.fn();
+
+  const products = [
+    { variantId: 199, quantity: 1, productOptions: [], productId: 99, extraInfo: 'foo' },
+    { variantId: 199, quantity: 1, productOptions: [], productId: 100, extraInfo: 'bar' },
+    { variantId: 199, quantity: 1, productOptions: [], productId: 101, extraInfo: 'baz' },
+    { variantId: 199, quantity: 1, productOptions: [], productId: 102, extraInfo: 'qux' },
+  ];
+
+  when(validateProduct)
+    .calledWith({ productId: 99, variantId: 199, quantity: 1, productOptions: [] })
+    .thenReturn({ data: { validateProduct: { responseType: 'SUCCESS', message: '' } } });
+  when(validateProduct)
+    .calledWith({ productId: 100, variantId: 199, quantity: 1, productOptions: [] })
+    .thenReturn({ data: { validateProduct: { responseType: 'WARNING', message: 'baz qux' } } });
+  when(validateProduct)
+    .calledWith({ productId: 101, variantId: 199, quantity: 1, productOptions: [] })
+    .thenReturn({ data: { validateProduct: { responseType: 'ERROR', message: 'foo bar' } } });
+  when(validateProduct)
+    .calledWith({ productId: 102, variantId: 199, quantity: 1, productOptions: [] })
+    .thenReject(new Error('network failure'));
+
+  server.use(
+    graphql.query('ValidateProduct', ({ variables }) =>
+      HttpResponse.json(validateProduct(variables)),
+    ),
+  );
+
+  const result = await validateProducts(products);
+
+  expect(result).toEqual({
+    success: [{ status: 'success', product: products[0] }],
+    warning: [{ status: 'warning', message: 'baz qux', product: products[1] }],
+    error: [
+      { status: 'error', error: { type: 'validation', message: 'foo bar' }, product: products[2] },
+      { status: 'error', error: { type: 'network' }, product: products[3] },
+    ],
+  });
+});
+
+// This is here until TS can handle the type correctly
+it('throws an error if the product shape is not valid', async () => {
+  await expect(() =>
+    validateProducts([{ productId: 1, variantId: 1, quantity: 1 }]),
+  ).rejects.toThrow('Unsupported product shape provided to validateProducts');
+});


### PR DESCRIPTION
Jira: [B2B-3942](https://bigcommercecloud.atlassian.net/browse/B2B-3942)

## What/Why?
`validateProducts` was forcing every consumer to shape‐shift their product objects into the cart API format before validation, then rebuild their original objects afterward. That made the reorder flow especially brittle because we lost fields like `variantId`, option selections, and custom payload properties midstream.

This PR makes `validateProducts` behave like a true generic utility:
* Accepts multiple product shapes (`Product`, `GraphQL node`, `CustomFieldItems`, etc.) via `ValidateProductsInput`
* Transforms those shapes internally using `transformProductForValidation`
* Returns the same type `T` that was passed in

With this change, callers only pass their existing product objects and receive them back with validation status attached.
<!--
  A description about what this pull request implements and its purpose.
  Try to be detailed and describe any technical details to simplify the job
  of the reviewer and the individual on production support.
-->

## Rollout/Rollback
revert and redeploy
<!--
Detail how this change will be rolled out. Include reference to any
experiments and how the success will be measured as the experiment is
ramped.

Document rollback procedures. Is rolling back the change as simple as
rolling back an experiment or does it require reverting code? Are there
database migrations that may change our decision to roll forward instead of
back?
-->

## Testing
typescript compiling successfully & unit tests passing
<!--
Provide as much information as you can about how you tested and how another
Engineer can test your change. Include screenshots, or test run output
where appropriate.
-->


[B2B-3942]: https://bigcommercecloud.atlassian.net/browse/B2B-3942?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors validateProducts to accept multiple product shapes and return the original typed payload, updates callers to use typed results, and adds unit tests.
> 
> - **Utils**:
>   - Refactor `validateProducts` to be generic over input `T` and return original product shape.
>   - Add `ValidateProductsInput` union, `transformProductForValidation`, and `transformProductOptions` to normalize inputs.
>   - Return grouped results as `success`/`warning`/`error` with typed `ValidatedProduct*<T>`.
> - **Pages**:
>   - `pages/QuoteDetail/index.tsx`: Strongly type `productList`, `fileList`, and `quoteValidationErrors` with generics; fix product name access in error snackbar; minor state initializations.
>   - `pages/QuickOrder/components/QuickAdd.tsx`: Update backend validation to use typed `ValidatedProductWarning<CustomFieldItems> | ValidatedProductError<CustomFieldItems>`.
> - **Tests**:
>   - Add `utils/validateProducts.test.ts` covering input-shape preservation, status grouping, and invalid shape error.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4d79dc5179be4e56efb91bb6dd014578d524a86d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->