### PR TITLE
fix(quick-order): B2B-4050 Show inline validation errors for QuickOrder/QuickAdd

### DIFF
--- a/apps/storefront/src/hooks/dom/utils.test.ts
+++ b/apps/storefront/src/hooks/dom/utils.test.ts
@@ -205,6 +205,9 @@ const buildValidateProductWith = builder<ValidateProduct>(() =>
       responseType: 'ERROR',
       message: faker.lorem.sentence(),
       errorCode: faker.helpers.arrayElement(['NON_PURCHASABLE', 'OOS', 'INVALID_FIELDS', 'OTHER']),
+      product: {
+        availableToSell: faker.number.int(),
+      },
     },
   ]),
 );

--- a/apps/storefront/src/lib/lang/locales/en.json
+++ b/apps/storefront/src/lib/lang/locales/en.json
@@ -301,6 +301,8 @@
   "purchasedProducts.quickAdd.notPurchaseableSku": "SKU {notPurchaseSku} no longer for sale",
   "purchasedProducts.quickAdd.insufficientStockSku": "{stockSku} does not have enough stock, please change the quantity ",
   "purchasedProducts.quickAdd.purchaseQuantityLimitMessage": "You need to purchase a {typeText} of {limit} of the {sku} per order",
+  "purchasedProducts.quickAdd.inlineErrors.notFoundSku": "SKU not found",
+  "purchasedProducts.quickAdd.inlineErrors.insufficientStockSku": "{count} available",
   "purchasedProducts.footer.selectOneItemToAdd": "Please select at least one item to add to cart",
   "purchasedProducts.footer.productsAdded": "Products were added to cart",
   "purchasedProducts.footer.productsLimit": "The quantity of each product in Quote is 1-1000000.",

--- a/apps/storefront/src/pages/OrderDetail/index.test.tsx
+++ b/apps/storefront/src/pages/OrderDetail/index.test.tsx
@@ -1790,6 +1790,7 @@ describe('when a personal customer visits an order', () => {
               errorCode: 'OOS',
               responseType: 'ERROR',
               message: 'A message from the backend',
+              product: { availableToSell: faker.number.int() },
             },
           },
         });
@@ -2133,6 +2134,7 @@ describe('when a personal customer visits an order', () => {
               responseType: 'ERROR',
               message: 'An error message from the backend',
               errorCode: 'OOS',
+              product: { availableToSell: faker.number.int() },
             },
           },
         });

--- a/apps/storefront/src/pages/QuickOrder/components/QuickAdd.tsx
+++ b/apps/storefront/src/pages/QuickOrder/components/QuickAdd.tsx
@@ -14,11 +14,7 @@ import { useAppSelector } from '@/store';
 import { snackbar } from '@/utils/b3Tip';
 import b3TriggerCartNumber from '@/utils/b3TriggerCartNumber';
 import { createOrUpdateExistingCart } from '@/utils/cartUtils';
-import {
-  ValidatedProductError,
-  ValidatedProductWarning,
-  validateProducts,
-} from '@/utils/validateProducts';
+import { ValidatedProductError, validateProducts } from '@/utils/validateProducts';
 
 import { SimpleObject } from '../../../types';
 import { getCartProductInfo } from '../utils';
