### PR TITLE
B2B-1934 Point buyer portal integration to the newly created app

### DIFF
--- a/apps/storefront/src/shared/service/request/base.ts
+++ b/apps/storefront/src/shared/service/request/base.ts
@@ -10,7 +10,7 @@ const ENVIRONMENT_B2B_API_URL: EnvSpecificConfig<string> = {
 // cspell:disable
 const ENVIRONMENT_B2B_APP_CLIENT_ID: EnvSpecificConfig<string> = {
   local: import.meta.env.VITE_LOCAL_APP_CLIENT_ID ?? 'dl7c39mdpul6hyc489yk0vzxl6jesyx',
-  integration: '28cflecujxmsbsuhn2ua0rhefvciowp',
+  integration: 'leg40ozqqvl0r08spvs0viatax4egbz',
   staging: 'sp4zailqe8uiep5ewafez3tc2emopz8',
   production: 'dl7c39mdpul6hyc489yk0vzxl6jesyx',
 };


### PR DESCRIPTION
Jira: [B2B-1934 ](https://bigcommercecloud.atlassian.net/browse/B2B-1934 )

## What/Why?
In prod, the value of `BC_MARKETPLACE_APP_CLIENT_ID ` is `qxvapwlk4fbb9dyogdcxk9o50d9jqjo` while the value of `BC_MARKETPLACE_LEGACY_APP_CLIENT_ID` is `dl7c39mdpul6hyc489yk0vzxl6jesyx`. `BC_MARKETPLACE_LEGACY_APP_CLIENT_ID` and the value `dl7c39mdpul6hyc489yk0vzxl6jesyx` actually represent the legacy production B2B app `Bundleb2b v2 PROD` (https://apps.bigcommerce.com/details/20244). This app cannot be installed but is still active. Its obvious that in this repo the prod value of `ENVIRONMENT_B2B_APP_CLIENT_ID` points to `dl7c39mdpul6hyc489yk0vzxl6jesyx`, not `qxvapwlk4fbb9dyogdcxk9o50d9jqjo`.

To make integration/staging the same as production, apps similar as `Bundleb2b v2 PROD` need to be created in corresponding integration/staging market places and the value of `ENVIRONMENT_B2B_APP_CLIENT_ID` need to be adjusted accordingly. The goal is that we need to make all environments similar as prod so that we can discover problems when they land on integration/staging.

This PR changes the value of `ENVIRONMENT_B2B_APP_CLIENT_ID`  for integration.

## Rollout/Rollback
Revert

## Testing
Will test on integration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates integration environment configuration.
> 
> - Changes `ENVIRONMENT_B2B_APP_CLIENT_ID.integration` in `apps/storefront/src/shared/service/request/base.ts` to a new client ID value
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 69690581f6ae4c985ac06be79c158ea05497279b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->