### PR TITLE
test(quick-order): B2B-4014 Added error code to the validateProducts API to simplify the error flow in backorder

### DIFF
--- a/apps/storefront/src/utils/validateProducts.test.ts
+++ b/apps/storefront/src/utils/validateProducts.test.ts
@@ -108,7 +108,9 @@ it('groups products by their validation status', async () => {
     .thenReturn({ data: { validateProduct: { responseType: 'WARNING', message: 'baz qux' } } });
   when(validateProduct)
     .calledWith({ productId: 101, variantId: 199, quantity: 1, productOptions: [] })
-    .thenReturn({ data: { validateProduct: { responseType: 'ERROR', message: 'foo bar' } } });
+    .thenReturn({
+      data: { validateProduct: { responseType: 'ERROR', message: 'foo bar', errorCode: 'OTHER' } },
+    });
   when(validateProduct)
     .calledWith({ productId: 102, variantId: 199, quantity: 1, productOptions: [] })
     .thenReject(new Error('network failure'));
@@ -125,8 +127,16 @@ it('groups products by their validation status', async () => {
     success: [{ status: 'success', product: products[0] }],
     warning: [{ status: 'warning', message: 'baz qux', product: products[1] }],
     error: [
-      { status: 'error', error: { type: 'validation', message: 'foo bar' }, product: products[2] },
-      { status: 'error', error: { type: 'network' }, product: products[3] },
+      {
+        status: 'error',
+        error: { type: 'validation', message: 'foo bar', errorCode: 'OTHER' },
+        product: products[2],
+      },
+      {
+        status: 'error',
+        error: { type: 'network', errorCode: 'NETWORK_ERROR' },
+        product: products[3],
+      },
     ],
   });
 });


### PR DESCRIPTION
Jira: [B2B-4014](https://bigcommercecloud.atlassian.net/browse/B2B-4014)

## What/Why?
Updated `validate products test` with errorCode

Available Error codes are ['OOS', 'NON_PURCHASABLE', 'NETWORK_ERROR'] other than this list error code will be undefined

## Rollout/Rollback
Revert

## Testing
Wrote Unit test

## Related PR
https://github.com/bigcommerce/b2b-buyer-portal/pull/665


[B2B-4014]: https://bigcommercecloud.atlassian.net/browse/B2B-4014?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update validateProducts tests to include and assert errorCode for validation and network errors.
> 
> - **Tests**
>   - `apps/storefront/src/utils/validateProducts.test.ts`
>     - Include `errorCode` in mocked `ValidateProduct` error response (e.g., `errorCode: 'OTHER'`).
>     - Update expectations to assert `error.errorCode` for:
>       - Validation errors (`{ type: 'validation', message: 'foo bar', errorCode: 'OTHER' }`).
>       - Network errors (`{ type: 'network', errorCode: 'NETWORK_ERROR' }`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 218cfacf8af1d5f8d6c445f9d80afd8bd433fd78. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->