### PR TITLE
fix(quick-order): B2B-4050 Improve SKU not found error messages for p…

### DIFF
--- a/apps/storefront/src/hooks/dom/utils.test.ts
+++ b/apps/storefront/src/hooks/dom/utils.test.ts
@@ -205,6 +205,9 @@ const buildValidateProductWith = builder<ValidateProduct>(() =>
       responseType: 'ERROR',
       message: faker.lorem.sentence(),
       errorCode: faker.helpers.arrayElement(['NON_PURCHASABLE', 'OOS', 'INVALID_FIELDS', 'OTHER']),
+      product: {
+        availableToSell: faker.number.int(),
+      },
     },
   ]),
 );

--- a/apps/storefront/src/lib/lang/locales/en.json
+++ b/apps/storefront/src/lib/lang/locales/en.json
@@ -301,6 +301,8 @@
   "purchasedProducts.quickAdd.notPurchaseableSku": "SKU {notPurchaseSku} no longer for sale",
   "purchasedProducts.quickAdd.insufficientStockSku": "{stockSku} does not have enough stock, please change the quantity ",
   "purchasedProducts.quickAdd.purchaseQuantityLimitMessage": "You need to purchase a {typeText} of {limit} of the {sku} per order",
+  "purchasedProducts.quickAdd.inlineErrors.notFoundSku": "SKU not found",
+  "purchasedProducts.quickAdd.inlineErrors.insufficientStockSku": "{count} available",
   "purchasedProducts.footer.selectOneItemToAdd": "Please select at least one item to add to cart",
   "purchasedProducts.footer.productsAdded": "Products were added to cart",
   "purchasedProducts.footer.productsLimit": "The quantity of each product in Quote is 1-1000000.",

--- a/apps/storefront/src/pages/OrderDetail/index.test.tsx
+++ b/apps/storefront/src/pages/OrderDetail/index.test.tsx
@@ -1790,6 +1790,7 @@ describe('when a personal customer visits an order', () => {
               errorCode: 'OOS',
               responseType: 'ERROR',
               message: 'A message from the backend',
+              product: { availableToSell: faker.number.int() },
             },
           },
         });
@@ -2133,6 +2134,7 @@ describe('when a personal customer visits an order', () => {
               responseType: 'ERROR',
               message: 'An error message from the backend',
               errorCode: 'OOS',
+              product: { availableToSell: faker.number.int() },
             },
           },
         });

--- a/apps/storefront/src/pages/QuickOrder/components/QuickAdd.validation.ts
+++ b/apps/storefront/src/pages/QuickOrder/components/QuickAdd.validation.ts
@@ -14,6 +14,7 @@ export interface CatalogProduct {
 
 interface ValidationPayloadItem {
   node: {
+    sku?: string;
     productId: number;
     quantity: number;
     productsSearch: {
@@ -76,6 +77,7 @@ export function mapCatalogToValidationPayload(
 
     return {
       node: {
+        sku: matchingSkuFromInput,
         productId: parseInt(catalogProduct.productId, 10) || 0,
         quantity: requestedQuantity,
         productsSearch: {

--- a/apps/storefront/src/pages/QuoteDetail/index.test.tsx
+++ b/apps/storefront/src/pages/QuoteDetail/index.test.tsx
@@ -344,6 +344,9 @@ describe('when the user is a B2B customer', () => {
             validateProduct: {
               responseType: 'ERROR',
               message: 'A product with the id of 123 does not have sufficient stock',
+              product: {
+                availableToSell: faker.number.int(),
+              },
             },
           },
         }),
@@ -470,6 +473,9 @@ describe('when the user is a B2B customer', () => {
             validateProduct: {
               responseType: 'ERROR',
               message: 'A product with the id of 123 does not have sufficient stock',
+              product: {
+                availableToSell: faker.number.int(),
+              },
             },
           },
         }),
@@ -650,6 +656,9 @@ describe('when the user is a B2B customer', () => {
             validateProduct: {
               responseType: 'ERROR',
               message: 'A product with the id of 123 does not have sufficient stock',
+              product: {
+                availableToSell: faker.number.int(),
+              },
             },
           },
         }),

--- a/apps/storefront/src/pages/QuoteDraft/index.test.tsx
+++ b/apps/storefront/src/pages/QuoteDraft/index.test.tsx
@@ -334,6 +334,9 @@ const buildValidateProductWith = builder<ValidateProduct>(() =>
       responseType: 'ERROR',
       message: faker.lorem.sentence(),
       errorCode: faker.helpers.arrayElement(['NON_PURCHASABLE', 'OOS', 'INVALID_FIELDS', 'OTHER']),
+      product: {
+        availableToSell: faker.number.int(),
+      },
     },
   ]),
 );
@@ -2624,6 +2627,9 @@ describe('when the user is a B2B customer', () => {
               validateProduct: buildValidateProductWith({
                 responseType: 'ERROR',
                 message: 'validation error',
+                product: {
+                  availableToSell: faker.number.int(),
+                },
               }),
             },
           });
@@ -3136,6 +3142,9 @@ describe('when the user is a B2B customer', () => {
               validateProduct: buildValidateProductWith({
                 responseType: 'ERROR',
                 message: 'validation error',
+                product: {
+                  availableToSell: faker.number.int(),
+                },
               }),
             },
           });
