### PR TITLE
B2b 4611

### DIFF
--- a/apps/storefront/knip.jsonc
+++ b/apps/storefront/knip.jsonc
@@ -30,5 +30,9 @@
     "terser" // Since Vite v3, terser has become an optional dependency. You need to install it.
   ],
   "prettier": true,
-  "ignore": ["src/types/gql/graphql.ts"]
+  "ignore": [
+    "src/types/gql/graphql.ts",
+    "src/shared/service/bc/graphql/base.ts",
+    "src/shared/service/bc/graphql/orders.ts"
+  ]
 }

--- a/apps/storefront/src/shared/service/bc/graphql/base.ts
+++ b/apps/storefront/src/shared/service/bc/graphql/base.ts
@@ -1,0 +1,26 @@
+/**
+ * Shared BC Storefront GraphQL type projections.
+ *
+ * These match the fields selected in SF GQL queries. No codegen exists
+ * for the SF GQL schema; replace with generated types when available.
+ */
+
+export interface Money {
+  currencyCode: string;
+  value: number;
+}
+
+export interface PageInfo {
+  hasNextPage: boolean;
+  hasPreviousPage: boolean;
+  startCursor: string | null;
+  endCursor: string | null;
+}
+
+export interface CollectionInfo {
+  totalItems: number | null;
+}
+
+export interface DateTimeExtended {
+  utc: string;
+}

--- a/apps/storefront/src/shared/service/bc/graphql/orders.ts
+++ b/apps/storefront/src/shared/service/bc/graphql/orders.ts
@@ -4,7 +4,7 @@
  * Replaces b2b/graphql/orders.ts. Base SF GQL types live in ./base.ts.
  * B2B extension types mirror rfc/graphql-schema/additionalTypeDefs/byPage/orders.ts.
  *
- * @see https://developer.bigcommerce.com/docs/storefront/graphql/orders
+ * @see https://docs.bigcommerce.com/developer/api-reference/graphql/storefront/queries/node#fields.body.Order
  */
 
 import { platform } from '@/utils/basicConfig';

--- a/apps/storefront/src/shared/service/bc/graphql/orders.ts
+++ b/apps/storefront/src/shared/service/bc/graphql/orders.ts
@@ -1,9 +1,9 @@
 /**
- * GraphQL Storefront API: Orders (Unified B2B + BC)
- * https://developer.bigcommerce.com/docs/storefront/graphql/orders
+ * Unified SF GQL Orders API (B2B + BC).
  *
- * Replaces the older B2B-specific orders API (b2b/graphql/orders.ts).
- * Follows the same migration pattern as register.ts → company.ts.
+ * Replaces b2b/graphql/orders.ts. Base SF GQL types live in ./base.ts.
+ * B2B extension types mirror rfc/graphql-schema/additionalTypeDefs/byPage/orders.ts.
+ *
  * @see https://developer.bigcommerce.com/docs/storefront/graphql/orders
  */
 
@@ -11,90 +11,64 @@ import { platform } from '@/utils/basicConfig';
 
 import B3Request from '../../request/b3Fetch';
 
-// ---------------------------------------------------------------------------
-// Shared primitive types
-// ---------------------------------------------------------------------------
+import type { CollectionInfo, DateTimeExtended, Money, PageInfo } from './base';
 
-export interface Money {
-  currencyCode: string;
-  value: number;
-}
+export type { CollectionInfo, DateTimeExtended, Money, PageInfo } from './base';
 
-export interface PageInfo {
-  hasNextPage: boolean;
-  hasPreviousPage: boolean;
-  startCursor: string;
-  endCursor: string;
-}
-
-export interface CollectionInfo {
-  totalItems: number;
-}
-
-/** BC Storefront GraphQL DateTimeExtended type. */
-export interface DateTimeExtended {
-  utc: string;
-}
-
-// ---------------------------------------------------------------------------
-// Order status
-// ---------------------------------------------------------------------------
+// ===========================================================================
+// Order-specific SF GQL type projections
+// ===========================================================================
 
 export interface OrderStatus {
-  value: string;
+  value: string | null;
   label: string;
 }
 
-// ---------------------------------------------------------------------------
-// Address
-// ---------------------------------------------------------------------------
-
+/** Covers both OrderBillingAddress and OrderShippingAddress (same interface fields). */
 export interface OrderAddress {
-  firstName: string;
-  lastName: string;
-  company: string;
-  address1: string;
-  address2: string;
-  city: string;
-  stateOrProvince: string;
+  firstName: string | null;
+  lastName: string | null;
+  company: string | null;
+  address1: string | null;
+  address2: string | null;
+  city: string | null;
+  stateOrProvince: string | null;
   postalCode: string;
   country: string;
   countryCode: string;
-  phone: string;
-  email: string;
+  phone: string | null;
+  email: string | null;
 }
 
