### PR TITLE
B2B-1934 Point buyer portal staging to the newly created app

### DIFF
--- a/apps/storefront/src/shared/service/request/base.ts
+++ b/apps/storefront/src/shared/service/request/base.ts
@@ -11,7 +11,7 @@ const ENVIRONMENT_B2B_API_URL: EnvSpecificConfig<string> = {
 const ENVIRONMENT_B2B_APP_CLIENT_ID: EnvSpecificConfig<string> = {
   local: import.meta.env.VITE_LOCAL_APP_CLIENT_ID ?? 'dl7c39mdpul6hyc489yk0vzxl6jesyx',
   integration: 'leg40ozqqvl0r08spvs0viatax4egbz',
-  staging: 'sp4zailqe8uiep5ewafez3tc2emopz8',
+  staging: 't2tu7i9ap01r4o7cpocngz3xose8dvp',
   production: 'dl7c39mdpul6hyc489yk0vzxl6jesyx',
 };
 // cspell:enable


### PR DESCRIPTION
Jira: [B2B-1934 ](https://bigcommercecloud.atlassian.net/browse/B2B-1934 )

## What/Why?
In b2b-api prod, the value of `BC_MARKETPLACE_APP_CLIENT_ID ` is `qxvapwlk4fbb9dyogdcxk9o50d9jqjo` while the value of `BC_MARKETPLACE_LEGACY_APP_CLIENT_ID` is `dl7c39mdpul6hyc489yk0vzxl6jesyx`. `BC_MARKETPLACE_LEGACY_APP_CLIENT_ID` and the value `dl7c39mdpul6hyc489yk0vzxl6jesyx` actually represent the legacy production B2B app `Bundleb2b v2 PROD` (https://apps.bigcommerce.com/details/20244). This app cannot be installed but is still active. This means in prod we have 2 apps running, with keys from both apps being used.

To make integration/staging the same as production, apps similar as `Bundleb2b v2 PROD` will need to be created in corresponding integration/staging marketplaces. I have created app Bundleb2b v2 Staging (https://build.staging.zone/apps/35156) in staging and thus the env variable `ENVIRONMENT_B2B_APP_CLIENT_ID` need to be adjusted so that we can actually use such app.

This PR changes the value of `ENVIRONMENT_B2B_APP_CLIENT_ID`  for staging.

## Rollout/Rollback
Revert

## Testing
TBA


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single constant change affecting only staging environment auth/client ID selection; low risk but could break staging login/JWT retrieval if the ID is incorrect.
> 
> **Overview**
> Updates the staging `ENVIRONMENT_B2B_APP_CLIENT_ID` in `request/base.ts` to point the storefront buyer portal at the newly created staging B2B marketplace app.
> 
> This changes which client ID is used when staging retrieves the current customer JWT (and related B2B API auth flows), without affecting local/integration/production values.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 72dcdb43ea4ae7cf77d9ed8168fd6972f1a04788. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->