### PR TITLE
fix(quotes): B2B-4163 Fix stock and threshold errors blocking add to quote

### DIFF
--- a/apps/storefront/src/pages/QuickOrder/components/QuickOrderFooter.tsx
+++ b/apps/storefront/src/pages/QuickOrder/components/QuickOrderFooter.tsx
@@ -32,7 +32,10 @@ import { conversionProductsList } from '@/utils/b3Product/shared/config';
 import { snackbar } from '@/utils/b3Tip';
 import b3TriggerCartNumber from '@/utils/b3TriggerCartNumber';
 import { createOrUpdateExistingCart } from '@/utils/cartUtils';
-import { validateProducts } from '@/utils/validateProducts';
+import {
+  convertStockAndThresholdValidationErrorToWarning,
+  validateProducts,
+} from '@/utils/validateProducts';
 
 import CreateShoppingList from '../../OrderDetail/components/CreateShoppingList';
 import OrderShoppingList from '../../OrderDetail/components/OrderShoppingList';
@@ -229,7 +232,9 @@ function QuickOrderFooter(props: QuickOrderFooterProps) {
   };
 
   const addToQuoteBackend = async (products: CustomFieldItems[]) => {
-    const { success, warning, error } = await validateProducts(products);
+    const validatedProducts = await validateProducts(products);
+    const { success, warning, error } =
+      convertStockAndThresholdValidationErrorToWarning(validatedProducts);
 
     const groupedErrors = groupBy(error, (err) =>
       ['OOS', 'NON_PURCHASABLE', 'NETWORK_ERROR'].includes(err.error.errorCode)
@@ -293,7 +298,6 @@ function QuickOrderFooter(props: QuickOrderFooterProps) {
 
     return true;
   };
-
   const addToQuote = backendValidationEnabled ? addToQuoteBackend : addToQuoteFrontend;
 
   const handleAddSelectedToQuote = async () => {

--- a/apps/storefront/src/pages/ShoppingListDetails/index.tsx
+++ b/apps/storefront/src/pages/ShoppingListDetails/index.tsx
@@ -55,7 +55,10 @@ import {
   deleteCartData,
   updateCart as rawUpdateCart,
 } from '@/utils/cartUtils';
-import { validateProducts } from '@/utils/validateProducts';
+import {
+  convertStockAndThresholdValidationErrorToWarning,
+  validateProducts,
+} from '@/utils/validateProducts';
 
 import { type PageProps } from '../PageProps';
 
@@ -612,7 +615,9 @@ function ShoppingListDetails({ setOpenPage }: PageProps) {
 
   const addToQuote = async (products: CustomFieldItems[]) => {
     if (backendValidationEnabled) {
-      const { success, warning, error } = await validateProducts(products);
+      const validatedProducts = await validateProducts(products);
+      const { success, warning, error } =
+        convertStockAndThresholdValidationErrorToWarning(validatedProducts);
 
       error.forEach((err) => {
         if (err.error.type === 'network') {


### PR DESCRIPTION
Jira: [B2B-4163](https://bigcommercecloud.atlassian.net/browse/B2B-4163)

## What/Why?
### Overview of the changes
In the merchant dashboard, there is a setting called: `Enable custom product creation for non-purchasable and out of stock products on quotes`
**Before the fix:**
When both the setting and backorder feature are enabled:
- Adding out of stock, non-purchasable, partial stock, and beyond threshold products, will result in products being added to the quote with No inline error message
When the setting is off but backorder feature is enabled:
- Adding out of stock, non-purchasable, partial stock and beyond threshold products will result in products not getting added to the quote.

**After the fix:**
When both the setting and backorder feature are enabled:
- Adding out of stock, non-purchasable, partial stock, and beyond threshold products, will result in products being added to the quote with inline error messages showing
When the setting is off but backorder feature is enabled:
- non purchasable products is not added to the quote
- Adding out of stock, partial stock, and beyond threshold products, will result in products being added to the quote with inline error messages showing


### Commit wise:
**Commit 1: fix(quotes): convert threshold and stock errors to warnings for add-to-quote**
Converted threshold and stock validation errors to warnings for add-to-quote flows, per ticket B2B-4163.
Key changes:
- Renames `isEnableProduct` to `isAddNonPurchasableOutOfStockToQuoteEnabled` to better reflect its purpose of controlling add-to-quote behavior for NP/OOS products.
- Added `convertStockAndThresholdValidationErrorToWarning()` to convert OOS (out of stock) and threshold errors (min/max qty) into warnings instead of blocking errors (`validateProducts.ts`)
- Threshold errors are identified by `errorCode: 'OTHER' + regex matching "purchase a (minimum|maximum) of"` (_this is not the best way to do it and after discussion with Ignacio, this is being done because of the release on 28th_)

Updated add-to-quote flows to use the converter:
- `QuoteDraft/index.tsx`
- `QuickOrder/components/QuickOrderFooter.tsx`
- `ShoppingListDetails/components/ShoppingDetailFooter.tsx`
- Now only actual errors (NON_PURCHASABLE, NETWORK_ERROR, etc.) block add-to-quote; stock/threshold issues are allowed through
Comprehensive test coverage :
- Added tests for threshold scenarios in `QuickOrder, QuoteDraft, and ShoppingList`
- Covered both flag states (NP/OOS enabled & disabled)
- Tests verify products are added successfully even with threshold/stock violations

**Commit 2: Inline Threshold Errors** 

Added inline threshold warning messages in the quote draft table.
Changes:
- Quote Table (`QuoteTable.tsx`):
- Added `getThresholdWarnings()` to compute min/max violations from product data
- Updated threshold tests to verify inline warning text appears after add

## Rollout/Rollback
The code needs to be reverted to rollback

## Testing
Testing done both locally and on staging store for all kinds of stock error products: Out Of Stock, Low Stock Product, Threshold (Min/Max) Product and Non-Purchasable Products

https://github.com/user-attachments/assets/67fdaa35-9a69-4c5c-9cdc-81b289c16992




[B2B-4163]: https://bigcommercecloud.atlassian.net/browse/B2B-4163?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements backend validation changes so stock and min/max threshold failures no longer block add-to-quote and are shown as warnings.
> 
> - Adds `convertStockAndThresholdValidationErrorToWarning` in `validateProducts.ts`; updates `QuickOrderFooter`, `QuoteDraft`, and `ShoppingListDetails` to use it so only `NON_PURCHASABLE` and `NETWORK_ERROR` block adding to quote
> - Renames setting usage to `isAddNonPurchasableOutOfStockToQuoteEnabled` and adjusts submit checks accordingly
> - Quote UI: `QuoteTable` now computes and displays inline threshold messages and availability/stock warnings (e.g., Insufficient stock)
> - Broad test updates: new threshold scenarios and expectations across QuickOrder/QuoteDraft/ShoppingList; added unit tests for the converter and updated validations to assert `validateProduct` calls and success messaging
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 248b48f45fe68ee7eadb81214d0e7119b13f70d5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->