### PR TITLE
feat(orders): B2B-4613 register B2B-4613.buyer_portal_unified_sf_gql_orders feature flag

### DIFF
--- a/apps/storefront/src/utils/featureFlags.ts
+++ b/apps/storefront/src/utils/featureFlags.ts
@@ -35,6 +35,10 @@ export const featureFlags = [
     key: 'B2B-4481.use_grpc_geo_for_state_required_flag',
     name: 'grpcGeoForStateRequiredFlag',
   },
+  {
+    key: 'B2B-4613.buyer_portal_unified_sf_gql_orders',
+    name: 'unifiedStorefrontGraphqlOrders',
+  },
 ] as const;
 
 export type FeatureFlagKey = (typeof featureFlags)[number]['key'];


### PR DESCRIPTION
Jira: [B2B-4613](https://bigcommercecloud.atlassian.net/browse/B2B-4613)

## What/Why?
To be able to utilise `B2B-4613.buyer_portal_unified_sf_gql_orders` feature flag for other orders unification project tickets on buyer portal, this basic setup has been done first.

## Rollout/Rollback
Revert this PR

## Testing
No testing needed, just basic setup for consumption

[B2B-4613]: https://bigcommercecloud.atlassian.net/browse/B2B-4613?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a single new feature-flag definition with no logic changes or data/security impact.
> 
> **Overview**
> Registers a new storefront feature flag, `B2B-4613.buyer_portal_unified_sf_gql_orders` (exposed as `unifiedStorefrontGraphqlOrders`), so it can be consumed by upcoming orders unification work.
> 
> Updates the `FeatureFlagKey` union automatically via the `featureFlags` list; no runtime behavior changes beyond the new flag being available.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20a1eacb8018f91c326edeef3640aa24086fb5ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->