### PR TITLE
fix(common): B2B-3803 Use vite/manifest.json to find out entry points

### DIFF
--- a/apps/storefront/vite.config.ts
+++ b/apps/storefront/vite.config.ts
@@ -76,6 +76,7 @@ export default defineConfig(({ mode }): UserConfig & Pick<ViteUserConfig, 'test'
       },
     },
     build: {
+      manifest: true,
       minify: true,
       sourcemap: true,
       rollupOptions: {


### PR DESCRIPTION


Jira: [B2B-3803](https://bigcommercecloud.atlassian.net/browse/B2B-3803)

## What/Why?
- Use `.vite/manifest.json` to figure out the hashed entry point files.
- Add integrity hashes to those files

After a recent change, we moved the chunks from the `assets` folder to the `chunks` folder.
This caused the `after.sh` script to fail to find the assets entry points.

This PR enables vite manifest generation and uses that to find the entry files.

## Rollout/Rollback
Revert

## Testing
Will test in integration.

[B2B-3803]: https://bigcommercecloud.atlassian.net/browse/B2B-3803?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