### PR TITLE
feat(quotes): B2B-4029 quote uuid added to session storage

### DIFF
--- a/apps/storefront/src/pages/QuoteDetail/index.tsx
+++ b/apps/storefront/src/pages/QuoteDetail/index.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useContext, useEffect, useMemo, useState } from 'react';
-import { useLocation, useNavigate, useParams } from 'react-router-dom';
+import { useLocation, useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import { Box, Button, Grid } from '@mui/material';
 import copy from 'copy-to-clipboard';
 import { get } from 'lodash-es';
@@ -95,7 +95,8 @@ const validateProducts = (products: ProductInfoProps[]) => {
 
 function useData() {
   const { id = '' } = useParams();
-
+  const [searchParams] = useSearchParams();
+  const uuid = searchParams.get('uuid') || undefined;
   const {
     state: { bcLanguage, quoteConfig },
   } = useContext(GlobalContext);
@@ -176,6 +177,7 @@ function useData() {
 
   return {
     id,
+    uuid,
     bcLanguage,
     quoteConfig,
     role,
@@ -253,6 +255,7 @@ function QuoteDetail() {
 
   const {
     id,
+    uuid,
     bcLanguage,
     quoteConfig,
     role,
@@ -528,7 +531,6 @@ function QuoteDetail() {
         return undefined;
       });
       const quoteExtraFieldInfos = await getQuoteExtraFields(quote.extraFields);
-
       setQuoteDetail({
         ...quote,
         extraFields: quoteExtraFieldInfos,
@@ -738,6 +740,7 @@ function QuoteDetail() {
       setQuoteCheckoutLoading(true);
       await handleQuoteCheckout({
         quoteId: id,
+        quoteUuid: uuid,
         role,
         location,
         navigate,
@@ -983,6 +986,7 @@ function QuoteDetail() {
                     role,
                     location,
                     quoteId: quoteDetail.id,
+                    quoteUuid: quoteDetail.uuid,
                     navigate,
                   });
                 }}

--- a/apps/storefront/src/pages/quote/utils/quoteCheckout.ts
+++ b/apps/storefront/src/pages/quote/utils/quoteCheckout.ts
@@ -11,10 +11,17 @@ interface QuoteCheckout {
   role: string | number;
   location: Location;
   quoteId: string;
+  quoteUuid?: string;
   navigate?: NavigateFunction;
 }
 
-export const handleQuoteCheckout = async ({ role, location, quoteId, navigate }: QuoteCheckout) => {
+export const handleQuoteCheckout = async ({
+  role,
+  location,
+  quoteId,
+  quoteUuid,
+  navigate,
+}: QuoteCheckout) => {
   try {
     store.dispatch(setQuoteDetailToCheckoutUrl(''));
 
@@ -34,7 +41,7 @@ export const handleQuoteCheckout = async ({ role, location, quoteId, navigate }:
       id: Number(quoteId),
     });
 
-    setQuoteToStorage(quoteId, date);
+    setQuoteToStorage(quoteId, date, quoteUuid);
     const {
       quoteCheckout: {
         quoteCheckout: { checkoutUrl, cartId },

--- a/apps/storefront/src/utils/b3checkout.ts
+++ b/apps/storefront/src/utils/b3checkout.ts
@@ -28,8 +28,9 @@ export const attemptCheckoutLoginAndRedirect = async (
   }
 };
 
-export const setQuoteToStorage = (quoteId: string, date: any) => {
+export const setQuoteToStorage = (quoteId: string, date: any, quoteUuid?: string) => {
   sessionStorage.setItem('isNewStorefront', JSON.stringify(true));
   sessionStorage.setItem('quoteCheckoutId', quoteId);
   sessionStorage.setItem('quoteDate', date?.toString());
+  sessionStorage.setItem('quoteCheckoutUuid', quoteUuid || '');
 };


### PR DESCRIPTION
Jira: [B2B-4029](https://bigcommercecloud.atlassian.net/browse/B2B-4029)

## What/Why?
- there was need to pass uuid from url to quotes detail api in checkout repo
- uuid is accessed from url and saved to session storage so that it can be accessed from checkout repo
- `getKey` has been added to B3Storage because storage keys exist only as types and they needed to be accesed in the test

## Rollout/Rollback

## Testing

With feature flag turned on

https://github.com/user-attachments/assets/09fc51ba-a18a-4acf-85b7-6755ef63de4d


[B2B-4029]: https://bigcommercecloud.atlassian.net/browse/B2B-4029?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

With feature flag turned off

https://github.com/user-attachments/assets/60dfc361-d261-4dd4-9ec6-cef71c016130





<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds UUID propagation and storage to support downstream checkout usage.
> 
> - Parse `uuid` from URL via `useSearchParams` in `QuoteDetail`, include in `getQuote` payload and pass to `handleQuoteCheckout`
> - Update `handleQuoteCheckout` to forward `quoteUuid` and call `setQuoteToStorage(quoteId, date, quoteUuid)`
> - Extend `setQuoteToStorage` to persist `quoteCheckoutUuid` alongside existing keys
> - Add tests in `QuoteDetail/index.test.tsx` verifying sessionStorage values when proceeding to checkout for quotes with and without `uuid`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7ea05b6f55981b9e2426afeef0ade8130fe0f964. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->