### PR TITLE
feat(quotes): BACK-600 quote draft shipping expectation

### DIFF
--- a/apps/storefront/src/pages/quote/components/QuoteSummary.test.tsx
+++ b/apps/storefront/src/pages/quote/components/QuoteSummary.test.tsx
@@ -1,0 +1,194 @@
+import { PersistPartial } from 'redux-persist/es/persistReducer';
+import { buildGlobalStateWith, renderWithProviders, screen } from 'tests/test-utils';
+
+import { QuoteInfoState } from '@/store/slices/quoteInfo';
+import { QuoteItem } from '@/types/quotes';
+
+import QuoteSummary from './QuoteSummary';
+
+const expectationMessage = 'Backordered items will ship separately.';
+
+const emptyDraftQuoteInfo: QuoteInfoState['draftQuoteInfo'] = {
+  userId: 0,
+  contactInfo: {
+    name: '',
+    email: '',
+    companyName: '',
+    phoneNumber: '',
+    quoteTitle: '',
+  },
+  shippingAddress: {
+    address: '',
+    addressId: 0,
+    apartment: '',
+    companyName: '',
+    city: '',
+    country: '',
+    firstName: '',
+    label: '',
+    lastName: '',
+    phoneNumber: '',
+    state: '',
+    zipCode: '',
+  },
+  billingAddress: {
+    address: '',
+    addressId: 0,
+    apartment: '',
+    companyName: '',
+    city: '',
+    country: '',
+    firstName: '',
+    label: '',
+    lastName: '',
+    phoneNumber: '',
+    state: '',
+    zipCode: '',
+  },
+  fileInfo: [],
+  note: '',
+  referenceNumber: '',
+  extraFields: [],
+  recipients: [],
+};
+
+function buildQuoteInfoWithList(draftQuoteList: QuoteItem[]): QuoteInfoState & PersistPartial {
+  return {
+    draftQuoteList,
+    draftQuoteInfo: emptyDraftQuoteInfo,
+    quoteDetailToCheckoutUrl: '',
+    _persist: { version: 1, rehydrated: true },
+  };
+}
+
+const withPromptEnabled = (draftQuoteList: QuoteItem[]) => ({
+  preloadedState: {
+    global: buildGlobalStateWith({
+      backorderEnabled: true,
+      backorderDisplaySettings: {
+        showDefaultShippingExpectationPrompt: true,
+        defaultShippingExpectationPrompt: expectationMessage,
+      },
+      featureFlags: {
+        'BACK-134.backorders_phase_1_1_control_messaging_on_storefront': true,
+      },
+    }),
+    quoteInfo: buildQuoteInfoWithList(draftQuoteList),
+  },
+});
+
+const withMessagingFlagDisabled = (draftQuoteList: QuoteItem[]) => ({
+  preloadedState: {
+    global: buildGlobalStateWith({
+      backorderEnabled: true,
+      backorderDisplaySettings: {
+        showDefaultShippingExpectationPrompt: true,
+        defaultShippingExpectationPrompt: expectationMessage,
+      },
+      featureFlags: {
+        'BACK-134.backorders_phase_1_1_control_messaging_on_storefront': false,
+      },
+    }),
+    quoteInfo: buildQuoteInfoWithList(draftQuoteList),
+  },
+});
+
+const withBackorderDisabled = (draftQuoteList: QuoteItem[]) => ({
+  preloadedState: {
+    global: buildGlobalStateWith({
+      backorderEnabled: false,
+      backorderDisplaySettings: {
+        showDefaultShippingExpectationPrompt: true,
+        defaultShippingExpectationPrompt: expectationMessage,
+      },
+      featureFlags: {
+        'BACK-134.backorders_phase_1_1_control_messaging_on_storefront': true,
+      },
+    }),
+    quoteInfo: buildQuoteInfoWithList(draftQuoteList),
+  },
+});
+
+const withDefaultShippingExpectationPromptDisabled = (draftQuoteList: QuoteItem[]) => ({
+  preloadedState: {
+    global: buildGlobalStateWith({
+      backorderEnabled: true,
+      backorderDisplaySettings: {
+        showDefaultShippingExpectationPrompt: false,
+        defaultShippingExpectationPrompt: expectationMessage,
+      },
+      featureFlags: {
+        'BACK-134.backorders_phase_1_1_control_messaging_on_storefront': true,
+      },
+    }),
+    quoteInfo: buildQuoteInfoWithList(draftQuoteList),
+  },
+});
+
+const lineItemWithBackorder: QuoteItem = {
+  node: {
+    id: 'item-1',
+    basePrice: 10,
+    taxPrice: 0,
+    quantity: 10,
+    variantSku: 'V1',
+    productsSearch: {
+      inventoryTracking: 'product',
+      totalOnHand: 3,
+      availableToSell: 10,
+      unlimitedBackorder: false,
+      backorderMessage: 'Restock soon',
+    },
+  },
+} as QuoteItem;
+
+const lineItemInStock: QuoteItem = {
+  node: {
+    id: 'item-1',
+    basePrice: 10,
+    taxPrice: 0,
+    quantity: 2,
+    variantSku: 'V1',
+    productsSearch: {
+      inventoryTracking: 'product',
+      totalOnHand: 5,
+      availableToSell: 10,
+      unlimitedBackorder: false,
+    },
+  },
+} as QuoteItem;
+
+describe('QuoteSummary shipping expectation prompt', () => {
+  it('shows the prompt when the draft has backordered items and messaging is enabled', () => {
+    renderWithProviders(<QuoteSummary />, withPromptEnabled([lineItemWithBackorder]));
+
+    expect(screen.getByText(expectationMessage)).toBeVisible();
+  });
+
+  it('hides the prompt when no item qualifies as backordered for display', () => {
+    renderWithProviders(<QuoteSummary />, withPromptEnabled([lineItemInStock]));
+
+    expect(screen.queryByText(expectationMessage)).toBeNull();
+  });
+
+  it('hides the prompt when storefront messaging feature flag is off, even with backordered items', () => {
+    renderWithProviders(<QuoteSummary />, withMessagingFlagDisabled([lineItemWithBackorder]));
+
+    expect(screen.queryByText(expectationMessage)).toBeNull();
+  });
+
+  it('hides the prompt when backorders are disabled for the store, even with backordered items', () => {
+    renderWithProviders(<QuoteSummary />, withBackorderDisabled([lineItemWithBackorder]));
+
+    expect(screen.queryByText(expectationMessage)).toBeNull();
+  });
+
+  it('hides the default shipping expectation prompt when showDefaultShippingExpectationPrompt is false, even with backordered items and messaging on', () => {
+    renderWithProviders(
+      <QuoteSummary />,
+      withDefaultShippingExpectationPromptDisabled([lineItemWithBackorder]),
+    );
+
+    expect(screen.queryByText(expectationMessage)).toBeNull();
+  });
+});

