### PR TITLE
feat(quotes): BACK-583 quote draft backorder display

### DIFF
--- a/apps/storefront/src/components/BackorderMessage.test.tsx
+++ b/apps/storefront/src/components/BackorderMessage.test.tsx
@@ -72,7 +72,7 @@ describe('BackorderMessage', () => {
     expect(screen.getByText('3 will be backordered')).toBeVisible();
   });
 
-  it('is hidden when visible is false', () => {
+  it('renders nothing when visible is false', () => {
     renderWithProviders(
       <BackorderMessage
         quantityBackordered={3}
@@ -82,6 +82,7 @@ describe('BackorderMessage', () => {
       withAllBackorderDisplayEnabled,
     );
 
-    expect(screen.getByText('3 will be backordered').closest('div')).not.toBeVisible();
+    expect(screen.queryByText('3 will be backordered')).toBeNull();
+    expect(screen.queryByText('Lead time 2-4 weeks')).toBeNull();
   });
 });

--- a/apps/storefront/src/components/BackorderMessage.tsx
+++ b/apps/storefront/src/components/BackorderMessage.tsx
@@ -1,4 +1,5 @@
 import { Box, Typography } from '@mui/material';
+import type { SxProps, Theme } from '@mui/material/styles';
 
 import { useB3Lang } from '@/lib/lang';
 import { useAppSelector } from '@/store';
@@ -9,6 +10,19 @@ interface BackorderMessageProps {
   backorderMessage?: string;
   visible: boolean;
 }
+
+const quantityLineSx: SxProps<Theme> = {
+  color: '#616161',
+  typography: 'body2',
+  whiteSpace: 'nowrap',
+};
+
+const messageLineSx: SxProps<Theme> = {
+  color: '#616161',
+  typography: 'body2',
+  overflowWrap: 'break-word',
+  wordBreak: 'break-word',
+};
 
 function BackorderMessage({
   totalOnHand,
@@ -22,25 +36,24 @@ function BackorderMessage({
   );
 
   if ((quantityBackordered ?? 0) <= 0) return null;
+  if (!visible) return null;
 
   return (
-    <Box sx={{ visibility: visible ? 'visible' : 'hidden' }}>
+    <Box>
       {showQuantityOnHand && (totalOnHand ?? 0) > 0 && (
-        <Typography variant="body1" color="#616161">
+        <Typography sx={quantityLineSx}>
           {b3Lang('quoteDetail.table.readyToShip', { totalOnHand: totalOnHand ?? 0 })}
         </Typography>
       )}
       {showQuantityOnBackorder && (
-        <Typography variant="body1" color="#616161">
+        <Typography sx={quantityLineSx}>
           {b3Lang('quoteDetail.table.willBeBackordered', {
             quantityBackordered: quantityBackordered ?? 0,
           })}
         </Typography>
       )}
       {showBackorderMessage && backorderMessage && (
-        <Typography variant="body1" color="#616161">
-          {backorderMessage}
-        </Typography>
+        <Typography sx={messageLineSx}>{backorderMessage}</Typography>
       )}
     </Box>
   );

--- a/apps/storefront/src/pages/quote/components/QuoteTable.tsx
+++ b/apps/storefront/src/pages/quote/components/QuoteTable.tsx
@@ -1,14 +1,21 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { Delete, Edit, Warning as WarningIcon } from '@mui/icons-material';
-import { Box, styled, TextField, Typography } from '@mui/material';
+import { Box, FormControlLabel, styled, Switch, TextField, Typography } from '@mui/material';
 import ceil from 'lodash-es/ceil';
 
+import BackorderMessage from '@/components/BackorderMessage';
 import { TableColumnItem } from '@/components/table/B3Table';
 import PaginationTable from '@/components/table/PaginationTable';
 import { PRODUCT_DEFAULT_IMAGE } from '@/constants';
+import { useFeatureFlag } from '@/hooks/useFeatureFlag';
 import { useIsBackorderEnabled } from '@/hooks/useIsBackorderEnabled';
 import { LangFormatFunction, useB3Lang } from '@/lib/lang';
-import { deleteProductFromDraftQuoteList, setDraftProduct, useAppDispatch } from '@/store';
+import {
+  deleteProductFromDraftQuoteList,
+  setDraftProduct,
+  useAppDispatch,
+  useAppSelector,
+} from '@/store';
 import { Product } from '@/types';
 import { QuoteItem } from '@/types/quotes';
 import { currencyFormat } from '@/utils/b3CurrencyFormat';
@@ -23,6 +30,11 @@ import { getProductOptionsFields } from '@/utils/b3Product/shared/config';
 import { snackbar } from '@/utils/b3Tip';
 
 import ChooseOptionsDialog from '../../ShoppingListDetails/components/ChooseOptionsDialog';
+import {
+  draftRowQuantityExceedsAvailableToSell,
+  getDraftBackorderDisplayFields,
+  getQuoteItemBackendAvailability,
+} from '../utils/getDraftBackorderDisplayFields';
 
 import QuoteTableCard from './QuoteTableCard';
 
@@ -52,13 +64,6 @@ const StyledImage = styled('img')(() => ({
   maxWidth: '60px',
   height: 'auto',
   marginRight: '0.5rem',
-}));
-
-const StyledTextField = styled(TextField)(() => ({
-  '& input': {
-    paddingTop: '12px',
-    paddingRight: '6px',
-  },
 }));
 
 const QUOTE_PRODUCT_QTY_MAX = 1000000;
@@ -122,31 +127,13 @@ function getAvailabilityWarningsBackend(
   row: QuoteItem['node'],
   b3Lang: LangFormatFunction,
 ): AvailabilityWarnings {
-  const product = {
-    ...row.productsSearch,
-    selectOptions: row.optionList,
-  };
+  const quoteItemBackendAvailability = getQuoteItemBackendAvailability(row);
 
-  let warningMessage: string | null = null;
-
-  if (product.inventoryTracking !== 'none') {
-    let hasUnlimitedBackorder = product.unlimitedBackorder;
-    let { availableToSell } = product;
-
-    if (product.inventoryTracking === 'variant' && product.variants) {
-      const currentVariant = product.variants.find(({ sku }) => sku === row.variantSku);
-      if (currentVariant) {
-        hasUnlimitedBackorder = currentVariant.unlimited_backorder;
-        availableToSell = currentVariant.available_to_sell;
-      }
-    }
-
-    if (!hasUnlimitedBackorder && availableToSell < row.quantity) {
-      warningMessage = b3Lang('quoteDraft.quoteTable.outOfStock.tipWithAvailability', {
-        availableToSell: availableToSell ?? 0,
-      });
-    }
-  }
+  const warningMessage = quoteItemBackendAvailability?.exceedsAvailableToSell
+    ? b3Lang('quoteDraft.quoteTable.outOfStock.tipWithAvailability', {
+        availableToSell: quoteItemBackendAvailability.availableToSell,
+      })
+    : null;
 
   return { warningMessage, warningDetails: null };
 }
@@ -183,6 +170,33 @@ function QuoteTable({ total, items, updateSummary }: QuoteTableProps) {
   const b3Lang = useB3Lang();
   const dispatch = useAppDispatch();
   const isBackorderEnabled = useIsBackorderEnabled();
+  const isBackorderMessagingEnabled = useFeatureFlag(
+    'BACK-134.backorders_phase_1_1_control_messaging_on_storefront',
+  );
+  const { showQuantityOnBackorder, showQuantityOnHand, showBackorderMessage } = useAppSelector(
+    ({ global }) => global.backorderDisplaySettings,
+  );
+  const hasAnyBackorderDisplay =
+    showQuantityOnBackorder || showQuantityOnHand || showBackorderMessage;
+
+  const [showBackorderDetails, setShowBackorderDetails] = useState(false);
+
+  const draftQuoteBackorderContextEnabled =
+    isBackorderEnabled && isBackorderMessagingEnabled && hasAnyBackorderDisplay;
+
+  const showBackorderMessageBase = draftQuoteBackorderContextEnabled && showBackorderDetails;
+
+  const hasBackorderedItems = useMemo(
+    () =>
+      items.some((quoteItem) => {
+        const fields = getDraftBackorderDisplayFields(quoteItem.node);
+        if (!fields) return false;
+        return !draftRowQuantityExceedsAvailableToSell(quoteItem.node);
+      }),
+    [items],
+  );
+
+  const showBackorderToggle = draftQuoteBackorderContextEnabled && hasBackorderedItems;
 
   const [isRequestLoading, setIsRequestLoading] = useState(false);
   const [chooseOptionsOpen, setSelectedOptionsOpen] = useState(false);
@@ -425,27 +439,49 @@ function QuoteTable({ total, items, updateSummary }: QuoteTableProps) {
     {
       key: 'Qty',
       title: b3Lang('quoteDraft.quoteTable.qty'),
-      render: (row) => (
-        <StyledTextField
-          size="small"
-          type="number"
-          variant="filled"
-          value={row.quantity}
-          inputProps={{
-            inputMode: 'numeric',
-            pattern: '[0-9]*',
-          }}
-          onChange={(e) => {
-            handleUpdateProductQty(row, Number(e.target.value));
-          }}
-          onBlur={(e) => {
-            handleCheckProductQty(row, Number(e.target.value));
-          }}
-          sx={{
-            width: '75%',
-          }}
-        />
-      ),
+      render: (row) => {
+        const backorderFields = getDraftBackorderDisplayFields(row);
+        const hideBackorderForStockError = draftRowQuantityExceedsAvailableToSell(row);
+        const shouldShowBackorder =
+          showBackorderMessageBase && Boolean(backorderFields) && !hideBackorderForStockError;
+        return (
+          <>
+            <TextField
+              size="small"
+              type="number"
+              variant="filled"
+              value={row.quantity}
+              inputProps={{
+                inputMode: 'numeric',
+                pattern: '[0-9]*',
+              }}
+              onChange={(e) => {
+                handleUpdateProductQty(row, Number(e.target.value));
+              }}
+              onBlur={(e) => {
+                handleCheckProductQty(row, Number(e.target.value));
+              }}
+              sx={{
+                width: '75%',
+                '& input': {
+                  paddingTop: '12px',
+                  paddingRight: '6px',
+                },
+              }}
+            />
+            {shouldShowBackorder && backorderFields && (
+              <Box sx={{ mt: 1.5 }}>
+                <BackorderMessage
+                  totalOnHand={backorderFields.totalOnHand}
+                  quantityBackordered={backorderFields.quantityBackordered}
+                  backorderMessage={backorderFields.backorderMessage}
+                  visible
+                />
+              </Box>
+            )}
+          </>
+        );
+      },
       width: '15%',
       style: {
         textAlign: 'right',
@@ -537,6 +573,19 @@ function QuoteTable({ total, items, updateSummary }: QuoteTableProps) {
         >
           {b3Lang('quoteDraft.quoteTable.totalProducts', { total: total || 0 })}
         </Typography>
+        {showBackorderToggle && (
+          <FormControlLabel
+            control={
+              <Switch
+                checked={showBackorderDetails}
+                onChange={(e) => setShowBackorderDetails(e.target.checked)}
+              />
+            }
+            label={b3Lang('quoteDetail.table.backorderDetails')}
+            labelPlacement="start"
+            sx={{ mr: 0, gap: '0.5rem' }}
+          />
+        )}
       </Box>
 
       <PaginationTable
@@ -556,6 +605,8 @@ function QuoteTable({ total, items, updateSummary }: QuoteTableProps) {
             onEdit={handleOpenProductEdit}
             onDelete={handleDeleteClick}
             handleUpdateProductQty={handleUpdateProductQty}
+            draftQuoteBackorderContextEnabled={draftQuoteBackorderContextEnabled}
+            showBackorderDetails={showBackorderDetails}
           />
         )}
       />

--- a/apps/storefront/src/pages/quote/components/QuoteTableCard.tsx
+++ b/apps/storefront/src/pages/quote/components/QuoteTableCard.tsx
@@ -1,6 +1,7 @@
 import { Delete, Edit } from '@mui/icons-material';
 import { Box, CardContent, styled, TextField, Typography } from '@mui/material';
 
+import BackorderMessage from '@/components/BackorderMessage';
 import { PRODUCT_DEFAULT_IMAGE } from '@/constants';
 import { useB3Lang } from '@/lib/lang';
 import { Product } from '@/types';
@@ -9,12 +10,19 @@ import { currencyFormat } from '@/utils/b3CurrencyFormat';
 import { getBCPrice, getDisplayPrice } from '@/utils/b3Product/b3Product';
 import { getProductOptionsFields } from '@/utils/b3Product/shared/config';
 
+import {
+  draftRowQuantityExceedsAvailableToSell,
+  getDraftBackorderDisplayFields,
+} from '../utils/getDraftBackorderDisplayFields';
+
 interface QuoteTableCardProps {
   item: QuoteItem['node'];
   onEdit: (item: Product, itemId: string) => void;
   onDelete: (id: string) => void;
   handleUpdateProductQty: (item: QuoteItem['node'], quantity: number) => void;
   isLast: boolean;
+  draftQuoteBackorderContextEnabled: boolean;
+  showBackorderDetails?: boolean;
 }
 
 const StyledImage = styled('img')(() => ({
@@ -29,6 +37,8 @@ function QuoteTableCard({
   onDelete,
   handleUpdateProductQty,
   isLast,
+  draftQuoteBackorderContextEnabled,
+  showBackorderDetails = false,
 }: QuoteTableCardProps) {
   const {
     basePrice,
@@ -42,6 +52,14 @@ function QuoteTableCard({
   } = item;
 
   const b3Lang = useB3Lang();
+  const backorderFields = getDraftBackorderDisplayFields(item);
+  const hideBackorderForStockError = draftRowQuantityExceedsAvailableToSell(item);
+
+  const showBackorderMessage =
+    draftQuoteBackorderContextEnabled &&
+    Boolean(backorderFields) &&
+    !hideBackorderForStockError &&
+    showBackorderDetails;
 
   const price = getBCPrice(Number(basePrice), Number(taxPrice));
 
@@ -141,31 +159,43 @@ function QuoteTableCard({
 
           <Typography sx={{ fontSize: '14px' }}>Price: {singlePrice}</Typography>
 
-          <TextField
-            size="small"
-            type="number"
-            variant="filled"
-            label="qty"
-            inputProps={{
-              inputMode: 'numeric',
-              pattern: '[0-9]*',
-            }}
-            value={quantity}
-            sx={{
-              margin: '1rem 0',
-              width: '60%',
-              maxWidth: '100px',
-              '& label': {
-                fontSize: '14px',
-              },
-              '& input': {
-                fontSize: '14px',
-              },
-            }}
-            onChange={(e) => {
-              handleUpdateProductQty(item, Number(e.target.value));
-            }}
-          />
+          <>
+            <TextField
+              size="small"
+              type="number"
+              variant="filled"
+              label="qty"
+              inputProps={{
+                inputMode: 'numeric',
+                pattern: '[0-9]*',
+              }}
+              value={quantity}
+              sx={{
+                margin: '1rem 0',
+                width: '60%',
+                maxWidth: '100px',
+                '& label': {
+                  fontSize: '14px',
+                },
+                '& input': {
+                  fontSize: '14px',
+                },
+              }}
+              onChange={(e) => {
+                handleUpdateProductQty(item, Number(e.target.value));
+              }}
+            />
+            {showBackorderMessage && backorderFields && (
+              <Box sx={{ mt: 1.5 }}>
+                <BackorderMessage
+                  totalOnHand={backorderFields.totalOnHand}
+                  quantityBackordered={backorderFields.quantityBackordered}
+                  backorderMessage={backorderFields.backorderMessage}
+                  visible
+                />
+              </Box>
+            )}
+          </>
           <Typography sx={{ fontSize: '14px' }}>Total: {totalPrice}</Typography>
           <Box
             sx={{

--- a/apps/storefront/src/pages/quote/utils/getDraftBackorderDisplayFields.test.ts
+++ b/apps/storefront/src/pages/quote/utils/getDraftBackorderDisplayFields.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it } from 'vitest';
+
+import type { QuoteItem } from '@/types/quotes';
+
+import {
+  draftRowQuantityExceedsAvailableToSell,
+  getDraftBackorderDisplayFields,
+  getQuoteItemBackendAvailability,
+} from './getDraftBackorderDisplayFields';
+
+type QuoteLineNode = QuoteItem['node'];
+
+describe('getDraftBackorderDisplayFields', () => {
+  it('returns null when inventory tracking is none', () => {
+    const row = {
+      quantity: 5,
+      variantSku: 'V1',
+      productsSearch: {
+        inventoryTracking: 'none',
+        totalOnHand: 2,
+      },
+    } as QuoteLineNode;
+
+    expect(getDraftBackorderDisplayFields(row)).toBeNull();
+  });
+
+  it('uses product-level totalOnHand and message for product tracking', () => {
+    const row = {
+      quantity: 10,
+      variantSku: 'V1',
+      productsSearch: {
+        inventoryTracking: 'product',
+        totalOnHand: 3,
+        backorderMessage: 'Restock soon',
+        unlimitedBackorder: false,
+      },
+    } as QuoteLineNode;
+
+    expect(getDraftBackorderDisplayFields(row)).toEqual({
+      totalOnHand: 3,
+      backorderMessage: 'Restock soon',
+      quantityBackordered: 7,
+    });
+  });
+
+  it('uses variant-level fields for variant tracking', () => {
+    const row = {
+      quantity: 4,
+      variantSku: 'SKU-B',
+      productsSearch: {
+        inventoryTracking: 'variant',
+        variants: [
+          { sku: 'SKU-A', total_on_hand: 100, backorder_message: 'A' },
+          { sku: 'SKU-B', total_on_hand: 1, backorder_message: 'B msg' },
+        ],
+      },
+    } as QuoteLineNode;
+
+    expect(getDraftBackorderDisplayFields(row)).toEqual({
+      totalOnHand: 1,
+      backorderMessage: 'B msg',
+      quantityBackordered: 3,
+    });
+  });
+
+  it('returns null when variant tracking but line sku is not in variants list', () => {
+    const row = {
+      quantity: 4,
+      variantSku: 'MISSING-SKU',
+      productsSearch: {
+        inventoryTracking: 'variant',
+        variants: [{ sku: 'SKU-A', total_on_hand: 100, backorder_message: 'A' }],
+      },
+    } as QuoteLineNode;
+
+    expect(getDraftBackorderDisplayFields(row)).toBeNull();
+  });
+
+  it('returns null when ordered quantity does not exceed on hand', () => {
+    const row = {
+      quantity: 2,
+      variantSku: 'V1',
+      productsSearch: {
+        inventoryTracking: 'product',
+        totalOnHand: 5,
+      },
+    } as QuoteLineNode;
+
+    expect(getDraftBackorderDisplayFields(row)).toBeNull();
+  });
+});
+
+describe('getQuoteItemBackendAvailability', () => {
+  it('returns null when inventory tracking is none', () => {
+    const row = {
+      quantity: 10,
+      variantSku: 'V1',
+      productsSearch: {
+        inventoryTracking: 'none' as const,
+        availableToSell: 0,
+        unlimitedBackorder: false,
+      },
+    } as QuoteLineNode;
+
+    expect(getQuoteItemBackendAvailability(row)).toBeNull();
+  });
+
+  it('matches draftRowQuantityExceedsAvailableToSell for product tracking', () => {
+    const row = {
+      quantity: 10,
+      variantSku: 'V1',
+      productsSearch: {
+        inventoryTracking: 'product',
+        availableToSell: 4,
+        unlimitedBackorder: false,
+      },
+    } as QuoteLineNode;
+
+    const quoteItemBackendAvailability = getQuoteItemBackendAvailability(row);
+    expect(quoteItemBackendAvailability).toEqual({
+      exceedsAvailableToSell: true,
+      availableToSell: 4,
+    });
+    expect(draftRowQuantityExceedsAvailableToSell(row)).toBe(
+      quoteItemBackendAvailability?.exceedsAvailableToSell,
+    );
+  });
+});
+
+describe('draftRowQuantityExceedsAvailableToSell', () => {
+  it('is true when quantity is greater than availableToSell without unlimited backorder (product)', () => {
+    const row = {
+      quantity: 10,
+      variantSku: 'V1',
+      productsSearch: {
+        inventoryTracking: 'product',
+        availableToSell: 4,
+        unlimitedBackorder: false,
+      },
+    } as QuoteLineNode;
+
+    expect(draftRowQuantityExceedsAvailableToSell(row)).toBe(true);
+  });
+
+  it('is false when quantity is within availableToSell', () => {
+    const row = {
+      quantity: 3,
+      variantSku: 'V1',
+      productsSearch: {
+        inventoryTracking: 'product',
+        availableToSell: 10,
+        unlimitedBackorder: false,
+      },
+    } as QuoteLineNode;
+
+    expect(draftRowQuantityExceedsAvailableToSell(row)).toBe(false);
+  });
+
+  it('is false when unlimited backorder even if qty exceeds ATS', () => {
+    const row = {
+      quantity: 100,
+      variantSku: 'V1',
+      productsSearch: {
+        inventoryTracking: 'product',
+        availableToSell: 2,
+        unlimitedBackorder: true,
+      },
+    } as QuoteLineNode;
+
+    expect(draftRowQuantityExceedsAvailableToSell(row)).toBe(false);
+  });
+
+  it('uses variant available_to_sell for variant tracking', () => {
+    const row = {
+      quantity: 5,
+      variantSku: 'SKU-B',
+      productsSearch: {
+        inventoryTracking: 'variant',
+        variants: [
+          { sku: 'SKU-A', available_to_sell: 99, unlimited_backorder: false },
+          { sku: 'SKU-B', available_to_sell: 2, unlimited_backorder: false },
+        ],
+      },
+    } as QuoteLineNode;
+
+    expect(draftRowQuantityExceedsAvailableToSell(row)).toBe(true);
+  });
+});

--- a/apps/storefront/src/pages/quote/utils/getDraftBackorderDisplayFields.ts
+++ b/apps/storefront/src/pages/quote/utils/getDraftBackorderDisplayFields.ts
@@ -1,0 +1,109 @@
+import type { Variant } from '@/types/products';
+import { QuoteItem } from '@/types/quotes';
+
+type QuoteItemBackendAvailability = {
+  exceedsAvailableToSell: boolean;
+  availableToSell: number;
+};
+
+export function getQuoteItemBackendAvailability(
+  row: QuoteItem['node'],
+): QuoteItemBackendAvailability | null {
+  const product = row.productsSearch;
+
+  if (product.inventoryTracking === 'none') return null;
+
+  let hasUnlimitedBackorder = Boolean(product.unlimitedBackorder);
+  let { availableToSell } = product;
+
+  if (product.inventoryTracking === 'variant' && product.variants) {
+    const currentVariant = product.variants.find(({ sku }) => sku === row.variantSku);
+    if (currentVariant) {
+      hasUnlimitedBackorder = Boolean(currentVariant.unlimited_backorder);
+      availableToSell = currentVariant.available_to_sell;
+    }
+  }
+
+  const qty = Number(row.quantity ?? 0);
+  const exceedsAvailableToSell = !hasUnlimitedBackorder && availableToSell < qty;
+
+  return { exceedsAvailableToSell, availableToSell };
+}
+
+export function draftRowQuantityExceedsAvailableToSell(row: QuoteItem['node']): boolean {
+  return getQuoteItemBackendAvailability(row)?.exceedsAvailableToSell ?? false;
+}
+
+interface DraftBackorderDisplayFields {
+  totalOnHand: number;
+  backorderMessage?: string;
+  quantityBackordered: number;
+}
+
+type DraftBackorderTracking = 'product' | 'variant';
+
+function getDraftBackorderTracking(row: QuoteItem['node']): DraftBackorderTracking | null {
+  const product = row.productsSearch;
+  const tracking = (product.inventoryTracking as string) || 'none';
+  if (tracking !== 'product' && tracking !== 'variant') return null;
+  return tracking;
+}
+
+function findDraftQuoteVariant(row: QuoteItem['node']): Variant | undefined {
+  return row.productsSearch.variants?.find(({ sku }) => sku === row.variantSku);
+}
+
+function getDraftBackorderTotalOnHand(
+  row: QuoteItem['node'],
+  tracking: DraftBackorderTracking,
+): number | null {
+  const product = row.productsSearch;
+  if (tracking === 'product') {
+    return product.totalOnHand ?? 0;
+  }
+  const variant = findDraftQuoteVariant(row);
+  if (!variant) return null;
+  return variant.total_on_hand ?? 0;
+}
+
+function getDraftBackorderBackorderMessage(
+  row: QuoteItem['node'],
+  tracking: DraftBackorderTracking,
+): string | undefined {
+  const product = row.productsSearch;
+  if (tracking === 'product') {
+    return product.backorderMessage ?? undefined;
+  }
+  const variant = findDraftQuoteVariant(row);
+  if (!variant) return undefined;
+  return variant.backorder_message ?? undefined;
+}
+
+function getDraftBackorderQuantityBackordered(
+  orderedQuantity: number,
+  totalOnHand: number,
+): number {
+  return Math.max(0, orderedQuantity - totalOnHand);
+}
+
+export function getDraftBackorderDisplayFields(
+  row: QuoteItem['node'],
+): DraftBackorderDisplayFields | null {
+  const tracking = getDraftBackorderTracking(row);
+  if (!tracking) return null;
+
+  const totalOnHand = getDraftBackorderTotalOnHand(row, tracking);
+  if (totalOnHand === null) return null;
+
+  const backorderMessage = getDraftBackorderBackorderMessage(row, tracking);
+  const qty = Number(row.quantity ?? 0);
+  const quantityBackordered = getDraftBackorderQuantityBackordered(qty, totalOnHand);
+
+  if (quantityBackordered <= 0) return null;
+
+  return {
+    totalOnHand,
+    backorderMessage,
+    quantityBackordered,
+  };
+}

--- a/apps/storefront/src/shared/service/b2b/graphql/product.ts
+++ b/apps/storefront/src/shared/service/b2b/graphql/product.ts
@@ -101,6 +101,8 @@ const getSearchProductsQuery = (data: CustomFieldItems, useVariablesImplementati
       isPriceHidden,
       availableToSell,
       unlimitedBackorder,
+      totalOnHand,
+      backorderMessage,
     }
   }
 `;
@@ -137,7 +139,9 @@ const getSearchProductsQuery = (data: CustomFieldItems, useVariablesImplementati
       taxClassId,
       isPriceHidden,
       availableToSell,
-      unlimitedBackorder
+      unlimitedBackorder,
+      totalOnHand,
+      backorderMessage
     }
   }
 `;
@@ -308,6 +312,10 @@ export interface ProductSearch {
   productUrl: string;
   taxClassId: number;
   isPriceHidden: boolean;
+  availableToSell?: number;
+  unlimitedBackorder?: boolean;
+  totalOnHand?: number | null;
+  backorderMessage?: string | null;
 }
 
 export interface B2BProducts {
@@ -347,6 +355,8 @@ export interface SearchProductsResponse {
         inventory_level: number;
         available_to_sell: number;
         unlimited_backorder: boolean;
+        total_on_hand?: number | null;
+        backorder_message?: string | null;
         bc_calculated_price: {
           as_entered: number;
           tax_inclusive: number;
@@ -385,6 +395,8 @@ export interface SearchProductsResponse {
       isPriceHidden: boolean;
       availableToSell: number;
       unlimitedBackorder: boolean;
+      totalOnHand?: number | null;
+      backorderMessage?: string | null;
     }>;
   };
 }

--- a/apps/storefront/src/types/products.ts
+++ b/apps/storefront/src/types/products.ts
@@ -84,6 +84,8 @@ export interface Variant {
   bc_calculated_price: BcCalculatedPrice;
   available_to_sell: number;
   unlimited_backorder: boolean;
+  total_on_hand?: number | null;
+  backorder_message?: string | null;
 }
 
 export interface ALlOptionValue {
@@ -175,6 +177,8 @@ export interface Product {
   product_options?: ProductOptionsItem[];
   unlimitedBackorder: boolean;
   availableToSell: number;
+  totalOnHand?: number | null;
+  backorderMessage?: string | null;
   [key: string]: any;
 }
 


### PR DESCRIPTION
Jira: [BACK-583](https://bigcommercecloud.atlassian.net/browse/BACK-583)

## What/Why?
Backorder display on quote draft line items so buyers see the same kind of messaging as on quote detail (ready-to-ship / backordered qty / store message), using data from `productsSearch`.

Additionally, adjusting the shared `BackorderMessage` component:
- `ready to ship` and `will be backordered` strings each stay on one line, merchant backorder message is allowed to wrap so long text doesn’t widen the column.
- Use `body2` typography for the whole block (closer to design).
- When display is disabled, component returns null instead of rendering with `visibility: hidden` (which leaves a blank gap under the quantity field).

## Rollout/Rollback
Backorder display is gated by `Feature_Backorder && BACK-134.backorders_phase_1_1_control_messaging_on_storefront`.

## Testing
Backorder display appears as expected, disappears when no line items are backordered.

https://github.com/user-attachments/assets/d22f8d9e-947c-474d-8425-324e52bc49cf

Backorder display appears as expected for a variety of conditions (e.g. on-hand + backorder, just backorder, backorder message/no message).

https://github.com/user-attachments/assets/8a475615-af6f-409d-8ecd-370648c88217

Backorder display does not appear for disabled `Feature_Backorder` or `BACK-134.backorders_phase_1_1_control_messaging_on_storefront`

https://github.com/user-attachments/assets/98c4f2b9-1f81-4638-875f-ed710e4443ed

Quote detail - layout changes in effect, as expected.

https://github.com/user-attachments/assets/32b68fee-0380-43e9-9474-3d3eb4fd5453

[BACK-583]: https://bigcommercecloud.atlassian.net/browse/BACK-583?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new backorder messaging UI and supporting availability logic in the quote draft flow, plus extends product search GraphQL fields/types; risk is moderate due to customer-visible behavior changes gated by feature flags.
> 
> **Overview**
> Enables **backorder details on quote draft line items** (desktop table and mobile card) by computing backorder display fields from `productsSearch` and conditionally rendering `BackorderMessage` under the quantity input.
> 
> The display is **gated** by `useIsBackorderEnabled`, the feature flag `BACK-134.backorders_phase_1_1_control_messaging_on_storefront`, and global `backorderDisplaySettings`, and adds a UI toggle (`Switch`) to show/hide details only when any lines are backordered.
> 
> Refactors `BackorderMessage` to *render nothing* when not visible (instead of `visibility: hidden`) and adjusts typography/wrapping styles; introduces `getDraftBackorderDisplayFields`/`getQuoteItemBackendAvailability` utilities with new unit tests, and expands the `productsSearch` GraphQL query + `Product`/`Variant` typings to include `totalOnHand` and `backorderMessage`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07029e98613fd05aac5fe03ec85b0a028d17fe24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->