### PR TITLE
fix(quotes): B2B-4215 resolve typing issues in handleAfterSubmit

### DIFF
--- a/apps/storefront/src/pages/QuoteDraft/index.test.tsx
+++ b/apps/storefront/src/pages/QuoteDraft/index.test.tsx
@@ -2159,9 +2159,6 @@ describe('when the user is a B2B customer', () => {
 
     it('navigates correctly when quote submission response dialog is shown and then closed', async () => {
       set(window, 'b2b.callbacks.dispatchEvent', vi.fn().mockReturnValue(true));
-      const deleteCart = vi
-        .fn()
-        .mockReturnValue({ data: { cart: { deleteCart: { deletedCartEntityId: '12345' } } } });
       const quote = buildQuoteWith({ data: { quote: { id: '272989', quoteNumber: '911911' } } });
 
       const state = { stateName: 'Jalisco', stateCode: 'JL' };
@@ -2191,8 +2188,6 @@ describe('when the user is a B2B customer', () => {
           },
         ],
       });
-
-      const preloadedState = { company: companyInfo, storeInfo: storeInfoWithDateFormat };
 
       const product = buildDraftQuoteItemWith({
         node: {
@@ -2228,7 +2223,8 @@ describe('when the user is a B2B customer', () => {
 
       const { navigation } = renderWithProviders(<QuoteDraft setOpenPage={vi.fn()} />, {
         preloadedState: {
-          ...preloadedState,
+          company: companyInfo,
+          storeInfo: storeInfoWithDateFormat,
           quoteInfo,
           global: buildGlobalStateWith({
             blockPendingQuoteNonPurchasableOOS: { isEnableProduct: false },
@@ -2255,7 +2251,9 @@ describe('when the user is a B2B customer', () => {
             }),
           ),
         ),
-        graphql.mutation('DeleteCart', ({ variables }) => HttpResponse.json(deleteCart(variables))),
+        graphql.mutation('DeleteCart', () =>
+          HttpResponse.json({ data: { cart: { deleteCart: { deletedCartEntityId: '12345' } } } }),
+        ),
         graphql.query('GetQuoteInfoB2B', () => HttpResponse.json(quote)),
         graphql.query('SearchProducts', () => HttpResponse.json({ data: { productsSearch: [] } })),
       );

--- a/apps/storefront/src/pages/QuoteDraft/index.tsx
+++ b/apps/storefront/src/pages/QuoteDraft/index.tsx
@@ -95,6 +95,12 @@ interface QuoteSummaryRef extends HTMLInputElement {
   refreshSummary: () => void;
 }
 
+type QuoteSubmissionDataRefType = {
+  id: string;
+  createdAt: string;
+  uuid?: string;
+};
+
 const shippingAddress = {
   address: '',
   addressId: 0,
@@ -194,13 +200,7 @@ function QuoteDraft({ setOpenPage }: PageProps) {
   const [quoteSubmissionResponseOpen, setQuoteSubmissionResponseOpen] = useState<boolean>(false);
   const [extraFields, setExtraFields] = useState<QuoteFormattedItemsProps[]>([]);
 
-  // Store quote submission data for navigation
-  const quoteSubmissionDataRef = useRef<{
-    id: string | number;
-    createdAt: string | number;
-    uuid?: string;
-  } | null>(null);
-
+  const quoteSubmissionDataRef = useRef<QuoteSubmissionDataRefType>();
   const quoteSummaryRef = useRef<QuoteSummaryRef | null>(null);
 
   const [isAddressCompanyHierarchy] = useValidatePermissionWithComparisonType({
@@ -504,10 +504,9 @@ function QuoteDraft({ setOpenPage }: PageProps) {
     B3LStorage.delete('cartToQuoteId');
   };
 
-  const handleAfterSubmit = () => {
-    if (quoteSubmissionDataRef.current && quoteSubmissionDataRef.current.id) {
-      const { id, createdAt, uuid } = quoteSubmissionDataRef.current;
-
+  const handleAfterSubmit = (quoteSubmissionData?: QuoteSubmissionDataRefType) => {
+    if (quoteSubmissionData && quoteSubmissionData.id) {
+      const { id, createdAt, uuid } = quoteSubmissionData;
       handleReset();
       const uuidParam = uuid ? `&uuid=${uuid}` : '';
       navigate(`/quoteDetail/${id}?date=${createdAt}${uuidParam}`, {
@@ -757,7 +756,7 @@ function QuoteDraft({ setOpenPage }: PageProps) {
       }
 
       if (quoteSubmissionResponseInfo.value === '0') {
-        handleAfterSubmit();
+        handleAfterSubmit(quoteSubmissionDataRef.current);
       } else {
         setQuoteSubmissionResponseOpen(true);
       }
@@ -771,7 +770,7 @@ function QuoteDraft({ setOpenPage }: PageProps) {
   const handleCloseQuoteSubmissionResponse = () => {
     setQuoteSubmissionResponseOpen(false);
 
-    handleAfterSubmit();
+    handleAfterSubmit(quoteSubmissionDataRef.current);
   };
 
   const backText = () => {


### PR DESCRIPTION
Jira: [B2B-4215 ](https://bigcommercecloud.atlassian.net/browse/B2B-4215 )

## What/Why?
Updated the typings for the handleAfterSubmit and also reduced the dependency on the quoteSubmissionDataRef
Previous PR - https://github.com/bigcommerce/b2b-buyer-portal/pull/705

## Rollout/Rollback
Revert this commit. This PR is intended to be backwards compatible with existing quotes, so this shouldn't need to be reverted, but the backend change rollout is controlled by feature flag [B2B-3491.quote_uuid_generation_and_access](https://app.launchdarkly.com/projects/default/flags/B2B-3491.quote_uuid_generation_and_access)

## Testing
Added a new test to verify correct navigation when the quote submission response dialog is shown and then closed, ensuring the updated navigation logic works as expected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves type safety and submission flow in Quote Draft.
> 
> - Introduces `QuoteSubmissionDataRefType` and updates `quoteSubmissionDataRef` typing
> - Refactors `handleAfterSubmit` to accept submission data instead of reading from a ref; updates callers to pass `quoteSubmissionDataRef.current`
> - Navigation now appends `uuid` when present; used on immediate submit and after closing the submission response dialog
> - Tests updated: add case verifying navigation after dialog close with `uuid`; simplify preloaded state setup; inline `DeleteCart` mock response
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 66004110456b3fc064c987189d9a221f79d3ea30. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->