### PR TITLE
[B2B-4613] Migrate My Orders data fetching to SF GQL

### DIFF
--- a/apps/storefront/src/pages/MyOrders/unified-orders.test.tsx
+++ b/apps/storefront/src/pages/MyOrders/unified-orders.test.tsx
@@ -88,10 +88,6 @@ const buildSfGqlB2COrderWith = builder<Order>(() => ({
   reference: null,
   company: null,
   placedBy: null,
-  history: [],
-  quote: null,
-  invoice: null,
-  extraFields: [],
 }));
 
 const buildSfGqlCustomerOrdersResponseWith = builder<GetCustomerOrdersResponse>(() => {

--- a/apps/storefront/src/pages/MyOrders/unified-orders.test.tsx
+++ b/apps/storefront/src/pages/MyOrders/unified-orders.test.tsx
@@ -1,0 +1,377 @@
+import {
+  buildCompanyStateWith,
+  builder,
+  buildGlobalStateWith,
+  buildStoreInfoStateWith,
+  bulk,
+  faker,
+  graphql,
+  HttpResponse,
+  renderWithProviders,
+  screen,
+  startMockServer,
+  waitForElementToBeRemoved,
+  within,
+} from 'tests/test-utils';
+
+import type {
+  GetCustomerOrdersResponse,
+  Order,
+  OrderPlacedBy,
+} from '@/shared/service/bc/graphql/orders';
+import { CompanyStatus, CustomerRole, UserTypes } from '@/types';
+
+import { CustomerOrderStatues, OrderStatus as LegacyOrderStatus } from '../order/orders';
+
+import MyOrders from '.';
+
+const { server } = startMockServer();
+
+// ---------------------------------------------------------------------------
+// Builders
+// ---------------------------------------------------------------------------
+
+const buildPlacedByWith = builder<OrderPlacedBy>(() => ({
+  entityId: faker.number.int({ min: 1, max: 9999 }),
+  firstName: faker.person.firstName(),
+  lastName: faker.person.lastName(),
+  email: faker.internet.email(),
+}));
+
+const buildSfGqlOrderWith = builder<Order>(() => ({
+  entityId: faker.number.int({ min: 1000, max: 99999 }),
+  orderedAt: { utc: faker.date.past().toISOString() },
+  updatedAt: { utc: faker.date.past().toISOString() },
+  status: { value: 'PENDING', label: 'Pending' },
+  billingAddress: {
+    firstName: faker.person.firstName(),
+    lastName: faker.person.lastName(),
+    company: faker.company.name(),
+    address1: faker.location.streetAddress(),
+    address2: null,
+    city: faker.location.city(),
+    stateOrProvince: faker.location.state(),
+    postalCode: faker.location.zipCode(),
+    country: faker.location.country(),
+    countryCode: faker.location.countryCode(),
+    phone: faker.phone.number(),
+    email: faker.internet.email(),
+  },
+  subTotal: { currencyCode: 'USD', value: 100 },
+  discountedSubTotal: null,
+  shippingCostTotal: { currencyCode: 'USD', value: 9.99 },
+  handlingCostTotal: { currencyCode: 'USD', value: 0 },
+  wrappingCostTotal: { currencyCode: 'USD', value: 0 },
+  taxTotal: { currencyCode: 'USD', value: 5 },
+  totalIncTax: { currencyCode: 'USD', value: 114.99 },
+  isTaxIncluded: false,
+  taxes: [{ name: 'Tax', amount: { currencyCode: 'USD', value: 5 } }],
+  discounts: {
+    couponDiscounts: [],
+    nonCouponDiscountTotal: { currencyCode: 'USD', value: 0 },
+    totalDiscount: null,
+  },
+  customerMessage: null,
+  totalProductQuantity: 2,
+  consignments: null,
+  reference: faker.string.alphanumeric(8),
+  company: { entityId: faker.number.int({ min: 1, max: 999 }), name: faker.company.name() },
+  placedBy: buildPlacedByWith('WHATEVER_VALUES'),
+  history: [],
+  quote: null,
+  invoice: null,
+  extraFields: [],
+}));
+
+const buildSfGqlB2COrderWith = builder<Order>(() => ({
+  ...buildSfGqlOrderWith('WHATEVER_VALUES'),
+  reference: null,
+  company: null,
+  placedBy: null,
+  history: [],
+  quote: null,
+  invoice: null,
+  extraFields: [],
+}));
+
+const buildSfGqlCustomerOrdersResponseWith = builder<GetCustomerOrdersResponse>(() => {
+  const numberOfOrders = faker.number.int({ min: 1, max: 5 });
+  return {
+    data: {
+      customer: {
+        orders: {
+          edges: bulk(
+            builder(() => ({
+              node: buildSfGqlOrderWith('WHATEVER_VALUES'),
+              cursor: faker.string.alphanumeric(20),
+            })),
+            'WHATEVER_VALUES',
+          ).times(numberOfOrders),
+          pageInfo: {
+            hasNextPage: false,
+            hasPreviousPage: false,
+            startCursor: faker.string.alphanumeric(20),
+            endCursor: faker.string.alphanumeric(20),
+          },
+        },
+      },
+    },
+  };
+});
+
+const buildLegacyOrderStatusWith = builder<LegacyOrderStatus>(() => ({
+  statusCode: faker.number.int().toString(),
+  systemLabel: faker.word.noun(),
+  customLabel: faker.word.noun(),
+}));
+
+const buildLegacyOrderStatusesResponseWith = builder<CustomerOrderStatues>(() => ({
+  data: {
+    bcOrderStatuses: bulk(buildLegacyOrderStatusWith, 'WHATEVER_VALUES').times(3),
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Preloaded states
+// ---------------------------------------------------------------------------
+
+const flagOn = { 'B2B-4613.buyer_portal_unified_sf_gql_orders': true } as const;
+const flagOff = { 'B2B-4613.buyer_portal_unified_sf_gql_orders': false } as const;
+
+const b2cStateWithFlag = (featureFlags: Record<string, boolean>) => ({
+  company: buildCompanyStateWith({
+    customer: { role: CustomerRole.B2C },
+  }),
+  global: buildGlobalStateWith({ featureFlags }),
+  storeInfo: buildStoreInfoStateWith({ timeFormat: { display: 'j F Y' } }),
+});
+
+const b2bStateWithFlag = (featureFlags: Record<string, boolean>) => ({
+  company: buildCompanyStateWith({
+    customer: { role: CustomerRole.ADMIN, userType: UserTypes.MULTIPLE_B2C },
+    companyInfo: { id: '123', companyName: 'Test Corp', status: CompanyStatus.APPROVED },
+  }),
+  global: buildGlobalStateWith({ featureFlags }),
+  storeInfo: buildStoreInfoStateWith({ timeFormat: { display: 'j F Y' } }),
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('My Orders — unified SF GQL orders (B2B-4613)', () => {
+  beforeEach(() => {
+    server.use(
+      graphql.query('GetCustomerOrderStatuses', () =>
+        HttpResponse.json(buildLegacyOrderStatusesResponseWith('WHATEVER_VALUES')),
+      ),
+    );
+  });
+
+  describe('flag OFF — old path unchanged', () => {
+    it('does not call the SF GQL query', async () => {
+      const sfGqlHandler = vi.fn();
+
+      server.use(
+        graphql.query('GetCustomerOrders', ({ query }) => {
+          if (query.includes('orderedAt')) {
+            sfGqlHandler();
+          }
+          return HttpResponse.json(buildSfGqlCustomerOrdersResponseWith('WHATEVER_VALUES'));
+        }),
+      );
+
+      renderWithProviders(<MyOrders />, { preloadedState: b2cStateWithFlag(flagOff) });
+
+      await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+      expect(sfGqlHandler).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('flag ON — unified SF GQL path', () => {
+    it('renders B2B orders with all fields', async () => {
+      const order = buildSfGqlOrderWith({
+        entityId: 12345,
+        reference: 'PO-9876',
+        status: { value: 'COMPLETED', label: 'Completed' },
+        totalIncTax: { currencyCode: 'USD', value: 250 },
+        orderedAt: { utc: '2025-03-13T00:00:00Z' },
+        company: { entityId: 1, name: 'Acme Corp' },
+        placedBy: { entityId: 1, firstName: 'Jane', lastName: 'Doe', email: 'jane@acme.com' },
+      });
+
+      server.use(
+        graphql.query('GetCustomerOrders', () =>
+          HttpResponse.json({
+            data: {
+              customer: {
+                orders: {
+                  edges: [{ node: order, cursor: 'abc' }],
+                  pageInfo: {
+                    hasNextPage: false,
+                    hasPreviousPage: false,
+                    startCursor: 'abc',
+                    endCursor: 'abc',
+                  },
+                },
+              },
+            },
+          } satisfies GetCustomerOrdersResponse),
+        ),
+      );
+
+      renderWithProviders(<MyOrders />, { preloadedState: b2bStateWithFlag(flagOn) });
+
+      await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+      const row = screen.getByRole('row', { name: /12345/ });
+      expect(row).toBeInTheDocument();
+      expect(within(row).getByText('PO-9876')).toBeInTheDocument();
+      expect(within(row).getByText(/Acme Corp/)).toBeInTheDocument();
+      expect(within(row).getByText(/Completed/)).toBeInTheDocument();
+    });
+
+    it('renders B2C orders with null B2B fields', async () => {
+      const order = buildSfGqlB2COrderWith({
+        entityId: 55555,
+        status: { value: 'PENDING', label: 'Pending' },
+        totalIncTax: { currencyCode: 'USD', value: 50 },
+        orderedAt: { utc: '2025-06-01T00:00:00Z' },
+      });
+
+      server.use(
+        graphql.query('GetCustomerOrders', () =>
+          HttpResponse.json({
+            data: {
+              customer: {
+                orders: {
+                  edges: [{ node: order, cursor: 'def' }],
+                  pageInfo: {
+                    hasNextPage: false,
+                    hasPreviousPage: false,
+                    startCursor: 'def',
+                    endCursor: 'def',
+                  },
+                },
+              },
+            },
+          } satisfies GetCustomerOrdersResponse),
+        ),
+      );
+
+      renderWithProviders(<MyOrders />, { preloadedState: b2cStateWithFlag(flagOn) });
+
+      await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+      const row = screen.getByRole('row', { name: /55555/ });
+      expect(row).toBeInTheDocument();
+      expect(within(row).getByText('–')).toBeInTheDocument();
+    });
+
+    it('preserves column visibility — company hidden for B2C', async () => {
+      server.use(
+        graphql.query('GetCustomerOrders', () =>
+          HttpResponse.json(buildSfGqlCustomerOrdersResponseWith('WHATEVER_VALUES')),
+        ),
+      );
+
+      renderWithProviders(<MyOrders />, { preloadedState: b2cStateWithFlag(flagOn) });
+
+      await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+      const table = screen.getByRole('table');
+      const headers = within(table).getAllByRole('columnheader');
+      const headerTexts = headers.map((h) => h.textContent);
+
+      expect(headerTexts).not.toContain('Company');
+      expect(headerTexts).not.toContain('Placed by');
+    });
+
+    it('preserves column visibility — company visible for B2B', async () => {
+      server.use(
+        graphql.query('GetCustomerOrders', () =>
+          HttpResponse.json(buildSfGqlCustomerOrdersResponseWith('WHATEVER_VALUES')),
+        ),
+      );
+
+      renderWithProviders(<MyOrders />, { preloadedState: b2bStateWithFlag(flagOn) });
+
+      await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+      const table = screen.getByRole('table');
+      const headers = within(table).getAllByRole('columnheader');
+      const headerTexts = headers.map((h) => h.textContent);
+
+      expect(headerTexts).toContain('Company');
+    });
+
+    it('formats currency correctly', async () => {
+      const order = buildSfGqlOrderWith({
+        entityId: 77777,
+        totalIncTax: { currencyCode: 'USD', value: 1234.56 },
+      });
+
+      server.use(
+        graphql.query('GetCustomerOrders', () =>
+          HttpResponse.json({
+            data: {
+              customer: {
+                orders: {
+                  edges: [{ node: order, cursor: 'cur' }],
+                  pageInfo: {
+                    hasNextPage: false,
+                    hasPreviousPage: false,
+                    startCursor: null,
+                    endCursor: null,
+                  },
+                },
+              },
+            },
+          } satisfies GetCustomerOrdersResponse),
+        ),
+      );
+
+      renderWithProviders(<MyOrders />, { preloadedState: b2bStateWithFlag(flagOn) });
+
+      await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+      const row = screen.getByRole('row', { name: /77777/ });
+      expect(within(row).getByText(/1,234\.56/)).toBeInTheDocument();
+    });
+
+    it('formats date correctly', async () => {
+      const order = buildSfGqlOrderWith({
+        entityId: 88888,
+        orderedAt: { utc: '2025-03-13T00:00:00Z' },
+      });
+
+      server.use(
+        graphql.query('GetCustomerOrders', () =>
+          HttpResponse.json({
+            data: {
+              customer: {
+                orders: {
+                  edges: [{ node: order, cursor: 'dt' }],
+                  pageInfo: {
+                    hasNextPage: false,
+                    hasPreviousPage: false,
+                    startCursor: null,
+                    endCursor: null,
+                  },
+                },
+              },
+            },
+          } satisfies GetCustomerOrdersResponse),
+        ),
+      );
+
+      renderWithProviders(<MyOrders />, { preloadedState: b2bStateWithFlag(flagOn) });
+
+      await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+      const row = screen.getByRole('row', { name: /88888/ });
+      expect(within(row).getByText(/13 March 2025/)).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/storefront/src/pages/order/Order.tsx
+++ b/apps/storefront/src/pages/order/Order.tsx
@@ -27,7 +27,7 @@ import {
   getOrderStatusText,
   sortKeys,
 } from './config';
-import { mapSfGqlOrderToListItem } from './mapSfGqlOrderToListItem';
+import { type ListItem, mapSfGqlOrderToListItem } from './mapSfGqlOrderToListItem';
 import { OrderItemCard } from './OrderItemCard';
 import {
   getB2BAllOrders,
@@ -36,32 +36,6 @@ import {
   getOrdersCreatedByUser,
   getOrderStatusType,
 } from './orders';
-
-interface CompanyInfoProps {
-  companyId: string;
-  companyName: string;
-  companyAddress: string;
-  companyCountry: string;
-  companyState: string;
-  companyCity: string;
-  companyZipCode: string;
-  phoneNumber: string;
-  bcId: string;
-}
-
-interface ListItem {
-  firstName: string;
-  lastName: string;
-  orderId: string;
-  poNumber?: string;
-  money?: string;
-  totalIncTax: string;
-  status: string;
-  statusText?: string;
-  createdAt: string;
-  companyName: string;
-  companyInfo?: CompanyInfoProps;
-}
 
 interface SearchChangeProps {
   startValue?: string;

--- a/apps/storefront/src/pages/order/Order.tsx
+++ b/apps/storefront/src/pages/order/Order.tsx
@@ -9,7 +9,7 @@ import { B2BAutoCompleteCheckbox } from '@/components/ui/B2BAutoCompleteCheckbox
 import { useFeatureFlag } from '@/hooks/useFeatureFlag';
 import { useMobile } from '@/hooks/useMobile';
 import { useB3Lang } from '@/lib/lang';
-import { getCustomerOrders, type Order as SfGqlOrder } from '@/shared/service/bc/graphql/orders';
+import { getCustomerOrders } from '@/shared/service/bc/graphql/orders';
 import { isB2BUserSelector, useAppSelector } from '@/store';
 import { CustomerRole } from '@/types';
 import { currencyFormat, ordersCurrencyFormat } from '@/utils/b3CurrencyFormat';
@@ -27,6 +27,7 @@ import {
   getOrderStatusText,
   sortKeys,
 } from './config';
+import { mapSfGqlOrderToListItem } from './mapSfGqlOrderToListItem';
 import { OrderItemCard } from './OrderItemCard';
 import {
   getB2BAllOrders,
@@ -127,32 +128,6 @@ interface OrderBy {
 const getOrderBy = ({ key, dir }: OrderBy) => {
   return dir === 'desc' ? `-${sortKeys[key]}` : sortKeys[key];
 };
-
-const mapSfGqlOrderToListItem = (order: SfGqlOrder): ListItem => ({
-  orderId: String(order.entityId),
-  poNumber: order.reference || '',
-  totalIncTax: String(order.totalIncTax.value),
-  status: order.status.label,
-  statusText: order.status.label,
-  createdAt: String(Math.floor(new Date(order.orderedAt.utc).getTime() / 1000)),
-  firstName: order.placedBy?.firstName || '',
-  lastName: order.placedBy?.lastName || '',
-  companyName: order.company?.name || '',
-  companyInfo: order.company
-    ? {
-        companyName: order.company.name,
-        companyId: String(order.company.entityId),
-        companyAddress: '',
-        companyCountry: '',
-        companyState: '',
-        companyCity: '',
-        companyZipCode: '',
-        phoneNumber: '',
-        bcId: '',
-      }
-    : undefined,
-  money: '',
-});
 
 function Order({ isCompanyOrder = false }: OrderProps) {
   const b3Lang = useB3Lang();

--- a/apps/storefront/src/pages/order/Order.tsx
+++ b/apps/storefront/src/pages/order/Order.tsx
@@ -6,8 +6,10 @@ import { useQuery } from '@tanstack/react-query';
 import B3Filter from '@/components/filter/B3Filter';
 import B3Spin from '@/components/spin/B3Spin';
 import { B2BAutoCompleteCheckbox } from '@/components/ui/B2BAutoCompleteCheckbox';
+import { useFeatureFlag } from '@/hooks/useFeatureFlag';
 import { useMobile } from '@/hooks/useMobile';
 import { useB3Lang } from '@/lib/lang';
+import { getCustomerOrders, type Order as SfGqlOrder } from '@/shared/service/bc/graphql/orders';
 import { isB2BUserSelector, useAppSelector } from '@/store';
 import { CustomerRole } from '@/types';
 import { currencyFormat, ordersCurrencyFormat } from '@/utils/b3CurrencyFormat';
@@ -126,9 +128,36 @@ const getOrderBy = ({ key, dir }: OrderBy) => {
   return dir === 'desc' ? `-${sortKeys[key]}` : sortKeys[key];
 };
 
+const mapSfGqlOrderToListItem = (order: SfGqlOrder): ListItem => ({
+  orderId: String(order.entityId),
+  poNumber: order.reference || '',
+  totalIncTax: String(order.totalIncTax.value),
+  status: order.status.label,
+  statusText: order.status.label,
+  createdAt: String(Math.floor(new Date(order.orderedAt.utc).getTime() / 1000)),
+  firstName: order.placedBy?.firstName || '',
+  lastName: order.placedBy?.lastName || '',
+  companyName: order.company?.name || '',
+  companyInfo: order.company
+    ? {
+        companyName: order.company.name,
+        companyId: String(order.company.entityId),
+        companyAddress: '',
+        companyCountry: '',
+        companyState: '',
+        companyCity: '',
+        companyZipCode: '',
+        phoneNumber: '',
+        bcId: '',
+      }
+    : undefined,
+  money: '',
+});
+
 function Order({ isCompanyOrder = false }: OrderProps) {
   const b3Lang = useB3Lang();
   const [isMobile] = useMobile();
+  const isUnifiedOrders = useFeatureFlag('B2B-4613.buyer_portal_unified_sf_gql_orders');
   const { role, isAgenting, companyId, isB2BUser, isEnabledCompanyHierarchy, selectedCompanyId } =
     useData();
 
@@ -221,6 +250,19 @@ function Order({ isCompanyOrder = false }: OrderProps) {
     createdBy,
     ...params
   }: Partial<FilterSearchProps>): Promise<{ edges: ListItem[]; totalCount: number }> => {
+    if (isUnifiedOrders) {
+      const result = await getCustomerOrders({
+        first: params.first as number,
+      });
+
+      const orders = result.data?.customer?.orders;
+      const edges = (orders?.edges || []).map((edge) => mapSfGqlOrderToListItem(edge.node));
+      const totalCount = edges.length;
+
+      setAllTotal(totalCount);
+      return { edges, totalCount };
+    }
+
     const { edges = [], totalCount } = isB2BUser
       ? await getB2BAllOrders({
           ...params,

--- a/apps/storefront/src/pages/order/Order.tsx
+++ b/apps/storefront/src/pages/order/Order.tsx
@@ -206,10 +206,8 @@ function Order({ isCompanyOrder = false }: OrderProps) {
 
       const orders = result.data?.customer?.orders;
       const edges = (orders?.edges || []).map((edge) => mapSfGqlOrderToListItem(edge.node));
-      const totalCount = edges.length;
 
-      setAllTotal(totalCount);
-      return { edges, totalCount };
+      return { edges, totalCount: -1 };
     }
 
     const { edges = [], totalCount } = isB2BUser

--- a/apps/storefront/src/pages/order/Order.tsx
+++ b/apps/storefront/src/pages/order/Order.tsx
@@ -199,7 +199,7 @@ function Order({ isCompanyOrder = false }: OrderProps) {
     createdBy,
     ...params
   }: Partial<FilterSearchProps>): Promise<{ edges: ListItem[]; totalCount: number }> => {
-    if (isUnifiedOrders) {
+    if (isUnifiedOrders && !isCompanyOrder) {
       const result = await getCustomerOrders({
         first: params.first as number,
       });

--- a/apps/storefront/src/pages/order/mapSfGqlOrderToListItem.ts
+++ b/apps/storefront/src/pages/order/mapSfGqlOrderToListItem.ts
@@ -1,18 +1,7 @@
 import type { Order as SfGqlOrder } from '@/shared/service/bc/graphql/orders';
+import type { CompanyInfoTypes } from '@/types/invoice';
 
-interface CompanyInfoProps {
-  companyId: string;
-  companyName: string;
-  companyAddress: string;
-  companyCountry: string;
-  companyState: string;
-  companyCity: string;
-  companyZipCode: string;
-  phoneNumber: string;
-  bcId: string;
-}
-
-interface ListItem {
+export interface ListItem {
   firstName: string;
   lastName: string;
   orderId: string;
@@ -23,7 +12,7 @@ interface ListItem {
   statusText?: string;
   createdAt: string;
   companyName: string;
-  companyInfo?: CompanyInfoProps;
+  companyInfo?: CompanyInfoTypes;
 }
 
 export const mapSfGqlOrderToListItem = (order: SfGqlOrder): ListItem => ({

--- a/apps/storefront/src/pages/order/mapSfGqlOrderToListItem.ts
+++ b/apps/storefront/src/pages/order/mapSfGqlOrderToListItem.ts
@@ -1,0 +1,53 @@
+import type { Order as SfGqlOrder } from '@/shared/service/bc/graphql/orders';
+
+interface CompanyInfoProps {
+  companyId: string;
+  companyName: string;
+  companyAddress: string;
+  companyCountry: string;
+  companyState: string;
+  companyCity: string;
+  companyZipCode: string;
+  phoneNumber: string;
+  bcId: string;
+}
+
+interface ListItem {
+  firstName: string;
+  lastName: string;
+  orderId: string;
+  poNumber?: string;
+  money?: string;
+  totalIncTax: string;
+  status: string;
+  statusText?: string;
+  createdAt: string;
+  companyName: string;
+  companyInfo?: CompanyInfoProps;
+}
+
+export const mapSfGqlOrderToListItem = (order: SfGqlOrder): ListItem => ({
+  orderId: String(order.entityId),
+  poNumber: order.reference || '',
+  totalIncTax: String(order.totalIncTax.value),
+  status: order.status.label,
+  statusText: order.status.label,
+  createdAt: String(Math.floor(new Date(order.orderedAt.utc).getTime() / 1000)),
+  firstName: order.placedBy?.firstName || '',
+  lastName: order.placedBy?.lastName || '',
+  companyName: order.company?.name || '',
+  companyInfo: order.company
+    ? {
+        companyName: order.company.name,
+        companyId: String(order.company.entityId),
+        companyAddress: '',
+        companyCountry: '',
+        companyState: '',
+        companyCity: '',
+        companyZipCode: '',
+        phoneNumber: '',
+        bcId: '',
+      }
+    : undefined,
+  money: '',
+});


### PR DESCRIPTION
Jira: [B2B-4613](https://bigcommercecloud.atlassian.net/browse/B2B-4613)

## What/Why?

Migrates the My Orders view data fetching from the dual-path B2B/B2C legacy queries
(`getB2BAllOrders` / `getBCAllOrders`) to the unified Storefront GraphQL `customer.orders`
query. This is the first UI surface connected to the SF GQL orders client.

When the feature flag `B2B-4613.buyer_portal_unified_sf_gql_orders` is enabled:
- Both B2B and B2C users fetch orders through a single `getCustomerOrders()` call
- The `isB2BUser` branching in `fetchList` is bypassed
- SF GQL response is mapped to the existing `ListItem` shape via `mapSfGqlOrderToListItem`,
  so all downstream components (table, mobile card, detail navigation) continue to work
  without changes

B2B extension fields (`reference`, `company`, `placedBy`) are populated for B2B orders and
null for B2C orders. Existing role-based column visibility logic (company hidden for B2C,
placed-by hidden on My Orders) is preserved.

Legacy query functions are left in place — they will be removed in ticket 5a.

## Scope & follow-up tickets

This PR implements **data fetching and adapter only**. The following are intentionally
deferred to subsequent tickets in the same stage:

| Not in this PR | Addressed in | Ticket |
|---|---|---|
| Filter/search/sort mapping to SF GQL input types | **2b** | [B2B-4614](https://bigcommercecloud.atlassian.net/browse/B2B-4614) |
| Cursor pagination (`first`/`after`, `last`/`before`) | **2c** | [B2B-4615](https://bigcommercecloud.atlassian.net/browse/B2B-4615) |
| `totalCount` from server (`collectionInfo` not available on `OrdersConnection`) | **2c** | [B2B-4615](https://bigcommercecloud.atlassian.net/browse/B2B-4615) — uses `hasNextPage`/`hasPreviousPage` instead |
| Status dropdown data source change | **2b** | [B2B-4614](https://bigcommercecloud.atlassian.net/browse/B2B-4614) — interim: existing B2B GQL |
| Old code removal | **5a** | [B2B-4630](https://bigcommercecloud.atlassian.net/browse/B2B-4630) |

**Known limitation:** `totalCount` is set to `edges.length` (current page count) because
SF GQL `OrdersConnection` does not include `collectionInfo.totalItems`. This is a tracked
platform gap (spike open item #5). For this PR, only the first page loads — 2c implements
real cursor-based pagination using `pageInfo`.

## Rollout/Rollback

This change is behind the feature toggle `B2B-4613.buyer_portal_unified_sf_gql_orders` which
will remain **off** until the BE implementation (PROJECT-7288) is deployed and validated.

Once BE is live, the flag will be enabled incrementally per store after verifying orders render
correctly in staging. To roll back, disable the feature flag — the code falls back to legacy
queries with no database migrations or code revert required.

## Testing

- Added `unified-orders.test.tsx` with 7 test cases covering:
  - Flag OFF: verifies SF GQL query is not called (legacy path unchanged)
  - Flag ON — B2B orders: renders all fields (order ID, PO reference, company, status)
  - Flag ON — B2C orders: renders correctly with null B2B fields
  - Column visibility: company column hidden for B2C, visible for B2B
  - Currency formatting with unified money type
  - Date formatting with `orderedAt.utc`
- Screenshots/videos to be attached.

[B2B-4613]: https://bigcommercecloud.atlassian.net/browse/B2B-4613?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[B2B-4614]: https://bigcommercecloud.atlassian.net/browse/B2B-4614?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new feature-flagged data-fetching path for the My Orders list using Storefront GraphQL and an adapter layer; risk comes from potential mismatches in mapped fields/formatting and the placeholder `totalCount` behavior affecting pagination/UI states.
> 
> **Overview**
> When `B2B-4613.buyer_portal_unified_sf_gql_orders` is enabled (and *not* in company-orders view), the My Orders list now fetches orders via the unified Storefront GraphQL `getCustomerOrders()` query instead of the legacy `getB2BAllOrders`/`getBCAllOrders` branching.
> 
> Adds `mapSfGqlOrderToListItem` to adapt SF GQL `customer.orders` nodes into the existing table/card `ListItem` shape (including B2B-only fields like PO reference, company, and placed-by when present), and introduces a new test suite validating flag on/off behavior, B2B vs B2C rendering/column visibility, and date/currency formatting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab292a7f9f3258112e4c01573b2c1f9ca9c98180. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->