### PR TITLE
fix(auth): gate protected routes behind BC session validation to prevent stale persisted credentials from firing API calls before auth completes

### DIFF
--- a/apps/storefront/src/App.tsx
+++ b/apps/storefront/src/App.tsx
@@ -1,4 +1,4 @@
-import { useContext, useEffect, useMemo, useState } from 'react';
+import { useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { HashRouter } from 'react-router-dom';
 
 import B3GlobalTip from '@/components/B3GlobalTip';
@@ -22,6 +22,7 @@ import { handleHideRegisterPage } from '@/utils/b3HideRegister';
 import { hideStorefrontElement } from '@/utils/b3HideStorefrontElement';
 import { getQuoteEnabled } from '@/utils/b3Init';
 
+import b2bVerifyBcLoginStatus from './utils/b2bVerifyBcLoginStatus';
 import { b2bJumpPath } from './utils/b3CheckPermissions/b2bPermissionPath';
 import clearInvoiceCart from './utils/b3ClearCart';
 import setDayjsLocale from './utils/b3DateFormat/setDayjsLocale';
@@ -29,6 +30,7 @@ import b2bLogger from './utils/b3Logger';
 import { isUserGotoLogin } from './utils/b3logout';
 import { isCompanyError } from './utils/companyUtils';
 import { getCompanyInfo, getCurrentCustomerInfo, loginInfo } from './utils/loginInfo';
+import { logoutSession } from './utils/logoutSession';
 import { getGlobalStoreTax, getStoreConfigs, setStorefrontConfig } from './utils/storefrontConfig';
 import { CHECKOUT_URL, PATH_ROUTES } from './constants';
 import {
@@ -105,6 +107,8 @@ export default function App() {
 
   const [customStyles, setCustomStyle] = useState<string>(CUSTOM_STYLES);
 
+  const sessionInvalidatedRef = useRef(false);
+
   useDomHooks({ setOpenPage, isOpen });
 
   // open storefront
@@ -161,6 +165,12 @@ export default function App() {
   useEffect(() => {
     storeDispatch(setOpenPageReducer(setOpenPage));
     loginAndRegister();
+
+    if (sessionInvalidatedRef.current) {
+      sessionInvalidatedRef.current = false;
+      return;
+    }
+
     const init = async () => {
       try {
         // bc graphql token
@@ -172,6 +182,22 @@ export default function App() {
         // load the store config before fetching other data
         // as some fetches depend on the store config or feature flags being present
         await getStoreConfigs(styleDispatch, dispatch);
+
+        if (customerId) {
+          const isBcSessionValid = await b2bVerifyBcLoginStatus().catch((err) => {
+            b2bLogger.error(err);
+            return false;
+          });
+
+          if (!isBcSessionValid) {
+            sessionInvalidatedRef.current = true;
+            logoutSession();
+            gotoPage('/login?loginFlag=loggedOutLogin');
+            showPageMask(false);
+            storeDispatch(setGlobalCommonState({ isPageComplete: true }));
+            return;
+          }
+        }
 
         await Promise.allSettled([
           getGlobalStoreTax(),

--- a/apps/storefront/src/components/layout/B3Layout.tsx
+++ b/apps/storefront/src/components/layout/B3Layout.tsx
@@ -1,5 +1,5 @@
 import { ReactNode, useContext, useEffect, useMemo, useState } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { Navigate, useLocation } from 'react-router-dom';
 import { Box, useMediaQuery } from '@mui/material';
 
 import { useMobile } from '@/hooks/useMobile';
@@ -40,14 +40,6 @@ export default function B3Layout({ children }: { children: ReactNode }) {
     state: { globalMessageDialog },
     dispatch,
   } = useContext(DynamicallyVariableContext);
-
-  const navigate = useNavigate();
-
-  useEffect(() => {
-    if ((!emailAddress || !customerId) && !getIsTokenGotoPage(location.pathname)) {
-      navigate('/login');
-    }
-  }, [emailAddress, customerId, location, navigate]);
 
   useEffect(() => {
     const itemsRoutes = routes.find((item) => item.path === location.pathname);
@@ -99,6 +91,10 @@ export default function B3Layout({ children }: { children: ReactNode }) {
 
     return {};
   }, [location]);
+
+  if ((!emailAddress || !customerId) && !getIsTokenGotoPage(location.pathname)) {
+    return <Navigate to="/login" replace />;
+  }
 
   return (
     <Box>

--- a/apps/storefront/src/shared/routes/index.tsx
+++ b/apps/storefront/src/shared/routes/index.tsx
@@ -129,7 +129,7 @@ const gotoAllowedAppPage = async (
   const currentState = store.getState();
 
   const { company } = currentState;
-  const isLoggedIn = company.customer || role !== CustomerRole.GUEST;
+  const isLoggedIn = company.customer.id && Number(role) !== CustomerRole.GUEST;
   if (!isLoggedIn) {
     gotoPage('/login?loginFlag=loggedOutLogin&&closeIsLogout=1');
     return;
@@ -141,16 +141,15 @@ const gotoAllowedAppPage = async (
     gotoPage('/login?loginFlag=invoiceErrorTip');
     return;
   }
-  try {
-    const isBcLogin = await b2bVerifyBcLoginStatus();
-
-    if (!isBcLogin && isB2bTokenPage()) {
-      logoutSession();
-      gotoPage('/login?loginFlag=deviceCrowdingLogIn');
-      return;
-    }
-  } catch (err: unknown) {
+  const isBcLogin = await b2bVerifyBcLoginStatus().catch((err: unknown) => {
     b2bLogger.error(err);
+    return false;
+  });
+
+  if (!isBcLogin && isB2bTokenPage()) {
+    logoutSession();
+    gotoPage('/login?loginFlag=deviceCrowdingLogIn');
+    return;
   }
 
   let url = hash.substring(1);

--- a/apps/storefront/src/utils/loginInfo.ts
+++ b/apps/storefront/src/utils/loginInfo.ts
@@ -192,7 +192,13 @@ const loginWithCurrentCustomerJWT = async () => {
     return undefined;
   });
 
-  if (!currentCustomerJWT || prevCurrentCustomerJWT === currentCustomerJWT) return undefined;
+  if (!currentCustomerJWT) {
+    store.dispatch(setB2BToken(''));
+    store.dispatch(setCurrentCustomerJWT(''));
+    return undefined;
+  }
+
+  if (prevCurrentCustomerJWT === currentCustomerJWT) return undefined;
 
   const data = await getB2BToken(currentCustomerJWT, channelId).catch((error) => {
     // eslint-disable-next-line no-console


### PR DESCRIPTION

## What/Why?

Fixes a race condition where the SPA renders protected routes and fires API calls with stale customer data from a previous session before BigCommerce JWT authentication completes.

When a user's BC session expires but `redux-persist` retains customer data in `sessionStorage`, the app trusts the persisted `customerId`/`role`/`tokens` and proceeds to open protected routes (e.g., `/dashboard`, `/orders`) without first validating whether the BC session is still active. This creates a window where page components mount and make API calls using a stale customer ID — potentially fetching data belonging to a different account.

**Root causes addressed:**

1. **No BC session validation for persisted state** — `App.tsx` skipped `getCurrentCustomerInfo()` entirely when `customerId` existed from `redux-persist`, assuming it was valid.
2. **Reactive auth guard in `B3Layout`** — The `useEffect` + `navigate('/login')` pattern allowed children to render (and fire API calls) before the redirect executed.
3. **`isLoggedIn` check was always truthy** — `company.customer || role !== CustomerRole.GUEST` never evaluated to false because `company.customer` is always an object (never null).
4. **Silent error swallowing in `gotoAllowedAppPage`** — If `b2bVerifyBcLoginStatus()` threw, the catch block logged and continued, allowing navigation to protected routes.

**Changes:**

- **`App.tsx`**: Validates BC session via `b2bVerifyBcLoginStatus()` before any routing when `customerId` is persisted. If invalid, clears state via `logoutSession()` and redirects to login. Uses a `sessionInvalidatedRef` to prevent the wasteful second init cycle caused by the useEffect dep changes.
- **`B3Layout.tsx`**: Replaced reactive `useEffect`/`navigate` with a synchronous `<Navigate to="/login" replace />` in the render path. Children never mount when auth data is missing.
- **`shared/routes/index.tsx`**: Fixed `isLoggedIn` to check `company.customer.id` (actual data) instead of `company.customer` (always-truthy object). Unified error handling with `.catch()` so exceptions from `b2bVerifyBcLoginStatus()` are treated as auth failure.
- **`utils/loginInfo.ts`**: When BC JWT validation fails (`getCurrentCustomerJWT` returns undefined), stale `B2BToken` and `currentCustomerJWT` are now explicitly cleared from Redux.

## Rollout/Rollback

**Rollout:** Standard deployment — no feature flags, experiments, or database migrations involved. Changes are purely frontend auth-guard logic.

**Rollback:** Safe to revert the commit. No persistent state changes beyond what `redux-persist` + `sessionStorage` already manages. Rolling back restores the previous (vulnerable) auth behavior. No data migrations or external dependencies affected.

**Risk assessment:** Low. All changes are additive guards on existing auth flow. No restructuring of routing, state management, or API contracts. Verified against 70 existing tests (Dashboard, Invoice, InvoicePayment) with zero regressions.

## Testing

**Automated:**
- `tsc --noEmit` — passes clean
- `eslint` — passes clean on all 4 changed files
- `vitest` — 70 tests pass (Dashboard: 23, Invoice: 40, InvoicePayment: 7)

**Manual test scenarios:**

1. **Stale session (the bug):** Log in → close tab → wait for BC session to expire → navigate directly to `#/dashboard` → should redirect to login immediately (no flash of dashboard content, no API calls with stale ID)
2. **Valid session:** Log in → navigate to protected routes → should work normally without extra login prompts
3. **Fresh guest visit:** Open portal without logging in → should redirect to login
4. **Token-exempt pages:** Navigate to `/quoteDraft` or `/quoteDetail/:id` without auth → should still render (not blocked by guard)
5. **Non-BigCommerce platform (headless):** If `platform !== 'bigcommerce'` and `B2BToken` exists, validation returns true immediately — no BC JWT check performed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication/session-guard logic and routing; mistakes could cause unexpected logouts or redirect loops, but changes are localized to frontend checks and token clearing.
> 
> **Overview**
> Prevents protected routes from rendering/issuing API calls when Redux-persisted customer data exists but the underlying BigCommerce session has expired.
> 
> `App.tsx` now validates the BC session (via `b2bVerifyBcLoginStatus`) during init when a persisted `customerId` is present; on failure it clears session state (`logoutSession`) and redirects to login, using a `useRef` flag to avoid a follow-up init loop.
> 
> Route guarding is tightened by making `B3Layout` redirect synchronously with `<Navigate>` (so children don’t mount before redirect), fixing `gotoAllowedAppPage`’s logged-in check to require `company.customer.id` and treating BC-session verification errors as auth failure, and clearing stale tokens when `getCurrentCustomerJWT` returns missing/undefined.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 477a685697900732610cb318110cc7cd59d7e3d5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->