### PR TITLE
chore(b2b): B2B-3698 update API URL in env-example to reflect local setup

### DIFF
--- a/apps/storefront/.env-example
+++ b/apps/storefront/.env-example
@@ -2,7 +2,7 @@
 # You do not need to set these for production builds
 
 # API URL for local development
-VITE_B2B_URL=https://api-b2b.bigcommerce.com
+VITE_B2B_URL=https://api-b2b.service.bcdev
 
 # App Client ID issued by B2B Edition for the storefront
 # cspell:disable-next-line


### PR DESCRIPTION
Jira: [B2B-3698](https://bigcommercecloud.atlassian.net/browse/B2B-3698)

## What/Why?
Local Buyer Portal cannot be accessed because we used to use production store for development. 
Now we use dev development environment with cdvm but the url is still point to production.

## Rollout/Rollback
Revert

## Testing
Circleci passed

[B2B-3698]: https://bigcommercecloud.atlassian.net/browse/B2B-3698?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Point `VITE_B2B_URL` in `apps/storefront/.env-example` to the bcdev endpoint for local development.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 51fad2ecef122cfd74e44d9653d7466a9fa9d496. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->