### PR TITLE
docs(common): B2B-4449 Update documentation to check Feature_StorefrontScripts value

### DIFF
--- a/docs/stencil.md
+++ b/docs/stencil.md
@@ -3,7 +3,8 @@
 ## Running Project Locally
 
 1. Activate store channel in the Channel Manager.
-2. Configure header and footer scripts:
+2. Make sure that the `Feature_StorefrontScripts` store config is set to `true`. You can check it by navigating to your https://store-{storeHash}.store.bcdev/tools/assetsmanager.php.
+3. Configure header and footer scripts:
   - Navigate to 
     - Multi-storefront: Channel Manager -> Scripts
     - Single storefront: Storefront -> Script Manager
@@ -55,14 +56,14 @@
 </script>
 ```
 
-3. Navigate to the B2B Edition App Dashboard and set the following values (not needed for single storefront):
+4. Navigate to the B2B Edition App Dashboard and set the following values (not needed for single storefront):
   - Global Config: In B2B Edition App dashboard -> Settings -> Buyer Portal for global config
 ![Buyer portal type global settings](../public/images/buyer-portal-type-settings-global.png)
   - Or B2B Edition App dashboard -> Storefront -> Desired channel -> Buyer Portal for specific channel config
 ![Buyer portal type channel settings](../public/images/buyer-portal-type-settings-channel.png) [alt text](README.md)
 
 
-4. Visit the headless storefront and attempt to sign in.
+5. Visit the headless storefront and attempt to sign in.
 
 **FAQs:**
 - linters are not working: run `yarn prepare` first.


### PR DESCRIPTION
Jira: [B2B-4449](https://bigcommercecloud.atlassian.net/browse/B2B-4449)

## What/Why?
`Feature_StorefrontScripts` seems to default to `false` for new clusters, which caused the script in Script Manager not run in storefront.

## Rollout/Rollback
Revert

## Testing
Only documentation


[B2B-4449]: https://bigcommercecloud.atlassian.net/browse/B2B-4449?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates local setup instructions; no runtime code paths are modified.
> 
> **Overview**
> Updates `docs/stencil.md` local run instructions to **explicitly require enabling** the `Feature_StorefrontScripts` store config (with a link to verify it) before configuring Script Manager scripts, and renumbers subsequent steps accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 16c3aef4ef6d601c09ec0ffad46cee5ffac11192. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->