### PR TITLE
fix(quick-order): B2B-3978 Fix ValidateProducts type

### DIFF
--- a/apps/storefront/src/shared/service/b2b/graphql/product.ts
+++ b/apps/storefront/src/shared/service/b2b/graphql/product.ts
@@ -111,7 +111,7 @@ const validateProductQuery = `
 `;
 
 const validateProductsQuery = `
-  query ValidateProducts ($products: [ValidateProductInputType]) {
+  query ValidateProducts ($products: [ValidateProductInputType]!) {
     validateProducts(products: $products, storeHash: "${storeHash}", channelId: ${channelId}) {
       isValid
       products {


### PR DESCRIPTION
Jira: [B2B-3978](https://bigcommercecloud.atlassian.net/browse/B2B-3978)

## What/Why?
Updated the GraphQL `ValidateProducts` query to require a non-nullable array of `ValidateProductInputType`.

## Rollout/Rollback
Revert

## Testing

### Before:
https://github.com/user-attachments/assets/0aace03e-659b-407f-9f8f-3f84c5875ede

### After:
https://github.com/user-attachments/assets/0a0e4d21-49df-4b96-a83f-5b7354313dc5

[B2B-3978]: https://bigcommercecloud.atlassian.net/browse/B2B-3978?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates `ValidateProducts` GraphQL query to require a non-nullable `[ValidateProductInputType]!` for `$products`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e85d3b6ec0279017e172e6ec07796ed801fdc7e7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->