### PR TITLE
fix(user-management): B2B-4176 fix stale session bug

### DIFF
--- a/apps/storefront/src/App.tsx
+++ b/apps/storefront/src/App.tsx
@@ -26,7 +26,9 @@ import { b2bJumpPath } from './utils/b3CheckPermissions/b2bPermissionPath';
 import clearInvoiceCart from './utils/b3ClearCart';
 import setDayjsLocale from './utils/b3DateFormat/setDayjsLocale';
 import b2bLogger from './utils/b3Logger';
+import b2bVerifyBcLoginStatus from './utils/b2bVerifyBcLoginStatus';
 import { isUserGotoLogin } from './utils/b3logout';
+import { logoutSession } from './utils/logoutSession';
 import { isCompanyError } from './utils/companyUtils';
 import { getCompanyInfo, getCurrentCustomerInfo, loginInfo } from './utils/loginInfo';
 import { getGlobalStoreTax, getStoreConfigs, setStorefrontConfig } from './utils/storefrontConfig';
@@ -164,6 +166,18 @@ export default function App() {
     loginAndRegister();
     const init = async () => {
       try {
+        // Verify BC session is still valid when we have a rehydrated customerId.
+        // Handles forced logouts (e.g., user logged in from another browser causing
+        // BC to invalidate this session and redirect to the login page).
+        if (customerId) {
+          const isBcLogin = await b2bVerifyBcLoginStatus();
+          if (!isBcLogin) {
+            logoutSession();
+            showPageMask(false);
+            return;
+          }
+        }
+
         // bc graphql token
         if (!bcGraphqlToken) {
           await loginInfo();

--- a/apps/storefront/src/App.tsx
+++ b/apps/storefront/src/App.tsx
@@ -22,15 +22,15 @@ import { handleHideRegisterPage } from '@/utils/b3HideRegister';
 import { hideStorefrontElement } from '@/utils/b3HideStorefrontElement';
 import { getQuoteEnabled } from '@/utils/b3Init';
 
+import b2bVerifyBcLoginStatus from './utils/b2bVerifyBcLoginStatus';
 import { b2bJumpPath } from './utils/b3CheckPermissions/b2bPermissionPath';
 import clearInvoiceCart from './utils/b3ClearCart';
 import setDayjsLocale from './utils/b3DateFormat/setDayjsLocale';
 import b2bLogger from './utils/b3Logger';
-import b2bVerifyBcLoginStatus from './utils/b2bVerifyBcLoginStatus';
 import { isUserGotoLogin } from './utils/b3logout';
-import { logoutSession } from './utils/logoutSession';
 import { isCompanyError } from './utils/companyUtils';
 import { getCompanyInfo, getCurrentCustomerInfo, loginInfo } from './utils/loginInfo';
+import { logoutSession } from './utils/logoutSession';
 import { getGlobalStoreTax, getStoreConfigs, setStorefrontConfig } from './utils/storefrontConfig';
 import { getStoreSettings } from './utils/storefrontSettings';
 import { CHECKOUT_URL, PATH_ROUTES } from './constants';

--- a/apps/storefront/src/components/outSideComponents/B3CompanyHierarchyExternalButton.test.tsx
+++ b/apps/storefront/src/components/outSideComponents/B3CompanyHierarchyExternalButton.test.tsx
@@ -46,7 +46,10 @@ describe('when there is a selected company within the company hierarchy', () => 
     });
 
     renderWithProviders(<B3CompanyHierarchyExternalButton isOpen setOpenPage={vi.fn()} />, {
-      preloadedState: { company: companyState, global: buildGlobalStateWith({ isPageComplete: true }) },
+      preloadedState: {
+        company: companyState,
+        global: buildGlobalStateWith({ isPageComplete: true }),
+      },
     });
 
     expect(await screen.findByText('You are representing')).toBeInTheDocument();
@@ -71,7 +74,10 @@ describe('when the user has "companyHierarchy" permissions and clicks on the com
     const setOpenPage = vi.fn();
 
     renderWithProviders(<B3CompanyHierarchyExternalButton isOpen setOpenPage={setOpenPage} />, {
-      preloadedState: { company: companyState, global: buildGlobalStateWith({ isPageComplete: true }) },
+      preloadedState: {
+        company: companyState,
+        global: buildGlobalStateWith({ isPageComplete: true }),
+      },
     });
 
     await userEvent.click(await screen.findByText('ACME'));
@@ -99,7 +105,12 @@ describe('when the user does not have "companyHierarchy" permission, but does ha
 
       renderWithProviders(
         <B3CompanyHierarchyExternalButton isOpen={false} setOpenPage={setOpenPage} />,
-        { preloadedState: { company: companyState, global: buildGlobalStateWith({ isPageComplete: true }) } },
+        {
+          preloadedState: {
+            company: companyState,
+            global: buildGlobalStateWith({ isPageComplete: true }),
+          },
+        },
       );
 
       await userEvent.click(await screen.findByText('ACME'));

--- a/apps/storefront/src/components/outSideComponents/B3CompanyHierarchyExternalButton.test.tsx
+++ b/apps/storefront/src/components/outSideComponents/B3CompanyHierarchyExternalButton.test.tsx
@@ -45,7 +45,7 @@ describe('when there is a selected company within the company hierarchy', () => 
     });
 
     renderWithProviders(<B3CompanyHierarchyExternalButton isOpen setOpenPage={vi.fn()} />, {
-      preloadedState: { company: companyState },
+      preloadedState: { company: companyState, global: { isPageComplete: true } },
     });
 
     expect(await screen.findByText('You are representing')).toBeInTheDocument();
@@ -70,7 +70,7 @@ describe('when the user has "companyHierarchy" permissions and clicks on the com
     const setOpenPage = vi.fn();
 
     renderWithProviders(<B3CompanyHierarchyExternalButton isOpen setOpenPage={setOpenPage} />, {
-      preloadedState: { company: companyState },
+      preloadedState: { company: companyState, global: { isPageComplete: true } },
     });
 
     await userEvent.click(await screen.findByText('ACME'));
@@ -98,7 +98,7 @@ describe('when the user does not have "companyHierarchy" permission, but does ha
 
       renderWithProviders(
         <B3CompanyHierarchyExternalButton isOpen={false} setOpenPage={setOpenPage} />,
-        { preloadedState: { company: companyState } },
+        { preloadedState: { company: companyState, global: { isPageComplete: true } } },
       );
 
       await userEvent.click(await screen.findByText('ACME'));

--- a/apps/storefront/src/components/outSideComponents/B3CompanyHierarchyExternalButton.test.tsx
+++ b/apps/storefront/src/components/outSideComponents/B3CompanyHierarchyExternalButton.test.tsx
@@ -37,6 +37,7 @@ describe('when there is a selected company within the company hierarchy', () => 
   it('displays a message explaining which company the user is representing', async () => {
     const acme = buildSubsidiaryWith({ companyName: 'ACME', parentCompanyId: undefined });
     const companyState = buildCompanyStateWith({
+      customer: { id: 1 },
       companyHierarchyInfo: {
         selectCompanyHierarchyId: acme.companyId,
         companyHierarchyList: [{ ...acme, parentCompanyName: undefined }],
@@ -58,6 +59,7 @@ describe('when the user has "companyHierarchy" permissions and clicks on the com
 
     const acme = buildSubsidiaryWith({ companyName: 'ACME', parentCompanyId: undefined });
     const companyState = buildCompanyStateWith({
+      customer: { id: 1 },
       companyHierarchyInfo: {
         selectCompanyHierarchyId: acme.companyId,
         companyHierarchyList: [{ ...acme, parentCompanyName: undefined }],
@@ -84,6 +86,7 @@ describe('when the user does not have "companyHierarchy" permission, but does ha
 
       const acme = buildSubsidiaryWith({ companyName: 'ACME', parentCompanyId: undefined });
       const companyState = buildCompanyStateWith({
+        customer: { id: 1 },
         companyHierarchyInfo: {
           selectCompanyHierarchyId: acme.companyId,
           companyHierarchyList: [{ ...acme, parentCompanyName: undefined }],

--- a/apps/storefront/src/components/outSideComponents/B3CompanyHierarchyExternalButton.test.tsx
+++ b/apps/storefront/src/components/outSideComponents/B3CompanyHierarchyExternalButton.test.tsx
@@ -1,3 +1,4 @@
+import { buildGlobalStateWith } from 'tests/storeStateBuilders';
 import {
   buildCompanyStateWith,
   builder,
@@ -45,7 +46,7 @@ describe('when there is a selected company within the company hierarchy', () => 
     });
 
     renderWithProviders(<B3CompanyHierarchyExternalButton isOpen setOpenPage={vi.fn()} />, {
-      preloadedState: { company: companyState, global: { isPageComplete: true } },
+      preloadedState: { company: companyState, global: buildGlobalStateWith({ isPageComplete: true }) },
     });
 
     expect(await screen.findByText('You are representing')).toBeInTheDocument();
@@ -70,7 +71,7 @@ describe('when the user has "companyHierarchy" permissions and clicks on the com
     const setOpenPage = vi.fn();
 
     renderWithProviders(<B3CompanyHierarchyExternalButton isOpen setOpenPage={setOpenPage} />, {
-      preloadedState: { company: companyState, global: { isPageComplete: true } },
+      preloadedState: { company: companyState, global: buildGlobalStateWith({ isPageComplete: true }) },
     });
 
     await userEvent.click(await screen.findByText('ACME'));
@@ -98,7 +99,7 @@ describe('when the user does not have "companyHierarchy" permission, but does ha
 
       renderWithProviders(
         <B3CompanyHierarchyExternalButton isOpen={false} setOpenPage={setOpenPage} />,
-        { preloadedState: { company: companyState, global: { isPageComplete: true } } },
+        { preloadedState: { company: companyState, global: buildGlobalStateWith({ isPageComplete: true }) } },
       );
 
       await userEvent.click(await screen.findByText('ACME'));

--- a/apps/storefront/src/components/outSideComponents/B3CompanyHierarchyExternalButton.tsx
+++ b/apps/storefront/src/components/outSideComponents/B3CompanyHierarchyExternalButton.tsx
@@ -38,7 +38,7 @@ function B3CompanyHierarchyExternalButton({
 
   const dispatch = useAppDispatch();
 
-  const customerId = useAppSelector(({ company }) => company.customer.id);
+  const customerId = useAppSelector(({ company }) => company.customer?.id);
   const isPageComplete = useAppSelector(({ global }) => global.isPageComplete);
 
   const { selectCompanyHierarchyId, companyHierarchyList } = useAppSelector(

--- a/apps/storefront/src/components/outSideComponents/B3CompanyHierarchyExternalButton.tsx
+++ b/apps/storefront/src/components/outSideComponents/B3CompanyHierarchyExternalButton.tsx
@@ -38,6 +38,8 @@ function B3CompanyHierarchyExternalButton({
 
   const dispatch = useAppDispatch();
 
+  const customerId = useAppSelector(({ company }) => company.customer.id);
+
   const { selectCompanyHierarchyId, companyHierarchyList } = useAppSelector(
     ({ company }) => company.companyHierarchyInfo,
   );
@@ -149,7 +151,7 @@ function B3CompanyHierarchyExternalButton({
 
   return (
     <>
-      {!!companyName && (
+      {!!companyName && !!customerId && (
         <Snackbar
           sx={{
             zIndex: Z_INDEX.NOTIFICATION,

--- a/apps/storefront/src/components/outSideComponents/B3CompanyHierarchyExternalButton.tsx
+++ b/apps/storefront/src/components/outSideComponents/B3CompanyHierarchyExternalButton.tsx
@@ -39,6 +39,7 @@ function B3CompanyHierarchyExternalButton({
   const dispatch = useAppDispatch();
 
   const customerId = useAppSelector(({ company }) => company.customer.id);
+  const isPageComplete = useAppSelector(({ global }) => global.isPageComplete);
 
   const { selectCompanyHierarchyId, companyHierarchyList } = useAppSelector(
     ({ company }) => company.companyHierarchyInfo,
@@ -151,7 +152,7 @@ function B3CompanyHierarchyExternalButton({
 
   return (
     <>
-      {!!companyName && !!customerId && (
+      {!!companyName && !!customerId && isPageComplete && (
         <Snackbar
           sx={{
             zIndex: Z_INDEX.NOTIFICATION,

--- a/apps/storefront/src/components/outSideComponents/B3MasqueradeGlobalTip.tsx
+++ b/apps/storefront/src/components/outSideComponents/B3MasqueradeGlobalTip.tsx
@@ -136,7 +136,9 @@ export default function B3MasqueradeGlobalTip(props: B3MasqueradeGlobalTipProps)
     }
   };
 
-  if (href.includes(CHECKOUT_URL) || !customerId) return null;
+  const isPageComplete = useAppSelector(({ global }) => global.isPageComplete);
+
+  if (href.includes(CHECKOUT_URL) || !customerId || !isPageComplete) return null;
 
   if (!isAgenting) return null;
 

--- a/apps/storefront/src/utils/b3logout.test.ts
+++ b/apps/storefront/src/utils/b3logout.test.ts
@@ -119,7 +119,7 @@ describe('b3logout utilities', () => {
     it('dispatches all three actions', () => {
       logoutSession();
 
-      expect(store.dispatch).toHaveBeenCalledTimes(3);
+      expect(store.dispatch).toHaveBeenCalledTimes(4);
     });
   });
 

--- a/apps/storefront/src/utils/b3logout.test.ts
+++ b/apps/storefront/src/utils/b3logout.test.ts
@@ -116,7 +116,7 @@ describe('b3logout utilities', () => {
       expect(store.dispatch).toHaveBeenCalledWith(resetDraftQuoteInfo());
     });
 
-    it('dispatches all three actions', () => {
+    it('dispatches all four actions', () => {
       logoutSession();
 
       expect(store.dispatch).toHaveBeenCalledTimes(4);

--- a/apps/storefront/src/utils/logoutSession.ts
+++ b/apps/storefront/src/utils/logoutSession.ts
@@ -1,9 +1,11 @@
 import { store } from '@/store';
+import { clearMasqueradeCompany } from '@/store/slices/b2bFeatures';
 import { clearCompanySlice } from '@/store/slices/company';
 import { resetDraftQuoteInfo, resetDraftQuoteList } from '@/store/slices/quoteInfo';
 
 export const logoutSession = () => {
   store.dispatch(clearCompanySlice());
+  store.dispatch(clearMasqueradeCompany());
   store.dispatch(resetDraftQuoteList());
   store.dispatch(resetDraftQuoteInfo());
 };


### PR DESCRIPTION
Jira: [B2B-4176](https://bigcommercecloud.atlassian.net/browse/B2B-4176)

## What/Why?

When BigCommerce invalidates a session (e.g., user logged in from another browser), it redirects to the Stencil login page. The B2B app re-mounts and Redux persist rehydrates stale state from sessionStorage/localStorage — including company hierarchy data and the customer ID. The `App.tsx` init flow never detects the invalid session because it sees a non-zero `customerId` from rehydrated state and skips `getCurrentCustomerInfo()`.

**This caused:**
- The company hierarchy snackbar and masquerade tip flickering on screen briefly for logged-out users (stale rehydrated state renders the UI before the async session check clears it)
- Masquerade company state persisting across sessions

**Changes:**

1. **`logoutSession.ts`** — Added `clearMasqueradeCompany()` dispatch so that `logoutSession()` clears all user-specific persisted state (company slice, masquerade state, and draft quotes).

2. **`App.tsx`** — Added BC session verification at the start of `init()`. When `customerId` is set (from rehydrated state), it calls `b2bVerifyBcLoginStatus()` to check if the BC JWT is still valid. If the session is invalid, it calls `logoutSession()` to clear all stale state and returns early. The effect re-runs with cleared state and proceeds as a guest.

3. **`B3CompanyHierarchyExternalButton.tsx`** — Added a `customerId` guard (matching `B3MasqueradeGlobalTip`'s pattern) and an `isPageComplete` guard. The snackbar now only renders when `companyName`, `customerId`, and `isPageComplete` are all truthy.

4. **`B3MasqueradeGlobalTip.tsx`** — Added an `isPageComplete` guard. The masquerade tip now waits for init to complete before rendering.

5. **`B3CompanyHierarchyExternalButton.test.tsx`** — Updated existing tests to provide a non-zero `customer.id` and `isPageComplete: true` in the test state, since the component now requires both.

**Flicker fix (`isPageComplete` guard):**

The snackbar/masquerade tip flicker occurred because Redux persist rehydrates stale state (e.g., `customerId`, `companyName`, `isAgenting`) *before* the async `b2bVerifyBcLoginStatus()` check completes. Components rendered immediately with this stale data, then disappeared once `logoutSession()` cleared state. To fix this, both components now also gate on `isPageComplete` — a flag in the non-persisted `global` slice that always starts as `false` and is only set `true` after `init()` finishes (including the session verification). This keeps the snackbars hidden during the rehydration-to-verification window.

## Rollout/Rollback

- **Rollout:** Standard deployment — no feature flags or experiments required. The change is additive (a new session check) and defensive (extra guard on UI rendering).
- **Rollback:** Safe to revert the code change.

## Testing

**Company hierarchy snackbar:**
   - Verify the hierarchy snackbar only appears when logged in with a valid company context.
   - Verify it does not flash briefly on page load when logged out.

**Masquerade state cleanup:**
   - Log in, enter masquerade mode for a company.
   - Trigger a forced logout (as above) — verify masquerade state is fully cleared.

**Unit tests:**
   - Run `B3CompanyHierarchyExternalButton` tests — all should pass with the updated fixtures.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds an early BigCommerce session validation step in app initialization and expands logout cleanup, which can affect login/logout flows and when user-specific UI appears.
> 
> **Overview**
> Prevents stale Redux-persisted user state from briefly rendering after BigCommerce invalidates a session by verifying BC login status during `App` init; if invalid, it now calls `logoutSession()` and exits early.
> 
> Tightens rendering guards for the company hierarchy snackbar and masquerade tip so they only appear when a real `customerId` exists and `global.isPageComplete` is true, avoiding flicker during rehydration. Also expands `logoutSession()` to clear masquerade state (`clearMasqueradeCompany`) and updates related unit tests/fixtures to include `customer.id` and `isPageComplete`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 555aecf07d10e6c5a1661e7c8edc86af31d0e4bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

[B2B-4176]: https://bigcommercecloud.atlassian.net/browse/B2B-4176?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