### PR TITLE
B2B-3546 : "Add to Quote" Success message cut off on mobile view

### DIFF
--- a/apps/storefront/src/components/B3Tip.tsx
+++ b/apps/storefront/src/components/B3Tip.tsx
@@ -28,7 +28,6 @@ function MessageAlert({
 
         '& .MuiAlert-message': {
           overflow: 'unset',
-          whiteSpace: 'nowrap',
         },
       }}
       variant="filled"
@@ -66,7 +65,6 @@ export default function B3Tip({
               }}
               sx={{
                 top: `${24 + index * 10 + index * (isMobile ? 80 : 90)}px !important`,
-                width: '320px',
                 height: 'auto',
               }}
             >


### PR DESCRIPTION
Jira: [B2B-3546](https://bigcommercecloud.atlassian.net/browse/B2B-3546)

## What/Why?
<!--
  A description about what this pull request implements and its purpose.
  Try to be detailed and describe any technical details to simplify the job
  of the reviewer and the individual on production support.
-->

When a user clicks **Add to quote** on the **PDP**, the success toast (snackbar) appears cut off in the top‑left corner, as if it’s partially hidden.
To resolve this, we aligned it with the existing snackbar design, which correctly handles text wrapping according to the Figma specifications.

## Rollout/Rollback
**N/A**
<!--
Detail how this change will be rolled out. Include reference to any
experiments and how the success will be measured as the experiment is
ramped.

Document rollback procedures. Is rolling back the change as simple as
rolling back an experiment or does it require reverting code? Are there
database migrations that may change our decision to roll forward instead of
back?
-->

## Testing
<!--
Provide as much information as you can about how you tested and how another
Engineer can test your change. Include screenshots, or test run output
where appropriate.
-->
**Before Code Fix**

<img width="1193" height="825" alt="Before - B2b-3546" src="https://github.com/user-attachments/assets/8a0db12f-ae84-40ca-b290-e50d9f2f52ba" />

**After Code Fix**

<img width="1459" height="873" alt="After - B2b-3546" src="https://github.com/user-attachments/assets/52047f1a-7118-42de-80e1-5a72168b2c19" />




[B2B-3546]: https://bigcommercecloud.atlassian.net/browse/B2B-3546?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, UI-only style adjustments to snackbar/alert layout; primary risk is minor visual regression in toast sizing/positioning across breakpoints.
> 
> **Overview**
> Adjusts `B3Tip` toast styling to avoid truncating success messages on mobile by **removing forced `whiteSpace: 'nowrap'`** from the alert message and **dropping the fixed `width: '320px'`** on the snackbar so content can wrap and size naturally.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 52cb98a2dab3042048fc238b0a97ea87f4c06bf2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->