### PR TITLE
fix(register): B2B-4460 Buyer Portal: Use stateRequired flag for state field validation instead of states list

### DIFF
--- a/apps/storefront/src/hooks/useGetCountry.ts
+++ b/apps/storefront/src/hooks/useGetCountry.ts
@@ -12,14 +12,14 @@ const useSetCountry = () => {
     dispatch,
   } = useContext(GlobalContext);
 
-  const useGrpcGeoForStateRequiredFlag = useFeatureFlag(
+  const grpcGeoForStateRequiredFlag = useFeatureFlag(
     'B2B-4481.use_grpc_geo_for_state_required_flag',
   );
 
   useEffect(() => {
     const init = async () => {
       if (countriesList && !countriesList.length) {
-        const { countries } = await getB2BCountries(useGrpcGeoForStateRequiredFlag);
+        const { countries } = await getB2BCountries(grpcGeoForStateRequiredFlag);
 
         dispatch({
           type: 'common',

--- a/apps/storefront/src/hooks/useGetCountry.ts
+++ b/apps/storefront/src/hooks/useGetCountry.ts
@@ -1,6 +1,7 @@
 import { useContext, useEffect } from 'react';
 import { Control, FieldValues, UseFormGetValues, UseFormSetValue, useWatch } from 'react-hook-form';
 
+import { useFeatureFlag } from '@/hooks/useFeatureFlag';
 import { GlobalContext } from '@/shared/global';
 import { Country, State } from '@/shared/global/context/config';
 import { getB2BCountries } from '@/shared/service/b2b';
@@ -11,10 +12,14 @@ const useSetCountry = () => {
     dispatch,
   } = useContext(GlobalContext);
 
+  const useGrpcGeoForStateRequiredFlag = useFeatureFlag(
+    'B2B-4481.use_grpc_geo_for_state_required_flag',
+  );
+
   useEffect(() => {
     const init = async () => {
       if (countriesList && !countriesList.length) {
-        const { countries } = await getB2BCountries();
+        const { countries } = await getB2BCountries(useGrpcGeoForStateRequiredFlag);
 
         dispatch({
           type: 'common',

--- a/apps/storefront/src/pages/AddressList/index.tsx
+++ b/apps/storefront/src/pages/AddressList/index.tsx
@@ -5,6 +5,7 @@ import B3Filter from '@/components/filter/B3Filter';
 import B3Spin from '@/components/spin/B3Spin';
 import { B3PaginationTable, GetRequestList } from '@/components/table/B3PaginationTable';
 import { useCardListColumn } from '@/hooks/useCardListColumn';
+import { useFeatureFlag } from '@/hooks/useFeatureFlag';
 import { useTableRef } from '@/hooks/useTableRef';
 import { useVerifyCreatePermission } from '@/hooks/useVerifyPermission';
 import { useB3Lang } from '@/lib/lang';
@@ -62,6 +63,9 @@ const isConfigEnabled = (configs: Config[] | undefined, key: string) => {
 };
 
 function Address() {
+  const useGrpcGeoForStateRequiredFlag = useFeatureFlag(
+    'B2B-4481.use_grpc_geo_for_state_required_flag',
+  );
   const isB2BUser = useAppSelector(isB2BUserSelector);
   const companyInfoId = useAppSelector(({ company }) => company.companyInfo.id);
   const role = useAppSelector(({ company }) => company.customer.role);
@@ -96,7 +100,7 @@ function Address() {
 
   useEffect(() => {
     const handleGetAddressFields = async () => {
-      const { countries } = await getB2BCountries();
+      const { countries } = await getB2BCountries(useGrpcGeoForStateRequiredFlag);
 
       setCountries(countries);
       setIsRequestLoading(true);
@@ -111,7 +115,7 @@ function Address() {
     };
 
     handleGetAddressFields();
-  }, [isBCPermission]);
+  }, [isBCPermission, useGrpcGeoForStateRequiredFlag]);
 
   const getAddressList: GetRequestList<FilterSearchProps, AddressItemType> = async (
     params = {},

--- a/apps/storefront/src/pages/AddressList/index.tsx
+++ b/apps/storefront/src/pages/AddressList/index.tsx
@@ -63,7 +63,7 @@ const isConfigEnabled = (configs: Config[] | undefined, key: string) => {
 };
 
 function Address() {
-  const useGrpcGeoForStateRequiredFlag = useFeatureFlag(
+  const grpcGeoForStateRequiredFlag = useFeatureFlag(
     'B2B-4481.use_grpc_geo_for_state_required_flag',
   );
   const isB2BUser = useAppSelector(isB2BUserSelector);
@@ -100,7 +100,7 @@ function Address() {
 
   useEffect(() => {
     const handleGetAddressFields = async () => {
-      const { countries } = await getB2BCountries(useGrpcGeoForStateRequiredFlag);
+      const { countries } = await getB2BCountries(grpcGeoForStateRequiredFlag);
 
       setCountries(countries);
       setIsRequestLoading(true);
@@ -115,7 +115,7 @@ function Address() {
     };
 
     handleGetAddressFields();
-  }, [isBCPermission, useGrpcGeoForStateRequiredFlag]);
+  }, [isBCPermission, grpcGeoForStateRequiredFlag]);
 
   const getAddressList: GetRequestList<FilterSearchProps, AddressItemType> = async (
     params = {},

--- a/apps/storefront/src/pages/Registered/RegisterSteps/index.tsx
+++ b/apps/storefront/src/pages/Registered/RegisterSteps/index.tsx
@@ -1,5 +1,6 @@
 import { useContext, useEffect, useState } from 'react';
 
+import { useFeatureFlag } from '@/hooks/useFeatureFlag';
 import { useB3Lang } from '@/lib/lang';
 import { LoginConfig } from '@/pages/Login/helper';
 import { CustomStyleContext } from '@/shared/customStyleButton';
@@ -34,6 +35,9 @@ export function RegisterSteps({ backgroundColor, handleFinish }: RegisterStepsPr
   const [activeStep, setActiveStep] = useState(0);
 
   const IframeDocument = useAppSelector(themeFrameSelector);
+  const useGrpcGeoForStateRequiredFlag = useFeatureFlag(
+    'B2B-4481.use_grpc_geo_for_state_required_flag',
+  );
 
   const {
     state: { accountLoginRegistration },
@@ -82,7 +86,7 @@ export function RegisterSteps({ backgroundColor, handleFinish }: RegisterStepsPr
         );
         const b2bAccountFormFields = getAccountFormFields(newB2bAccountFormFields || []);
 
-        const { countries } = await getB2BCountries();
+        const { countries } = await getB2BCountries(useGrpcGeoForStateRequiredFlag);
 
         const newAddressInformationFields =
           b2bAccountFormFields.address?.map(

--- a/apps/storefront/src/pages/Registered/RegisterSteps/index.tsx
+++ b/apps/storefront/src/pages/Registered/RegisterSteps/index.tsx
@@ -35,7 +35,7 @@ export function RegisterSteps({ backgroundColor, handleFinish }: RegisterStepsPr
   const [activeStep, setActiveStep] = useState(0);
 
   const IframeDocument = useAppSelector(themeFrameSelector);
-  const useGrpcGeoForStateRequiredFlag = useFeatureFlag(
+  const grpcGeoForStateRequiredFlag = useFeatureFlag(
     'B2B-4481.use_grpc_geo_for_state_required_flag',
   );
 
@@ -86,7 +86,7 @@ export function RegisterSteps({ backgroundColor, handleFinish }: RegisterStepsPr
         );
         const b2bAccountFormFields = getAccountFormFields(newB2bAccountFormFields || []);
 
-        const { countries } = await getB2BCountries(useGrpcGeoForStateRequiredFlag);
+        const { countries } = await getB2BCountries(grpcGeoForStateRequiredFlag);
 
         const newAddressInformationFields =
           b2bAccountFormFields.address?.map(

--- a/apps/storefront/src/pages/Registered/RegisterSteps/steps/DetailStep.tsx
+++ b/apps/storefront/src/pages/Registered/RegisterSteps/steps/DetailStep.tsx
@@ -9,7 +9,7 @@ import { useFeatureFlag } from '@/hooks/useFeatureFlag';
 import { useB3Lang } from '@/lib/lang';
 import { CustomStyleContext } from '@/shared/customStyleButton';
 
-import { Country, State, getIsStateRequired, validateExtraFields } from '../../config';
+import { Country, getIsStateRequired, State, validateExtraFields } from '../../config';
 import { RegisteredContext } from '../../Context';
 import { RegisterFields } from '../../types';
 import { PrimaryButton } from '../PrimaryButton';

--- a/apps/storefront/src/pages/Registered/RegisterSteps/steps/DetailStep.tsx
+++ b/apps/storefront/src/pages/Registered/RegisterSteps/steps/DetailStep.tsx
@@ -32,7 +32,9 @@ export default function DetailStep({ handleBack, handleNext }: DetailStepProps) 
   } = useContext(CustomStyleContext);
 
   const customColor = getContrastColor(backgroundColor);
-  const isStateRequiredEnabled = useFeatureFlag('B2B-4481.use_grpc_geo_for_state_required_flag');
+  const useGrpcGeoForStateRequiredFlag = useFeatureFlag(
+    'B2B-4481.use_grpc_geo_for_state_required_flag',
+  );
 
   const [errorMessage, setErrorMessage] = useState('');
 
@@ -65,11 +67,15 @@ export default function DetailStep({ handleBack, handleNext }: DetailStepProps) 
 
   const handleCountryChange = useCallback(
     (countryCode: string, stateCode = '') => {
-      const country = countryList.find(
+      const selectedCountry = countryList.find(
         (c: Country) => c.countryCode === countryCode || c.countryName === countryCode,
       );
-      const stateList = country?.states || [];
-      const isStateRequired = getIsStateRequired(country, stateList, isStateRequiredEnabled);
+      const stateList = selectedCountry?.states || [];
+      const isStateRequired = getIsStateRequired(
+        selectedCountry,
+        stateList,
+        useGrpcGeoForStateRequiredFlag,
+      );
       const stateFields = addressBasicList.find(
         (formFields: RegisterFields) => formFields.name === 'state',
       );
@@ -114,7 +120,7 @@ export default function DetailStep({ handleBack, handleNext }: DetailStepProps) 
       addressBasicName,
       bcAddressBasicFields,
       countryList,
-      isStateRequiredEnabled,
+      useGrpcGeoForStateRequiredFlag,
     ],
   );
 

--- a/apps/storefront/src/pages/Registered/RegisterSteps/steps/DetailStep.tsx
+++ b/apps/storefront/src/pages/Registered/RegisterSteps/steps/DetailStep.tsx
@@ -9,7 +9,7 @@ import { useFeatureFlag } from '@/hooks/useFeatureFlag';
 import { useB3Lang } from '@/lib/lang';
 import { CustomStyleContext } from '@/shared/customStyleButton';
 
-import { Country, State, validateExtraFields } from '../../config';
+import { Country, State, getIsStateRequired, validateExtraFields } from '../../config';
 import { RegisteredContext } from '../../Context';
 import { RegisterFields } from '../../types';
 import { PrimaryButton } from '../PrimaryButton';
@@ -69,9 +69,7 @@ export default function DetailStep({ handleBack, handleNext }: DetailStepProps) 
         (c: Country) => c.countryCode === countryCode || c.countryName === countryCode,
       );
       const stateList = country?.states || [];
-      const isStateRequired = isStateRequiredEnabled
-        ? (country?.stateRequired ?? stateList.length > 0)
-        : stateList.length > 0;
+      const isStateRequired = getIsStateRequired(country, stateList, isStateRequiredEnabled);
       const stateFields = addressBasicList.find(
         (formFields: RegisterFields) => formFields.name === 'state',
       );

--- a/apps/storefront/src/pages/Registered/RegisterSteps/steps/DetailStep.tsx
+++ b/apps/storefront/src/pages/Registered/RegisterSteps/steps/DetailStep.tsx
@@ -5,6 +5,7 @@ import isEmpty from 'lodash-es/isEmpty';
 
 import { B3CustomForm } from '@/components/B3CustomForm';
 import { getContrastColor } from '@/components/outSideComponents/utils/b3CustomStyles';
+import { useFeatureFlag } from '@/hooks/useFeatureFlag';
 import { useB3Lang } from '@/lib/lang';
 import { CustomStyleContext } from '@/shared/customStyleButton';
 
@@ -31,6 +32,7 @@ export default function DetailStep({ handleBack, handleNext }: DetailStepProps) 
   } = useContext(CustomStyleContext);
 
   const customColor = getContrastColor(backgroundColor);
+  const isStateRequiredEnabled = useFeatureFlag('B2B-4481.use_grpc_geo_for_state_required_flag');
 
   const [errorMessage, setErrorMessage] = useState('');
 
@@ -63,11 +65,13 @@ export default function DetailStep({ handleBack, handleNext }: DetailStepProps) 
 
   const handleCountryChange = useCallback(
     (countryCode: string, stateCode = '') => {
-      const stateList =
-        countryList.find(
-          (country: Country) =>
-            country.countryCode === countryCode || country.countryName === countryCode,
-        )?.states || [];
+      const country = countryList.find(
+        (c: Country) => c.countryCode === countryCode || c.countryName === countryCode,
+      );
+      const stateList = country?.states || [];
+      const isStateRequired = isStateRequiredEnabled
+        ? (country?.stateRequired ?? stateList.length > 0)
+        : stateList.length > 0;
       const stateFields = addressBasicList.find(
         (formFields: RegisterFields) => formFields.name === 'state',
       );
@@ -76,11 +80,11 @@ export default function DetailStep({ handleBack, handleNext }: DetailStepProps) 
         if (stateList.length > 0) {
           stateFields.fieldType = 'dropdown';
           stateFields.options = stateList;
-          stateFields.required = true;
+          stateFields.required = isStateRequired;
         } else {
           stateFields.fieldType = 'text';
           stateFields.options = [];
-          stateFields.required = false;
+          stateFields.required = isStateRequired;
         }
       }
 
@@ -106,7 +110,14 @@ export default function DetailStep({ handleBack, handleNext }: DetailStepProps) 
     },
     // disabling as we don't need dispatchers here
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [addressBasicFields, addressBasicList, addressBasicName, bcAddressBasicFields, countryList],
+    [
+      addressBasicFields,
+      addressBasicList,
+      addressBasicName,
+      bcAddressBasicFields,
+      countryList,
+      isStateRequiredEnabled,
+    ],
   );
 
   useEffect(() => {

--- a/apps/storefront/src/pages/Registered/RegisterSteps/steps/DetailStep.tsx
+++ b/apps/storefront/src/pages/Registered/RegisterSteps/steps/DetailStep.tsx
@@ -32,7 +32,7 @@ export default function DetailStep({ handleBack, handleNext }: DetailStepProps) 
   } = useContext(CustomStyleContext);
 
   const customColor = getContrastColor(backgroundColor);
-  const useGrpcGeoForStateRequiredFlag = useFeatureFlag(
+  const grpcGeoForStateRequiredFlag = useFeatureFlag(
     'B2B-4481.use_grpc_geo_for_state_required_flag',
   );
 
@@ -74,7 +74,7 @@ export default function DetailStep({ handleBack, handleNext }: DetailStepProps) 
       const isStateRequired = getIsStateRequired(
         selectedCountry,
         stateList,
-        useGrpcGeoForStateRequiredFlag,
+        grpcGeoForStateRequiredFlag,
       );
       const stateFields = addressBasicList.find(
         (formFields: RegisterFields) => formFields.name === 'state',
@@ -120,7 +120,7 @@ export default function DetailStep({ handleBack, handleNext }: DetailStepProps) 
       addressBasicName,
       bcAddressBasicFields,
       countryList,
-      useGrpcGeoForStateRequiredFlag,
+      grpcGeoForStateRequiredFlag,
     ],
   );
 

--- a/apps/storefront/src/pages/Registered/config.ts
+++ b/apps/storefront/src/pages/Registered/config.ts
@@ -50,9 +50,9 @@ export interface State {
 export function getIsStateRequired(
   country: Country | undefined,
   stateList: State[] | null | undefined,
-  useGrpcGeoForStateRequiredFlag: boolean,
+  grpcGeoForStateRequiredFlag: boolean,
 ): boolean {
-  return useGrpcGeoForStateRequiredFlag ? !!country?.stateRequired : (stateList?.length ?? 0) > 0;
+  return grpcGeoForStateRequiredFlag ? !!country?.stateRequired : (stateList?.length ?? 0) > 0;
 }
 
 type EmailError = {

--- a/apps/storefront/src/pages/Registered/config.ts
+++ b/apps/storefront/src/pages/Registered/config.ts
@@ -49,13 +49,10 @@ export interface State {
 
 export function getIsStateRequired(
   country: Country | undefined,
-  stateList: State[],
-  isStateRequiredEnabled: boolean,
+  stateList: State[] | null | undefined,
+  useGrpcGeoForStateRequiredFlag: boolean,
 ): boolean {
-  if (isStateRequiredEnabled) {
-    return country?.stateRequired ?? stateList.length > 0;
-  }
-  return stateList.length > 0;
+  return useGrpcGeoForStateRequiredFlag ? !!country?.stateRequired : (stateList?.length ?? 0) > 0;
 }
 
 type EmailError = {

--- a/apps/storefront/src/pages/Registered/config.ts
+++ b/apps/storefront/src/pages/Registered/config.ts
@@ -38,6 +38,7 @@ export interface Country {
   countryCode: string;
   countryName: string;
   id?: string;
+  stateRequired?: boolean;
   states: [];
 }
 export interface State {

--- a/apps/storefront/src/pages/Registered/config.ts
+++ b/apps/storefront/src/pages/Registered/config.ts
@@ -47,6 +47,17 @@ export interface State {
   id?: string;
 }
 
+export function getIsStateRequired(
+  country: Country | undefined,
+  stateList: State[],
+  isStateRequiredEnabled: boolean,
+): boolean {
+  if (isStateRequiredEnabled) {
+    return country?.stateRequired ?? stateList.length > 0;
+  }
+  return stateList.length > 0;
+}
+
 type EmailError = {
   [k: number]: string;
 };

--- a/apps/storefront/src/pages/RegisteredBCToB2B/Register.tsx
+++ b/apps/storefront/src/pages/RegisteredBCToB2B/Register.tsx
@@ -5,6 +5,7 @@ import { Box } from '@mui/material';
 import { B3Card } from '@/components/B3Card';
 import { getContrastColor } from '@/components/outSideComponents/utils/b3CustomStyles';
 import B3Spin from '@/components/spin/B3Spin';
+import { useFeatureFlag } from '@/hooks/useFeatureFlag';
 import { useMobile } from '@/hooks/useMobile';
 import { useB3Lang } from '@/lib/lang';
 import { CustomStyleContext } from '@/shared/customStyleButton';
@@ -43,6 +44,9 @@ export function Register({ logo, ...props }: RegisterProps) {
 
   const b3Lang = useB3Lang();
   const [isMobile] = useMobile();
+  const useGrpcGeoForStateRequiredFlag = useFeatureFlag(
+    'B2B-4481.use_grpc_geo_for_state_required_flag',
+  );
 
   const navigate = useNavigate();
 
@@ -94,7 +98,7 @@ export function Register({ logo, ...props }: RegisterProps) {
       });
 
       const bcToB2BAccountFormFields = getAccountFormFields(newAccountFormFields || []);
-      const { countries } = await getB2BCountries();
+      const { countries } = await getB2BCountries(useGrpcGeoForStateRequiredFlag);
 
       const newAddressInformationFields = (bcToB2BAccountFormFields.address ?? []).map(
         (addressFields: Partial<RegisterFieldsItems>): Partial<RegisterFieldsItems> => {
@@ -156,7 +160,15 @@ export function Register({ logo, ...props }: RegisterProps) {
     } finally {
       showLoading(false);
     }
-  }, [dispatch, emailAddress, firstName, lastName, phoneNumber, showLoading]);
+  }, [
+    dispatch,
+    emailAddress,
+    firstName,
+    useGrpcGeoForStateRequiredFlag,
+    lastName,
+    phoneNumber,
+    showLoading,
+  ]);
 
   useEffect(() => {
     getBCAdditionalFields();

--- a/apps/storefront/src/pages/RegisteredBCToB2B/Register.tsx
+++ b/apps/storefront/src/pages/RegisteredBCToB2B/Register.tsx
@@ -44,7 +44,7 @@ export function Register({ logo, ...props }: RegisterProps) {
 
   const b3Lang = useB3Lang();
   const [isMobile] = useMobile();
-  const useGrpcGeoForStateRequiredFlag = useFeatureFlag(
+  const grpcGeoForStateRequiredFlag = useFeatureFlag(
     'B2B-4481.use_grpc_geo_for_state_required_flag',
   );
 
@@ -98,7 +98,7 @@ export function Register({ logo, ...props }: RegisterProps) {
       });
 
       const bcToB2BAccountFormFields = getAccountFormFields(newAccountFormFields || []);
-      const { countries } = await getB2BCountries(useGrpcGeoForStateRequiredFlag);
+      const { countries } = await getB2BCountries(grpcGeoForStateRequiredFlag);
 
       const newAddressInformationFields = (bcToB2BAccountFormFields.address ?? []).map(
         (addressFields: Partial<RegisterFieldsItems>): Partial<RegisterFieldsItems> => {
@@ -164,7 +164,7 @@ export function Register({ logo, ...props }: RegisterProps) {
     dispatch,
     emailAddress,
     firstName,
-    useGrpcGeoForStateRequiredFlag,
+    grpcGeoForStateRequiredFlag,
     lastName,
     phoneNumber,
     showLoading,

--- a/apps/storefront/src/pages/RegisteredBCToB2B/RegistrationForm/useRegistrationForm.ts
+++ b/apps/storefront/src/pages/RegisteredBCToB2B/RegistrationForm/useRegistrationForm.ts
@@ -38,7 +38,7 @@ interface UseRegistrationFormParams {
 export function useRegistrationForm({ onRegistrationSuccess }: UseRegistrationFormParams) {
   const b3Lang = useB3Lang();
   const isRegisterCompanyFlowEnabled = useFeatureFlag('B2B-4466.use_register_company_flow');
-  const useGrpcGeoForStateRequiredFlag = useFeatureFlag(
+  const grpcGeoForStateRequiredFlag = useFeatureFlag(
     'B2B-4481.use_grpc_geo_for_state_required_flag',
   );
   const [isMobile] = useMobile();
@@ -98,7 +98,7 @@ export function useRegistrationForm({ onRegistrationSuccess }: UseRegistrationFo
       const isStateRequired = getIsStateRequired(
         country,
         stateList,
-        useGrpcGeoForStateRequiredFlag,
+        grpcGeoForStateRequiredFlag,
       );
       const stateFields = bcTob2bAddressBasicFields.find(
         (formFields: RegisterFields) => formFields.name === 'state',

--- a/apps/storefront/src/pages/RegisteredBCToB2B/RegistrationForm/useRegistrationForm.ts
+++ b/apps/storefront/src/pages/RegisteredBCToB2B/RegistrationForm/useRegistrationForm.ts
@@ -5,7 +5,7 @@ import isEmpty from 'lodash-es/isEmpty';
 import { useFeatureFlag } from '@/hooks/useFeatureFlag';
 import { useMobile } from '@/hooks/useMobile';
 import { useB3Lang } from '@/lib/lang';
-import { Country, State, getIsStateRequired } from '@/pages/Registered/config';
+import { Country, getIsStateRequired, State } from '@/pages/Registered/config';
 import { RegisteredContext } from '@/pages/Registered/Context';
 import type { RegisterFields } from '@/pages/Registered/types';
 import { CustomStyleContext } from '@/shared/customStyleButton';

--- a/apps/storefront/src/pages/RegisteredBCToB2B/RegistrationForm/useRegistrationForm.ts
+++ b/apps/storefront/src/pages/RegisteredBCToB2B/RegistrationForm/useRegistrationForm.ts
@@ -5,7 +5,7 @@ import isEmpty from 'lodash-es/isEmpty';
 import { useFeatureFlag } from '@/hooks/useFeatureFlag';
 import { useMobile } from '@/hooks/useMobile';
 import { useB3Lang } from '@/lib/lang';
-import { Country, State } from '@/pages/Registered/config';
+import { Country, State, getIsStateRequired } from '@/pages/Registered/config';
 import { RegisteredContext } from '@/pages/Registered/Context';
 import type { RegisterFields } from '@/pages/Registered/types';
 import { CustomStyleContext } from '@/shared/customStyleButton';
@@ -93,9 +93,7 @@ export function useRegistrationForm({ onRegistrationSuccess }: UseRegistrationFo
         (c: Country) => c.countryCode === countryCode || c.countryName === countryCode,
       );
       const stateList = country?.states || [];
-      const isStateRequired = isStateRequiredEnabled
-        ? (country?.stateRequired ?? stateList.length > 0)
-        : stateList.length > 0;
+      const isStateRequired = getIsStateRequired(country, stateList, isStateRequiredEnabled);
       const stateFields = bcTob2bAddressBasicFields.find(
         (formFields: RegisterFields) => formFields.name === 'state',
       );

--- a/apps/storefront/src/pages/RegisteredBCToB2B/RegistrationForm/useRegistrationForm.ts
+++ b/apps/storefront/src/pages/RegisteredBCToB2B/RegistrationForm/useRegistrationForm.ts
@@ -95,11 +95,7 @@ export function useRegistrationForm({ onRegistrationSuccess }: UseRegistrationFo
         (c: Country) => c.countryCode === countryCode || c.countryName === countryCode,
       );
       const stateList = country?.states || [];
-      const isStateRequired = getIsStateRequired(
-        country,
-        stateList,
-        grpcGeoForStateRequiredFlag,
-      );
+      const isStateRequired = getIsStateRequired(country, stateList, grpcGeoForStateRequiredFlag);
       const stateFields = bcTob2bAddressBasicFields.find(
         (formFields: RegisterFields) => formFields.name === 'state',
       );

--- a/apps/storefront/src/pages/RegisteredBCToB2B/RegistrationForm/useRegistrationForm.ts
+++ b/apps/storefront/src/pages/RegisteredBCToB2B/RegistrationForm/useRegistrationForm.ts
@@ -38,7 +38,9 @@ interface UseRegistrationFormParams {
 export function useRegistrationForm({ onRegistrationSuccess }: UseRegistrationFormParams) {
   const b3Lang = useB3Lang();
   const isRegisterCompanyFlowEnabled = useFeatureFlag('B2B-4466.use_register_company_flow');
-  const isStateRequiredEnabled = useFeatureFlag('B2B-4481.use_grpc_geo_for_state_required_flag');
+  const useGrpcGeoForStateRequiredFlag = useFeatureFlag(
+    'B2B-4481.use_grpc_geo_for_state_required_flag',
+  );
   const [isMobile] = useMobile();
   const [errorMessage, setErrorMessage] = useState('');
 
@@ -93,7 +95,11 @@ export function useRegistrationForm({ onRegistrationSuccess }: UseRegistrationFo
         (c: Country) => c.countryCode === countryCode || c.countryName === countryCode,
       );
       const stateList = country?.states || [];
-      const isStateRequired = getIsStateRequired(country, stateList, isStateRequiredEnabled);
+      const isStateRequired = getIsStateRequired(
+        country,
+        stateList,
+        useGrpcGeoForStateRequiredFlag,
+      );
       const stateFields = bcTob2bAddressBasicFields.find(
         (formFields: RegisterFields) => formFields.name === 'state',
       );

--- a/apps/storefront/src/pages/RegisteredBCToB2B/RegistrationForm/useRegistrationForm.ts
+++ b/apps/storefront/src/pages/RegisteredBCToB2B/RegistrationForm/useRegistrationForm.ts
@@ -38,6 +38,7 @@ interface UseRegistrationFormParams {
 export function useRegistrationForm({ onRegistrationSuccess }: UseRegistrationFormParams) {
   const b3Lang = useB3Lang();
   const isRegisterCompanyFlowEnabled = useFeatureFlag('B2B-4466.use_register_company_flow');
+  const isStateRequiredEnabled = useFeatureFlag('B2B-4481.use_grpc_geo_for_state_required_flag');
   const [isMobile] = useMobile();
   const [errorMessage, setErrorMessage] = useState('');
 
@@ -88,11 +89,13 @@ export function useRegistrationForm({ onRegistrationSuccess }: UseRegistrationFo
 
   useEffect(() => {
     const handleCountryChange = (countryCode: string, stateCode = '') => {
-      const stateList =
-        countryList.find(
-          (country: Country) =>
-            country.countryCode === countryCode || country.countryName === countryCode,
-        )?.states || [];
+      const country = countryList.find(
+        (c: Country) => c.countryCode === countryCode || c.countryName === countryCode,
+      );
+      const stateList = country?.states || [];
+      const isStateRequired = isStateRequiredEnabled
+        ? (country?.stateRequired ?? stateList.length > 0)
+        : stateList.length > 0;
       const stateFields = bcTob2bAddressBasicFields.find(
         (formFields: RegisterFields) => formFields.name === 'state',
       );
@@ -101,11 +104,11 @@ export function useRegistrationForm({ onRegistrationSuccess }: UseRegistrationFo
         if (stateList.length > 0) {
           stateFields.fieldType = 'dropdown';
           stateFields.options = stateList;
-          stateFields.required = true;
+          stateFields.required = isStateRequired;
         } else {
           stateFields.fieldType = 'text';
           stateFields.options = [];
-          stateFields.required = false;
+          stateFields.required = isStateRequired;
         }
       }
 

--- a/apps/storefront/src/shared/global/context/config.ts
+++ b/apps/storefront/src/shared/global/context/config.ts
@@ -12,6 +12,7 @@ export interface Country {
   countryCode: string;
   countryName: string;
   id?: string;
+  stateRequired?: boolean;
   states: State[];
 }
 

--- a/apps/storefront/src/shared/service/b2b/graphql/register.ts
+++ b/apps/storefront/src/shared/service/b2b/graphql/register.ts
@@ -101,12 +101,12 @@ const getCustomerInfo = () => `{
   }
 }`;
 
-const getCountries = (useGrpcGeoForStateRequiredFlag: boolean) => `query Countries {
+const getCountries = (grpcGeoForStateRequiredFlag: boolean) => `query Countries {
   countries(storeHash:"${storeHash}") {
     id
     countryName
     countryCode
-    ${useGrpcGeoForStateRequiredFlag ? 'stateRequired' : ''}
+    ${grpcGeoForStateRequiredFlag ? 'stateRequired' : ''}
     states {
       stateName
       stateCode
@@ -218,9 +218,9 @@ export const getB2BCompanyUserInfo = () =>
     query: getCustomerInfo(),
   });
 
-export const getB2BCountries = (useGrpcGeoForStateRequiredFlag = false) =>
+export const getB2BCountries = (grpcGeoForStateRequiredFlag = false) =>
   B3Request.graphqlB2B({
-    query: getCountries(useGrpcGeoForStateRequiredFlag),
+    query: getCountries(grpcGeoForStateRequiredFlag),
   });
 
 export const createB2BCompanyUser = (data: CustomFieldItems) =>

--- a/apps/storefront/src/shared/service/b2b/graphql/register.ts
+++ b/apps/storefront/src/shared/service/b2b/graphql/register.ts
@@ -1,3 +1,4 @@
+import { store } from '@/store';
 import { channelId, storeHash } from '@/utils/basicConfig';
 import { convertArrayToGraphql, convertObjectOrArrayKeysToCamel } from '@/utils/graphqlDataConvert';
 
@@ -101,11 +102,12 @@ const getCustomerInfo = () => `{
   }
 }`;
 
-const getCountries = () => `query Countries {
+const getCountries = (includeStateRequired: boolean) => `query Countries {
   countries(storeHash:"${storeHash}") {
     id
     countryName
     countryCode
+    ${includeStateRequired ? 'stateRequired' : ''}
     states {
       stateName
       stateCode
@@ -217,10 +219,15 @@ export const getB2BCompanyUserInfo = () =>
     query: getCustomerInfo(),
   });
 
-export const getB2BCountries = () =>
-  B3Request.graphqlB2B({
-    query: getCountries(),
+export const getB2BCountries = () => {
+  const { featureFlags } = store.getState().global;
+  const includeStateRequired =
+    featureFlags['B2B-4481.use_grpc_geo_for_state_required_flag'] ?? false;
+
+  return B3Request.graphqlB2B({
+    query: getCountries(includeStateRequired),
   });
+};
 
 export const createB2BCompanyUser = (data: CustomFieldItems) =>
   B3Request.graphqlB2B({

--- a/apps/storefront/src/shared/service/b2b/graphql/register.ts
+++ b/apps/storefront/src/shared/service/b2b/graphql/register.ts
@@ -1,4 +1,3 @@
-import { store } from '@/store';
 import { channelId, storeHash } from '@/utils/basicConfig';
 import { convertArrayToGraphql, convertObjectOrArrayKeysToCamel } from '@/utils/graphqlDataConvert';
 
@@ -102,12 +101,12 @@ const getCustomerInfo = () => `{
   }
 }`;
 
-const getCountries = (includeStateRequired: boolean) => `query Countries {
+const getCountries = (useGrpcGeoForStateRequiredFlag: boolean) => `query Countries {
   countries(storeHash:"${storeHash}") {
     id
     countryName
     countryCode
-    ${includeStateRequired ? 'stateRequired' : ''}
+    ${useGrpcGeoForStateRequiredFlag ? 'stateRequired' : ''}
     states {
       stateName
       stateCode
@@ -219,15 +218,10 @@ export const getB2BCompanyUserInfo = () =>
     query: getCustomerInfo(),
   });
 
-export const getB2BCountries = () => {
-  const { featureFlags } = store.getState().global;
-  const includeStateRequired =
-    featureFlags['B2B-4481.use_grpc_geo_for_state_required_flag'] ?? false;
-
-  return B3Request.graphqlB2B({
-    query: getCountries(includeStateRequired),
+export const getB2BCountries = (useGrpcGeoForStateRequiredFlag = false) =>
+  B3Request.graphqlB2B({
+    query: getCountries(useGrpcGeoForStateRequiredFlag),
   });
-};
 
 export const createB2BCompanyUser = (data: CustomFieldItems) =>
   B3Request.graphqlB2B({

--- a/apps/storefront/src/utils/featureFlags.ts
+++ b/apps/storefront/src/utils/featureFlags.ts
@@ -31,6 +31,10 @@ export const featureFlags = [
     key: 'B2B-4466.use_register_company_flow',
     name: 'useRegisterCompanyFlow',
   },
+  {
+    key: 'B2B-4481.use_grpc_geo_for_state_required_flag',
+    name: 'useGrpcGeoForStateRequiredFlag',
+  },
 ] as const;
 
 export type FeatureFlagKey = (typeof featureFlags)[number]['key'];

--- a/apps/storefront/src/utils/featureFlags.ts
+++ b/apps/storefront/src/utils/featureFlags.ts
@@ -33,7 +33,7 @@ export const featureFlags = [
   },
   {
     key: 'B2B-4481.use_grpc_geo_for_state_required_flag',
-    name: 'useGrpcGeoForStateRequiredFlag',
+    name: 'grpcGeoForStateRequiredFlag',
   },
 ] as const;
 


### PR DESCRIPTION
Jira: [B2B-4460](https://bigcommercecloud.atlassian.net/browse/B2B-4460)

## What/Why?
<!--
  A description about what this pull request implements and its purpose.
  Try to be detailed and describe any technical details to simplify the job
  of the reviewer and the individual on production support.
-->

Introduced a new **FF** `B2B-4481.use_grpc_geo_for_state_required_flag` on graphql Level to control how the “State” field’s required validation is determined during new registration.

When **FF** `B2B-4481.use_grpc_geo_for_state_required_flag` enabled, the app uses the backend’s authoritative stateRequired value from the gRPC geo service, falling back to the legacy client‑side heuristic only if the backend value is missing.

When **FF** `B2B-4481.use_grpc_geo_for_state_required_flag` disabled, the existing client‑side logic remains unchanged.

The previous behavior relied solely on a hardcoded client‑side rule: the state field was required whenever a country had a non‑empty state list(states.length > 0). This heuristic doesn’t always reflect the backend’s canonical rules and can lead to mismatches of business rules on backend logic.

## Rollout/Rollback
<!--
Detail how this change will be rolled out. Include reference to any
experiments and how the success will be measured as the experiment is
ramped.

Document rollback procedures. Is rolling back the change as simple as
rolling back an experiment or does it require reverting code? Are there
database migrations that may change our decision to roll forward instead of
back?
-->
FE is behind feature flag we can turn of the feature flag and it will rollback to previous logic

## Feature Flag

FE uses backend FF
`B2B-4481.use_grpc_geo_for_state_required_flag`

## Testing
<!--
Provide as much information as you can about how you tested and how another
Engineer can test your change. Include screenshots, or test run output
where appropriate.
-->

https://github.com/user-attachments/assets/d157a185-59e6-4296-bba9-513fe469fcce


https://github.com/user-attachments/assets/8eec04f5-bd63-4a6e-a388-1649b7cd4c72




[B2B-4460]: https://bigcommercecloud.atlassian.net/browse/B2B-4460?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches registration and address country/state handling and changes the `getB2BCountries` GraphQL query shape behind a feature flag; incorrect flag behavior or missing data could affect state-field validation for some countries.
> 
> **Overview**
> **Adds a new feature-flagged path for determining whether the address `state` field is required.** When `B2B-4481.use_grpc_geo_for_state_required_flag` is enabled, the app requests `stateRequired` from the `countries` GraphQL query and uses it (via new `getIsStateRequired`) instead of inferring required-ness solely from `states.length`.
> 
> The flag is threaded through all `getB2BCountries` call sites (registration flows, BC→B2B registration, address list, and global country caching), and country/state form logic is updated so the `state` field’s `required` attribute follows the backend-provided rule while preserving legacy behavior when the flag is off.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4b5f560882aeefb9385ebd8b37ac57dca432d3f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->