@@ -3839,6 +3848,9 @@ describe('when the user is a B2B customer', () => {
               validateProduct: buildValidateProductWith({
                 responseType: 'ERROR',
                 message: 'validation error',
+                product: {
+                  availableToSell: faker.number.int(),
+                },
               }),
             },
           });

--- a/apps/storefront/src/pages/ShoppingListDetails/index.test.tsx
+++ b/apps/storefront/src/pages/ShoppingListDetails/index.test.tsx
@@ -383,6 +383,9 @@ const buildValidateProductWith = builder<ValidateProduct>(() =>
       responseType: 'ERROR',
       message: faker.lorem.sentence(),
       errorCode: faker.helpers.arrayElement(['NON_PURCHASABLE', 'OOS', 'INVALID_FIELDS', 'OTHER']),
+      product: {
+        availableToSell: faker.number.int(),
+      },
     },
   ]),
 );

--- a/apps/storefront/src/shared/service/b2b/graphql/product.ts
+++ b/apps/storefront/src/shared/service/b2b/graphql/product.ts
@@ -106,6 +106,9 @@ const validateProductQuery = `
       responseType
       message
       errorCode
+      product {
+        availableToSell
+      }
     }
   }
 `;
@@ -345,6 +348,9 @@ interface ValidateProductError {
   responseType: 'ERROR';
   errorCode: 'NON_PURCHASABLE' | 'OOS' | 'INVALID_FIELDS' | 'OTHER';
   message: string;
+  product: {
+    availableToSell: number;
+  };
 }
 
 interface ValidateProductWarning {

--- a/apps/storefront/src/utils/validateProducts.test.ts
+++ b/apps/storefront/src/utils/validateProducts.test.ts
@@ -109,7 +109,14 @@ it('groups products by their validation status', async () => {
   when(validateProduct)
     .calledWith({ productId: 101, variantId: 199, quantity: 1, productOptions: [] })
     .thenReturn({
-      data: { validateProduct: { responseType: 'ERROR', message: 'foo bar', errorCode: 'OTHER' } },
+      data: {
+        validateProduct: {
+          responseType: 'ERROR',
+          message: 'foo bar',
+          errorCode: 'OTHER',
+          product: { availableToSell: 12 },
+        },
+      },
     });
   when(validateProduct)
     .calledWith({ productId: 102, variantId: 199, quantity: 1, productOptions: [] })
@@ -129,7 +136,7 @@ it('groups products by their validation status', async () => {
     error: [
       {
         status: 'error',
-        error: { type: 'validation', message: 'foo bar', errorCode: 'OTHER' },
+        error: { type: 'validation', message: 'foo bar', errorCode: 'OTHER', availableToSell: 12 },
         product: products[2],
       },
       {


### PR DESCRIPTION
Jira: [B2B-4050](https://bigcommercecloud.atlassian.net/browse/B2B-4050)

⚠️ This PR builds atop of these 2, please ignore the first 2 commits:

- ~https://github.com/bigcommerce/b2b-buyer-portal/pull/669~
- ~https://github.com/bigcommerce/b2b-buyer-portal/pull/668~


## What/Why?
Implement proper error handling for validation messages when backordering & backend validation are enabled.

## Rollout/Rollback
Revert

## Testing

### Before:
https://github.com/user-attachments/assets/66c165e6-4b0a-4a9e-8fc1-0c9f314c046d


### After:
https://github.com/user-attachments/assets/46e857e8-d814-4ec1-b1ca-87f1972d2807



[B2B-4050]: https://bigcommercecloud.atlassian.net/browse/B2B-4050?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves Quick Add/backend validation by surfacing OOS available counts, adding inline SKU-not-found/stock messages, wiring availableToSell through GraphQL/types, and updating related tests.
> 
> - **Quick Order – QuickAdd**:
>   - Show inline field errors for `SKU` not found and insufficient stock (uses `purchasedProducts.quickAdd.inlineErrors.*`).
>   - Display OOS available count per item using backend `availableToSell`.
>   - Handle warnings and network errors distinctly; clear inputs only for successfully added SKUs; add `data-testid="quick-add"`.
> - **Validation utilities**:
>   - Extend `validateProducts` to include server error details with `availableToSell`; add typed network/server error variants.
>   - Map validation payload to include `node.sku` and merge with catalog for cart items.
> - **GraphQL/types**:
>   - Update `ValidateProduct` response schema to include `product { availableToSell }` and expose in TypeScript interfaces.
> - **i18n**:
>   - Add `purchasedProducts.quickAdd.inlineErrors.notFoundSku` and `.insufficientStockSku` strings.
> - **Tests**:
>   - Update/extend tests across Quick Order, OrderDetail, QuoteDetail/Draft, ShoppingListDetails, and utils to assert new error handling, messages, and `availableToSell` propagation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 14d7eaa28ec8917ba57a63dc2407b5415bfb9e69. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->