### PR TITLE
test(shopping-lists): B2B-4066 Reduce number of Options per product and use something with more entropy

### DIFF
--- a/apps/storefront/src/pages/Invoice/index.test.tsx
+++ b/apps/storefront/src/pages/Invoice/index.test.tsx
@@ -1301,14 +1301,20 @@ it('exports selected invoices as CSV', async () => {
                   node: {
                     id: '1441',
                     invoiceNumber: '3322',
-                    companyInfo: { companyId: preloadedState.company.companyInfo.id },
+                    companyInfo: {
+                      companyId: preloadedState.company.companyInfo.id,
+                      companyName: 'Acme Inc.',
+                    },
                   },
                 }),
                 buildInvoiceWith({
                   node: {
                     id: '1313',
                     invoiceNumber: '4343',
-                    companyInfo: { companyId: preloadedState.company.companyInfo.id },
+                    companyInfo: {
+                      companyId: preloadedState.company.companyInfo.id,
+                      companyName: 'Acme Inc.',
+                    },
                   },
                 }),
               ],
@@ -1353,11 +1359,13 @@ it('exports selected invoices as CSV', async () => {
 
   await waitForElementToBeRemoved(() => screen.queryByText(/loading/i));
 
-  const row1 = screen.getByRole('row', { name: /3322/ });
-  const row2 = screen.getByRole('row', { name: /4343/ });
+  const rows = screen.getAllByRole('row', { name: /Acme Inc./ });
 
-  await userEvent.click(within(row1).getByRole('checkbox'));
-  await userEvent.click(within(row2).getByRole('checkbox'));
+  await Promise.all(
+    rows
+      .map((row) => within(row).getByRole('checkbox'))
+      .map((checkbox) => userEvent.click(checkbox)),
+  );
 
   const exportButton = screen.getByRole('button', { name: 'Export selected as CSV' });
   await userEvent.click(exportButton);

--- a/apps/storefront/src/pages/MyOrders/index.test.tsx
+++ b/apps/storefront/src/pages/MyOrders/index.test.tsx
@@ -1,4 +1,5 @@
 import {
+  act,
   buildB2BFeaturesStateWith,
   buildCompanyStateWith,
   builder,
@@ -74,6 +75,10 @@ const buildGetCustomerOrdersWith = builder<GetCustomerOrders>(() => {
       },
     },
   };
+});
+
+afterEach(() => {
+  vi.useRealTimers();
 });
 
 describe('when a personal customer', () => {
@@ -1261,6 +1266,8 @@ describe('when a company customer', () => {
     });
 
     it('can search for orders', async () => {
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+
       const getOrders = vi.fn().mockReturnValue(buildCompanyOrdersWith('WHATEVER_VALUES'));
 
       server.use(graphql.query('GetAllOrders', ({ query }) => HttpResponse.json(getOrders(query))));
@@ -1285,6 +1292,8 @@ describe('when a company customer', () => {
       const searchBox = screen.getByPlaceholderText(/Search/);
 
       await userEvent.type(searchBox, '66996');
+
+      await act(() => vi.advanceTimersByTimeAsync(500));
 
       await waitFor(() => {
         expect(screen.getByRole('row', { name: /66996/ })).toBeInTheDocument();

--- a/apps/storefront/src/pages/ShoppingListDetails/index.test.tsx
+++ b/apps/storefront/src/pages/ShoppingListDetails/index.test.tsx
@@ -166,12 +166,12 @@ const buildSearchB2BProductV3OptionValueWith = builder<SearchB2BProductV3OptionV
 const buildSearchB2BProductV3OptionWith = builder<SearchB2BProductV3Option>(() => ({
   id: faker.number.int(),
   product_id: faker.number.int(),
-  name: faker.commerce.productMaterial(),
-  display_name: faker.commerce.productMaterial(),
+  name: faker.commerce.productName(),
+  display_name: faker.commerce.productName(),
   type: faker.helpers.arrayElement(['rectangles', 'swatch']),
   sort_order: faker.number.int(),
   option_values: bulk(buildSearchB2BProductV3OptionValueWith, 'WHATEVER_VALUES').times(
-    faker.number.int({ min: 0, max: 10 }),
+    faker.number.int({ min: 0, max: 3 }),
   ),
   config: [],
 }));
@@ -180,11 +180,11 @@ const buildSearchB2BProductVariantWith = builder<SearchB2BProductVariants>(() =>
   variant_id: faker.number.int({ min: 1, max: 10000 }),
   product_id: faker.number.int(),
   sku: faker.number.int().toString(),
-  option_values: Array.from({ length: faker.number.int({ min: 0, max: 10 }) }, () => ({
+  option_values: Array.from({ length: faker.number.int({ min: 0, max: 3 }) }, () => ({
     id: faker.number.int(),
     label: faker.commerce.productAdjective(),
     option_id: faker.number.int(),
-    option_display_name: faker.commerce.productMaterial(),
+    option_display_name: faker.commerce.productName(),
   })),
   calculated_price: Number(faker.commerce.price()),
   image_url: faker.image.url(),
@@ -214,19 +214,19 @@ const buildSearchB2BProductWith = builder<SearchB2BProduct>(() => ({
   orderQuantityMinimum: faker.number.int(),
   orderQuantityMaximum: faker.number.int(),
   variants: bulk(buildSearchB2BProductVariantWith, 'WHATEVER_VALUES').times(
-    faker.number.int({ min: 0, max: 10 }),
+    faker.number.int({ min: 0, max: 3 }),
   ),
   currencyCode: faker.finance.currencyCode(),
   imageUrl: faker.image.url(),
   modifiers: [],
-  options: Array.from({ length: faker.number.int({ min: 0, max: 10 }) }, () => ({
+  options: Array.from({ length: faker.number.int({ min: 0, max: 3 }) }, () => ({
     option_id: faker.number.int(),
-    display_name: faker.commerce.productMaterial(),
+    display_name: faker.commerce.productName(),
     sort_order: faker.number.int(),
     is_required: faker.datatype.boolean(),
   })),
   optionsV3: bulk(buildSearchB2BProductV3OptionWith, 'WHATEVER_VALUES').times(
-    faker.number.int({ min: 0, max: 10 }),
+    faker.number.int({ min: 0, max: 3 }),
   ),
   channelId: [],
   productUrl: faker.internet.url(),


### PR DESCRIPTION
Jira: [B2B-4066](https://bigcommercecloud.atlassian.net/browse/B2B-4066)

## What/Why?
`faker.commerce.productMaterial` has very little entropy, this combined with the maximum of 10 options per product causes duplicate options to show up fairly frequently. Since we use `optionName` as the key in react, this causes warnings to show up in the terminal. Using 3 as max and `productName` as `optionValues` reduces this issue.

Couple of other fixes for flaky tests.

## Rollout/Rollback
Revert

## Testing
This PR is only modifying test files. 

[B2B-4066]: https://bigcommercecloud.atlassian.net/browse/B2B-4066?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> - Reduce generated test data volume: cap `options`, `optionsV3`, and variant `option_values` to max 3 and switch names to `faker.commerce.productName()` to increase uniqueness in `ShoppingListDetails` tests.
> - Make MyOrders search tests debounce-aware: import `act`, use `vi.useFakeTimers` and advance 500ms; ensure timers reset with `afterEach(vi.useRealTimers)()`.
> - Adjust Invoice CSV export test data to include `companyInfo.companyName` and select rows by company name, clicking checkboxes in bulk before exporting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5e3d14f9c49b0f4e2cf8f85f8e6ddf76154372d7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->