### PR TITLE
fix(quotes): B2B-4055 Added uuid for quote checkout mutation and quote info

### DIFF
--- a/apps/storefront/src/pages/quote/utils/quoteCheckout.ts
+++ b/apps/storefront/src/pages/quote/utils/quoteCheckout.ts
@@ -39,6 +39,7 @@ export const handleQuoteCheckout = async ({
 
     const res = await quoteCheckout({
       id: Number(quoteId),
+      uuid: quoteUuid,
     });
 
     setQuoteToStorage(quoteId, date, quoteUuid);

--- a/apps/storefront/src/shared/service/b2b/graphql/quote.ts
+++ b/apps/storefront/src/shared/service/b2b/graphql/quote.ts
@@ -157,13 +157,18 @@ const quoteUpdate = (data: CustomFieldItems) => `mutation{
   }
 }`;
 
-const getQuoteInfo = (data: { id: number; date: string; uuid?: string }) => `
-  query GetQuoteInfoB2B {
+const getQuoteInfo = `
+  query GetQuoteInfoB2B(
+    $id: Int!
+    $storeHash: String!
+    $date: String!
+    $uuid: String
+  ) {
     quote(
-      id: ${data.id},
-      storeHash: "${storeHash}",
-      date:  "${data?.date || ''}",
-      ${data.uuid ? `uuid: "${data.uuid}",` : ''}
+      id: $id,
+      storeHash: $storeHash,
+      date: $date,
+      uuid: $uuid
     ) {
       id,
       createdAt,
@@ -311,10 +316,15 @@ const getExportQuotePdfQuery = (data: {
   }
 }`;
 
-const getQuoteCheckoutQuery = (data: { id: number }) => `mutation CheckoutQuote {
+const getQuoteCheckoutQuery = `mutation CheckoutQuote(
+  $id: Int!
+  $storeHash: String!
+  $uuid: String
+) {
   quoteCheckout(
-    id: ${data.id},
-    storeHash: "${storeHash}",
+    id: $id,
+    storeHash: $storeHash,
+    uuid: $uuid
   ) {
     quoteCheckout {
       checkoutUrl,
@@ -625,12 +635,24 @@ export interface B2BQuoteDetail {
 
 export const getB2BQuoteDetail = (data: { id: number; date: string; uuid?: string }) =>
   B3Request.graphqlB2B({
-    query: getQuoteInfo(data),
+    query: getQuoteInfo,
+    variables: {
+      id: data.id,
+      storeHash,
+      date: data.date || '',
+      uuid: data.uuid || null,
+    },
   });
 
 export const getBcQuoteDetail = (data: { id: number; date: string; uuid?: string }) =>
   B3Request.graphqlB2B({
-    query: getQuoteInfo(data),
+    query: getQuoteInfo,
+    variables: {
+      id: data.id,
+      storeHash,
+      date: data.date || '',
+      uuid: data.uuid || null,
+    },
   });
 
 export const exportQuotePdf = (data: {
@@ -643,9 +665,14 @@ export const exportQuotePdf = (data: {
     query: getExportQuotePdfQuery(data),
   });
 
-export const quoteCheckout = (data: { id: number }) =>
+export const quoteCheckout = ({ id, uuid }: { id: number; uuid?: string }) =>
   B3Request.graphqlB2B({
-    query: getQuoteCheckoutQuery(data),
+    query: getQuoteCheckoutQuery,
+    variables: {
+      id,
+      storeHash,
+      uuid: uuid || null,
+    },
   });
 
 export const quoteDetailAttachFileCreate = (data: CustomFieldItems) =>


### PR DESCRIPTION
Jira: [B2B-4055 ](https://bigcommercecloud.atlassian.net/browse/B2B-4055 )

## What/Why?
Due to the uuid addition for a cybermed security fix, the associated buyer portal call needs to be updated to include the uuid in the parameter body of the graphql call. This is a part of the quote viewing process.

## Rollout/Rollback
Revert

## Testing
**FF ON**
<img width="1784" height="983" alt="Screenshot 2026-01-20 at 5 44 00 am" src="https://github.com/user-attachments/assets/7e99f342-575f-4c0f-b26f-a18739eceb8b" />

**FF OFF**
<img width="1784" height="984" alt="Screenshot 2026-01-20 at 6 04 42 am" src="https://github.com/user-attachments/assets/fcbb9d2f-49a7-4aae-b58e-718dddb81c30" />


This pull request updates the quote checkout functionality to support an optional `uuid` parameter in addition to the existing `id`. This change ensures that the `uuid` is passed through the checkout process when available, improving the flexibility and traceability of quote checkouts.

**Quote checkout enhancements:**

* Updated the `quoteCheckout` and `getQuoteCheckoutQuery` functions in `apps/storefront/src/shared/service/b2b/graphql/quote.ts` to accept an optional `uuid` parameter and include it in the GraphQL mutation if provided. [[1]](diffhunk://#diff-4ee4637803bf951131f5bdccf8ddf161247bfbad7dd1619d86de7475e7a07d60L314-R318) [[2]](diffhunk://#diff-4ee4637803bf951131f5bdccf8ddf161247bfbad7dd1619d86de7475e7a07d60L646-R647)
* Modified the `handleQuoteCheckout` function in `apps/storefront/src/pages/quote/utils/quoteCheckout.ts` to pass the `quoteUuid` to `quoteCheckout` and persist it in storage.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements `uuid` support across quote retrieval and checkout while migrating to variable-based GraphQL operations.
> 
> - Adds optional `uuid` to `quoteCheckout` flow, passing from `handleQuoteCheckout` and persisting via `setQuoteToStorage` (`quoteCheckout.ts`).
> - Converts `quote` query and `quoteCheckout` mutation to use variables (`$id`, `$storeHash`, `$date`, `$uuid`) instead of string interpolation; updates service methods to supply `variables` (`quote.ts`).
> - Updates `getB2BQuoteDetail`, `getBcQuoteDetail`, and `quoteCheckout` wrappers to pass `storeHash`, `date`, and `uuid` via `variables`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d01bcf0d1f033faf0aed1c4bb873f905f0436ccd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->