@@ -325,18 +321,16 @@ export default function QuickAdd() {
     variantInfoList: CatalogProduct[],
     skuValue: SimpleObject,
     skus: string[],
-  ): Promise<{
-    productItems: CustomFieldItems[];
-    passSku: string[];
-    notFoundSkus: string[];
-    validationErrors: Array<
-      ValidatedProductWarning<CustomFieldItems> | ValidatedProductError<CustomFieldItems>
-    >;
-  }> => {
+  ) => {
     const notFoundSkus = filterInputSkusForNotFoundProducts(skus, variantInfoList);
 
     if (variantInfoList.length === 0) {
-      return { productItems: [], passSku: [], notFoundSkus, validationErrors: [] };
+      return {
+        productItems: [],
+        notFoundSkus,
+        error: [],
+        warning: [],
+      };
     }
 
     const productsToValidate = mapCatalogToValidationPayload(variantInfoList, skuValue);
@@ -345,13 +339,9 @@ export default function QuickAdd() {
 
     const validProducts = success.map((product) => product.product);
 
-    const errors = [...warning, ...error];
-
     const productItems = mergeValidatedWithCatalog(validProducts, variantInfoList);
 
-    const passSku = productItems.map((item) => item.variantSku);
-
-    return { productItems, passSku, notFoundSkus, validationErrors: errors };
+    return { productItems, notFoundSkus, warning, error };
   };
 
   const addProductsToCart = async (products: CustomFieldItems[]) => {
@@ -375,6 +365,45 @@ export default function QuickAdd() {
     b3TriggerCartNumber();
   };
 
+  const showErrorMessage = (
+    formData: FieldValues,
+    error: ValidatedProductError<CustomFieldItems>,
+  ) => {
+    const sku = error.product.node?.sku || '';
+
+    if (error.error.type === 'network') {
+      const productName = error.product.node?.productName || '';
+      snackbar.error(b3Lang('quotes.productValidationFailed', { productName }));
+      if (sku) {
+        showErrors(formData, [sku], 'sku', '');
+      }
+      return;
+    }
+
+    if (error.error.errorCode === 'OOS') {
+      if (sku) {
+        const message = b3Lang('purchasedProducts.quickAdd.inlineErrors.insufficientStockSku', {
+          count: error.error.availableToSell,
+        });
+
+        showErrors(formData, [sku], 'qty', message);
+      }
+
+      snackbar.error(
+        b3Lang('purchasedProducts.quickAdd.insufficientStockSku', {
+          stockSku: sku || '',
+        }),
+      );
+
+      return;
+    }
+
+    if (sku) {
+      showErrors(formData, [sku], 'sku', '');
+    }
+    snackbar.error(error.error.message);
+  };
+
   const handleAddToList = () => {
     if (blockPendingAccountViewPrice && companyStatus === 0) {
       snackbar.info(
@@ -395,26 +424,33 @@ export default function QuickAdd() {
         const variantInfoList = await getVariantList(skus);
 
         if (featureFlags['B2B-3318.move_stock_and_backorder_validation_to_backend']) {
-          const result = await handleBackendValidation(variantInfoList, skuQuantityMap, skus);
-          const { productItems, passSku, notFoundSkus, validationErrors } = result;
+          const { productItems, notFoundSkus, warning, error } = await handleBackendValidation(
+            variantInfoList,
+            skuQuantityMap,
+            skus,
+          );
 
-          validationErrors.forEach((err) => {
-            if (err.status === 'error') {
-              if (err.error.type === 'network') {
-                snackbar.error(
-                  b3Lang('quotes.productValidationFailed', {
-                    productName: err.product.node?.productName || '',
-                  }),
-                );
-              } else {
-                snackbar.error(err.error.message);
-              }
-            } else {
-              snackbar.error(err.message);
+          error.forEach((err) => {
+            showErrorMessage(formData, err);
+          });
+
+          warning.forEach((warn) => {
+            snackbar.warning(warn.message);
+            const sku = warn.product.node?.sku;
+
+            if (sku) {
+              showErrors(formData, [sku], 'sku', '');
             }
           });
 
           if (notFoundSkus.length > 0) {
+            showErrors(
+              formData,
+              notFoundSkus,
+              'sku',
+              b3Lang('purchasedProducts.quickAdd.inlineErrors.notFoundSku'),
+            );
+
             snackbar.error(
               b3Lang('purchasedProducts.quickAdd.notFoundSku', {
                 count: notFoundSkus.length,
@@ -425,7 +461,8 @@ export default function QuickAdd() {
 
           if (productItems.length > 0) {
             await addProductsToCart(productItems);
-            clearInputValue(formData, passSku);
+            const skus = productItems.map((item) => item.variantSku);
+            clearInputValue(formData, skus);
           }
         } else {
           const { productItems, passSku } = await handleFrontendValidation(
@@ -458,7 +495,7 @@ export default function QuickAdd() {
 
   return (
     <B3Spin isSpinning={isLoading} spinningHeight="auto">
-      <Box sx={{ width: '100%' }}>
+      <Box sx={{ width: '100%' }} data-testid="quick-add">
         <Grid
           container
           sx={{

--- a/apps/storefront/src/pages/QuickOrder/components/QuickAdd.validation.ts
+++ b/apps/storefront/src/pages/QuickOrder/components/QuickAdd.validation.ts
@@ -14,6 +14,7 @@ export interface CatalogProduct {
 
 interface ValidationPayloadItem {
   node: {
+    sku?: string;
     productId: number;
     quantity: number;
     productsSearch: {
@@ -76,6 +77,7 @@ export function mapCatalogToValidationPayload(
 
     return {
       node: {
+        sku: matchingSkuFromInput,
         productId: parseInt(catalogProduct.productId, 10) || 0,
         quantity: requestedQuantity,
         productsSearch: {

--- a/apps/storefront/src/pages/QuoteDetail/index.test.tsx
+++ b/apps/storefront/src/pages/QuoteDetail/index.test.tsx
@@ -345,6 +345,9 @@ describe('when the user is a B2B customer', () => {
             validateProduct: {
               responseType: 'ERROR',
               message: 'A product with the id of 123 does not have sufficient stock',
+              product: {
+                availableToSell: faker.number.int(),
+              },
             },
           },
         }),
@@ -471,6 +474,9 @@ describe('when the user is a B2B customer', () => {
             validateProduct: {
               responseType: 'ERROR',
               message: 'A product with the id of 123 does not have sufficient stock',
+              product: {
+                availableToSell: faker.number.int(),
+              },
             },
           },
         }),
@@ -657,6 +663,9 @@ describe('when the user is a B2B customer', () => {
             validateProduct: {
               responseType: 'ERROR',
               message: 'A product with the id of 123 does not have sufficient stock',
+              product: {
+                availableToSell: faker.number.int(),
+              },
             },
           },
         });

--- a/apps/storefront/src/pages/QuoteDraft/index.test.tsx
+++ b/apps/storefront/src/pages/QuoteDraft/index.test.tsx
@@ -334,6 +334,9 @@ const buildValidateProductWith = builder<ValidateProduct>(() =>
       responseType: 'ERROR',
       message: faker.lorem.sentence(),
       errorCode: faker.helpers.arrayElement(['NON_PURCHASABLE', 'OOS', 'INVALID_FIELDS', 'OTHER']),
+      product: {
+        availableToSell: faker.number.int(),
+      },
     },
   ]),
 );
@@ -2624,6 +2627,9 @@ describe('when the user is a B2B customer', () => {
               validateProduct: buildValidateProductWith({
                 responseType: 'ERROR',
                 message: 'validation error',
+                product: {
+                  availableToSell: faker.number.int(),
+                },
               }),
             },
           });
@@ -3136,6 +3142,9 @@ describe('when the user is a B2B customer', () => {
               validateProduct: buildValidateProductWith({
                 responseType: 'ERROR',
                 message: 'validation error',
+                product: {
+                  availableToSell: faker.number.int(),
+                },
               }),
             },
           });
@@ -3839,6 +3848,9 @@ describe('when the user is a B2B customer', () => {
               validateProduct: buildValidateProductWith({
                 responseType: 'ERROR',
                 message: 'validation error',
+                product: {
+                  availableToSell: faker.number.int(),
+                },
               }),
             },
           });

--- a/apps/storefront/src/pages/ShoppingListDetails/index.test.tsx
+++ b/apps/storefront/src/pages/ShoppingListDetails/index.test.tsx
@@ -383,6 +383,9 @@ const buildValidateProductWith = builder<ValidateProduct>(() =>
       responseType: 'ERROR',
       message: faker.lorem.sentence(),
       errorCode: faker.helpers.arrayElement(['NON_PURCHASABLE', 'OOS', 'INVALID_FIELDS', 'OTHER']),
+      product: {
+        availableToSell: faker.number.int(),
+      },
     },
   ]),
 );

--- a/apps/storefront/src/shared/service/b2b/graphql/product.ts
+++ b/apps/storefront/src/shared/service/b2b/graphql/product.ts
@@ -106,6 +106,9 @@ const validateProductQuery = `
       responseType
       message
       errorCode
+      product {
+        availableToSell
+      }
     }
   }
 `;
@@ -345,6 +348,9 @@ interface ValidateProductError {
   responseType: 'ERROR';
   errorCode: 'NON_PURCHASABLE' | 'OOS' | 'INVALID_FIELDS' | 'OTHER';
   message: string;
+  product: {
+    availableToSell: number;
+  };
 }
 
 interface ValidateProductWarning {

--- a/apps/storefront/src/utils/validateProducts.test.ts
+++ b/apps/storefront/src/utils/validateProducts.test.ts
@@ -109,7 +109,14 @@ it('groups products by their validation status', async () => {
   when(validateProduct)
     .calledWith({ productId: 101, variantId: 199, quantity: 1, productOptions: [] })
     .thenReturn({
-      data: { validateProduct: { responseType: 'ERROR', message: 'foo bar', errorCode: 'OTHER' } },
+      data: {
+        validateProduct: {
+          responseType: 'ERROR',
+          message: 'foo bar',
+          errorCode: 'OTHER',
+          product: { availableToSell: 12 },
+        },
+      },
     });
   when(validateProduct)
     .calledWith({ productId: 102, variantId: 199, quantity: 1, productOptions: [] })
@@ -129,7 +136,7 @@ it('groups products by their validation status', async () => {
     error: [
       {
         status: 'error',
-        error: { type: 'validation', message: 'foo bar', errorCode: 'OTHER' },
+        error: { type: 'validation', message: 'foo bar', errorCode: 'OTHER', availableToSell: 12 },
         product: products[2],
       },
       {


### PR DESCRIPTION
Jira: [B2B-4050](https://bigcommercecloud.atlassian.net/browse/B2B-4050)

~⚠️ This PR builds atop of these 2, please ignore the first 2 commits:~

- ~https://github.com/bigcommerce/b2b-buyer-portal/pull/669~
- ~https://github.com/bigcommerce/b2b-buyer-portal/pull/668~


## What/Why?
Implement proper error handling for validation messages when backordering & backend validation are enabled.

## Rollout/Rollback
Revert

## Testing

### Before:
https://github.com/user-attachments/assets/66c165e6-4b0a-4a9e-8fc1-0c9f314c046d


### After:
https://github.com/user-attachments/assets/46e857e8-d814-4ec1-b1ca-87f1972d2807



[B2B-4050]: https://bigcommercecloud.atlassian.net/browse/B2B-4050?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements inline error display for QuickAdd when backend validation is enabled and propagates stock info from the backend.
> 
> - **QuickAdd UX**: Backend validation results now set inline field errors per row: not-found SKUs mark `sku` fields; OOS marks `qty` with `{count} available`; warnings are surfaced; inputs for successfully added SKUs are cleared; added `data-testid="quick-add"`.
> - **Validation plumbing**: `validateProduct` GraphQL now returns `product.availableToSell`; `validateProducts` differentiates network vs validation errors and includes `availableToSell`; validation payload/items now carry `sku` for mapping; merging preserves `variantSku` for cart ops.
> - **Locales**: Added `purchasedProducts.quickAdd.inlineErrors.notFoundSku` and `.insufficientStockSku` strings.
> - **Tests**: Updated/added tests across QuickOrder, OrderDetail, QuoteDetail, QuoteDraft, and ShoppingList to assert inline errors and include `availableToSell` in mock responses; minor fixture tweaks (e.g., `availableToSell: 0`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7855a2c15883cd36007e721804d4b552626bbfdd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->