### PR TITLE
fix(quick-order): B2B-4050 Improve SKU not found error messages for pluralization

### DIFF
--- a/apps/storefront/src/lib/lang/locales/en.json
+++ b/apps/storefront/src/lib/lang/locales/en.json
@@ -297,7 +297,7 @@
   "purchasedProducts.quickAdd.sku": "SKU#",
   "purchasedProducts.quickAdd.qty": "Qty",
   "purchasedProducts.quickAdd.incorrectNumber": "Incorrect number",
-  "purchasedProducts.quickAdd.notFoundSku": "SKU {notFoundSku} were not found, please check entered values",
+  "purchasedProducts.quickAdd.notFoundSku": "{count, plural, one {SKU {notFoundSku} was not found} other {SKUs {notFoundSku} were not found}}, please check entered values",
   "purchasedProducts.quickAdd.notPurchaseableSku": "SKU {notPurchaseSku} no longer for sale",
   "purchasedProducts.quickAdd.insufficientStockSku": "{stockSku} does not have enough stock, please change the quantity ",
   "purchasedProducts.quickAdd.purchaseQuantityLimitMessage": "You need to purchase a {typeText} of {limit} of the {sku} per order",

--- a/apps/storefront/src/pages/QuickOrder/components/QuickAdd.tsx
+++ b/apps/storefront/src/pages/QuickOrder/components/QuickAdd.tsx
@@ -1,5 +1,5 @@
 import { Fragment, KeyboardEventHandler, useState } from 'react';
-import { useForm } from 'react-hook-form';
+import { FieldValues, useForm } from 'react-hook-form';
 import { Box, Grid, Typography } from '@mui/material';
 
 import CustomButton from '@/components/button/CustomButton';
