### PR TITLE
chore(common): B2B-4227 Remove individual codeowners, keep @bigcommerce/team-b2b

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @bigcommerce/team-b2b @leeBigCommerce @icatalina
+* @bigcommerce/team-b2b


### PR DESCRIPTION
Jira: [B2B-4227](https://bigcommercecloud.atlassian.net/browse/B2B-4227)

## What/Why?
Remove @leeBigCommerce and @icatalina from the codeowners list.

## Rollout/Rollback
Revert

## Testing
n/a

[B2B-4227]: https://bigcommercecloud.atlassian.net/browse/B2B-4227?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Simplifies repository ownership configuration.
> 
> - Updates `.github/CODEOWNERS` to remove `@leeBigCommerce` and `@icatalina`, retaining only `@bigcommerce/team-b2b`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 096ac4ecd8c8b7ed07c437cb5021b5c6c9a3912d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->