### PR TITLE
feat(orders): BACK-577 [SPIKE] for backorder information display in quotes that have been ordered.

### DIFF
--- a/apps/storefront/src/pages/QuoteDetail/index.tsx
+++ b/apps/storefront/src/pages/QuoteDetail/index.tsx
@@ -564,7 +564,26 @@ function QuoteDetail() {
         totalAmount: quote.totalAmount,
       });
 
-      const productListResponse = productsWithMoreInfo ?? [];
+      const isOrdered = Number(quote.status) === 4;
+      const snapshotProducts = quote.orderSnapshot?.products ?? [];
+      const productListResponse = (productsWithMoreInfo ?? []).map((product) => {
+        if (!isOrdered) return product;
+        const snapshot = snapshotProducts.find((s) => s.sku === product.sku);
+        if (!snapshot) {
+          return {
+            ...product,
+            totalOnHand: undefined,
+            quantityBackordered: undefined,
+            backorderMessage: undefined,
+          };
+        }
+        return {
+          ...product,
+          totalOnHand: snapshot.totalOnHand,
+          quantityBackordered: snapshot.quantityBackordered,
+          backorderMessage: snapshot.backorderMessage ?? undefined,
+        };
+      });
       setProductList(productListResponse);
 
       const { salesRep, salesRepEmail } = quote;
