### PR TITLE
chore(common): B2B-4646 Add B2B checkout dynamic test suite to trigger on Staging Launchbay deployments as non-blocking

### DIFF
--- a/.infrastructure/regression.tf
+++ b/.infrastructure/regression.tf
@@ -1,4 +1,4 @@
-# Staging regression suite
+# Staging test suites
 
 module "staging_run_suite_staging_b2b_e2e_suite" {
   source     = "git@github.com:bigcommerce/terraform-services-modules.git//modules/run_regression_suite_from_other_project"
@@ -12,7 +12,19 @@ module "staging_run_suite_staging_b2b_e2e_suite" {
   delay_in_seconds   = 0
 }
 
-# Production regression suite
+module "staging_run_suite_staging_b2b_checkout_suite" {
+  source     = "git@github.com:bigcommerce/terraform-services-modules.git//modules/run_regression_suite_from_other_project"
+  project_id = module.service.id
+  target_ids = [
+    module.service.target_ids["staging-us"]
+  ]
+  other_project_name = "functional-tests"
+  other_target_name  = "staging"
+  profile_name       = "staging_b2b_checkout_suite"
+  delay_in_seconds   = 0
+}
+
+# Production deployment requirements
 
 module "production_require_suite_staging_b2b_e2e_suite" {
   source     = "git@github.com:bigcommerce/terraform-services-modules.git//modules/require_regression_suite_from_another_project"


### PR DESCRIPTION
Jira: [B2B-4646](https://bigcommercecloud.atlassian.net/browse/B2B-4646)

## What/Why?
<!--
  A description about what this pull request implements and its purpose.
  Try to be detailed and describe any technical details to simplify the job
  of the reviewer and the individual on production support.
-->

Add B2B checkout dynamic test suite to trigger on Staging Launchbay deployments as non-blocking

## Rollout/Rollback
<!--
Detail how this change will be rolled out. Include reference to any
experiments and how the success will be measured as the experiment is
ramped.

Document rollback procedures. Is rolling back the change as simple as
rolling back an experiment or does it require reverting code? Are there
database migrations that may change our decision to roll forward instead of
back?
-->

Revert this PR and run atlantis commands

## Testing
<!--
Provide as much information as you can about how you tested and how another
Engineer can test your change. Include screenshots, or test run output
where appropriate.
-->

- CI

@bigcommerce/team-b2b 

[B2B-4646]: https://bigcommercecloud.atlassian.net/browse/B2B-4646?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk Terraform change that only adds an additional non-blocking staging test-suite trigger; no production gating logic is modified.
> 
> **Overview**
> Adds a second staging test trigger in `.infrastructure/regression.tf` to run the `staging_b2b_checkout_suite` from the `functional-tests` project on `staging-us` deployments (in addition to the existing `staging_b2b_e2e_suite`).
> 
> Renames the top-level comment to reflect multiple staging suites and clarifies the production section as **deployment requirements**, leaving the existing production requirement for `staging_b2b_e2e_suite` unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d92cf04f2fb3d78fc2c82471060af6a5986d7b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->