### PR TITLE
fix(checkout): Moved Up Product Validation Api Call with product list…

### DIFF
--- a/apps/storefront/src/pages/QuoteDetail/index.tsx
+++ b/apps/storefront/src/pages/QuoteDetail/index.tsx
@@ -275,7 +275,6 @@ function QuoteDetail() {
   const [quoteDetail, setQuoteDetail] = useState<any>({});
   const [productList, setProductList] = useState<ProductInfoProps[]>([]);
   const [fileList, setFileList] = useState<FileObjects[]>([]);
-  const [quoteReviewedBySalesRep, setQuoteWasReviewedBySalesRep] = useState(false);
   const [isHideQuoteCheckout, setIsHideQuoteCheckout] = useState(true);
   const [quoteValidationErrors, setQuoteValidationErrors] = useState<
     ValidatedProductError<ProductInfoProps>[]
@@ -316,6 +315,11 @@ function QuoteDetail() {
   const isAutoQuotingEnabled =
     quoteConfig.find((item) => item.key === 'quote_auto_quoting')?.value === '1';
 
+  const quoteReviewedBySalesRep =
+    Object.keys(quoteDetail).length === 0
+      ? false
+      : !!quoteDetail.salesRep || !!quoteDetail.salesRepEmail;
+
   useEffect(() => {
     if (!quoteDetail?.id) return;
 
@@ -350,12 +354,15 @@ function QuoteDetail() {
     });
   }, [isB2BUser, quoteDetail, selectCompanyHierarchyId, purchasabilityPermission]);
 
-  const quoteDetailBackendValidations = async () => {
-    if (!productList.length) {
+  const quoteDetailBackendValidations = async (
+    productListResponse: ProductInfoProps[],
+    quoteReviewedBySalesRepResponse: boolean,
+  ) => {
+    if (!productListResponse.length) {
       return;
     }
 
-    const { error, warning } = await validateProducts(productList);
+    const { error, warning } = await validateProducts(productListResponse);
 
     if (!error.length && !warning.length) {
       setShouldHidePrices(false);
@@ -368,18 +375,21 @@ function QuoteDetail() {
       }
     });
 
-    if (quoteReviewedBySalesRep) {
+    if (quoteReviewedBySalesRepResponse) {
       setShouldHidePrices(false);
     }
 
     setQuoteValidationErrors(error);
   };
 
-  const quoteDetailFrontendValidations = () => {
+  const quoteDetailFrontendValidations = (
+    productListResponse: ProductInfoProps[],
+    quoteReviewedBySalesRepResponse: boolean,
+  ) => {
     let oosErrorList = '';
     let nonPurchasableErrorList = '';
 
-    productList.forEach((item: CustomFieldItems) => {
+    productListResponse.forEach((item: CustomFieldItems) => {
       const buyerInfo = getVariantInfoOOSAndPurchase(item);
 
       if (buyerInfo?.type && isEnableProduct && !item?.purchaseHandled) {
@@ -394,7 +404,7 @@ function QuoteDetail() {
     });
 
     const isHideCheckout = !!oosErrorList || !!nonPurchasableErrorList;
-    if (isEnableProduct && quoteReviewedBySalesRep && isHideCheckout) {
+    if (isEnableProduct && quoteReviewedBySalesRepResponse && isHideCheckout) {
       if (oosErrorList)
         snackbar.error(
           b3Lang('quoteDetail.message.insufficientStock', {
@@ -441,12 +451,6 @@ function QuoteDetail() {
 
     return false;
   };
-
-  useEffect(() => {
-    validateQuoteProducts();
-    // disabling since b3Lang is a dependency that will trigger rendering issues
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isEnableProduct, quoteReviewedBySalesRep, productList]);
 
   const hasQuoteValidationErrorsFrontendFlow = useCallback(() => {
     if (isHideQuoteCheckout) {
@@ -540,7 +544,16 @@ function QuoteDetail() {
         shipping: quote.shippingTotal,
         totalAmount: quote.totalAmount,
       });
-      setProductList(productsWithMoreInfo ?? []);
+
+      const productListResponse = productsWithMoreInfo ?? [];
+      setProductList(productListResponse);
+
+      const { salesRep, salesRepEmail } = quote;
+      const quoteReviewedBySalesRepResponse = Boolean(salesRep || salesRepEmail);
+
+      await Promise.resolve(
+        validateQuoteProducts(productListResponse, quoteReviewedBySalesRepResponse),
+      );
 
       if (Number(quote.shippingTotal) === 0) {
         setQuoteDetailTax(Number(quote.taxTotal));
@@ -562,15 +575,7 @@ function QuoteDetail() {
         setQuoteDetailTax(taxPrice);
       }
 
-      const {
-        backendAttachFiles = [],
-        storefrontAttachFiles = [],
-        salesRep,
-        salesRepEmail,
-      } = quote;
-
-      setQuoteWasReviewedBySalesRep(!!salesRep || !!salesRepEmail);
-
+      const { backendAttachFiles = [], storefrontAttachFiles = [] } = quote;
       const newFileList: FileObjects[] = [];
       storefrontAttachFiles.forEach((file: CustomFieldItems) => {
         newFileList.push({

--- a/apps/storefront/tests/test-utils.tsx
+++ b/apps/storefront/tests/test-utils.tsx
@@ -155,7 +155,7 @@ export function FakeProductDataProvider({ productId, quantity, sku, options }: P
 }
 
 export { startMockServer } from './mockServer';
-export { graphql, http, HttpResponse } from 'msw';
+export { graphql, http, HttpResponse, delay } from 'msw';
 export { assertQueryParams } from './assertQueryParams';
 export * from '@testing-library/react';
 export { default as userEvent } from '@testing-library/user-event';


### PR DESCRIPTION
… to not display TBD after loading

Jira: [JIRA_TOKEN](https://bigcommercecloud.atlassian.net/browse/JIRA_TOKEN)

## What/Why?
<!--
  A description about what this pull request implements and its purpose.
  Try to be detailed and describe any technical details to simplify the job
  of the reviewer and the individual on production support.
-->
TBD was visible for around a second after loading. 
TBD depends on `validateQuoteProduct` api call which is made after the loading is done. So the `validateQuoteProduct` Api was moved up along with `getQuote` and `products` api calls which are responsible for loading. 

`validateQuoteProduct` depends on `quoteReviewedBySalesRep`(derived state from quote) and `productList`.
Previously both `quoteReviewedBySalesRep` and `productList` were first set in state and then the `useEffect` having the both as deps was used to call the validateQuoteProduct api. 

Now `validateQuoteProduct` is moved along with `getQuote` and `products` api call, we needed `quoteReviewedBySalesRep` and `productList` immediately and not after the state update. So `quoteReviewedBySalesRep` and `productList` are passed as params to `validateQuoteProduct`.

Since `quoteReviewedBySalesRep` is a derived state, it doesn't need to be in the state, hence removed it from the state.

## Rollout/Rollback
<!--
Detail how this change will be rolled out. Include reference to any
experiments and how the success will be measured as the experiment is
ramped.

Document rollback procedures. Is rolling back the change as simple as
rolling back an experiment or does it require reverting code? Are there
database migrations that may change our decision to roll forward instead of
back?
-->

## Testing
In Quote Summary, values should be visible right after loading is done, it shouldn't show TBD.
There were tests to check the value of quote summary, Updated those tests and added delay of 1.2 seconds to the api response to mimick the original api response time. Made sure to synchronously find and expect elements to be in the DOM right after loading, previously the elements were being searched for async and waited to be present in the document.

Before:

https://github.com/user-attachments/assets/ac686431-28cd-42d4-bbd3-ef8205b9624d


After:

https://github.com/user-attachments/assets/2397c0c3-eaec-4637-9a40-dcce0542ab79




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents temporary `TBD` in quote summary by validating products before rendering and removing unnecessary state.
> 
> - Move `validateQuoteProducts` into `getQuoteDetail` and pass `productList` and derived `quoteReviewedBySalesRep` directly (no `useEffect` dependency, no stored state)
> - Update backend/frontend validation functions to accept parameters; set `shouldHidePrices`/warnings based on results for immediate price display
> - Derive `quoteReviewedBySalesRep` from `quoteDetail` (`salesRep`/`salesRepEmail`) instead of state
> - Tests: add `msw` `delay`, mock `ValidateProduct` with async delay, and switch to synchronous `getBy*` assertions to verify prices appear right after loading
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9c283d1d7132bc3b6f7957190db571915153d164. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->