### PR TITLE
fix(carts): add target parameter to decouple cart validation from quote NP/OOS flag

### DIFF
--- a/apps/storefront/src/pages/OrderDetail/components/OrderDialog.tsx
+++ b/apps/storefront/src/pages/OrderDetail/components/OrderDialog.tsx
@@ -82,6 +82,7 @@ const validateProducts = async (products: EditableProductItem[]) => {
 
       allOptions: product.product_options,
     })),
+    'CART',
   );
 };
 

--- a/apps/storefront/src/pages/OrderDetail/index.test.tsx
+++ b/apps/storefront/src/pages/OrderDetail/index.test.tsx
@@ -1723,6 +1723,7 @@ describe('when a personal customer visits an order', () => {
           variantId: 456,
           quantity: 1,
           productOptions: [{ optionId: 22, optionValue: 'bar' }],
+          target: 'CART',
         })
         .thenReturn({
           data: {
@@ -1814,6 +1815,7 @@ describe('when a personal customer visits an order', () => {
           variantId: 456,
           quantity: 1,
           productOptions: [],
+          target: 'CART',
         })
         .thenReturn({
           data: {
@@ -1935,6 +1937,7 @@ describe('when a personal customer visits an order', () => {
           variantId: 456,
           quantity: 2,
           productOptions: [],
+          target: 'CART',
         })
         .thenReturn({
           data: {
@@ -2032,6 +2035,7 @@ describe('when a personal customer visits an order', () => {
           variantId: laughCanister.variant_id,
           quantity: 1,
           productOptions: [],
+          target: 'CART',
         })
         .thenReturn({ data: { validateProduct: { responseType: 'SUCCESS', message: '' } } });
 
@@ -2041,6 +2045,7 @@ describe('when a personal customer visits an order', () => {
           variantId: screamCanister.variant_id,
           quantity: 2,
           productOptions: [],
+          target: 'CART',
         })
         .thenReturn({ data: { validateProduct: { responseType: 'SUCCESS', message: '' } } });
 
@@ -2133,6 +2138,7 @@ describe('when a personal customer visits an order', () => {
           variantId: laughCanister.variant_id,
           quantity: 1,
           productOptions: [],
+          target: 'CART',
         })
         .thenReturn({ data: { validateProduct: { responseType: 'SUCCESS', message: '' } } });
 
@@ -2142,6 +2148,7 @@ describe('when a personal customer visits an order', () => {
           variantId: productWithWarning.variant_id,
           quantity: 2,
           productOptions: [],
+          target: 'CART',
         })
         .thenReturn({
           data: {
@@ -2158,6 +2165,7 @@ describe('when a personal customer visits an order', () => {
           variantId: productWithError.variant_id,
           quantity: 2,
           productOptions: [],
+          target: 'CART',
         })
         .thenReturn({
           data: {

--- a/apps/storefront/src/pages/QuickOrder/components/QuickAdd.tsx
+++ b/apps/storefront/src/pages/QuickOrder/components/QuickAdd.tsx
@@ -335,7 +335,7 @@ export default function QuickAdd() {
 
     const productsToValidate = mapCatalogToValidationPayload(variantInfoList, skuValue);
 
-    const { success, warning, error } = await validateProductsLegacy(productsToValidate);
+    const { success, warning, error } = await validateProductsLegacy(productsToValidate, 'CART');
 
     const validProducts = success.map((product) => product.product);
 

--- a/apps/storefront/src/pages/QuickOrder/components/QuickOrderPad.tsx
+++ b/apps/storefront/src/pages/QuickOrder/components/QuickOrderPad.tsx
@@ -269,24 +269,14 @@ export default function QuickOrderPad() {
           })) || [],
       }));
 
-      const validationResult = await validateProducts({ products: productsToValidate });
+      const validationResult = await validateProducts({
+        products: productsToValidate,
+        target: 'CART',
+      });
 
       const outOfStockProducts = validationResult.products.filter(
         (product) => product.errorCode === 'OOS',
       );
-
-      outOfStockProducts.forEach(({ product }) => {
-        snackbar.warning(
-          b3Lang('purchasedProducts.quickOrderPad.notEnoughStock', {
-            variantSku: product.sku,
-          }),
-          {
-            description: b3Lang('purchasedProducts.quickOrderPad.availableAmount', {
-              availableAmount: product.availableToSell,
-            }),
-          },
-        );
-      });
 
       if (outOfStockProducts.length > 0 && stockErrorFile) {
         snackbar.error(
@@ -302,6 +292,19 @@ export default function QuickOrderPad() {
             },
           },
         );
+      } else {
+        outOfStockProducts.forEach(({ product }) => {
+          snackbar.error(
+            b3Lang('purchasedProducts.quickOrderPad.notEnoughStock', {
+              variantSku: product.sku,
+            }),
+            {
+              description: b3Lang('purchasedProducts.quickOrderPad.availableAmount', {
+                availableAmount: product.availableToSell,
+              }),
+            },
+          );
+        });
       }
 
       const nonPurchasableProducts = validationResult.products.filter(

--- a/apps/storefront/src/pages/QuickOrder/index.main.test.tsx
+++ b/apps/storefront/src/pages/QuickOrder/index.main.test.tsx
@@ -4224,6 +4224,7 @@ describe('when backorder validation is enabled', () => {
               quantity: 2,
             }),
           ]),
+          target: 'CART',
         })
         .thenReturn({
           data: {
@@ -4388,6 +4389,7 @@ describe('when backorder validation is enabled', () => {
                 quantity: 3,
               }),
             ]),
+            target: 'CART',
           })
           .thenReturn({
             data: {
@@ -4633,6 +4635,7 @@ describe('when backorder validation is enabled', () => {
               quantity: 1,
             }),
           ]),
+          target: 'CART',
         })
         .thenReturn({
           data: {
@@ -4779,6 +4782,7 @@ describe('when backorder validation is enabled', () => {
               quantity: 5,
             }),
           ]),
+          target: 'CART',
         })
         .thenReturn({
           data: {

--- a/apps/storefront/src/pages/ShoppingListDetails/index.test.tsx
+++ b/apps/storefront/src/pages/ShoppingListDetails/index.test.tsx
@@ -2091,6 +2091,7 @@ describe('when backend validation is enabled', () => {
             productOptions: expect.any(Array),
           },
         ],
+        target: 'CART',
       })
       .thenReturn({
         data: {
@@ -2198,6 +2199,7 @@ describe('when backend validation is enabled', () => {
             productOptions: expect.any(Array),
           },
         ],
+        target: 'CART',
       })
       .thenReturn({
         data: {
@@ -2326,6 +2328,7 @@ describe('when backend validation is enabled', () => {
             productOptions: expect.any(Array),
           },
         ],
+        target: 'CART',
       })
       .thenReturn({
         data: {
@@ -2440,6 +2443,7 @@ describe('when backend validation is enabled', () => {
             productOptions: expect.any(Array),
           },
         ],
+        target: 'CART',
       })
       .thenReturn({
         data: {
@@ -2553,6 +2557,7 @@ describe('when backend validation is enabled', () => {
             productOptions: expect.any(Array),
           },
         ],
+        target: 'CART',
       })
       .thenReturn({
         data: {
@@ -2707,6 +2712,7 @@ describe('when backend validation is enabled', () => {
             productOptions: expect.any(Array),
           },
         ],
+        target: 'CART',
       })
       .thenReturn({
         data: {
@@ -2910,6 +2916,7 @@ describe('when backend validation is enabled', () => {
             productOptions: [{ optionId: 202, optionValue: 'Large' }],
           },
         ],
+        target: 'CART',
       })
       .thenReturn({
         data: {
@@ -3048,6 +3055,7 @@ describe('when backend validation is enabled', () => {
             productOptions: expect.any(Array),
           },
         ],
+        target: 'CART',
       })
       .thenReturn({
         data: {
@@ -3151,6 +3159,7 @@ describe('when backend validation is enabled', () => {
             productOptions: expect.any(Array),
           },
         ],
+        target: 'CART',
       })
       .thenReturn({
         data: {
@@ -3251,6 +3260,7 @@ describe('when backend validation is enabled', () => {
             productOptions: [{ optionId: 303, optionValue: 'Blue' }],
           },
         ],
+        target: 'CART',
       })
       .thenReturn({
         data: {

--- a/apps/storefront/src/pages/ShoppingListDetails/index.tsx
+++ b/apps/storefront/src/pages/ShoppingListDetails/index.tsx
@@ -188,6 +188,7 @@ const partialAddToCart = async (checkedArr: ProductsProps[]) => {
         productOptions: getOptionsList(JSON.parse(item.node.optionList || '[]')),
         item,
       })),
+      'CART',
     );
 
     if (success.length > 0) {

--- a/apps/storefront/src/shared/service/b2b/graphql/product.ts
+++ b/apps/storefront/src/shared/service/b2b/graphql/product.ts
@@ -144,7 +144,7 @@ const getSearchProductsQuery = (data: CustomFieldItems, useVariablesImplementati
 };
 
 const validateProductQuery = `
-  query ValidateProduct ($productId: Int!, $variantId: Int!, $quantity: Int!, $productOptions: [GenericScalar]) {
+  query ValidateProduct ($productId: Int!, $variantId: Int!, $quantity: Int!, $productOptions: [GenericScalar], $target: String) {
     validateProduct(
       productId: $productId
       variantId: $variantId
@@ -152,6 +152,7 @@ const validateProductQuery = `
       productOptions: $productOptions
       storeHash: "${storeHash}"
       channelId: ${channelId}
+      target: $target
     ) {
       responseType
       message
@@ -164,8 +165,8 @@ const validateProductQuery = `
 `;
 
 const validateProductsQuery = `
-  query ValidateProducts ($products: [ValidateProductInputType]!) {
-    validateProducts(products: $products, storeHash: "${storeHash}", channelId: ${channelId}) {
+  query ValidateProducts ($products: [ValidateProductInputType]!, $target: String) {
+    validateProducts(products: $products, storeHash: "${storeHash}", channelId: ${channelId}, target: $target) {
       isValid
       products {
         errorCode
@@ -498,6 +499,8 @@ export const searchProducts = (data: CustomFieldItems = {}) => {
   });
 };
 
+export type ValidationTarget = 'QUOTE' | 'CART';
+
 interface ValidateProductVariables {
   productId: number;
   variantId: number;
@@ -506,9 +509,11 @@ interface ValidateProductVariables {
     optionId: number;
     optionValue: string;
   }[];
+  target?: ValidationTarget;
 }
 interface ValidateProductsVariables {
-  products: ValidateProductVariables[];
+  products: Omit<ValidateProductVariables, 'target'>[];
+  target?: ValidationTarget;
 }
 
 export const validateProduct = (data: ValidateProductVariables) => {

--- a/apps/storefront/src/utils/validateProducts.ts
+++ b/apps/storefront/src/utils/validateProducts.ts
@@ -3,6 +3,7 @@ import {
   QUOTE_VALIDATION_ERROR_CODES,
   validateProduct,
   validateProducts as validateProductsService,
+  type ValidationTarget,
 } from '@/shared/service/b2b/graphql/product';
 
 interface Option {
@@ -181,9 +182,10 @@ function mapToValidateProducts<T extends ValidateProductsInput>(product: T) {
  */
 export const validateProductsLegacy = async <T extends ValidateProductsInput>(
   products: T[],
+  target?: ValidationTarget,
 ): Promise<ValidateProductsLegacyResult<T>> => {
   const results = await Promise.allSettled(
-    products.map(mapToValidateProducts).map(validateProduct),
+    products.map(mapToValidateProducts).map((product) => validateProduct({ ...product, target })),
   );
 
   const validatedProducts = products.map<ValidatedProductLegacy<T>>((product, index) => {
@@ -236,9 +238,11 @@ export const validateProductsLegacy = async <T extends ValidateProductsInput>(
 
 export const validateProducts = async <T extends ValidateProductsInput>(
   products: T[],
+  target?: ValidationTarget,
 ): Promise<ValidateProductsResult<T>> => {
   const { products: results } = await validateProductsService({
     products: products.map(mapToValidateProducts),
+    target,
   });
 
   const validatedProducts = products.map<ValidatedProduct<T>>((product, index) => {


### PR DESCRIPTION
Jira: [B2B-4497](https://bigcommercecloud.atlassian.net/browse/B2B-4497)

## What/Why?

The store-level NP/OOS (Non-Purchasable/Out of Stock) flag is a **quote-level setting** that allows OOS and non-purchasable products to be added to quotes by converting validation errors to warnings. However, all cart flows shared the same `validateProducts` API with no way to opt out of this behavior.

**The bug:** When the NP/OOS flag was enabled, cart flows would receive `WARNING` for OOS/NP products during validation, treat them as valid, and attempt to add them to the cart — only for BigCommerce's cart API to independently reject them. This caused confusing UX where validation passed but cart addition failed.

**The fix:** A new `target` parameter was added to the backend `validateProducts` API (default: `"QUOTE"`). When `target` is `"CART"`, the backend ignores the NP/OOS store flag and always returns `ERROR` for OOS/NP products.

This PR wires up the frontend to pass `target: "CART"` for all cart flows:
- **Quick Order Pad** — CSV bulk upload (`handleAddCSVToCart`)
- **Quick Add** — SKU input (`handleBackendValidation`)
- **Shopping List** — add to cart (`partialAddToCart`)
- **Order Detail** — reorder (`handleReorderBackend`)

Quote flows are unchanged — they omit `target`, defaulting to `"QUOTE"`.

### Changes

**Service layer** (`shared/service/b2b/graphql/product.ts`):
- Added `$target: String` variable to both `validateProductQuery` and `validateProductsQuery` GraphQL queries
- Exported `ValidationTarget` type (`"QUOTE" | "CART"`)
- Added optional `target` field to variable interfaces

**Utility layer** (`utils/validateProducts.ts`):
- Added optional `target` parameter to `validateProducts()` and `validateProductsLegacy()`
- Threaded through to service calls

**Call sites:**
- `QuickOrderPad.tsx` — passes `target: 'CART'` to batch `validateProducts`
- `QuickAdd.tsx` — passes `'CART'` to `validateProductsLegacy`
- `ShoppingListDetails/index.tsx` — passes `'CART'` in `partialAddToCart`
- `OrderDialog.tsx` — passes `'CART'` in reorder validation wrapper

**Tests:**
- Updated mock expectations in `ShoppingListDetails/index.test.tsx`, `OrderDetail/index.test.tsx`, and `QuickOrder/index.main.test.tsx` to include `target: 'CART'` in `calledWith` matchers

## Rollout/Rollback

**Dependency:** This change requires the backend `target` parameter to be deployed first. The backend defaults `target` to `"QUOTE"`, so deploying the frontend before the backend is safe — the parameter will simply be ignored by the old backend.

**Rollback:** Revert this PR. Cart flows will go back to inheriting the quote-level NP/OOS flag behavior. No database migrations or experiment flags involved.

**Behavioral changes when NP/OOS flag is ON:**
| Flow | Before | After |
|------|--------|-------|
| Quick Add (OOS product) | Warning snackbar, not added to cart | Error snackbar with available stock count, not added to cart |
| Shopping List → Cart (OOS product) | No visible change  | No visible change  |
| Quick Order Pad CSV, Order Detail Reorder | No visible change | No visible change |

## Testing
All these have backorder enabled and Non Purchasable & OOS setting enabled in quotes

### Quick Order Pad — CSV Bulk Upload (backorder enabled)
Before:

<img width="1920" height="1014" alt="Before Quick Order Pad Bulk Upload CSV" src="https://github.com/user-attachments/assets/0df30779-018c-44e0-b2af-16db82cb5eeb" />

After:
Also removed the warnings here because that was incorrect behaviour:

<img width="1510" height="822" alt="After Quick Order Pad Bulk Upload CSV with warnings removed" src="https://github.com/user-attachments/assets/7e866ff5-f810-4cc5-a321-d4a8ec1aed9e" />


### Quick Add — SKU input 
Before: 
<img width="1920" height="950" alt="Before Quick Add Sku Input" src="https://github.com/user-attachments/assets/4c3d1d54-df8c-410f-8835-3e9c6baed747" />

After:
<img width="1918" height="930" alt="After Quick Order Sku Input" src="https://github.com/user-attachments/assets/43c0e2fa-4cc9-4f4f-a573-ca94e274e056" />



### Order Detail — Reorder (backorder enabled)

Before:
<img width="1920" height="945" alt="Before Reorder Add To Cart" src="https://github.com/user-attachments/assets/05818a3a-52b1-4d4c-b08e-c531e9adf828" />

After:
<img width="1920" height="936" alt="Screenshot 2026-04-16 at 2 11 29 pm" src="https://github.com/user-attachments/assets/81b44cdb-138c-437a-bde5-eeeb4ec89dd4" />


### Shopping List — Re-add to Cart dialog

Failure dialog correctly shows stock information for OOS products:

Before:
<img width="1352" height="1005" alt="Before Shopping List Add To Cart Error" src="https://github.com/user-attachments/assets/71971b4a-9e9a-4981-8ef2-cdbe19cc4c4b" />

After:
<img width="1512" height="828" alt="After Shopping List Add To Cart Error" src="https://github.com/user-attachments/assets/b5becb2a-8286-4798-9c03-bffa1d2f9277" />

[B2B-4497]: https://bigcommercecloud.atlassian.net/browse/B2B-4497?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared product-validation plumbing and multiple cart entry points, so mistakes could change which items are considered addable to cart or alter error/warning UX. The change also depends on backend support for the new `target` variable, though it should be backward-tolerant if ignored.
> 
> **Overview**
> Cart-related validation now explicitly opts into cart semantics by passing `target: 'CART'` through the validation stack (GraphQL queries in `shared/service/b2b/graphql/product.ts`, utility wrappers in `utils/validateProducts.ts`, and cart entry points like Quick Add, Quick Order Pad CSV, Shopping List add-to-cart, and Order Detail reorder).
> 
> Quick Order Pad CSV handling also adjusts messaging so out-of-stock items surface as errors (and only offers the CSV download action when a `stockErrorFile` is available). Tests were updated to assert the new `target` parameter is included in validation requests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65db4754021e9852499da048fdafe8f1118b603b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->