@@ -623,7 +642,7 @@ function QuoteDetail() {
 
       setFileList(newFileList);
 
-      return quote;
+      return { ...quote, productsList: productListResponse };
     } catch (error: unknown) {
       if (error instanceof Error) {
         snackbar.error(error.message);
@@ -918,7 +937,6 @@ function QuoteDetail() {
                 getQuoteTableDetails={getQuoteTableDetails}
                 getTaxRate={getTaxRate}
                 displayDiscount={quoteDetail.displayDiscount}
-                status={quoteDetail.status}
               />
             </Box>
           </Grid>

--- a/apps/storefront/src/pages/quote/components/QuoteDetailTable.tsx
+++ b/apps/storefront/src/pages/quote/components/QuoteDetailTable.tsx
@@ -50,7 +50,6 @@ interface ShoppingDetailTableProps {
   getTaxRate: (taxClassId: number, variants: any) => number;
   displayDiscount: boolean;
   currency: CurrencyProps;
-  status: string | number;
 }
 
 interface SearchProps {
@@ -113,10 +112,7 @@ function QuoteDetailTable(props: ShoppingDetailTableProps, ref: Ref<unknown>) {
     quoteReviewedBySalesRep,
     displayDiscount,
     currency,
-    status,
   } = props;
-  const isOrdered = Number(status) === 4;
-
   const isEnableProduct = useAppSelector(
     ({ global }) => global.blockPendingQuoteNonPurchasableOOS.isEnableProduct,
   );
@@ -315,7 +311,7 @@ function QuoteDetailTable(props: ShoppingDetailTableProps, ref: Ref<unknown>) {
       render: (row) => (
         <Box>
           <Typography sx={{ padding: '12px 0' }}>{row.quantity}</Typography>
-          {isBackorderEnabled && isBackorderMessagingEnabled && !isOrdered && (
+          {isBackorderEnabled && isBackorderMessagingEnabled && (
             <BackorderMessage
               totalOnHand={row.totalOnHand}
               quantityBackordered={row.quantityBackordered}
@@ -420,7 +416,6 @@ function QuoteDetailTable(props: ShoppingDetailTableProps, ref: Ref<unknown>) {
         </Typography>
         {isBackorderEnabled &&
           isBackorderMessagingEnabled &&
-          !isOrdered &&
           hasAnyBackorderDisplay &&
           hasBackorderedItems && (
             <FormControlLabel
@@ -459,7 +454,6 @@ function QuoteDetailTable(props: ShoppingDetailTableProps, ref: Ref<unknown>) {
             displayDiscount={displayDiscount}
             getTaxRate={getTaxRate}
             showBackorderDetails={showBackorderDetails}
-            status={status}
           />
         )}
       />

--- a/apps/storefront/src/pages/quote/components/QuoteDetailTableCard.tsx
+++ b/apps/storefront/src/pages/quote/components/QuoteDetailTableCard.tsx
@@ -17,7 +17,6 @@ interface QuoteTableCardProps {
   displayDiscount: boolean;
   currency: CurrencyProps;
   showBackorderDetails?: boolean;
-  status?: string | number;
 }
 
 const StyledImage = styled('img')(() => ({
@@ -36,9 +35,7 @@ function QuoteDetailTableCard(props: QuoteTableCardProps) {
     currency,
     displayDiscount,
     showBackorderDetails = false,
-    status,
   } = props;
-  const isOrdered = Number(status) === 4;
   const b3Lang = useB3Lang();
   const enteredInclusiveTax = useAppSelector(
     ({ storeConfigs }) => storeConfigs.currencies.enteredInclusiveTax,
@@ -149,7 +146,7 @@ function QuoteDetailTableCard(props: QuoteTableCardProps) {
           <Typography variant="body1" color="#616161">
             {notes}
           </Typography>
-          {isBackorderEnabled && isBackorderMessagingEnabled && !isOrdered && (
+          {isBackorderEnabled && isBackorderMessagingEnabled && (
             <BackorderMessage
               totalOnHand={totalOnHand}
               quantityBackordered={quantityBackordered}

--- a/apps/storefront/src/shared/service/b2b/graphql/quote.ts
+++ b/apps/storefront/src/shared/service/b2b/graphql/quote.ts
@@ -276,6 +276,17 @@ const getQuoteInfo = `
       allowCheckout,
       displayDiscount,
       uuid,
+      orderSnapshot {
+        bcOrderId,
+        status,
+        products {
+          productId,
+          sku,
+          totalOnHand,
+          quantityBackordered,
+          backorderMessage,
+        },
+      },
     }
   }
 `;
@@ -654,6 +665,17 @@ export interface B2BQuoteDetail {
       allowCheckout: boolean;
       displayDiscount: boolean;
       uuid?: string;
+      orderSnapshot?: {
+        bcOrderId: number;
+        status: string;
+        products: {
+          productId: number;
+          sku: string;
+          totalOnHand: number;
+          quantityBackordered: number;
+          backorderMessage: string | null;
+        }[];
+      };
     };
   };
 }


### PR DESCRIPTION
Jira: [BACK-577](https://bigcommercecloud.atlassian.net/browse/BACK-577)

## What/Why?
POC for consuming the backorder information snapshot for b2b quotes that have been ordered so we can show a historical display of what was ordered and under what circumstances. 

**NOTE:** This PR relies on the information provided by [this PR](https://github.com/bigcommerce/b2b-edition-api/pull/6455).

Once all of those tickets are across the line we can consume the backorder_snapshot information to display in the buyers portal.
for example 
```
 "orderSnapshot": {
                "bcOrderId": 113,
                "status": "Completed",
                "products": [
                    {
                        "productId": 1,
                        "sku": "TEST-SKU-1",
                        "totalOnHand": 3,
                        "quantityBackordered": 2,
                        "backorderMessage": "Lead time 2-4 weeks"
                    },
                    {
                        "productId": 2,
                        "sku": "TEST-SKU-2",
                        "totalOnHand": 5,
                        "quantityBackordered": 0,
                        "backorderMessage": null
                    }
                ]
            }
```

Once that is available, this PR removes the check for order status, and then consumes the above data if available,
If the data is not available it should display nothing for a quote order.
If the quote is not in ordered status it should fall back to the draftQuote/quote display.

## Rollout/Rollback
POC, I assume this won't get merged.

## Feature Flags
Wrapped in `BACK-134.backorders_phase_1_1_control_messaging_on_storefront`

## Testing
Given this order-confirmation page:
<img width="1288" height="703" alt="Screenshot 2026-04-10 at 2 35 34 pm" src="https://github.com/user-attachments/assets/43800ad8-e483-45b8-8882-4e5dc89ac6c8" />
The order quote will now display:
<img width="1451" height="792" alt="Screenshot 2026-04-10 at 2 35 42 pm" src="https://github.com/user-attachments/assets/60b6f01c-605b-41bf-abe2-74738506ace3" />

ping @animesh1987 @declankirk 

[BACK-577]: https://bigcommercecloud.atlassian.net/browse/BACK-577?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