### PR TITLE
fix(login): B2B-4242 clear session when an inactive company user attempts to log in

### DIFF
--- a/apps/storefront/src/pages/Login/index.test.tsx
+++ b/apps/storefront/src/pages/Login/index.test.tsx
@@ -1,5 +1,6 @@
 import userEvent from '@testing-library/user-event';
 import {
+  buildCompanyStateWith,
   graphql,
   HttpResponse,
   renderWithProviders,
@@ -8,6 +9,7 @@ import {
   waitFor,
 } from 'tests/test-utils';
 
+import { CustomerRole } from '@/types';
 import { snackbar } from '@/utils/b3Tip';
 import { getCurrentCustomerInfo } from '@/utils/loginInfo';
 
@@ -124,7 +126,7 @@ describe('LoginPage', () => {
 
     it('should show error message for invalid login credentials', async () => {
       const logoutMock = vi.fn();
-      vi.mocked(useLogout).mockImplementation(() => logoutMock);
+      vi.mocked(useLogout).mockReturnValue(logoutMock);
 
       server.use(
         graphql.mutation('Login', () => {
@@ -152,7 +154,7 @@ describe('LoginPage', () => {
 
     it('should show pending approval message for features/products/pricing and logout silently', async () => {
       const logoutMock = vi.fn();
-      vi.mocked(useLogout).mockImplementation(() => logoutMock);
+      vi.mocked(useLogout).mockReturnValue(logoutMock);
 
       server.use(
         graphql.mutation('Login', () => {
@@ -185,7 +187,7 @@ describe('LoginPage', () => {
 
     it('should show pending approval message for products/pricing/ordering and logout silently', async () => {
       const logoutMock = vi.fn();
-      vi.mocked(useLogout).mockImplementation(() => logoutMock);
+      vi.mocked(useLogout).mockReturnValue(logoutMock);
 
       server.use(
         graphql.mutation('Login', () => {
@@ -217,7 +219,7 @@ describe('LoginPage', () => {
 
     it('should show pending approval message for business features and logout silently', async () => {
       const logoutMock = vi.fn();
-      vi.mocked(useLogout).mockImplementation(() => logoutMock);
+      vi.mocked(useLogout).mockReturnValue(logoutMock);
 
       server.use(
         graphql.mutation('Login', () => {
@@ -250,7 +252,7 @@ describe('LoginPage', () => {
 
     it('should show inactive account message and logout silently', async () => {
       const logoutMock = vi.fn();
-      vi.mocked(useLogout).mockImplementation(() => logoutMock);
+      vi.mocked(useLogout).mockReturnValue(logoutMock);
 
       server.use(
         graphql.mutation('Login', () => {
@@ -279,6 +281,102 @@ describe('LoginPage', () => {
       await waitFor(() => {
         expect(logoutMock).toHaveBeenCalledWith({ showLogoutBanner: false });
       });
+    });
+  });
+
+  describe('URL parameter-driven logout behavior', () => {
+    it('should logout with banner when loginFlag=loggedOutLogin and user is logged in', async () => {
+      const logoutMock = vi.fn();
+      vi.mocked(useLogout).mockReturnValue(logoutMock);
+
+      const preloadedState = {
+        company: buildCompanyStateWith({
+          customer: {
+            role: CustomerRole.ADMIN,
+          },
+          tokens: {
+            B2BToken: 'test-token',
+            bcGraphqlToken: '',
+            currentCustomerJWT: '',
+          },
+        }),
+      };
+
+      renderWithProviders(<LoginPage setOpenPage={vi.fn()} />, {
+        preloadedState,
+        initialEntries: ['/?loginFlag=loggedOutLogin'],
+      });
+
+      await waitFor(() => {
+        expect(logoutMock).toHaveBeenCalledWith({ showLogoutBanner: true });
+      });
+    });
+
+    it.each([
+      'pendingApprovalToViewPrices',
+      'pendingApprovalToOrder',
+      'pendingApprovalToAccessFeatures',
+      'accountInactive',
+      'loggedOutLogin',
+    ] as const)(
+      'should logout without banner when loginFlag=%s and user is not logged in',
+      async (loginFlag) => {
+        const logoutMock = vi.fn();
+        vi.mocked(useLogout).mockReturnValue(logoutMock);
+
+        // User is not logged in (GUEST role)
+        const preloadedState = {
+          company: buildCompanyStateWith({
+            customer: {
+              role: CustomerRole.GUEST,
+            },
+            tokens: {
+              B2BToken: '',
+              bcGraphqlToken: '',
+              currentCustomerJWT: '',
+            },
+          }),
+        };
+
+        renderWithProviders(<LoginPage setOpenPage={vi.fn()} />, {
+          preloadedState,
+          initialEntries: [`/?loginFlag=${loginFlag}`],
+        });
+
+        await waitFor(() => {
+          expect(logoutMock).toHaveBeenCalledWith({ showLogoutBanner: false });
+        });
+      },
+    );
+
+    it('should not logout when loginFlag is not a logout-triggering flag', async () => {
+      const logoutMock = vi.fn();
+      vi.mocked(useLogout).mockReturnValue(logoutMock);
+
+      const preloadedState = {
+        company: buildCompanyStateWith({
+          customer: {
+            role: CustomerRole.ADMIN,
+          },
+          tokens: {
+            B2BToken: 'test-token',
+            bcGraphqlToken: '',
+            currentCustomerJWT: '',
+          },
+        }),
+      };
+
+      renderWithProviders(<LoginPage setOpenPage={vi.fn()} />, {
+        preloadedState,
+        initialEntries: ['/?loginFlag=accountIncorrect'],
+      });
+
+      await waitFor(() => {
+        expect(screen.queryByText(/loading/i)).not.toBeInTheDocument();
+      });
+
+      // Should not call logout for flags not in shouldLogout array
+      expect(logoutMock).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/storefront/src/pages/Login/index.tsx
+++ b/apps/storefront/src/pages/Login/index.tsx
@@ -125,8 +125,11 @@ function Login(props: PageProps) {
         if (isLoginFlagType(loginFlag)) {
           setLoginFlag(loginFlag);
 
-          if (isLoggedIn && shouldLogout.includes(loginFlag)) {
-            await logout({ showLogoutBanner: loginFlag === 'loggedOutLogin' });
+          if (isLoggedIn && loginFlag === 'loggedOutLogin') {
+            await logout({ showLogoutBanner: true });
+            // All company-related flags have isLoggedIn set to false.
+          } else if (!isLoggedIn && shouldLogout.includes(loginFlag)) {
+            await logout({ showLogoutBanner: false });
           }
         }
 


### PR DESCRIPTION
Jira: [B2B-4242 ](https://bigcommercecloud.atlassian.net/browse/B2B-4242 )

## What/Why?
When a user belonging to an inactive company attempts to log in via bc control panel, the session is not cleared properly.
As a result, stale session data persists even after the login restriction is triggered, which may lead to inconsistent application behaviour.


## Rollout/Rollback
Revert

## Testing
**Before** 

https://github.com/user-attachments/assets/7b7c35e9-6584-4e48-ad7b-2547ce211551

**After**

https://github.com/user-attachments/assets/efdb5292-2d9b-43fd-a5cc-b89e07ab0d58

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches login/session-clearing behavior driven by URL parameters, which can affect when users are logged out and whether a banner is shown. Added targeted tests reduce risk, but regressions could impact authentication UX.
> 
> **Overview**
> Fixes `Login` page handling of the `loginFlag` URL parameter so logout is triggered **even when the app considers the user not logged in** (e.g., inactive/pending company scenarios), while still showing the logout banner only for `loggedOutLogin` when a user is actually logged in.
> 
> Updates `Login` tests to cover this parameter-driven logout matrix (logged-in vs guest) and refactors `useLogout` mocking, including new preloaded Redux state setup for role/token scenarios.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 26f7b346638c72051ce0aee4c5902438a836b0a2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->