@@ -217,16 +217,16 @@ export default function QuickAdd() {
   };
 
   const showErrors = (
-    value: CustomFieldItems,
+    formData: FieldValues,
     skus: string[],
     inputType: 'sku' | 'qty',
     message: string,
   ) => {
-    skus.forEach((sku) => {
-      const skuFieldName = Object.keys(value).find((name) => value[name] === sku) || '';
+    const lowerCaseSkus = skus.map((sku) => sku.toLowerCase());
 
-      if (skuFieldName) {
-        setError(skuFieldName.replace('sku', inputType), {
+    Object.entries(formData).forEach(([key, value]) => {
+      if (typeof value === 'string' && lowerCaseSkus.includes(value.toLowerCase())) {
+        setError(key.replace('sku', inputType), {
           type: 'manual',
           message,
         });
@@ -256,7 +256,7 @@ export default function QuickAdd() {
   };
 
   const handleFrontendValidation = async (
-    value: CustomFieldItems,
+    value: FieldValues,
     variantInfoList: CustomFieldItems[],
     skuValue: SimpleObject,
     skus: string[],
@@ -268,7 +268,8 @@ export default function QuickAdd() {
       showErrors(value, notFoundSku, 'sku', '');
       snackbar.error(
         b3Lang('purchasedProducts.quickAdd.notFoundSku', {
-          notFoundSku: notFoundSku.join(','),
+          count: notFoundSku.length,
+          notFoundSku: notFoundSku.join(', '),
         }),
       );
     }
@@ -277,7 +278,7 @@ export default function QuickAdd() {
       showErrors(value, notPurchaseSku, 'sku', '');
       snackbar.error(
         b3Lang('purchasedProducts.quickAdd.notPurchaseableSku', {
-          notPurchaseSku: notPurchaseSku.join(','),
+          notPurchaseSku: notPurchaseSku.join(', '),
         }),
       );
     }
@@ -293,7 +294,7 @@ export default function QuickAdd() {
 
       snackbar.error(
         b3Lang('purchasedProducts.quickAdd.insufficientStockSku', {
-          stockSku: stockSku.join(','),
+          stockSku: stockSku.join(', '),
         }),
       );
     }
@@ -416,7 +417,8 @@ export default function QuickAdd() {
           if (notFoundSkus.length > 0) {
             snackbar.error(
               b3Lang('purchasedProducts.quickAdd.notFoundSku', {
-                notFoundSku: notFoundSkus.join(','),
+                count: notFoundSkus.length,
+                notFoundSku: notFoundSkus.join(', '),
               }),
             );
           }

--- a/apps/storefront/src/pages/QuickOrder/index.main.test.tsx
+++ b/apps/storefront/src/pages/QuickOrder/index.main.test.tsx
@@ -3263,7 +3263,7 @@ describe('When backend validation feature flag is on', () => {
     await userEvent.click(addButton);
 
     const error = await screen.findByText(
-      'SKU NON-EXISTENT-SKU were not found, please check entered values',
+      'SKU NON-EXISTENT-SKU was not found, please check entered values',
     );
     expect(error).toBeInTheDocument();
   });
@@ -3364,7 +3364,7 @@ describe('When backend validation feature flag is on', () => {
     expect(await screen.findByText('Products were added to cart')).toBeInTheDocument();
 
     expect(
-      await screen.findByText('SKU NOT-FOUND-SKU were not found, please check entered values'),
+      await screen.findByText('SKU NOT-FOUND-SKU was not found, please check entered values'),
     ).toBeInTheDocument();
   });
 
@@ -3511,7 +3511,7 @@ describe('When backend validation feature flag is on', () => {
     expect(await screen.findByText('Products were added to cart')).toBeInTheDocument();
 
     expect(
-      await screen.findByText('SKU NOT-FOUND-SKU were not found, please check entered values'),
+      await screen.findByText('SKU NOT-FOUND-SKU was not found, please check entered values'),
     ).toBeInTheDocument();
   });
 

--- a/apps/storefront/src/pages/QuickOrder/index.quickadd.test.tsx
+++ b/apps/storefront/src/pages/QuickOrder/index.quickadd.test.tsx
@@ -297,7 +297,7 @@ it('only clears inputs that are added to the cart, keeps the rest', async () => 
   await userEvent.click(screen.getByRole('button', { name: 'Add products to cart' }));
 
   expect(
-    await screen.findByText('SKU S-456 were not found, please check entered values'),
+    await screen.findByText('SKU S-456 was not found, please check entered values'),
   ).toBeInTheDocument();
 
   expect(await screen.findByText('Products were added to cart')).toBeInTheDocument();
@@ -331,7 +331,7 @@ it('submits the form when pressing enter on either of the inputs', async () => {
 
   await waitFor(() => {
     expect(
-      screen.getByText('SKU S-123 were not found, please check entered values'),
+      screen.getByText('SKU S-123 was not found, please check entered values'),
     ).toBeInTheDocument();
   });
 
@@ -340,7 +340,7 @@ it('submits the form when pressing enter on either of the inputs', async () => {
 
   await waitFor(() => {
     expect(
-      screen.getByText('SKU S-456 were not found, please check entered values'),
+      screen.getByText('SKU S-456 was not found, please check entered values'),
     ).toBeInTheDocument();
   });
 });
@@ -551,7 +551,7 @@ describe('when there is a problem with some of the skus', () => {
 
     await waitFor(() => {
       expect(
-        screen.getByText('SKU S-123,S-456 were not found, please check entered values'),
+        screen.getByText('SKUs S-123, S-456 were not found, please check entered values'),
       ).toBeInTheDocument();
     });
 
@@ -781,7 +781,7 @@ describe('when there is a problem with some of the skus', () => {
 
       await waitFor(() => {
         expect(
-          screen.getByText('SKU S-123,S-456 were not found, please check entered values'),
+          screen.getByText('SKUs S-123, S-456 were not found, please check entered values'),
         ).toBeInTheDocument();
       });
 


### PR DESCRIPTION

Jira: [B2B-4050](https://bigcommercecloud.atlassian.net/browse/B2B-4050)

## What/Why?
Use ReactIntl for pluralisation, allowing for proper plural error messages.

The message was using the plural form for single skus in the past. Use ReactIntl to properly translate the message.

## Rollout/Rollback
Revert

## Testing

Before:

https://github.com/user-attachments/assets/99311a46-c598-4894-be65-2dc6d4b6cac7


After:

https://github.com/user-attachments/assets/02958552-a508-4ba3-b7b9-b639412a14b2



[B2B-4050]: https://bigcommercecloud.atlassian.net/browse/B2B-4050?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Use ICU pluralization for not-found SKU messages and update Quick Add to case-insensitively map errors from form data; tests adjusted accordingly.
> 
> - **Localization**:
>   - Update `purchasedProducts.quickAdd.notFoundSku` in `apps/storefront/src/lib/lang/locales/en.json` to ICU plural format with `count` and space-separated SKUs.
> - **Quick Add (frontend)**:
>   - Switch validation helpers to `FieldValues` and update `showErrors` to iterate form data and match SKUs case-insensitively.
>   - Include `count` in `b3Lang` calls and present SKU lists joined by `", ".`
> - **Tests**:
>   - Update Quick Order/Quick Add tests to expect singular "was not found" for one SKU and plural "SKUs ... were not found" for multiple, with spacing adjustments.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a3a4888563c2cb7238d812c8c848344b6a5e748d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->