-// ---------------------------------------------------------------------------
-// Line items & consignments
-// ---------------------------------------------------------------------------
-
-export interface OrderProductOption {
+export interface OrderLineItemProductOption {
   name: string;
   value: string;
 }
 
+/** Projects OrderPhysicalLineItem; OrderDigitalLineItem has a similar shape. */
 export interface OrderLineItem {
   entityId: number;
-  brand: string;
+  brand: string | null;
   name: string;
   quantity: number;
-  productOptions: OrderProductOption[];
+  productOptions: OrderLineItemProductOption[];
   subTotalListPrice: Money;
 }
 
 export interface OrderShipmentTracking {
-  number: string;
-  url: string;
+  number?: string;
+  url?: string;
 }
 
 export interface OrderShipment {
   entityId: number;
-  shippedAt: string;
+  shippedAt: DateTimeExtended;
   shippingMethodName: string;
   shippingProviderName: string;
   tracking: OrderShipmentTracking | null;
 }
 
+/** Projects OrderShippingConsignment. */
 export interface ShippingConsignment {
   entityId: number;
   shippingAddress: OrderAddress;
@@ -107,13 +81,17 @@ export interface OrderConsignments {
   shipping: { edges: Array<{ cursor: string; node: ShippingConsignment }> };
 }
 
-// ---------------------------------------------------------------------------
-// Financial types
-// ---------------------------------------------------------------------------
-
-export interface OrderDiscount {
+/** Nested inside OrderDiscounts.couponDiscounts. */
+export interface OrderCouponDiscount {
   couponCode: string;
   discountedAmount: Money;
+}
+
+/** What Order.discounts returns (OrderDiscounts in SF GQL). */
+export interface OrderDiscounts {
+  couponDiscounts: OrderCouponDiscount[];
+  nonCouponDiscountTotal: Money;
+  totalDiscount: Money | null;
 }
 
 export interface OrderTax {
@@ -121,15 +99,17 @@ export interface OrderTax {
   amount: Money;
 }
 
-// ---------------------------------------------------------------------------
-// B2B extension types
-// ---------------------------------------------------------------------------
+// ===========================================================================
+// B2B extension types (from additionalTypeDefs/byPage/orders.ts)
+// ===========================================================================
 
+/** Projection of Company — selects entityId and name. */
 export interface OrderCompany {
   entityId: number;
   name: string;
 }
 
+/** Projection of Customer — selects identity fields. */
 export interface OrderPlacedBy {
   entityId: number;
   firstName: string;
@@ -148,6 +128,7 @@ export interface OrderHistoryEvent {
   status: string;
   source: string | null;
   createdBy: OrderPlacedBy | null;
+  details: Record<string, unknown> | null;
   createdAt: string;
 }
 
@@ -164,9 +145,9 @@ export interface ExtraFieldValue {
   value: string;
 }
 
-// ---------------------------------------------------------------------------
-// Main Order type (BC base + B2B extensions)
-// ---------------------------------------------------------------------------
+// ===========================================================================
+// Order (base SF GQL fields + B2B extensions)
+// ===========================================================================
 
 export interface Order {
   entityId: number;
@@ -177,7 +158,7 @@ export interface Order {
 
   // Financial
   subTotal: Money;
-  discountedSubTotal: Money;
+  discountedSubTotal: Money | null;
   shippingCostTotal: Money;
   handlingCostTotal: Money;
   wrappingCostTotal: Money;
@@ -185,14 +166,14 @@ export interface Order {
   totalIncTax: Money;
   isTaxIncluded: boolean;
   taxes: OrderTax[];
-  discounts: OrderDiscount[];
+  discounts: OrderDiscounts;
 
   // Content
-  customerMessage: string;
+  customerMessage: string | null;
   totalProductQuantity: number;
-  consignments: OrderConsignments;
+  consignments: OrderConsignments | null;
 
-  // B2B extensions
+  // B2B extensions (null for B2C orders)
   reference: string | null;
   company: OrderCompany | null;
   placedBy: OrderPlacedBy | null;
@@ -202,9 +183,9 @@ export interface Order {
   extraFields: ExtraFieldValue[];
 }
 
-// ---------------------------------------------------------------------------
-// Connection types
-// ---------------------------------------------------------------------------
+// ===========================================================================
+// B2B connection types
+// ===========================================================================
 
 export interface CompanyOrdersEdge {
   node: Order;
@@ -214,7 +195,7 @@ export interface CompanyOrdersEdge {
 export interface CompanyOrdersConnection {
   edges: CompanyOrdersEdge[];
   pageInfo: PageInfo;
-  collectionInfo: CollectionInfo;
+  collectionInfo: CollectionInfo | null;
 }
 
 export interface CompanyCustomerEdge {
@@ -227,9 +208,9 @@ export interface CompanyCustomerConnection {
   pageInfo: PageInfo;
 }
 
-// ---------------------------------------------------------------------------
-// Filter & sort types
-// ---------------------------------------------------------------------------
+// ===========================================================================
+// B2B filter & sort types
+// ===========================================================================
 
 export enum OrdersSortInput {
   ID_A_TO_Z = 'ID_A_TO_Z',
@@ -257,7 +238,13 @@ export interface CompanyOrdersFiltersInput {
   companyIds?: string[];
 }
 
-export interface CustomerOrdersFiltersInput {
+/**
+ * SF GQL OrdersFiltersInput (base) + B2B extension fields.
+ * Base: status, dateRange. Extension: search, companyName, companyIds.
+ */
+export interface OrdersFiltersInput {
+  status?: string;
+  dateRange?: OrderDateRangeFilterInput;
   search?: string;
   companyName?: string;
   companyIds?: string[];
@@ -267,9 +254,9 @@ export interface CustomerWithOrdersFiltersInput {
   companyIds?: string[];
 }
 
-// ---------------------------------------------------------------------------
-// Response types
-// ---------------------------------------------------------------------------
+// ===========================================================================
+// Response wrappers (client-side only)
+// ===========================================================================
 
 export interface GetCompanyOrdersResponse {
   data?: {
@@ -286,9 +273,8 @@ export interface GetCustomerOrdersResponse {
   data?: {
     customer?: {
       orders?: {
-        edges: Array<{ node: Order }>;
+        edges: Array<{ node: Order; cursor: string }>;
         pageInfo: PageInfo;
-        collectionInfo: CollectionInfo;
       };
     };
   };
@@ -315,9 +301,9 @@ export interface GetCustomersWithOrdersResponse {
   errors?: Array<{ message: string }>;
 }
 
-// ---------------------------------------------------------------------------
+// ===========================================================================
 // Fragments
-// ---------------------------------------------------------------------------
+// ===========================================================================
 
 const moneyFields = `currencyCode
   value`;
@@ -353,7 +339,9 @@ const orderLineItemFields = `entityId
       }`;
 
 const orderShipmentFields = `entityId
-      shippedAt
+      shippedAt {
+        utc
+      }
       shippingMethodName
       shippingProviderName
       tracking {
@@ -429,8 +417,16 @@ const orderFinancialFields = `subTotal {
     }
   }
   discounts {
-    couponCode
-    discountedAmount {
+    couponDiscounts {
+      couponCode
+      discountedAmount {
+        ${moneyFields}
+      }
+    }
+    nonCouponDiscountTotal {
+      ${moneyFields}
+    }
+    totalDiscount {
       ${moneyFields}
     }
   }`;
@@ -457,6 +453,7 @@ const orderB2BFields = `reference
       lastName
       email
     }
+    details
     createdAt
   }
   quote {
@@ -490,11 +487,11 @@ export const orderListNodeFields = `entityId
     lastName
   }`;
 
-// ---------------------------------------------------------------------------
+// ===========================================================================
 // Queries
-// ---------------------------------------------------------------------------
+// ===========================================================================
 
-/** Company-scoped order list (B2B). Replaces old `allOrders`. */
+/** Company-scoped order list (B2B). Entry: customer.company.orders. */
 export const GET_COMPANY_ORDERS = `query GetCompanyOrders(
   $filters: CompanyOrdersFiltersInput
   $sortBy: OrdersSortInput
@@ -533,7 +530,12 @@ export const GET_COMPANY_ORDERS = `query GetCompanyOrders(
   }
 }`;
 
-/** Personal order list (customer-scoped). Replaces old `customerOrders`. */
+/**
+ * My Orders (customer-scoped, B2B + B2C). Entry: customer.orders.
+ * B2B fields auto-populate for B2B users, null for B2C.
+ *
+ * Note: OrdersConnection lacks collectionInfo; add once SF GQL team ships it.
+ */
 export const GET_CUSTOMER_ORDERS = `query GetCustomerOrders(
   $filters: OrdersFiltersInput
   $first: Int
@@ -557,14 +559,11 @@ export const GET_CUSTOMER_ORDERS = `query GetCustomerOrders(
         startCursor
         endCursor
       }
-      collectionInfo {
-        totalItems
-      }
     }
   }
 }`;
 
-/** Single order detail. Replaces old `order` / `customerOrder`. */
+/** Single order detail. Entry: site.order. */
 export const GET_ORDER_DETAIL = `query GetOrderDetail($entityId: Int!) {
   site {
     order(filter: { entityId: $entityId }) {
@@ -588,7 +587,7 @@ export const GET_ORDER_DETAIL = `query GetOrderDetail($entityId: Int!) {
   }
 }`;
 
-/** Customers who have placed orders within a company. Used for "Placed By" filter dropdown. */
+/** Company customers who have placed orders. For "Placed By" filter dropdown. */
 export const GET_CUSTOMERS_WITH_ORDERS = `query GetCustomersWithOrders(
   $filters: CustomerWithOrdersFiltersInput
   $first: Int
@@ -621,9 +620,9 @@ export const GET_CUSTOMERS_WITH_ORDERS = `query GetCustomersWithOrders(
   }
 }`;
 
-// ---------------------------------------------------------------------------
+// ===========================================================================
 // Service functions
-// ---------------------------------------------------------------------------
+// ===========================================================================
 
 function graphqlRequest<T>(data: { query: string; variables?: object }): Promise<T> {
   return platform === 'bigcommerce'
@@ -631,11 +630,7 @@ function graphqlRequest<T>(data: { query: string; variables?: object }): Promise
     : B3Request.graphqlBCProxy<T>(data);
 }
 
-/**
- * Fetch company-scoped orders (B2B).
- * Replaces old `getB2BAllOrders`.
- * @see https://developer.bigcommerce.com/docs/storefront/graphql/orders
- */
+/** Company Orders — all orders from all company members (B2B only). */
 export async function getCompanyOrders(variables: {
   filters?: CompanyOrdersFiltersInput;
   sortBy?: OrdersSortInput;
@@ -650,13 +645,9 @@ export async function getCompanyOrders(variables: {
   });
 }
 
-/**
- * Fetch customer-scoped orders (personal / B2C).
- * Replaces old `getBCAllOrders`.
- * @see https://developer.bigcommerce.com/docs/storefront/graphql/orders
- */
+/** My Orders — customer-scoped, unified for B2B and B2C. */
 export async function getCustomerOrders(variables: {
-  filters?: CustomerOrdersFiltersInput;
+  filters?: OrdersFiltersInput;
   first?: number;
   after?: string;
 }): Promise<GetCustomerOrdersResponse> {
@@ -666,11 +657,7 @@ export async function getCustomerOrders(variables: {
   });
 }
 
-/**
- * Fetch a single order detail by entityId.
- * Replaces old `getB2BOrderDetails` / `getBCOrderDetails`.
- * @see https://developer.bigcommerce.com/docs/storefront/graphql/orders
- */
+/** Single order detail by entityId. */
 export async function getOrderDetail(entityId: number): Promise<GetOrderDetailResponse> {
   return graphqlRequest<GetOrderDetailResponse>({
     query: GET_ORDER_DETAIL,
@@ -678,10 +665,7 @@ export async function getOrderDetail(entityId: number): Promise<GetOrderDetailRe
   });
 }
 
-/**
- * Fetch customers who have placed orders within a company.
- * Used for "Placed By" filter dropdown.
- */
+/** Customers who have placed orders within a company. */
 export async function getCustomersWithOrders(variables: {
   filters?: CustomerWithOrdersFiltersInput;
   first?: number;

--- a/apps/storefront/src/shared/service/bc/graphql/orders.ts
+++ b/apps/storefront/src/shared/service/bc/graphql/orders.ts
@@ -1,0 +1,694 @@
+/**
+ * GraphQL Storefront API: Orders (Unified B2B + BC)
+ * https://developer.bigcommerce.com/docs/storefront/graphql/orders
+ *
+ * Replaces the older B2B-specific orders API (b2b/graphql/orders.ts).
+ * Follows the same migration pattern as register.ts → company.ts.
+ * @see https://developer.bigcommerce.com/docs/storefront/graphql/orders
+ */
+
+import { platform } from '@/utils/basicConfig';
+
+import B3Request from '../../request/b3Fetch';
+
+// ---------------------------------------------------------------------------
+// Shared primitive types
+// ---------------------------------------------------------------------------
+
+export interface Money {
+  currencyCode: string;
+  value: number;
+}
+
+export interface PageInfo {
+  hasNextPage: boolean;
+  hasPreviousPage: boolean;
+  startCursor: string;
+  endCursor: string;
+}
+
+export interface CollectionInfo {
+  totalItems: number;
+}
+
+/** BC Storefront GraphQL DateTimeExtended type. */
+export interface DateTimeExtended {
+  utc: string;
+}
+
+// ---------------------------------------------------------------------------
+// Order status
+// ---------------------------------------------------------------------------
+
+export interface OrderStatus {
+  value: string;
+  label: string;
+}
+
+// ---------------------------------------------------------------------------
+// Address
+// ---------------------------------------------------------------------------
+
+export interface OrderAddress {
+  firstName: string;
+  lastName: string;
+  company: string;
+  address1: string;
+  address2: string;
+  city: string;
+  stateOrProvince: string;
+  postalCode: string;
+  country: string;
+  countryCode: string;
+  phone: string;
+  email: string;
+}
+
+// ---------------------------------------------------------------------------
+// Line items & consignments
+// ---------------------------------------------------------------------------
+
+export interface OrderProductOption {
+  name: string;
+  value: string;
+}
+
+export interface OrderLineItem {
+  entityId: number;
+  brand: string;
+  name: string;
+  quantity: number;
+  productOptions: OrderProductOption[];
+  subTotalListPrice: Money;
+}
+
+export interface OrderShipmentTracking {
+  number: string;
+  url: string;
+}
+
+export interface OrderShipment {
+  entityId: number;
+  shippedAt: string;
+  shippingMethodName: string;
+  shippingProviderName: string;
+  tracking: OrderShipmentTracking | null;
+}
+
+export interface ShippingConsignment {
+  entityId: number;
+  shippingAddress: OrderAddress;
+  shippingCost: Money;
+  lineItems: { edges: Array<{ node: OrderLineItem }> };
+  shipments: { edges: Array<{ node: OrderShipment }> };
+}
+
+export interface OrderConsignments {
+  shipping: { edges: Array<{ cursor: string; node: ShippingConsignment }> };
+}
+
+// ---------------------------------------------------------------------------
+// Financial types
+// ---------------------------------------------------------------------------
+
+export interface OrderDiscount {
+  couponCode: string;
+  discountedAmount: Money;
+}
+
+export interface OrderTax {
+  name: string;
+  amount: Money;
+}
+
+// ---------------------------------------------------------------------------
+// B2B extension types
+// ---------------------------------------------------------------------------
+
+export interface OrderCompany {
+  entityId: number;
+  name: string;
+}
+
+export interface OrderPlacedBy {
+  entityId: number;
+  firstName: string;
+  lastName: string;
+  email: string;
+}
+
+export enum OrderHistoryEventType {
+  ORDER_CREATED = 'ORDER_CREATED',
+  ORDER_UPDATED = 'ORDER_UPDATED',
+}
+
+export interface OrderHistoryEvent {
+  id: string;
+  eventType: OrderHistoryEventType;
+  status: string;
+  source: string | null;
+  createdBy: OrderPlacedBy | null;
+  createdAt: string;
+}
+
+export interface OrderQuote {
+  id: string;
+}
+
+export interface OrderInvoice {
+  id: string;
+}
+
+export interface ExtraFieldValue {
+  name: string;
+  value: string;
+}
+
+// ---------------------------------------------------------------------------
+// Main Order type (BC base + B2B extensions)
+// ---------------------------------------------------------------------------
+
+export interface Order {
+  entityId: number;
+  orderedAt: DateTimeExtended;
+  updatedAt: DateTimeExtended;
+  status: OrderStatus;
+  billingAddress: OrderAddress;
+
+  // Financial
+  subTotal: Money;
+  discountedSubTotal: Money;
+  shippingCostTotal: Money;
+  handlingCostTotal: Money;
+  wrappingCostTotal: Money;
+  taxTotal: Money;
+  totalIncTax: Money;
+  isTaxIncluded: boolean;
+  taxes: OrderTax[];
+  discounts: OrderDiscount[];
+
+  // Content
+  customerMessage: string;
+  totalProductQuantity: number;
+  consignments: OrderConsignments;
+
+  // B2B extensions
+  reference: string | null;
+  company: OrderCompany | null;
+  placedBy: OrderPlacedBy | null;
+  history: OrderHistoryEvent[];
+  quote: OrderQuote | null;
+  invoice: OrderInvoice | null;
+  extraFields: ExtraFieldValue[];
+}
+
+// ---------------------------------------------------------------------------
+// Connection types
+// ---------------------------------------------------------------------------
+
+export interface CompanyOrdersEdge {
+  node: Order;
+  cursor: string;
+}
+
+export interface CompanyOrdersConnection {
+  edges: CompanyOrdersEdge[];
+  pageInfo: PageInfo;
+  collectionInfo: CollectionInfo;
+}
+
+export interface CompanyCustomerEdge {
+  node: OrderPlacedBy;
+  cursor: string;
+}
+
+export interface CompanyCustomerConnection {
+  edges: CompanyCustomerEdge[];
+  pageInfo: PageInfo;
+}
+
+// ---------------------------------------------------------------------------
+// Filter & sort types
+// ---------------------------------------------------------------------------
+
+export enum OrdersSortInput {
+  ID_A_TO_Z = 'ID_A_TO_Z',
+  ID_Z_TO_A = 'ID_Z_TO_A',
+  REFERENCE_A_TO_Z = 'REFERENCE_A_TO_Z',
+  REFERENCE_Z_TO_A = 'REFERENCE_Z_TO_A',
+  HIGHEST_TOTAL_INC_TAX = 'HIGHEST_TOTAL_INC_TAX',
+  LOWEST_TOTAL_INC_TAX = 'LOWEST_TOTAL_INC_TAX',
+  STATUS_A_TO_Z = 'STATUS_A_TO_Z',
+  STATUS_Z_TO_A = 'STATUS_Z_TO_A',
+  CREATED_AT_NEWEST = 'CREATED_AT_NEWEST',
+  CREATED_AT_OLDEST = 'CREATED_AT_OLDEST',
+}
+
+export interface OrderDateRangeFilterInput {
+  from: string;
+  to?: string;
+}
+
+export interface CompanyOrdersFiltersInput {
+  search?: string;
+  dateRange?: OrderDateRangeFilterInput;
+  status?: string[];
+  customerId?: number[];
+  companyIds?: string[];
+}
+
+export interface CustomerOrdersFiltersInput {
+  search?: string;
+  companyName?: string;
+  companyIds?: string[];
+}
+
+export interface CustomerWithOrdersFiltersInput {
+  companyIds?: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Response types
+// ---------------------------------------------------------------------------
+
+export interface GetCompanyOrdersResponse {
+  data?: {
+    customer?: {
+      company?: {
+        orders?: CompanyOrdersConnection;
+      };
+    };
+  };
+  errors?: Array<{ message: string }>;
+}
+
+export interface GetCustomerOrdersResponse {
+  data?: {
+    customer?: {
+      orders?: {
+        edges: Array<{ node: Order }>;
+        pageInfo: PageInfo;
+        collectionInfo: CollectionInfo;
+      };
+    };
+  };
+  errors?: Array<{ message: string }>;
+}
+
+export interface GetOrderDetailResponse {
+  data?: {
+    site?: {
+      order?: Order;
+    };
+  };
+  errors?: Array<{ message: string }>;
+}
+
+export interface GetCustomersWithOrdersResponse {
+  data?: {
+    customer?: {
+      company?: {
+        customersWithOrders?: CompanyCustomerConnection;
+      };
+    };
+  };
+  errors?: Array<{ message: string }>;
+}
+
+// ---------------------------------------------------------------------------
+// Fragments
+// ---------------------------------------------------------------------------
+
+const moneyFields = `currencyCode
+  value`;
+
+const orderStatusFields = `status {
+    value
+    label
+  }`;
+
+const orderAddressFields = `firstName
+    lastName
+    company
+    address1
+    address2
+    city
+    stateOrProvince
+    postalCode
+    country
+    countryCode
+    phone
+    email`;
+
+const orderLineItemFields = `entityId
+      brand
+      name
+      quantity
+      productOptions {
+        name
+        value
+      }
+      subTotalListPrice {
+        ${moneyFields}
+      }`;
+
+const orderShipmentFields = `entityId
+      shippedAt
+      shippingMethodName
+      shippingProviderName
+      tracking {
+        ... on OrderShipmentNumberAndUrlTracking {
+          number
+          url
+        }
+        ... on OrderShipmentNumberOnlyTracking {
+          number
+        }
+        ... on OrderShipmentUrlOnlyTracking {
+          url
+        }
+      }`;
+
+const orderConsignmentsFields = `consignments {
+    shipping {
+      edges {
+        cursor
+        node {
+          entityId
+          shippingAddress {
+            ${orderAddressFields}
+          }
+          shippingCost {
+            ${moneyFields}
+          }
+          lineItems {
+            edges {
+              node {
+                ${orderLineItemFields}
+              }
+            }
+          }
+          shipments {
+            edges {
+              node {
+                ${orderShipmentFields}
+              }
+            }
+          }
+        }
+      }
+    }
+  }`;
+
+const orderFinancialFields = `subTotal {
+    ${moneyFields}
+  }
+  discountedSubTotal {
+    ${moneyFields}
+  }
+  shippingCostTotal {
+    ${moneyFields}
+  }
+  handlingCostTotal {
+    ${moneyFields}
+  }
+  wrappingCostTotal {
+    ${moneyFields}
+  }
+  taxTotal {
+    ${moneyFields}
+  }
+  totalIncTax {
+    ${moneyFields}
+  }
+  isTaxIncluded
+  taxes {
+    name
+    amount {
+      ${moneyFields}
+    }
+  }
+  discounts {
+    couponCode
+    discountedAmount {
+      ${moneyFields}
+    }
+  }`;
+
+const orderB2BFields = `reference
+  company {
+    entityId
+    name
+  }
+  placedBy {
+    entityId
+    firstName
+    lastName
+    email
+  }
+  history {
+    id
+    eventType
+    status
+    source
+    createdBy {
+      entityId
+      firstName
+      lastName
+      email
+    }
+    createdAt
+  }
+  quote {
+    id
+  }
+  invoice {
+    id
+  }
+  extraFields {
+    name
+    value
+  }`;
+
+/** Lightweight fields for order list views. */
+export const orderListNodeFields = `entityId
+  orderedAt {
+    utc
+  }
+  ${orderStatusFields}
+  totalIncTax {
+    ${moneyFields}
+  }
+  reference
+  company {
+    entityId
+    name
+  }
+  placedBy {
+    entityId
+    firstName
+    lastName
+  }`;
+
+// ---------------------------------------------------------------------------
+// Queries
+// ---------------------------------------------------------------------------
+
+/** Company-scoped order list (B2B). Replaces old `allOrders`. */
+export const GET_COMPANY_ORDERS = `query GetCompanyOrders(
+  $filters: CompanyOrdersFiltersInput
+  $sortBy: OrdersSortInput
+  $first: Int
+  $after: String
+  $last: Int
+  $before: String
+) {
+  customer {
+    company {
+      orders(
+        filters: $filters
+        sortBy: $sortBy
+        first: $first
+        after: $after
+        last: $last
+        before: $before
+      ) {
+        edges {
+          node {
+            ${orderListNodeFields}
+          }
+          cursor
+        }
+        pageInfo {
+          hasNextPage
+          hasPreviousPage
+          startCursor
+          endCursor
+        }
+        collectionInfo {
+          totalItems
+        }
+      }
+    }
+  }
+}`;
+
+/** Personal order list (customer-scoped). Replaces old `customerOrders`. */
+export const GET_CUSTOMER_ORDERS = `query GetCustomerOrders(
+  $filters: OrdersFiltersInput
+  $first: Int
+  $after: String
+) {
+  customer {
+    orders(
+      filters: $filters
+      first: $first
+      after: $after
+    ) {
+      edges {
+        node {
+          ${orderListNodeFields}
+        }
+        cursor
+      }
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      collectionInfo {
+        totalItems
+      }
+    }
+  }
+}`;
+
+/** Single order detail. Replaces old `order` / `customerOrder`. */
+export const GET_ORDER_DETAIL = `query GetOrderDetail($entityId: Int!) {
+  site {
+    order(filter: { entityId: $entityId }) {
+      entityId
+      orderedAt {
+        utc
+      }
+      updatedAt {
+        utc
+      }
+      ${orderStatusFields}
+      billingAddress {
+        ${orderAddressFields}
+      }
+      ${orderFinancialFields}
+      customerMessage
+      totalProductQuantity
+      ${orderConsignmentsFields}
+      ${orderB2BFields}
+    }
+  }
+}`;
+
+/** Customers who have placed orders within a company. Used for "Placed By" filter dropdown. */
+export const GET_CUSTOMERS_WITH_ORDERS = `query GetCustomersWithOrders(
+  $filters: CustomerWithOrdersFiltersInput
+  $first: Int
+  $after: String
+) {
+  customer {
+    company {
+      customersWithOrders(
+        filters: $filters
+        first: $first
+        after: $after
+      ) {
+        edges {
+          node {
+            entityId
+            firstName
+            lastName
+            email
+          }
+          cursor
+        }
+        pageInfo {
+          hasNextPage
+          hasPreviousPage
+          startCursor
+          endCursor
+        }
+      }
+    }
+  }
+}`;
+
+// ---------------------------------------------------------------------------
+// Service functions
+// ---------------------------------------------------------------------------
+
+function graphqlRequest<T>(data: { query: string; variables?: object }): Promise<T> {
+  return platform === 'bigcommerce'
+    ? B3Request.graphqlBC<T>(data)
+    : B3Request.graphqlBCProxy<T>(data);
+}
+
+/**
+ * Fetch company-scoped orders (B2B).
+ * Replaces old `getB2BAllOrders`.
+ * @see https://developer.bigcommerce.com/docs/storefront/graphql/orders
+ */
+export async function getCompanyOrders(variables: {
+  filters?: CompanyOrdersFiltersInput;
+  sortBy?: OrdersSortInput;
+  first?: number;
+  after?: string;
+  last?: number;
+  before?: string;
+}): Promise<GetCompanyOrdersResponse> {
+  return graphqlRequest<GetCompanyOrdersResponse>({
+    query: GET_COMPANY_ORDERS,
+    variables,
+  });
+}
+
+/**
+ * Fetch customer-scoped orders (personal / B2C).
+ * Replaces old `getBCAllOrders`.
+ * @see https://developer.bigcommerce.com/docs/storefront/graphql/orders
+ */
+export async function getCustomerOrders(variables: {
+  filters?: CustomerOrdersFiltersInput;
+  first?: number;
+  after?: string;
+}): Promise<GetCustomerOrdersResponse> {
+  return graphqlRequest<GetCustomerOrdersResponse>({
+    query: GET_CUSTOMER_ORDERS,
+    variables,
+  });
+}
+
+/**
+ * Fetch a single order detail by entityId.
+ * Replaces old `getB2BOrderDetails` / `getBCOrderDetails`.
+ * @see https://developer.bigcommerce.com/docs/storefront/graphql/orders
+ */
+export async function getOrderDetail(entityId: number): Promise<GetOrderDetailResponse> {
+  return graphqlRequest<GetOrderDetailResponse>({
+    query: GET_ORDER_DETAIL,
+    variables: { entityId },
+  });
+}
+
+/**
+ * Fetch customers who have placed orders within a company.
+ * Used for "Placed By" filter dropdown.
+ */
+export async function getCustomersWithOrders(variables: {
+  filters?: CustomerWithOrdersFiltersInput;
+  first?: number;
+  after?: string;
+}): Promise<GetCustomersWithOrdersResponse> {
+  return graphqlRequest<GetCustomersWithOrdersResponse>({
+    query: GET_CUSTOMERS_WITH_ORDERS,
+    variables,
+  });
+}

--- a/apps/storefront/src/shared/service/bc/graphql/orders.ts
+++ b/apps/storefront/src/shared/service/bc/graphql/orders.ts
@@ -538,6 +538,7 @@ const GET_COMPANY_ORDERS = `query GetCompanyOrders(
  */
 const GET_CUSTOMER_ORDERS = `query GetCustomerOrders(
   $filters: OrdersFiltersInput
+  $sortBy: OrdersSortInput
   $first: Int
   $after: String
   $last: Int
@@ -546,6 +547,7 @@ const GET_CUSTOMER_ORDERS = `query GetCustomerOrders(
   customer {
     orders(
       filters: $filters
+      sortBy: $sortBy
       first: $first
       after: $after
       last: $last
@@ -652,6 +654,7 @@ export async function getCompanyOrders(variables: {
 /** My Orders — customer-scoped, unified for B2B and B2C. */
 export async function getCustomerOrders(variables: {
   filters?: OrdersFiltersInput;
+  sortBy?: OrdersSortInput;
   first?: number;
   after?: string;
   last?: number;

--- a/apps/storefront/src/shared/service/bc/graphql/orders.ts
+++ b/apps/storefront/src/shared/service/bc/graphql/orders.ts
@@ -468,7 +468,7 @@ const orderB2BFields = `reference
   }`;
 
 /** Lightweight fields for order list views. */
-export const orderListNodeFields = `entityId
+const orderListNodeFields = `entityId
   orderedAt {
     utc
   }
@@ -492,7 +492,7 @@ export const orderListNodeFields = `entityId
 // ===========================================================================
 
 /** Company-scoped order list (B2B). Entry: customer.company.orders. */
-export const GET_COMPANY_ORDERS = `query GetCompanyOrders(
+const GET_COMPANY_ORDERS = `query GetCompanyOrders(
   $filters: CompanyOrdersFiltersInput
   $sortBy: OrdersSortInput
   $first: Int
@@ -536,16 +536,20 @@ export const GET_COMPANY_ORDERS = `query GetCompanyOrders(
  *
  * Note: OrdersConnection lacks collectionInfo; add once SF GQL team ships it.
  */
-export const GET_CUSTOMER_ORDERS = `query GetCustomerOrders(
+const GET_CUSTOMER_ORDERS = `query GetCustomerOrders(
   $filters: OrdersFiltersInput
   $first: Int
   $after: String
+  $last: Int
+  $before: String
 ) {
   customer {
     orders(
       filters: $filters
       first: $first
       after: $after
+      last: $last
+      before: $before
     ) {
       edges {
         node {
@@ -564,7 +568,7 @@ export const GET_CUSTOMER_ORDERS = `query GetCustomerOrders(
 }`;
 
 /** Single order detail. Entry: site.order. */
-export const GET_ORDER_DETAIL = `query GetOrderDetail($entityId: Int!) {
+const GET_ORDER_DETAIL = `query GetOrderDetail($entityId: Int!) {
   site {
     order(filter: { entityId: $entityId }) {
       entityId
@@ -588,7 +592,7 @@ export const GET_ORDER_DETAIL = `query GetOrderDetail($entityId: Int!) {
 }`;
 
 /** Company customers who have placed orders. For "Placed By" filter dropdown. */
-export const GET_CUSTOMERS_WITH_ORDERS = `query GetCustomersWithOrders(
+const GET_CUSTOMERS_WITH_ORDERS = `query GetCustomersWithOrders(
   $filters: CustomerWithOrdersFiltersInput
   $first: Int
   $after: String
@@ -650,6 +654,8 @@ export async function getCustomerOrders(variables: {
   filters?: OrdersFiltersInput;
   first?: number;
   after?: string;
+  last?: number;
+  before?: string;
 }): Promise<GetCustomerOrdersResponse> {
   return graphqlRequest<GetCustomerOrdersResponse>({
     query: GET_CUSTOMER_ORDERS,
@@ -658,10 +664,12 @@ export async function getCustomerOrders(variables: {
 }
 
 /** Single order detail by entityId. */
-export async function getOrderDetail(entityId: number): Promise<GetOrderDetailResponse> {
+export async function getOrderDetail(variables: {
+  entityId: number;
+}): Promise<GetOrderDetailResponse> {
   return graphqlRequest<GetOrderDetailResponse>({
     query: GET_ORDER_DETAIL,
-    variables: { entityId },
+    variables,
   });
 }
 

--- a/apps/storefront/src/shared/service/bc/index.ts
+++ b/apps/storefront/src/shared/service/bc/index.ts
@@ -3,3 +3,4 @@ export { default as getActiveBcCurrency } from './graphql/currency';
 export * from './graphql/login';
 export * from './graphql/company';
 export * from './graphql/user';
+export * from './graphql/orders';


### PR DESCRIPTION
Jira: [B2B-4611](https://bigcommercecloud.atlassian.net/browse/B2B-4611)

## What/Why?

Defines the SF GQL query documents, fragments, and TypeScript types for the unified Orders API (B2B + BC). This is ticket **1a** of the Orders migration (PROJECT-7918) and establishes the type-safe contract that all subsequent migration tickets build against.

### What changed

**New file: `bc/graphql/base.ts`**
Shared SF GQL type projections reusable across domains: `Money`, `PageInfo`, `CollectionInfo`, `DateTimeExtended`.

**New file: `bc/graphql/orders.ts`**
Order-specific types, fragments, queries, and service functions replacing `b2b/graphql/orders.ts`.

- **4 queries**: `GET_CUSTOMER_ORDERS` (My Orders, B2B+B2C), `GET_COMPANY_ORDERS` (Company Orders, B2B), `GET_ORDER_DETAIL` (single order), `GET_CUSTOMERS_WITH_ORDERS` (Placed By dropdown)
- **4 service functions**: `getCustomerOrders`, `getCompanyOrders`, `getOrderDetail`, `getCustomersWithOrders` — all routed through `graphqlRequest<T>()` which handles platform branching (`graphqlBC` vs `graphqlBCProxy`)
- **9 fragments**: `moneyFields`, `orderStatusFields`, `orderAddressFields`, `orderLineItemFields`, `orderShipmentFields`, `orderConsignmentsFields`, `orderFinancialFields`, `orderB2BFields`, `orderListNodeFields`
- **TypeScript types** for all query response shapes, B2B extension types aligned with the [unified schema gist](https://gist.github.com/bc-keelan/40523ed19d9ad8274fbcbc93631cdb60), and SF GQL base types validated via live schema introspection

### Why

The old orders code (`b2b/graphql/orders.ts`) talks to the B2B Edition API with 6 separate service functions that branch on `isB2BUser`. The new unified SF GQL API eliminates this — one `Order` type serves both B2B and B2C, with B2B fields returning `null` for B2C orders. Branching shifts from user type to view (My Orders vs Company Orders).

### Schema validation performed

Base SF GQL types were validated via live schema introspection (was done with the help of Claude). Two bugs were found and fixed during validation:

1. **`shippedAt`** — `OrderShipment.shippedAt` is `DateTimeExtended!` (an object with `.utc`), not a plain string. Query updated from `shippedAt` to `shippedAt { utc }`, type updated accordingly.
2. **`discounts`** — `Order.discounts` returns `OrderDiscounts` which nests coupon data inside `couponDiscounts[]`. Query restructured from flat `discounts { couponCode ... }` to `discounts { couponDiscounts { couponCode ... } nonCouponDiscountTotal { ... } totalDiscount { ... } }`.

Nullability corrections applied based on introspection (e.g., `PageInfo.startCursor/endCursor`, `CollectionInfo.totalItems`, `OrderStatus.value`, several `OrderAddress` fields, `Order.discountedSubTotal`, `Order.consignments`, `Order.customerMessage`).

All B2B extension types verified 1-to-1 against the unified schema gist.

## Rollout/Rollback

No rollout risk. This PR adds new files only (`base.ts`, `orders.ts`) with no consumers yet. The old `b2b/graphql/orders.ts` is untouched. Subsequent tickets (1b, 2a, etc.) will wire these into the UI.

Rollback: revert the commit. No database migrations, no feature flags, no runtime impact.

## Testing

- TypeScript compilation passes with no errors (`npx tsc --noEmit`)
- No existing code imports from the new files yet, so no runtime behavior changes
- Types validated against:
  - Live SF GQL schema introspection (all base type fields, nullability, query paths confirmed)
  - Unified schema gist (all B2B extension types, enums, inputs, connections matched 1-to-1)
  - B2B-4611 acceptance criteria (all items checked — see below)

### B2B-4611 AC checklist

**Fragments:**
- [x] Order list fields (ID, status, totals, reference, company, placedBy, currency)
- [x] Order detail fields (consignments, billingAddress, history, extraFields, invoice, quote)
- [x] `OrderHistoryEvent` fields (id, eventType, status, source, createdBy, details, createdAt)
- [x] `ExtraFieldValue` fields (name, value)
- [x] `CompanyOrdersConnection` / `CompanyOrdersEdge` / `PageInfo` with `collectionInfo.totalItems`
- [x] `OrdersConnection` / `OrdersEdge` structure (no `collectionInfo` yet)

**Queries:**
- [x] My Orders listing (`customer.orders`) extended with B2B fields
- [x] Company Orders listing (`customer.company.orders`) with `CompanyOrdersFiltersInput`, `OrdersSortInput`, cursor pagination
- [x] Single order detail by ID (`site.order`) with full B2B extensions
- [x] Placed-by users (`customer.company.customersWithOrders`) with `CustomerWithOrdersFiltersInput`

**TypeScript types replacing old types:**
- [x] `B2BOrderData` -> unified `Order`
- [x] `OrderProductItem`, `EditableProductItem` -> `OrderLineItem`
- [x] `OrderShippingsItem`, `OrderShipmentItem` -> `ShippingConsignment`, `OrderShipment`
- [x] `OrderHistoryItem` -> `OrderHistoryEvent`
- [x] `MoneyFormat` -> `Money`
- [x] `OrderPayment`, `OrderBillings`, `OrderSummary` -> derived from `Order` financial fields

**Other:**
- [x] Types align with unified schema gist + local `additionalTypeDefs`
- [x] `CompanyOrdersFiltersInput` includes search, dateRange, status, customerId, companyIds
- [x] `OrdersSortInput` enum (10 values)
- [x] `OrdersFiltersInput` includes base fields (status, dateRange) + B2B extension fields (search, companyName, companyIds)


[B2B-4611]: https://bigcommercecloud.atlassian.net/browse/B2B-4611?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because this PR only adds new TypeScript types/query documents and service wrappers (plus an export/knip ignore) without changing existing order flows or consumers.
> 
> **Overview**
> Introduces a new unified Storefront GraphQL Orders module (`bc/graphql/orders.ts`) with typed projections, reusable query fragments, and four query wrappers (`getCustomerOrders`, `getCompanyOrders`, `getOrderDetail`, `getCustomersWithOrders`) that route via `graphqlBC` vs `graphqlBCProxy` based on `platform`.
> 
> Adds shared SF GQL base projections in `bc/graphql/base.ts`, exports the new orders module from `bc/index.ts`, and updates `knip.jsonc` ignores to avoid unused-file reports for these new non-codegen type/query files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3db651b999c4aed7f40a5818689aac565dc1439. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->