--- a/apps/storefront/src/pages/quote/components/QuoteSummary.tsx
+++ b/apps/storefront/src/pages/quote/components/QuoteSummary.tsx
@@ -5,16 +5,21 @@ import {
   useEffect,
   useId,
   useImperativeHandle,
+  useMemo,
   useState,
 } from 'react';
 import { Box, Card, CardContent, Grid, Typography } from '@mui/material';
 
+import ShippingExpectationPrompt from '@/components/ShippingExpectationPrompt';
+import { useFeatureFlag } from '@/hooks/useFeatureFlag';
+import { useIsBackorderEnabled } from '@/hooks/useIsBackorderEnabled';
 import { useB3Lang } from '@/lib/lang';
 import { useAppSelector } from '@/store';
 import { currencyFormat } from '@/utils/b3CurrencyFormat';
 import { getBCPrice } from '@/utils/b3Product/b3Product';
 
 import getQuoteDraftShowPriceTBD from '../shared/utils';
+import { draftQuoteListHasBackorderedItemsForDisplay } from '../utils/getDraftBackorderDisplayFields';
 
 interface Summary {
   subtotal: number;
@@ -40,6 +45,20 @@ const QuoteSummary = forwardRef((_, ref: Ref<unknown>) => {
   const [isHideQuoteDraftPrice, setHideQuoteDraftPrice] = useState<boolean>(false);
   const showInclusiveTaxPrice = useAppSelector(({ global }) => global.showInclusiveTaxPrice);
   const draftQuoteList = useAppSelector(({ quoteInfo }) => quoteInfo.draftQuoteList);
+  const backorderEnabled = useIsBackorderEnabled();
+  const isBackorderMessagingEnabled = useFeatureFlag(
+    'BACK-134.backorders_phase_1_1_control_messaging_on_storefront',
+  );
+  const { showDefaultShippingExpectationPrompt, defaultShippingExpectationPrompt } = useAppSelector(
+    ({ global }) => global.backorderDisplaySettings,
+  );
+
+  const hasBackorderedItems = useMemo(() => {
+    if (!isBackorderMessagingEnabled) {
+      return false;
+    }
+    return draftQuoteListHasBackorderedItemsForDisplay(draftQuoteList);
+  }, [draftQuoteList, isBackorderMessagingEnabled]);
 
   const priceCalc = (price: number) => parseFloat(String(price));
 
@@ -140,6 +159,15 @@ const QuoteSummary = forwardRef((_, ref: Ref<unknown>) => {
                 {b3Lang('quoteDraft.quoteSummary.tbd')}
               </Typography>
             </Grid>
+
+            {isBackorderMessagingEnabled && (
+              <ShippingExpectationPrompt
+                backorderEnabled={backorderEnabled}
+                hasBackorderedItems={hasBackorderedItems}
+                showDefaultShippingExpectationPrompt={showDefaultShippingExpectationPrompt}
+                defaultShippingExpectationPrompt={defaultShippingExpectationPrompt}
+              />
+            )}
 
             <Grid
               container

--- a/apps/storefront/src/pages/quote/components/QuoteTable.test.tsx
+++ b/apps/storefront/src/pages/quote/components/QuoteTable.test.tsx
@@ -1,0 +1,67 @@
+import { buildGlobalStateWith, renderWithProviders, screen } from 'tests/test-utils';
+import { vi } from 'vitest';
+
+import { Product } from '@/types';
+import { QuoteItem } from '@/types/quotes';
+
+import QuoteTable from './QuoteTable';
+
+const lineItemWithBackorder: QuoteItem = {
+  node: {
+    id: 'item-1',
+    optionList: '[]',
+    calculatedValue: {},
+    basePrice: 10,
+    taxPrice: 0,
+    quantity: 10,
+    variantSku: 'V1',
+    productName: 'Test product',
+    productsSearch: {
+      inventoryTracking: 'product',
+      totalOnHand: 3,
+      availableToSell: 10,
+      unlimitedBackorder: false,
+      backorderMessage: 'Restock soon',
+    } as Product,
+  },
+};
+
+const withBackorderContextAndMessaging = (featureEnabled: boolean) => ({
+  preloadedState: {
+    global: buildGlobalStateWith({
+      backorderEnabled: true,
+      backorderDisplaySettings: {
+        showQuantityOnBackorder: true,
+        showQuantityOnHand: false,
+        showBackorderMessage: false,
+        showDefaultShippingExpectationPrompt: false,
+        defaultShippingExpectationPrompt: '',
+      },
+      featureFlags: {
+        'BACK-134.backorders_phase_1_1_control_messaging_on_storefront': featureEnabled,
+      },
+    }),
+  },
+});
+
+describe('QuoteTable backorder messaging', () => {
+  it('shows the backorder details toggle when items are backordered for display and messaging is enabled', () => {
+    const updateSummary = vi.fn();
+    renderWithProviders(
+      <QuoteTable total={1} items={[lineItemWithBackorder]} updateSummary={updateSummary} />,
+      withBackorderContextAndMessaging(true),
+    );
+
+    expect(screen.getByText('Backorder details')).toBeInTheDocument();
+  });
+
+  it('hides the backorder details toggle when storefront backorder messaging is disabled, even with backordered items', () => {
+    const updateSummary = vi.fn();
+    renderWithProviders(
+      <QuoteTable total={1} items={[lineItemWithBackorder]} updateSummary={updateSummary} />,
+      withBackorderContextAndMessaging(false),
+    );
+
+    expect(screen.queryByText('Backorder details')).not.toBeInTheDocument();
+  });
+});

--- a/apps/storefront/src/pages/quote/components/QuoteTable.tsx
+++ b/apps/storefront/src/pages/quote/components/QuoteTable.tsx
@@ -31,6 +31,7 @@ import { snackbar } from '@/utils/b3Tip';
 
 import ChooseOptionsDialog from '../../ShoppingListDetails/components/ChooseOptionsDialog';
 import {
+  draftQuoteListHasBackorderedItemsForDisplay,
   draftRowQuantityExceedsAvailableToSell,
   getDraftBackorderDisplayFields,
   getQuoteItemBackendAvailability,
@@ -186,15 +187,12 @@ function QuoteTable({ total, items, updateSummary }: QuoteTableProps) {
 
   const showBackorderMessageBase = draftQuoteBackorderContextEnabled && showBackorderDetails;
 
-  const hasBackorderedItems = useMemo(
-    () =>
-      items.some((quoteItem) => {
-        const fields = getDraftBackorderDisplayFields(quoteItem.node);
-        if (!fields) return false;
-        return !draftRowQuantityExceedsAvailableToSell(quoteItem.node);
-      }),
-    [items],
-  );
+  const hasBackorderedItems = useMemo(() => {
+    if (!isBackorderMessagingEnabled) {
+      return false;
+    }
+    return draftQuoteListHasBackorderedItemsForDisplay(items);
+  }, [items, isBackorderMessagingEnabled]);
 
   const showBackorderToggle = draftQuoteBackorderContextEnabled && hasBackorderedItems;
 

--- a/apps/storefront/src/pages/quote/utils/getDraftBackorderDisplayFields.test.ts
+++ b/apps/storefront/src/pages/quote/utils/getDraftBackorderDisplayFields.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import type { QuoteItem } from '@/types/quotes';
 
 import {
+  draftQuoteListHasBackorderedItemsForDisplay,
   draftRowQuantityExceedsAvailableToSell,
   getDraftBackorderDisplayFields,
   getQuoteItemBackendAvailability,
@@ -184,5 +185,56 @@ describe('draftRowQuantityExceedsAvailableToSell', () => {
     } as QuoteLineNode;
 
     expect(draftRowQuantityExceedsAvailableToSell(row)).toBe(true);
+  });
+});
+
+describe('draftQuoteListHasBackorderedItemsForDisplay', () => {
+  it('returns false for an empty list', () => {
+    expect(draftQuoteListHasBackorderedItemsForDisplay([])).toBe(false);
+  });
+
+  it('returns true when an item has backorder fields and quantity is within available-to-sell', () => {
+    const row = {
+      quantity: 10,
+      variantSku: 'V1',
+      productsSearch: {
+        inventoryTracking: 'product',
+        totalOnHand: 3,
+        availableToSell: 10,
+        unlimitedBackorder: false,
+      },
+    } as QuoteLineNode;
+
+    expect(draftQuoteListHasBackorderedItemsForDisplay([{ node: row }] as QuoteItem[])).toBe(true);
+  });
+
+  it('returns false when ordered quantity is within total on hand (no backordered quantity)', () => {
+    const row = {
+      quantity: 2,
+      variantSku: 'V1',
+      productsSearch: {
+        inventoryTracking: 'product',
+        totalOnHand: 5,
+        availableToSell: 10,
+        unlimitedBackorder: false,
+      },
+    } as QuoteLineNode;
+
+    expect(draftQuoteListHasBackorderedItemsForDisplay([{ node: row }] as QuoteItem[])).toBe(false);
+  });
+
+  it('returns false when quantity exceeds available-to-sell even with on-hand backorder', () => {
+    const row = {
+      quantity: 10,
+      variantSku: 'V1',
+      productsSearch: {
+        inventoryTracking: 'product',
+        totalOnHand: 3,
+        availableToSell: 4,
+        unlimitedBackorder: false,
+      },
+    } as QuoteLineNode;
+
+    expect(draftQuoteListHasBackorderedItemsForDisplay([{ node: row }] as QuoteItem[])).toBe(false);
   });
 });

--- a/apps/storefront/src/pages/quote/utils/getDraftBackorderDisplayFields.ts
+++ b/apps/storefront/src/pages/quote/utils/getDraftBackorderDisplayFields.ts
@@ -107,3 +107,11 @@ export function getDraftBackorderDisplayFields(
     quantityBackordered,
   };
 }
+
+export function draftQuoteListHasBackorderedItemsForDisplay(draftQuoteList: QuoteItem[]): boolean {
+  return draftQuoteList.some((quoteItem) => {
+    const fields = getDraftBackorderDisplayFields(quoteItem.node);
+    if (!fields) return false;
+    return !draftRowQuantityExceedsAvailableToSell(quoteItem.node);
+  });
+}


### PR DESCRIPTION
Jira: [BACK-600](https://bigcommercecloud.atlassian.net/browse/BACK-600)

## What/Why?
Adding the shipping expectation message to the quote draft view. Also introducing `draftQuoteListHasBackorderedItemsForDisplay` function to centralise the “any qualifying backorder line?” logic for `QuoteSummary` and `QuoteTable`.

## Rollout/Rollback
Backorder display is gated by `Feature_Backorder && BACK-134.backorders_phase_1_1_control_messaging_on_storefront`.

## Testing
Shipping expectation message appears for quotes with any backordered quantity.

https://github.com/user-attachments/assets/7de92ea5-2269-4d01-ac5c-12f7f566c737

Shipping expectation message does not appear for disabled `ShowDefaultShippingExpectationPrompt`.

https://github.com/user-attachments/assets/92cc2736-2d96-4cb0-ad19-92d3cb353703

Shipping expectation message does not appear for disabled `Feature_Backorder` or `BACK-134.backorders_phase_1_1_control_messaging_on_storefront`.

https://github.com/user-attachments/assets/189bcc57-3cab-43e2-8818-5976fd948f1b

[BACK-600]: https://bigcommercecloud.atlassian.net/browse/BACK-600?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/UX change gated behind existing backorder settings and a feature flag, plus test coverage; the main risk is incorrect backorder-qualification logic affecting prompt/toggle visibility.
> 
> **Overview**
> Adds a shipping expectation message to the quote draft `QuoteSummary`, shown only when **backorders are enabled**, the storefront messaging flag `BACK-134.backorders_phase_1_1_control_messaging_on_storefront` is on, the default prompt setting is enabled, and the draft contains at least one backordered line.
> 
> Centralizes “any qualifying backorder line?” detection in the new utility `draftQuoteListHasBackorderedItemsForDisplay`, reusing it in both `QuoteSummary` and `QuoteTable` (including hiding the "Backorder details" toggle when messaging is disabled). Adds unit tests covering the new prompt/toggle gating and the helper’s edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c0f8bcca8e74f8a6dc7b84cd99c68b76bdbb375. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->