### PR TITLE
Fix: forgotPassword page incorrectly redirects to /login on browser refresh

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -13,7 +13,7 @@
     "clickaway",
     "Enduser",
     "extrafields",
-    "forgotpassword",
+    "forgotPassword",
     "gql.tada",
     "msword",
     "purchasability",

--- a/apps/storefront/src/utils/b3logout.test.ts
+++ b/apps/storefront/src/utils/b3logout.test.ts
@@ -46,8 +46,8 @@ describe('b3logout utilities', () => {
       expect(isB2bTokenPage('/quoteDetail/123')).toBe(false);
     });
 
-    it('returns false for forgotpassword page URL', () => {
-      expect(isB2bTokenPage('/forgotpassword')).toBe(false);
+    it('returns false for forgotPassword page URL', () => {
+      expect(isB2bTokenPage('/forgotPassword')).toBe(false);
     });
 
     it('returns true for B2B token-required pages', () => {
@@ -153,8 +153,8 @@ describe('b3logout utilities', () => {
         expect(store.dispatch).not.toHaveBeenCalled();
       });
 
-      it('returns false for forgotpassword page and does not call logoutSession', async () => {
-        const result = await isUserGotoLogin('/forgotpassword');
+      it('returns false for forgotPassword page and does not call logoutSession', async () => {
+        const result = await isUserGotoLogin('/forgotPassword');
 
         expect(result).toBe(false);
         expect(store.dispatch).not.toHaveBeenCalled();

--- a/apps/storefront/src/utils/b3logout.ts
+++ b/apps/storefront/src/utils/b3logout.ts
@@ -3,7 +3,7 @@ import b2bLogger from './b3Logger';
 import { logoutSession } from './logoutSession';
 
 export const isB2bTokenPage = (gotoUrl?: string) => {
-  const noB2bTokenPages = ['quoteDraft', 'quoteDetail', 'register', 'login', 'forgotpassword'];
+  const noB2bTokenPages = ['quoteDraft', 'quoteDetail', 'register', 'login', 'forgotPassword'];
 
   if (gotoUrl) {
     return !noB2bTokenPages.some((item: string) => gotoUrl.includes(item));


### PR DESCRIPTION
## Summary

- Fixed a case-sensitive string mismatch in `isB2bTokenPage()` that caused the
  Forgot Password page to redirect to `/login` on every browser refresh.
- The `noB2bTokenPages` array in `src/utils/b3logout.ts` used `'forgotpassword'`
  (all lowercase), but the actual route is `/forgotPassword` (camelCase).
  `String.includes()` is case-sensitive, so the match always failed, causing the
  page to be treated as a B2B-token-required page.
- Updated the cspell word list and test assertions to use the correct casing.

## Changes

- `apps/storefront/src/utils/b3logout.ts` — `'forgotpassword'` → `'forgotPassword'`
- `apps/storefront/src/utils/b3logout.test.ts` — updated test descriptions and URLs to match
- `.cspell.json` — updated spelling word entry to `'forgotPassword'`

## Test plan

- [x] All existing tests pass (`yarn test src/utils/b3logout.test.ts`)
- [ ] Navigate to `/#/forgotPassword` and refresh the browser — should stay on the page
- [ ] Verify login, register, quoteDraft, and quoteDetail pages are unaffected

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small string-casing correction in route allowlisting plus test/spellcheck updates; impact is limited to redirect gating for the `forgotPassword` page.
> 
> **Overview**
> Fixes an incorrect redirect on browser refresh by updating the `isB2bTokenPage()` non-token page allowlist to match the actual `forgotPassword` route casing.
> 
> Updates the corresponding `b3logout` unit tests and the `.cspell.json` dictionary entry to use `forgotPassword` consistently.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 01327a17413db2992bc5c43fd1a411d48c136652. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->