### PR TITLE
fix(quotes): B2B-4052 Expand 3 rows instead of 1 row

### DIFF
--- a/apps/storefront/src/pages/QuoteDraft/index.test.tsx
+++ b/apps/storefront/src/pages/QuoteDraft/index.test.tsx
@@ -1140,6 +1140,59 @@ describe('when the user is a B2B customer', () => {
     expect(await screen.findByText('Product was added to your quote.')).toBeInTheDocument();
   });
 
+  describe('when opening the "Add to quote" panel', () => {
+    it('shows 3 rows in the quick add', async () => {
+      const quoteInfo = buildQuoteInfoStateWith({
+        draftQuoteInfo: {
+          contactInfo: { email: customerEmail },
+          billingAddress: noAddress,
+          shippingAddress: noAddress,
+        },
+      });
+
+      renderWithProviders(<QuoteDraft setOpenPage={vi.fn()} />, {
+        preloadedState: { ...preloadedState, quoteInfo },
+      });
+
+      await userEvent.click(screen.getByText('Add to quote'));
+
+      const quickAddProducts = screen.getAllByLabelText('SKU#');
+
+      expect(quickAddProducts).toHaveLength(3);
+
+      const quantityProducts = screen.getAllByLabelText('Qty');
+
+      expect(quantityProducts).toHaveLength(3);
+    });
+
+    describe('when "show more rows" is clicked', () => {
+      it('shows 3 more rows in the quick add', async () => {
+        const quoteInfo = buildQuoteInfoStateWith({
+          draftQuoteInfo: {
+            contactInfo: { email: customerEmail },
+            billingAddress: noAddress,
+            shippingAddress: noAddress,
+          },
+        });
+
+        renderWithProviders(<QuoteDraft setOpenPage={vi.fn()} />, {
+          preloadedState: { ...preloadedState, quoteInfo },
+        });
+
+        await userEvent.click(screen.getByText('Add to quote'));
+        await userEvent.click(screen.getByRole('button', { name: 'Show more rows' }));
+
+        const quickAddProducts = screen.getAllByLabelText('SKU#');
+
+        expect(quickAddProducts).toHaveLength(6);
+
+        const quantityProducts = screen.getAllByLabelText('Qty');
+
+        expect(quantityProducts).toHaveLength(6);
+      });
+    });
+  });
+
   it('add product by sku to draft quote', async () => {
     const searchProducts = vi.fn<(...arg: unknown[]) => SearchProductsResponse>();
 
@@ -1232,9 +1285,9 @@ describe('when the user is a B2B customer', () => {
     });
 
     await userEvent.click(screen.getByText('Add to quote'));
-    const quickAddProduct = screen.getByLabelText('SKU#');
+    const quickAddProduct = screen.getAllByLabelText('SKU#')[0];
     await userEvent.type(quickAddProduct, 'LC-123');
-    const quantityProduct = screen.getByLabelText('Qty');
+    const quantityProduct = screen.getAllByLabelText('Qty')[0];
     await userEvent.type(quantityProduct, '1');
     await userEvent.click(screen.getByRole('button', { name: 'Add products to Quote' }));
 
@@ -2861,9 +2914,9 @@ describe('when the user is a B2B customer', () => {
         });
 
         await userEvent.click(screen.getByText('Add to quote'));
-        const quickAddProduct = screen.getByLabelText('SKU#');
+        const quickAddProduct = screen.getAllByLabelText('SKU#')[0];
         await userEvent.type(quickAddProduct, 'LC-123');
-        const quantityProduct = screen.getByLabelText('Qty');
+        const quantityProduct = screen.getAllByLabelText('Qty')[0];
         await userEvent.type(quantityProduct, '1');
         await userEvent.click(screen.getByRole('button', { name: 'Add products to Quote' }));
 
@@ -2995,9 +3048,9 @@ describe('when the user is a B2B customer', () => {
         });
 
         await userEvent.click(screen.getByText('Add to quote'));
-        const quickAddProduct = screen.getByLabelText('SKU#');
+        const quickAddProduct = screen.getAllByLabelText('SKU#')[0];
         await userEvent.type(quickAddProduct, 'LC-123');
-        const quantityProduct = screen.getByLabelText('Qty');
+        const quantityProduct = screen.getAllByLabelText('Qty')[0];
         await userEvent.type(quantityProduct, '1');
         await userEvent.click(screen.getByRole('button', { name: 'Add products to Quote' }));
 
@@ -3129,9 +3182,9 @@ describe('when the user is a B2B customer', () => {
         });
 
         await userEvent.click(screen.getByText('Add to quote'));
-        const quickAddProduct = screen.getByLabelText('SKU#');
+        const quickAddProduct = screen.getAllByLabelText('SKU#')[0];
         await userEvent.type(quickAddProduct, 'LC-123');
-        const quantityProduct = screen.getByLabelText('Qty');
+        const quantityProduct = screen.getAllByLabelText('Qty')[0];
         await userEvent.type(quantityProduct, '1');
         await userEvent.click(screen.getByRole('button', { name: 'Add products to Quote' }));
 
@@ -3255,9 +3308,9 @@ describe('when the user is a B2B customer', () => {
         });
 
         await userEvent.click(screen.getByText('Add to quote'));
-        const quickAddProduct = screen.getByLabelText('SKU#');
+        const quickAddProduct = screen.getAllByLabelText('SKU#')[0];
         await userEvent.type(quickAddProduct, 'LC-123');
-        const quantityProduct = screen.getByLabelText('Qty');
+        const quantityProduct = screen.getAllByLabelText('Qty')[0];
         await userEvent.type(quantityProduct, '1');
         await userEvent.click(screen.getByRole('button', { name: 'Add products to Quote' }));
 
@@ -4480,9 +4533,9 @@ describe('when the user is a B2B customer', () => {
       });
 
       await userEvent.click(screen.getByText('Add to quote'));
-      const quickAddProduct = screen.getByLabelText('SKU#');
+      const quickAddProduct = screen.getAllByLabelText('SKU#')[0];
       await userEvent.type(quickAddProduct, 'LC-123');
-      const quantityProduct = screen.getByLabelText('Qty');
+      const quantityProduct = screen.getAllByLabelText('Qty')[0];
       await userEvent.type(quantityProduct, '1');
       await userEvent.click(screen.getByRole('button', { name: 'Add products to Quote' }));
 
@@ -4595,8 +4648,8 @@ describe('when the user is a B2B customer', () => {
 
       await userEvent.click(screen.getByText('Add to quote'));
 
-      await userEvent.type(screen.getByLabelText('SKU#'), 'LC-123');
-      await userEvent.type(screen.getByLabelText('Qty'), '1');
+      await userEvent.type(screen.getAllByLabelText('SKU#')[0], 'LC-123');
+      await userEvent.type(screen.getAllByLabelText('Qty')[0], '1');
 
       await userEvent.click(screen.getByRole('button', { name: 'Add products to Quote' }));
 

--- a/apps/storefront/src/pages/ShoppingListDetails/components/QuickAdd.tsx
+++ b/apps/storefront/src/pages/ShoppingListDetails/components/QuickAdd.tsx
@@ -18,18 +18,18 @@ import { ShoppingListAddProductOption, SimpleObject } from '../../../types';
 interface AddToListContentProps {
   updateList: () => void;
   quickAddToList: (products: CustomFieldItems[]) => Promise<void>;
-  level?: number;
   buttonText?: string;
   buttonLoading?: boolean;
   type: 'shoppingList' | 'quoteDraft';
 }
+
+const rowStepSize = 3;
 
 export default function QuickAdd(props: AddToListContentProps) {
   const b3Lang = useB3Lang();
   const {
     updateList,
     quickAddToList,
-    level = 3,
     buttonText = b3Lang('shoppingList.quickAdd.addToShoppingList'),
     buttonLoading = false,
     type,
@@ -43,7 +43,7 @@ export default function QuickAdd(props: AddToListContentProps) {
 
   const [blockPendingAccountViewPrice] = useBlockPendingAccountViewPrice();
 
-  const [rows, setRows] = useState(level);
+  const [rows, setRows] = useState(rowStepSize);
   const [formFields, setFormFields] = useState<CustomFieldItems[]>([]);
   const [isLoading, setIsLoading] = useState(false);
 
@@ -60,10 +60,6 @@ export default function QuickAdd(props: AddToListContentProps) {
     // disabling since b3Lang since it has rendering issues
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [rows]);
-
-  const handleAddRowsClick = () => {
-    setRows(rows + level);
-  };
 
   const {
     control,
@@ -413,7 +409,7 @@ export default function QuickAdd(props: AddToListContentProps) {
                 ml: '-8px',
                 fontWeight: '400',
               }}
-              onClick={handleAddRowsClick}
+              onClick={() => setRows(rows + rowStepSize)}
             >
               {b3Lang('shoppingList.quickAdd.showMoreRows')}
             </CustomButton>

--- a/apps/storefront/src/pages/quote/components/AddToQuote.tsx
+++ b/apps/storefront/src/pages/quote/components/AddToQuote.tsx
@@ -280,7 +280,6 @@ export default function AddToQuote(props: AddToListProps) {
             updateList={updateList}
             quickAddToList={quickAddToList}
             type="quoteDraft"
-            level={1}
             buttonText={b3Lang('quoteDraft.button.addProductsToAddToQuote')}
           />
 


### PR DESCRIPTION
Jira: [B2B-4052](https://bigcommercecloud.atlassian.net/browse/B2B-4052)

## What/Why?
To be consistent on the experience on other pages

## Rollout/Rollback
Revert

## Testing
Added tests and manual testing



https://github.com/user-attachments/assets/61273340-578b-42fc-a66a-42efb0a06b01



[B2B-4052]: https://bigcommercecloud.atlassian.net/browse/B2B-4052?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Quick add now defaults to 3 rows and expands in steps of 3; removed the `level` prop and updated tests accordingly.
> 
> - **Quote Draft – Quick Add**:
>   - Default rows set to `3` and "Show more rows" adds `3` per click via `rowStepSize`.
>   - Removed `level` prop from `QuickAdd`; updated `AddToQuote` usage accordingly.
> - **Tests**:
>   - Added tests verifying 3 initial rows and +3 on expand in `QuoteDraft`.
>   - Updated selectors to use `getAllByLabelText(...)[0]` where multiple quick-add rows exist.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 96defb13e353f6f7cdefcc48b055930340f68098. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->