### PR TITLE
fix(quick-order): B2B-4050 Clear QuickAdd inputs correctly when the case does not match

### DIFF
--- a/apps/storefront/src/pages/QuickOrder/components/QuickAdd.tsx
+++ b/apps/storefront/src/pages/QuickOrder/components/QuickAdd.tsx
@@ -234,13 +234,13 @@ export default function QuickAdd() {
     });
   };
 
-  const clearInputValue = (value: CustomFieldItems, skus: string[]) => {
-    skus.forEach((sku) => {
-      const skuFieldName = Object.keys(value).find((name) => value[name] === sku) || '';
+  const clearInputValue = (formData: FieldValues, skus: string[]) => {
+    const lowerCaseSkus = skus.map((sku) => sku.toLowerCase());
 
-      if (skuFieldName) {
-        setValue(skuFieldName, '');
-        setValue(skuFieldName.replace('sku', 'qty'), '');
+    Object.entries(formData).forEach(([key, value]) => {
+      if (typeof value === 'string' && lowerCaseSkus.includes(value.toLowerCase())) {
+        setValue(key, '');
+        setValue(key.replace('sku', 'qty'), '');
       }
     });
   };

--- a/apps/storefront/src/pages/ShoppingListDetails/components/QuickAdd.tsx
+++ b/apps/storefront/src/pages/ShoppingListDetails/components/QuickAdd.tsx
@@ -277,12 +277,12 @@ export default function QuickAdd(props: AddToListContentProps) {
   };
 
   const clearInputValue = (value: CustomFieldItems, skus: string[]) => {
-    skus.forEach((sku) => {
-      const skuFieldName = Object.keys(value).find((name) => value[name] === sku) || '';
+    const lowerCaseSkus = skus.map((sku) => sku.toLowerCase());
 
-      if (skuFieldName) {
-        setValue(skuFieldName, '');
-        setValue(skuFieldName.replace('sku', 'qty'), '');
+    Object.entries(value).forEach(([key, value]) => {
+      if (typeof value === 'string' && lowerCaseSkus.includes(value.toLowerCase())) {
+        setValue(key, '');
+        setValue(key.replace('sku', 'qty'), '');
       }
     });
   };


### PR DESCRIPTION
Jira: [B2B-4050](https://bigcommercecloud.atlassian.net/browse/B2B-4050)

## What/Why?
Make the SKU comparison case insensitive.

The API responds with uppercase skus, if the user has typed with a different casing the UI will struggle to clean up the successful lines.

## Rollout/Rollback
Revert

## Testing

### Before

https://github.com/user-attachments/assets/2b065dea-6b26-42f9-8ab6-35fee90b8e4a

### After
https://github.com/user-attachments/assets/66885de8-74b9-4aa3-bd0b-321198a9d368



[B2B-4050]: https://bigcommercecloud.atlassian.net/browse/B2B-4050?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Makes SKU matching case-insensitive when clearing QuickAdd inputs after successful add; updates implementations in QuickOrder and ShoppingListDetails and adds targeted tests.
> 
> - **Frontend**:
>   - `apps/storefront/src/pages/QuickOrder/components/QuickAdd.tsx`: Update `clearInputValue` to iterate over form entries and clear `sku`/`qty` using case-insensitive SKU comparison; change parameter to `FieldValues`.
>   - `apps/storefront/src/pages/ShoppingListDetails/components/QuickAdd.tsx`: Same case-insensitive `clearInputValue` logic applied.
> - **Tests**:
>   - `apps/storefront/src/pages/QuickOrder/index.main.test.tsx`: Add test ensuring QuickAdd clears inputs after adding valid products (case-insensitive SKU); minor test name tweaks.
>   - `apps/storefront/src/pages/ShoppingListDetails/index.quickadd.test.tsx`: Add test to verify only passed items are cleared and that clearing is case-insensitive; minor copy fixes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 61ccdb0b75535b9e31440a1c5936a012c65d7e9a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->