### PR TITLE
B2b 4614 migrate My Orders filter / search / sort state to the SF unified GraphQL 

### DIFF
--- a/apps/storefront/src/pages/MyOrders/index.test.tsx
+++ b/apps/storefront/src/pages/MyOrders/index.test.tsx
@@ -3,7 +3,6 @@ import {
   buildB2BFeaturesStateWith,
   buildCompanyStateWith,
   builder,
-  buildGlobalStateWith,
   buildStoreInfoStateWith,
   bulk,
   faker,
@@ -83,17 +82,7 @@ afterEach(() => {
   vi.useRealTimers();
 });
 
-// Run each /orders scenario under both FF states. Bridge produces wire-identical
-// GraphQL, so all assertions hold either way; drift on any role cut fails one test.
-const FF_KEY = 'B2B-4613.buyer_portal_unified_sf_gql_orders';
-const ordersFilterFFStates = [
-  { ffOn: false, label: 'legacy b2b api path' },
-  { ffOn: true, label: 'unified storefront api path' },
-];
-const buildFFGlobalState = (ffOn: boolean) =>
-  buildGlobalStateWith({ featureFlags: { [FF_KEY]: ffOn } });
-
-describe.each(ordersFilterFFStates)('when a personal customer ($label)', ({ ffOn }) => {
+describe('when a personal customer', () => {
   const preloadedState = {
     company: buildCompanyStateWith({
       customer: {
@@ -101,7 +90,6 @@ describe.each(ordersFilterFFStates)('when a personal customer ($label)', ({ ffOn
       },
     }),
     storeInfo: buildStoreInfoStateWith({ timeFormat: { display: 'j F Y' } }),
-    global: buildFFGlobalState(ffOn),
   };
 
   beforeEach(() => {
@@ -829,7 +817,7 @@ const buildCompanyOrderStatusesWith = builder<CompanyOrderStatuses>(() => ({
   },
 }));
 
-describe.each(ordersFilterFFStates)('when a company customer ($label)', ({ ffOn }) => {
+describe('when a company customer', () => {
   const preloadedState = {
     company: buildCompanyStateWith({
       customer: {
@@ -841,7 +829,6 @@ describe.each(ordersFilterFFStates)('when a company customer ($label)', ({ ffOn 
       },
     }),
     storeInfo: buildStoreInfoStateWith({ timeFormat: { display: 'j F Y' } }),
-    global: buildFFGlobalState(ffOn),
   };
 
   beforeEach(() => {
@@ -1590,151 +1577,147 @@ describe.each(ordersFilterFFStates)('when a company customer ($label)', ({ ffOn 
   });
 });
 
-describe.each(ordersFilterFFStates)(
-  'when a customer is masquerading as a company customer ($label)',
-  ({ ffOn }) => {
-    const preloadedState = {
-      company: buildCompanyStateWith({
-        customer: {
-          role: CustomerRole.SUPER_ADMIN,
-        },
-      }),
-      storeInfo: buildStoreInfoStateWith({ timeFormat: { display: 'j F Y' } }),
-      b2bFeatures: buildB2BFeaturesStateWith({
-        masqueradeCompany: {
-          id: 433,
-          isAgenting: true,
-        },
-      }),
-      global: buildFFGlobalState(ffOn),
-    };
+describe('when a customer is masquerading as a company customer', () => {
+  const preloadedState = {
+  company: buildCompanyStateWith({
+    customer: {
+      role: CustomerRole.SUPER_ADMIN,
+    },
+  }),
+  storeInfo: buildStoreInfoStateWith({ timeFormat: { display: 'j F Y' } }),
+  b2bFeatures: buildB2BFeaturesStateWith({
+    masqueradeCompany: {
+      id: 433,
+      isAgenting: true,
+    },
+  }),
+};
 
-    beforeEach(() => {
+  beforeEach(() => {
+    server.use(
+      graphql.query('GetOrderStatuses', () =>
+        HttpResponse.json(buildCompanyOrderStatusesWith('WHATEVER_VALUES')),
+      ),
+    );
+  });
+
+  describe('has placed orders', () => {
+    it('displays a table with order information', async () => {
       server.use(
-        graphql.query('GetOrderStatuses', () =>
-          HttpResponse.json(buildCompanyOrderStatusesWith('WHATEVER_VALUES')),
+        graphql.query('GetAllOrders', () =>
+          HttpResponse.json(buildCompanyOrdersWith('WHATEVER_VALUES')),
         ),
       );
-    });
-
-    describe('has placed orders', () => {
-      it('displays a table with order information', async () => {
-        server.use(
-          graphql.query('GetAllOrders', () =>
-            HttpResponse.json(buildCompanyOrdersWith('WHATEVER_VALUES')),
-          ),
-        );
-
-        renderWithProviders(<MyOrders />, { preloadedState });
-
-        await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
-
-        const table = screen.getByRole('table');
-
-        const columnHeaders = within(table).getAllByRole('columnheader');
-
-        expect(columnHeaders[0]).toHaveTextContent('Order');
-        expect(columnHeaders[1]).toHaveTextContent('Company');
-        expect(columnHeaders[2]).toHaveTextContent('PO / Reference');
-        expect(columnHeaders[3]).toHaveTextContent('Grand total');
-        expect(columnHeaders[4]).toHaveTextContent('Order status');
-        expect(columnHeaders[5]).toHaveTextContent('Created on');
-      });
-    });
-
-    it('displays all the orders associated with the company', async () => {
-      const getAllOrders = vi.fn();
-
-      server.use(
-        graphql.query('GetAllOrders', ({ query }) => HttpResponse.json(getAllOrders(query))),
-      );
-
-      when(getAllOrders)
-        .calledWith(
-          // isShowMy controls whether to show the orders for the current user, setting it to "1" will filter for currentUser
-          stringContainingAll('companyIds: [433,]', 'isShowMy: "1"', 'orderBy: "-bcOrderId"'),
-        )
-        .thenReturn(
-          buildCompanyOrdersWith({
-            data: {
-              allOrders: {
-                totalCount: 2,
-                edges: [
-                  buildCompanyOrderNodeWith({ node: { orderId: '66996' } }),
-                  buildCompanyOrderNodeWith({ node: { orderId: '66986' } }),
-                ],
-              },
-            },
-          }),
-        );
 
       renderWithProviders(<MyOrders />, { preloadedState });
 
       await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
 
-      expect(screen.getByRole('row', { name: /66996/ })).toBeInTheDocument();
-      expect(screen.getByRole('row', { name: /66986/ })).toBeInTheDocument();
-    });
+      const table = screen.getByRole('table');
 
-    it('displays all the information associated with an order', async () => {
-      const order66996 = buildCompanyOrderNodeWith({
-        node: {
-          orderId: '66996',
-          poNumber: '0022',
-          totalIncTax: 100,
-          status: 'Pending',
-          createdAt: getUnixTime(new Date('13 March 2025')),
-          companyInfo: {
-            companyName: 'Monsters Inc.',
+      const columnHeaders = within(table).getAllByRole('columnheader');
+
+      expect(columnHeaders[0]).toHaveTextContent('Order');
+      expect(columnHeaders[1]).toHaveTextContent('Company');
+      expect(columnHeaders[2]).toHaveTextContent('PO / Reference');
+      expect(columnHeaders[3]).toHaveTextContent('Grand total');
+      expect(columnHeaders[4]).toHaveTextContent('Order status');
+      expect(columnHeaders[5]).toHaveTextContent('Created on');
+    });
+  });
+
+  it('displays all the orders associated with the company', async () => {
+    const getAllOrders = vi.fn();
+
+    server.use(
+      graphql.query('GetAllOrders', ({ query }) => HttpResponse.json(getAllOrders(query))),
+    );
+
+    when(getAllOrders)
+      .calledWith(
+        // isShowMy controls whether to show the orders for the current user, setting it to "1" will filter for currentUser
+        stringContainingAll('companyIds: [433,]', 'isShowMy: "1"', 'orderBy: "-bcOrderId"'),
+      )
+      .thenReturn(
+        buildCompanyOrdersWith({
+          data: {
+            allOrders: {
+              totalCount: 2,
+              edges: [
+                buildCompanyOrderNodeWith({ node: { orderId: '66996' } }),
+                buildCompanyOrderNodeWith({ node: { orderId: '66986' } }),
+              ],
+            },
           },
-        },
-      });
-
-      const getAllOrders = vi.fn();
-
-      server.use(
-        graphql.query('GetOrderStatuses', () => {
-          return HttpResponse.json(
-            buildCompanyOrderStatusesWith({
-              data: {
-                orderStatuses: [
-                  buildOrderStatusWith({ systemLabel: 'Pending', customLabel: 'Pending' }),
-                  buildOrderStatusWith('WHATEVER_VALUES'),
-                ],
-              },
-            }),
-          );
         }),
-        graphql.query('GetAllOrders', ({ query }) => HttpResponse.json(getAllOrders(query))),
       );
 
-      when(getAllOrders)
-        .calledWith(stringContainingAll('companyIds: [433,]', 'orderBy: "-bcOrderId"'))
-        .thenReturn(
-          buildCompanyOrdersWith({
+    renderWithProviders(<MyOrders />, { preloadedState });
+
+    await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+    expect(screen.getByRole('row', { name: /66996/ })).toBeInTheDocument();
+    expect(screen.getByRole('row', { name: /66986/ })).toBeInTheDocument();
+  });
+
+  it('displays all the information associated with an order', async () => {
+    const order66996 = buildCompanyOrderNodeWith({
+      node: {
+        orderId: '66996',
+        poNumber: '0022',
+        totalIncTax: 100,
+        status: 'Pending',
+        createdAt: getUnixTime(new Date('13 March 2025')),
+        companyInfo: {
+          companyName: 'Monsters Inc.',
+        },
+      },
+    });
+
+    const getAllOrders = vi.fn();
+
+    server.use(
+      graphql.query('GetOrderStatuses', () => {
+        return HttpResponse.json(
+          buildCompanyOrderStatusesWith({
             data: {
-              allOrders: {
-                totalCount: 1,
-                edges: [order66996],
-              },
+              orderStatuses: [
+                buildOrderStatusWith({ systemLabel: 'Pending', customLabel: 'Pending' }),
+                buildOrderStatusWith('WHATEVER_VALUES'),
+              ],
             },
           }),
         );
+      }),
+      graphql.query('GetAllOrders', ({ query }) => HttpResponse.json(getAllOrders(query))),
+    );
 
-      renderWithProviders(<MyOrders />, { preloadedState });
+    when(getAllOrders)
+      .calledWith(stringContainingAll('companyIds: [433,]', 'orderBy: "-bcOrderId"'))
+      .thenReturn(
+        buildCompanyOrdersWith({
+          data: {
+            allOrders: {
+              totalCount: 1,
+              edges: [order66996],
+            },
+          },
+        }),
+      );
 
-      await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+    renderWithProviders(<MyOrders />, { preloadedState });
 
-      const row = screen.getByRole('row', { name: /66996/ });
+    await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
 
-      expect(within(row).getByRole('cell', { name: '66996' })).toBeInTheDocument();
-      expect(within(row).getByRole('cell', { name: 'Monsters Inc.' })).toBeInTheDocument();
-      expect(within(row).getByRole('cell', { name: '0022' })).toBeInTheDocument();
-      expect(within(row).getByRole('cell', { name: '$100.00' })).toBeInTheDocument();
-      expect(within(row).getByRole('cell', { name: 'Pending' })).toBeInTheDocument();
-      expect(within(row).getByRole('cell', { name: '13 March 2025' })).toBeInTheDocument();
-    });
-  },
-);
+    const row = screen.getByRole('row', { name: /66996/ });
+
+    expect(within(row).getByRole('cell', { name: '66996' })).toBeInTheDocument();
+    expect(within(row).getByRole('cell', { name: 'Monsters Inc.' })).toBeInTheDocument();
+    expect(within(row).getByRole('cell', { name: '0022' })).toBeInTheDocument();
+    expect(within(row).getByRole('cell', { name: '$100.00' })).toBeInTheDocument();
+    expect(within(row).getByRole('cell', { name: 'Pending' })).toBeInTheDocument();
+    expect(within(row).getByRole('cell', { name: '13 March 2025' })).toBeInTheDocument();
+  });
+});
 
 describe.todo('when a customer is part of a company hierarchy');

--- a/apps/storefront/src/pages/MyOrders/index.test.tsx
+++ b/apps/storefront/src/pages/MyOrders/index.test.tsx
@@ -3,6 +3,7 @@ import {
   buildB2BFeaturesStateWith,
   buildCompanyStateWith,
   builder,
+  buildGlobalStateWith,
   buildStoreInfoStateWith,
   bulk,
   faker,
@@ -18,6 +19,7 @@ import {
   waitForElementToBeRemoved,
   within,
 } from 'tests/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { when } from 'vitest-when';
 
 import { CompanyStatus, CustomerRole, UserTypes } from '@/types';
@@ -81,7 +83,17 @@ afterEach(() => {
   vi.useRealTimers();
 });
 
-describe('when a personal customer', () => {
+// Run each /orders scenario under both FF states. Bridge produces wire-identical
+// GraphQL, so all assertions hold either way; drift on any role cut fails one test.
+const FF_KEY = 'B2B-4613.buyer_portal_unified_sf_gql_orders';
+const ordersFilterFFStates = [
+  { ffOn: false, label: 'legacy b2b api path' },
+  { ffOn: true, label: 'unified storefront api path' },
+];
+const buildFFGlobalState = (ffOn: boolean) =>
+  buildGlobalStateWith({ featureFlags: { [FF_KEY]: ffOn } });
+
+describe.each(ordersFilterFFStates)('when a personal customer ($label)', ({ ffOn }) => {
   const preloadedState = {
     company: buildCompanyStateWith({
       customer: {
@@ -89,6 +101,7 @@ describe('when a personal customer', () => {
       },
     }),
     storeInfo: buildStoreInfoStateWith({ timeFormat: { display: 'j F Y' } }),
+    global: buildFFGlobalState(ffOn),
   };
 
   beforeEach(() => {
@@ -816,7 +829,7 @@ const buildCompanyOrderStatusesWith = builder<CompanyOrderStatuses>(() => ({
   },
 }));
 
-describe('when a company customer', () => {
+describe.each(ordersFilterFFStates)('when a company customer ($label)', ({ ffOn }) => {
   const preloadedState = {
     company: buildCompanyStateWith({
       customer: {
@@ -828,6 +841,7 @@ describe('when a company customer', () => {
       },
     }),
     storeInfo: buildStoreInfoStateWith({ timeFormat: { display: 'j F Y' } }),
+    global: buildFFGlobalState(ffOn),
   };
 
   beforeEach(() => {
@@ -1576,147 +1590,151 @@ describe('when a company customer', () => {
   });
 });
 
-describe('when a customer is masquerading as a company customer', () => {
-  const preloadedState = {
-    company: buildCompanyStateWith({
-      customer: {
-        role: CustomerRole.SUPER_ADMIN,
-      },
-    }),
-    storeInfo: buildStoreInfoStateWith({ timeFormat: { display: 'j F Y' } }),
-    b2bFeatures: buildB2BFeaturesStateWith({
-      masqueradeCompany: {
-        id: 433,
-        isAgenting: true,
-      },
-    }),
-  };
+describe.each(ordersFilterFFStates)(
+  'when a customer is masquerading as a company customer ($label)',
+  ({ ffOn }) => {
+    const preloadedState = {
+      company: buildCompanyStateWith({
+        customer: {
+          role: CustomerRole.SUPER_ADMIN,
+        },
+      }),
+      storeInfo: buildStoreInfoStateWith({ timeFormat: { display: 'j F Y' } }),
+      b2bFeatures: buildB2BFeaturesStateWith({
+        masqueradeCompany: {
+          id: 433,
+          isAgenting: true,
+        },
+      }),
+      global: buildFFGlobalState(ffOn),
+    };
 
-  beforeEach(() => {
-    server.use(
-      graphql.query('GetOrderStatuses', () =>
-        HttpResponse.json(buildCompanyOrderStatusesWith('WHATEVER_VALUES')),
-      ),
-    );
-  });
-
-  describe('has placed orders', () => {
-    it('displays a table with order information', async () => {
+    beforeEach(() => {
       server.use(
-        graphql.query('GetAllOrders', () =>
-          HttpResponse.json(buildCompanyOrdersWith('WHATEVER_VALUES')),
+        graphql.query('GetOrderStatuses', () =>
+          HttpResponse.json(buildCompanyOrderStatusesWith('WHATEVER_VALUES')),
         ),
       );
+    });
+
+    describe('has placed orders', () => {
+      it('displays a table with order information', async () => {
+        server.use(
+          graphql.query('GetAllOrders', () =>
+            HttpResponse.json(buildCompanyOrdersWith('WHATEVER_VALUES')),
+          ),
+        );
+
+        renderWithProviders(<MyOrders />, { preloadedState });
+
+        await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+        const table = screen.getByRole('table');
+
+        const columnHeaders = within(table).getAllByRole('columnheader');
+
+        expect(columnHeaders[0]).toHaveTextContent('Order');
+        expect(columnHeaders[1]).toHaveTextContent('Company');
+        expect(columnHeaders[2]).toHaveTextContent('PO / Reference');
+        expect(columnHeaders[3]).toHaveTextContent('Grand total');
+        expect(columnHeaders[4]).toHaveTextContent('Order status');
+        expect(columnHeaders[5]).toHaveTextContent('Created on');
+      });
+    });
+
+    it('displays all the orders associated with the company', async () => {
+      const getAllOrders = vi.fn();
+
+      server.use(
+        graphql.query('GetAllOrders', ({ query }) => HttpResponse.json(getAllOrders(query))),
+      );
+
+      when(getAllOrders)
+        .calledWith(
+          // isShowMy controls whether to show the orders for the current user, setting it to "1" will filter for currentUser
+          stringContainingAll('companyIds: [433,]', 'isShowMy: "1"', 'orderBy: "-bcOrderId"'),
+        )
+        .thenReturn(
+          buildCompanyOrdersWith({
+            data: {
+              allOrders: {
+                totalCount: 2,
+                edges: [
+                  buildCompanyOrderNodeWith({ node: { orderId: '66996' } }),
+                  buildCompanyOrderNodeWith({ node: { orderId: '66986' } }),
+                ],
+              },
+            },
+          }),
+        );
 
       renderWithProviders(<MyOrders />, { preloadedState });
 
       await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
 
-      const table = screen.getByRole('table');
-
-      const columnHeaders = within(table).getAllByRole('columnheader');
-
-      expect(columnHeaders[0]).toHaveTextContent('Order');
-      expect(columnHeaders[1]).toHaveTextContent('Company');
-      expect(columnHeaders[2]).toHaveTextContent('PO / Reference');
-      expect(columnHeaders[3]).toHaveTextContent('Grand total');
-      expect(columnHeaders[4]).toHaveTextContent('Order status');
-      expect(columnHeaders[5]).toHaveTextContent('Created on');
+      expect(screen.getByRole('row', { name: /66996/ })).toBeInTheDocument();
+      expect(screen.getByRole('row', { name: /66986/ })).toBeInTheDocument();
     });
-  });
 
-  it('displays all the orders associated with the company', async () => {
-    const getAllOrders = vi.fn();
-
-    server.use(
-      graphql.query('GetAllOrders', ({ query }) => HttpResponse.json(getAllOrders(query))),
-    );
-
-    when(getAllOrders)
-      .calledWith(
-        // isShowMy controls whether to show the orders for the current user, setting it to "1" will filter for currentUser
-        stringContainingAll('companyIds: [433,]', 'isShowMy: "1"', 'orderBy: "-bcOrderId"'),
-      )
-      .thenReturn(
-        buildCompanyOrdersWith({
-          data: {
-            allOrders: {
-              totalCount: 2,
-              edges: [
-                buildCompanyOrderNodeWith({ node: { orderId: '66996' } }),
-                buildCompanyOrderNodeWith({ node: { orderId: '66986' } }),
-              ],
-            },
+    it('displays all the information associated with an order', async () => {
+      const order66996 = buildCompanyOrderNodeWith({
+        node: {
+          orderId: '66996',
+          poNumber: '0022',
+          totalIncTax: 100,
+          status: 'Pending',
+          createdAt: getUnixTime(new Date('13 March 2025')),
+          companyInfo: {
+            companyName: 'Monsters Inc.',
           },
+        },
+      });
+
+      const getAllOrders = vi.fn();
+
+      server.use(
+        graphql.query('GetOrderStatuses', () => {
+          return HttpResponse.json(
+            buildCompanyOrderStatusesWith({
+              data: {
+                orderStatuses: [
+                  buildOrderStatusWith({ systemLabel: 'Pending', customLabel: 'Pending' }),
+                  buildOrderStatusWith('WHATEVER_VALUES'),
+                ],
+              },
+            }),
+          );
         }),
+        graphql.query('GetAllOrders', ({ query }) => HttpResponse.json(getAllOrders(query))),
       );
 
-    renderWithProviders(<MyOrders />, { preloadedState });
-
-    await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
-
-    expect(screen.getByRole('row', { name: /66996/ })).toBeInTheDocument();
-    expect(screen.getByRole('row', { name: /66986/ })).toBeInTheDocument();
-  });
-
-  it('displays all the information associated with an order', async () => {
-    const order66996 = buildCompanyOrderNodeWith({
-      node: {
-        orderId: '66996',
-        poNumber: '0022',
-        totalIncTax: 100,
-        status: 'Pending',
-        createdAt: getUnixTime(new Date('13 March 2025')),
-        companyInfo: {
-          companyName: 'Monsters Inc.',
-        },
-      },
-    });
-
-    const getAllOrders = vi.fn();
-
-    server.use(
-      graphql.query('GetOrderStatuses', () => {
-        return HttpResponse.json(
-          buildCompanyOrderStatusesWith({
+      when(getAllOrders)
+        .calledWith(stringContainingAll('companyIds: [433,]', 'orderBy: "-bcOrderId"'))
+        .thenReturn(
+          buildCompanyOrdersWith({
             data: {
-              orderStatuses: [
-                buildOrderStatusWith({ systemLabel: 'Pending', customLabel: 'Pending' }),
-                buildOrderStatusWith('WHATEVER_VALUES'),
-              ],
+              allOrders: {
+                totalCount: 1,
+                edges: [order66996],
+              },
             },
           }),
         );
-      }),
-      graphql.query('GetAllOrders', ({ query }) => HttpResponse.json(getAllOrders(query))),
-    );
 
-    when(getAllOrders)
-      .calledWith(stringContainingAll('companyIds: [433,]', 'orderBy: "-bcOrderId"'))
-      .thenReturn(
-        buildCompanyOrdersWith({
-          data: {
-            allOrders: {
-              totalCount: 1,
-              edges: [order66996],
-            },
-          },
-        }),
-      );
+      renderWithProviders(<MyOrders />, { preloadedState });
 
-    renderWithProviders(<MyOrders />, { preloadedState });
+      await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
 
-    await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+      const row = screen.getByRole('row', { name: /66996/ });
 
-    const row = screen.getByRole('row', { name: /66996/ });
-
-    expect(within(row).getByRole('cell', { name: '66996' })).toBeInTheDocument();
-    expect(within(row).getByRole('cell', { name: 'Monsters Inc.' })).toBeInTheDocument();
-    expect(within(row).getByRole('cell', { name: '0022' })).toBeInTheDocument();
-    expect(within(row).getByRole('cell', { name: '$100.00' })).toBeInTheDocument();
-    expect(within(row).getByRole('cell', { name: 'Pending' })).toBeInTheDocument();
-    expect(within(row).getByRole('cell', { name: '13 March 2025' })).toBeInTheDocument();
-  });
-});
+      expect(within(row).getByRole('cell', { name: '66996' })).toBeInTheDocument();
+      expect(within(row).getByRole('cell', { name: 'Monsters Inc.' })).toBeInTheDocument();
+      expect(within(row).getByRole('cell', { name: '0022' })).toBeInTheDocument();
+      expect(within(row).getByRole('cell', { name: '$100.00' })).toBeInTheDocument();
+      expect(within(row).getByRole('cell', { name: 'Pending' })).toBeInTheDocument();
+      expect(within(row).getByRole('cell', { name: '13 March 2025' })).toBeInTheDocument();
+    });
+  },
+);
 
 describe.todo('when a customer is part of a company hierarchy');

--- a/apps/storefront/src/pages/MyOrders/index.test.tsx
+++ b/apps/storefront/src/pages/MyOrders/index.test.tsx
@@ -1579,19 +1579,19 @@ describe('when a company customer', () => {
 
 describe('when a customer is masquerading as a company customer', () => {
   const preloadedState = {
-  company: buildCompanyStateWith({
-    customer: {
-      role: CustomerRole.SUPER_ADMIN,
-    },
-  }),
-  storeInfo: buildStoreInfoStateWith({ timeFormat: { display: 'j F Y' } }),
-  b2bFeatures: buildB2BFeaturesStateWith({
-    masqueradeCompany: {
-      id: 433,
-      isAgenting: true,
-    },
-  }),
-};
+    company: buildCompanyStateWith({
+      customer: {
+        role: CustomerRole.SUPER_ADMIN,
+      },
+    }),
+    storeInfo: buildStoreInfoStateWith({ timeFormat: { display: 'j F Y' } }),
+    b2bFeatures: buildB2BFeaturesStateWith({
+      masqueradeCompany: {
+        id: 433,
+        isAgenting: true,
+      },
+    }),
+  };
 
   beforeEach(() => {
     server.use(

--- a/apps/storefront/src/pages/MyOrders/unified-orders.test.tsx
+++ b/apps/storefront/src/pages/MyOrders/unified-orders.test.tsx
@@ -10,9 +10,13 @@ import {
   renderWithProviders,
   screen,
   startMockServer,
+  userEvent,
+  waitFor,
   waitForElementToBeRemoved,
   within,
 } from 'tests/test-utils';
+import { vi } from 'vitest';
+import { when } from 'vitest-when';
 
 import type {
   GetCustomerOrdersResponse,
@@ -21,7 +25,11 @@ import type {
 } from '@/shared/service/bc/graphql/orders';
 import { CompanyStatus, CustomerRole, UserTypes } from '@/types';
 
-import { CustomerOrderStatues, OrderStatus as LegacyOrderStatus } from '../order/orders';
+import {
+  CompanyOrderStatuses,
+  CustomerOrderStatues,
+  OrderStatus as LegacyOrderStatus,
+} from '../order/orders';
 
 import MyOrders from '.';
 
@@ -115,6 +123,7 @@ const buildSfGqlCustomerOrdersResponseWith = builder<GetCustomerOrdersResponse>(
   };
 });
 
+// TODO: Needs to be removed when order statuses api gets added to unified graphql api
 const buildLegacyOrderStatusWith = builder<LegacyOrderStatus>(() => ({
   statusCode: faker.number.int().toString(),
   systemLabel: faker.word.noun(),
@@ -124,6 +133,12 @@ const buildLegacyOrderStatusWith = builder<LegacyOrderStatus>(() => ({
 const buildLegacyOrderStatusesResponseWith = builder<CustomerOrderStatues>(() => ({
   data: {
     bcOrderStatuses: bulk(buildLegacyOrderStatusWith, 'WHATEVER_VALUES').times(3),
+  },
+}));
+
+const buildLegacyB2BOrderStatusesResponseWith = builder<CompanyOrderStatuses>(() => ({
+  data: {
+    orderStatuses: bulk(buildLegacyOrderStatusWith, 'WHATEVER_VALUES').times(3),
   },
 }));
 
@@ -161,7 +176,14 @@ describe('My Orders — unified SF GQL orders (B2B-4613)', () => {
       graphql.query('GetCustomerOrderStatuses', () =>
         HttpResponse.json(buildLegacyOrderStatusesResponseWith('WHATEVER_VALUES')),
       ),
+      graphql.query('GetOrderStatuses', () =>
+        HttpResponse.json(buildLegacyB2BOrderStatusesResponseWith('WHATEVER_VALUES')),
+      ),
     );
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   describe('flag OFF — old path unchanged', () => {
@@ -368,6 +390,407 @@ describe('My Orders — unified SF GQL orders (B2B-4613)', () => {
 
       const row = screen.getByRole('row', { name: /88888/ });
       expect(within(row).getByText(/13 March 2025/)).toBeInTheDocument();
+    });
+
+    describe('filter behavior', () => {
+      const filteredOrderResponse = (entityId: number): GetCustomerOrdersResponse => ({
+        data: {
+          customer: {
+            orders: {
+              edges: [
+                {
+                  node: buildSfGqlOrderWith({ entityId }),
+                  cursor: 'filtered',
+                },
+              ],
+              pageInfo: {
+                hasNextPage: false,
+                hasPreviousPage: false,
+                startCursor: 'filtered',
+                endCursor: 'filtered',
+              },
+            },
+          },
+        },
+      });
+
+      describe('as a B2C customer', () => {
+        it('filters by search input', async () => {
+          const getOrders = vi
+            .fn()
+            .mockReturnValue(buildSfGqlCustomerOrdersResponseWith('WHATEVER_VALUES'));
+
+          server.use(
+            graphql.query('GetCustomerOrders', ({ variables }) =>
+              HttpResponse.json(getOrders(variables)),
+            ),
+          );
+
+          renderWithProviders(<MyOrders />, { preloadedState: b2cStateWithFlag(flagOn) });
+
+          await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+          when(getOrders)
+            .calledWith(
+              expect.objectContaining({
+                filters: expect.objectContaining({ search: '66996' }),
+              }),
+            )
+            .thenReturn(filteredOrderResponse(66996));
+
+          await userEvent.type(screen.getByPlaceholderText(/Search/), '66996');
+
+          await waitFor(() => {
+            expect(screen.getByRole('row', { name: /66996/ })).toBeInTheDocument();
+          });
+        });
+
+        it('filters by status and date together', async () => {
+          vi.setSystemTime(new Date('21 November 2022'));
+
+          const getOrders = vi
+            .fn()
+            .mockReturnValue(buildSfGqlCustomerOrdersResponseWith('WHATEVER_VALUES'));
+
+          server.use(
+            graphql.query('GetCustomerOrderStatuses', () =>
+              HttpResponse.json(
+                buildLegacyOrderStatusesResponseWith({
+                  data: {
+                    bcOrderStatuses: [
+                      buildLegacyOrderStatusWith({
+                        systemLabel: 'Pending',
+                        customLabel: 'Pending',
+                      }),
+                    ],
+                  },
+                }),
+              ),
+            ),
+            graphql.query('GetCustomerOrders', ({ variables }) =>
+              HttpResponse.json(getOrders(variables)),
+            ),
+          );
+
+          renderWithProviders(<MyOrders />, { preloadedState: b2cStateWithFlag(flagOn) });
+
+          await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+          when(getOrders)
+            .calledWith(
+              expect.objectContaining({
+                filters: expect.objectContaining({
+                  status: 'Pending',
+                  dateRange: { from: '2022-11-15', to: '2022-11-26' },
+                }),
+              }),
+            )
+            .thenReturn(filteredOrderResponse(66996));
+
+          await userEvent.click(screen.getByRole('button', { name: /edit/ }));
+
+          const dialog = await screen.findByRole('dialog', { name: 'Filters' });
+
+          await userEvent.click(within(dialog).getByRole('combobox', { name: 'Order status' }));
+          await userEvent.click(screen.getByRole('option', { name: 'Pending' }));
+
+          await userEvent.click(within(dialog).getByRole('textbox', { name: 'From' }));
+          await userEvent.click(screen.getByRole('gridcell', { name: /15/ }));
+
+          await userEvent.click(within(dialog).getByRole('textbox', { name: 'To' }));
+          await userEvent.click(screen.getByRole('gridcell', { name: /26/ }));
+
+          await userEvent.click(screen.getByRole('button', { name: 'Apply' }));
+
+          await waitFor(() => {
+            expect(screen.getByRole('row', { name: /66996/ })).toBeInTheDocument();
+          });
+        });
+
+        it('filters by date range', async () => {
+          vi.setSystemTime(new Date('21 November 2022'));
+
+          const getOrders = vi
+            .fn()
+            .mockReturnValue(buildSfGqlCustomerOrdersResponseWith('WHATEVER_VALUES'));
+
+          server.use(
+            graphql.query('GetCustomerOrders', ({ variables }) =>
+              HttpResponse.json(getOrders(variables)),
+            ),
+          );
+
+          renderWithProviders(<MyOrders />, { preloadedState: b2cStateWithFlag(flagOn) });
+
+          await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+          when(getOrders)
+            .calledWith(
+              expect.objectContaining({
+                filters: expect.objectContaining({
+                  dateRange: { from: '2022-11-15', to: '2022-11-26' },
+                }),
+              }),
+            )
+            .thenReturn(filteredOrderResponse(66996));
+
+          await userEvent.click(screen.getByRole('button', { name: /edit/ }));
+
+          const dialog = await screen.findByRole('dialog', { name: 'Filters' });
+
+          await userEvent.click(within(dialog).getByRole('textbox', { name: 'From' }));
+          await userEvent.click(screen.getByRole('gridcell', { name: /15/ }));
+
+          await userEvent.click(within(dialog).getByRole('textbox', { name: 'To' }));
+          await userEvent.click(screen.getByRole('gridcell', { name: /26/ }));
+
+          await userEvent.click(screen.getByRole('button', { name: 'Apply' }));
+
+          await waitFor(() => {
+            expect(screen.getByRole('row', { name: /66996/ })).toBeInTheDocument();
+          });
+        });
+
+        it('resolves custom status label to systemLabel before sending', async () => {
+          const getOrders = vi
+            .fn()
+            .mockReturnValue(buildSfGqlCustomerOrdersResponseWith('WHATEVER_VALUES'));
+
+          server.use(
+            graphql.query('GetCustomerOrderStatuses', () =>
+              HttpResponse.json(
+                buildLegacyOrderStatusesResponseWith({
+                  data: {
+                    bcOrderStatuses: [
+                      buildLegacyOrderStatusWith({
+                        systemLabel: 'Pending',
+                        customLabel: 'Awaiting',
+                      }),
+                    ],
+                  },
+                }),
+              ),
+            ),
+            graphql.query('GetCustomerOrders', ({ variables }) =>
+              HttpResponse.json(getOrders(variables)),
+            ),
+          );
+
+          renderWithProviders(<MyOrders />, { preloadedState: b2cStateWithFlag(flagOn) });
+
+          await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+          when(getOrders)
+            .calledWith(
+              expect.objectContaining({
+                filters: expect.objectContaining({ status: 'Pending' }),
+              }),
+            )
+            .thenReturn(filteredOrderResponse(66996));
+
+          await userEvent.click(screen.getByRole('button', { name: /edit/ }));
+
+          const dialog = await screen.findByRole('dialog', { name: 'Filters' });
+
+          await userEvent.click(within(dialog).getByRole('combobox', { name: 'Order status' }));
+          await userEvent.click(screen.getByRole('option', { name: 'Awaiting' }));
+
+          await userEvent.click(screen.getByRole('button', { name: 'Apply' }));
+
+          await waitFor(() => {
+            expect(screen.getByRole('row', { name: /66996/ })).toBeInTheDocument();
+          });
+        });
+      });
+
+      describe('as a B2B customer', () => {
+        it('filters by search input', async () => {
+          const getOrders = vi
+            .fn()
+            .mockReturnValue(buildSfGqlCustomerOrdersResponseWith('WHATEVER_VALUES'));
+
+          server.use(
+            graphql.query('GetCustomerOrders', ({ variables }) =>
+              HttpResponse.json(getOrders(variables)),
+            ),
+          );
+
+          renderWithProviders(<MyOrders />, { preloadedState: b2bStateWithFlag(flagOn) });
+
+          await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+          when(getOrders)
+            .calledWith(
+              expect.objectContaining({
+                filters: expect.objectContaining({ search: '66996' }),
+              }),
+            )
+            .thenReturn(filteredOrderResponse(66996));
+
+          await userEvent.type(screen.getByPlaceholderText(/Search/), '66996');
+
+          await waitFor(() => {
+            expect(screen.getByRole('row', { name: /66996/ })).toBeInTheDocument();
+          });
+        });
+
+        it('filters by status and date together', async () => {
+          vi.setSystemTime(new Date('21 November 2022'));
+
+          const getOrders = vi
+            .fn()
+            .mockReturnValue(buildSfGqlCustomerOrdersResponseWith('WHATEVER_VALUES'));
+
+          server.use(
+            graphql.query('GetOrderStatuses', () =>
+              HttpResponse.json(
+                buildLegacyB2BOrderStatusesResponseWith({
+                  data: {
+                    orderStatuses: [
+                      buildLegacyOrderStatusWith({
+                        systemLabel: 'Pending',
+                        customLabel: 'Pending',
+                      }),
+                    ],
+                  },
+                }),
+              ),
+            ),
+            graphql.query('GetCustomerOrders', ({ variables }) =>
+              HttpResponse.json(getOrders(variables)),
+            ),
+          );
+
+          renderWithProviders(<MyOrders />, { preloadedState: b2bStateWithFlag(flagOn) });
+
+          await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+          when(getOrders)
+            .calledWith(
+              expect.objectContaining({
+                filters: expect.objectContaining({
+                  status: 'Pending',
+                  dateRange: { from: '2022-11-15', to: '2022-11-26' },
+                }),
+              }),
+            )
+            .thenReturn(filteredOrderResponse(66996));
+
+          await userEvent.click(screen.getByRole('button', { name: /edit/ }));
+
+          const dialog = await screen.findByRole('dialog', { name: 'Filters' });
+
+          await userEvent.click(within(dialog).getByRole('combobox', { name: 'Order status' }));
+          await userEvent.click(screen.getByRole('option', { name: 'Pending' }));
+
+          await userEvent.click(within(dialog).getByRole('textbox', { name: 'From' }));
+          await userEvent.click(screen.getByRole('gridcell', { name: /15/ }));
+
+          await userEvent.click(within(dialog).getByRole('textbox', { name: 'To' }));
+          await userEvent.click(screen.getByRole('gridcell', { name: /26/ }));
+
+          await userEvent.click(screen.getByRole('button', { name: 'Apply' }));
+
+          await waitFor(() => {
+            expect(screen.getByRole('row', { name: /66996/ })).toBeInTheDocument();
+          });
+        });
+
+        it('filters by date range', async () => {
+          vi.setSystemTime(new Date('21 November 2022'));
+
+          const getOrders = vi
+            .fn()
+            .mockReturnValue(buildSfGqlCustomerOrdersResponseWith('WHATEVER_VALUES'));
+
+          server.use(
+            graphql.query('GetCustomerOrders', ({ variables }) =>
+              HttpResponse.json(getOrders(variables)),
+            ),
+          );
+
+          renderWithProviders(<MyOrders />, { preloadedState: b2bStateWithFlag(flagOn) });
+
+          await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+          when(getOrders)
+            .calledWith(
+              expect.objectContaining({
+                filters: expect.objectContaining({
+                  dateRange: { from: '2022-11-15', to: '2022-11-26' },
+                }),
+              }),
+            )
+            .thenReturn(filteredOrderResponse(66996));
+
+          await userEvent.click(screen.getByRole('button', { name: /edit/ }));
+
+          const dialog = await screen.findByRole('dialog', { name: 'Filters' });
+
+          await userEvent.click(within(dialog).getByRole('textbox', { name: 'From' }));
+          await userEvent.click(screen.getByRole('gridcell', { name: /15/ }));
+
+          await userEvent.click(within(dialog).getByRole('textbox', { name: 'To' }));
+          await userEvent.click(screen.getByRole('gridcell', { name: /26/ }));
+
+          await userEvent.click(screen.getByRole('button', { name: 'Apply' }));
+
+          await waitFor(() => {
+            expect(screen.getByRole('row', { name: /66996/ })).toBeInTheDocument();
+          });
+        });
+
+        it('resolves custom status label to systemLabel before sending', async () => {
+          const getOrders = vi
+            .fn()
+            .mockReturnValue(buildSfGqlCustomerOrdersResponseWith('WHATEVER_VALUES'));
+
+          server.use(
+            graphql.query('GetOrderStatuses', () =>
+              HttpResponse.json(
+                buildLegacyB2BOrderStatusesResponseWith({
+                  data: {
+                    orderStatuses: [
+                      buildLegacyOrderStatusWith({
+                        systemLabel: 'Pending',
+                        customLabel: 'Awaiting',
+                      }),
+                    ],
+                  },
+                }),
+              ),
+            ),
+            graphql.query('GetCustomerOrders', ({ variables }) =>
+              HttpResponse.json(getOrders(variables)),
+            ),
+          );
+
+          renderWithProviders(<MyOrders />, { preloadedState: b2bStateWithFlag(flagOn) });
+
+          await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+          when(getOrders)
+            .calledWith(
+              expect.objectContaining({
+                filters: expect.objectContaining({ status: 'Pending' }),
+              }),
+            )
+            .thenReturn(filteredOrderResponse(66996));
+
+          await userEvent.click(screen.getByRole('button', { name: /edit/ }));
+
+          const dialog = await screen.findByRole('dialog', { name: 'Filters' });
+
+          await userEvent.click(within(dialog).getByRole('combobox', { name: 'Order status' }));
+          await userEvent.click(screen.getByRole('option', { name: 'Awaiting' }));
+
+          await userEvent.click(screen.getByRole('button', { name: 'Apply' }));
+
+          await waitFor(() => {
+            expect(screen.getByRole('row', { name: /66996/ })).toBeInTheDocument();
+          });
+        });
+      });
     });
   });
 });

--- a/apps/storefront/src/pages/order/Order.tsx
+++ b/apps/storefront/src/pages/order/Order.tsx
@@ -167,6 +167,8 @@ function Order({ isCompanyOrder = false }: OrderProps) {
     if (isUnifiedOrdersNonCompanyOrderPath) {
       const result = await getCustomerOrders({
         first: params.first as number,
+        filters: customerFilterState.filters,
+        sortBy: customerFilterState.sortBy,
       });
 
       const orders = result.data?.customer?.orders;

--- a/apps/storefront/src/pages/order/Order.tsx
+++ b/apps/storefront/src/pages/order/Order.tsx
@@ -109,6 +109,7 @@ function Order({ isCompanyOrder = false }: OrderProps) {
   const customerFilterState = useCustomerOrdersFilterState({
     companyId: selectedCompanyId,
     orderStatuses: getOrderStatuses,
+    isCompanyOrder,
   });
 
   const {

--- a/apps/storefront/src/pages/order/Order.tsx
+++ b/apps/storefront/src/pages/order/Order.tsx
@@ -16,16 +16,13 @@ import { currencyFormat, ordersCurrencyFormat } from '@/utils/b3CurrencyFormat';
 import { displayFormat } from '@/utils/b3DateFormat';
 
 import OrderStatus from './components/OrderStatus';
-import { orderStatusTranslationVariables } from './shared/getOrderStatus';
 import { B3Table, PossibleNodeWrapper, TableColumnItem } from './table/B3Table';
+import { adaptUnifiedToLegacyFilterParams } from './adaptUnifiedToLegacyFilterParams';
 import {
-  assertSortKey,
   FilterSearchProps,
-  getCompanyInitFilter,
-  getCustomerInitFilter,
   getFilterMoreData,
   getOrderStatusText,
-  sortKeys,
+  translateFilterMoreData,
 } from './config';
 import { type ListItem, mapSfGqlOrderToListItem } from './mapSfGqlOrderToListItem';
 import { OrderItemCard } from './OrderItemCard';
@@ -33,17 +30,11 @@ import {
   getB2BAllOrders,
   getBCAllOrders,
   getBcOrderStatusType,
-  getOrdersCreatedByUser,
+  getCreatedByUserForOrders,
   getOrderStatusType,
 } from './orders';
-
-interface SearchChangeProps {
-  startValue?: string;
-  endValue?: string;
-  PlacedBy?: string;
-  orderStatus?: string | number;
-  company?: string;
-}
+import { useCustomerOrdersFilterState } from './useCustomerOrdersFilterState';
+import { useLegacyOrdersFilterState } from './useLegacyOrdersFilterState';
 
 interface OrderProps {
   isCompanyOrder?: boolean;
@@ -94,15 +85,6 @@ const getName = (haystack: string = '') => {
   return createdByUserRegArr?.length ? createdByUserRegArr[0].trim() : '';
 };
 
-interface OrderBy {
-  key: keyof typeof sortKeys;
-  dir: 'asc' | 'desc';
-}
-
-const getOrderBy = ({ key, dir }: OrderBy) => {
-  return dir === 'desc' ? `-${sortKeys[key]}` : sortKeys[key];
-};
-
 function Order({ isCompanyOrder = false }: OrderProps) {
   const b3Lang = useB3Lang();
   const [isMobile] = useMobile();
@@ -113,93 +95,76 @@ function Order({ isCompanyOrder = false }: OrderProps) {
   const [pagination, setPagination] = useState({ offset: 0, first: 10 });
 
   const [allTotal, setAllTotal] = useState(0);
-  const [filterData, setFilterData] = useState<Partial<FilterSearchProps>>();
-  const [filterInfo, setFilterInfo] = useState<Array<any>>([]);
+  const [filterMoreInfo, setFilterMoreInfo] = useState<Array<any>>([]);
   const [getOrderStatuses, setOrderStatuses] = useState<Array<any>>([]);
 
-  const [orderBy, setOrderBy] = useState<OrderBy>({
-    key: 'orderId',
-    dir: 'desc',
+  const isUnifiedOrdersNonCompanyOrderPath = isUnifiedOrders && !isCompanyOrder;
+
+  const legacyFilterState = useLegacyOrdersFilterState({
+    isB2BUser,
+    isCompanyOrder,
+    selectedCompanyId,
+    orderStatuses: getOrderStatuses,
+  });
+  const customerFilterState = useCustomerOrdersFilterState({
+    companyId: selectedCompanyId,
+    orderStatuses: getOrderStatuses,
   });
 
-  const handleSetOrderBy = (key: string) => {
-    setOrderBy((prev) => {
-      assertSortKey(key);
+  const {
+    activeSort,
+    handleSearchChange,
+    handleFilterChange,
+    handleCompanyIdsChange,
+    handleSetOrderBy,
+  } = isUnifiedOrdersNonCompanyOrderPath ? customerFilterState : legacyFilterState;
 
-      if (prev.key === key) {
-        return {
-          key,
-          dir: prev.dir === 'asc' ? 'desc' : 'asc',
-        };
-      }
-
-      return {
-        key,
-        dir: 'desc',
-      };
-    });
-  };
+  const { filterData, orderBy } = isUnifiedOrdersNonCompanyOrderPath
+    ? adaptUnifiedToLegacyFilterParams({
+        filters: customerFilterState.filters,
+        activeSort: customerFilterState.activeSort,
+        isB2BUser,
+      })
+    : { filterData: legacyFilterState.filterData, orderBy: legacyFilterState.orderBy };
 
   useEffect(() => {
-    const search = isB2BUser
-      ? getCompanyInitFilter(isCompanyOrder, selectedCompanyId)
-      : getCustomerInitFilter();
-
-    setFilterData(search);
-
     // TODO: Guest customer should not be able to see the order list
     if (role === CustomerRole.GUEST) return;
 
     const initFilter = async () => {
       const createdByUsers =
-        isB2BUser && isCompanyOrder ? await getOrdersCreatedByUser(Number(companyId)) : {};
-
+        isB2BUser && isCompanyOrder ? await getCreatedByUserForOrders(Number(companyId)) : {};
+      //  Caution: This api hasn't yet been ported to unified order api
       const orderStatuses = isB2BUser ? await getOrderStatusType() : await getBcOrderStatusType();
-
-      const filterInfo = getFilterMoreData(
-        isB2BUser,
-        role,
-        isCompanyOrder,
-        isAgenting,
-        createdByUsers,
-        orderStatuses,
-      );
-
       setOrderStatuses(orderStatuses);
 
-      const filterInfoWithTranslatedLabel = filterInfo.map((element) => {
-        const translatedElement = element;
-        translatedElement.label = b3Lang(element.idLang);
-
-        if (element.name === 'orderStatus') {
-          translatedElement.options = element.options.map(
-            (option: { customLabel: string; systemLabel: string }) => {
-              const optionLabel = orderStatusTranslationVariables[option.systemLabel];
-              const elementOption = option;
-              elementOption.customLabel =
-                b3Lang(optionLabel) === elementOption.systemLabel
-                  ? elementOption.customLabel
-                  : b3Lang(optionLabel);
-
-              return option;
-            },
-          );
-        }
-
-        return element;
-      });
-
-      setFilterInfo(filterInfoWithTranslatedLabel);
+      /* 
+        returns what all fields to show in more filter (funnel icon)
+        and styles associated to those fields
+      */
+      setFilterMoreInfo(
+        translateFilterMoreData(
+          getFilterMoreData(
+            isB2BUser,
+            role,
+            isCompanyOrder,
+            isAgenting,
+            createdByUsers,
+            orderStatuses,
+          ),
+          b3Lang,
+        ),
+      );
     };
 
     initFilter();
-  }, [b3Lang, companyId, isAgenting, isB2BUser, isCompanyOrder, role, selectedCompanyId]);
+  }, [b3Lang, companyId, isAgenting, isB2BUser, isCompanyOrder, role]);
 
   const fetchList = async ({
     createdBy,
     ...params
   }: Partial<FilterSearchProps>): Promise<{ edges: ListItem[]; totalCount: number }> => {
-    if (isUnifiedOrders && !isCompanyOrder) {
+    if (isUnifiedOrdersNonCompanyOrderPath) {
       const result = await getCustomerOrders({
         first: params.first as number,
       });
@@ -234,7 +199,7 @@ function Order({ isCompanyOrder = false }: OrderProps) {
         currentIndex: index,
         searchParams: {
           ...filterData,
-          orderBy: getOrderBy(orderBy),
+          orderBy,
         },
         totalCount: allTotal,
         isCompanyOrder,
@@ -317,50 +282,12 @@ function Order({ isCompanyOrder = false }: OrderProps) {
     return getNewColumnItems;
   };
 
-  const handleChange = (key: string, value: string) => {
-    if (key === 'search') {
-      setFilterData((data) => ({
-        ...data,
-        q: value,
-      }));
-    }
-  };
-
-  const handleFilterChange = (value: SearchChangeProps) => {
-    let currentStatus = value?.orderStatus || '';
-    if (currentStatus) {
-      const originStatus = getOrderStatuses.find(
-        (status) => status.customLabel === currentStatus || status.systemLabel === currentStatus,
-      );
-
-      currentStatus = originStatus?.systemLabel || currentStatus;
-    }
-
-    setFilterData((data) => ({
-      ...data,
-      beginDateAt: value?.startValue || null,
-      endDateAt: value?.endValue || null,
-      createdBy: value?.PlacedBy || '',
-      statusCode: currentStatus,
-      companyName: value?.company || '',
-    }));
-  };
-
   const columnItems = getColumnItems();
-
-  const handleSelectCompanies = (company: number[]) => {
-    const newCompanyIds = company.includes(-1) ? [] : company;
-
-    setFilterData((data) => ({
-      ...data,
-      companyIds: newCompanyIds,
-    }));
-  };
 
   const { data, isFetching } = useQuery({
     queryKey: ['orderList', filterData, pagination, orderBy],
     enabled: Boolean(filterData),
-    queryFn: () => fetchList({ ...filterData, ...pagination, orderBy: getOrderBy(orderBy) }),
+    queryFn: () => fetchList({ ...filterData, ...pagination, orderBy }),
   });
 
   const listItems = useMemo(
@@ -397,7 +324,7 @@ function Order({ isCompanyOrder = false }: OrderProps) {
         >
           {isEnabledCompanyHierarchy && (
             <Box sx={{ mr: isMobile ? 0 : '10px', mb: '30px' }}>
-              <B2BAutoCompleteCheckbox handleChangeCompanyIds={handleSelectCompanies} />
+              <B2BAutoCompleteCheckbox handleChangeCompanyIds={handleCompanyIdsChange} />
             </Box>
           )}
           <B3Filter
@@ -413,8 +340,8 @@ function Order({ isCompanyOrder = false }: OrderProps) {
               defaultValue: filterData?.endDateAt || null,
               pickerKey: 'end',
             }}
-            filterMoreInfo={filterInfo}
-            handleChange={handleChange}
+            filterMoreInfo={filterMoreInfo}
+            handleChange={handleSearchChange}
             handleFilterChange={handleFilterChange}
             pcTotalWidth="100%"
             pcContainerWidth="100%"
@@ -432,9 +359,9 @@ function Order({ isCompanyOrder = false }: OrderProps) {
             <OrderItemCard key={row.orderId} goToDetail={() => goToDetail(row, index)} item={row} />
           )}
           onClickRow={goToDetail}
-          sortDirection={orderBy.dir}
+          sortDirection={activeSort.dir}
           sortByFn={handleSetOrderBy}
-          orderBy={orderBy.key}
+          orderBy={activeSort.key}
         />
       </Box>
     </B3Spin>

--- a/apps/storefront/src/pages/order/Order.tsx
+++ b/apps/storefront/src/pages/order/Order.tsx
@@ -9,7 +9,11 @@ import { B2BAutoCompleteCheckbox } from '@/components/ui/B2BAutoCompleteCheckbox
 import { useFeatureFlag } from '@/hooks/useFeatureFlag';
 import { useMobile } from '@/hooks/useMobile';
 import { useB3Lang } from '@/lib/lang';
-import { getCustomerOrders } from '@/shared/service/bc/graphql/orders';
+import {
+  getCustomerOrders,
+  OrdersFiltersInput,
+  OrdersSortInput,
+} from '@/shared/service/bc/graphql/orders';
 import { isB2BUserSelector, useAppSelector } from '@/store';
 import { CustomerRole } from '@/types';
 import { currencyFormat, ordersCurrencyFormat } from '@/utils/b3CurrencyFormat';
@@ -161,23 +165,26 @@ function Order({ isCompanyOrder = false }: OrderProps) {
     initFilter();
   }, [b3Lang, companyId, isAgenting, isB2BUser, isCompanyOrder, role]);
 
-  const fetchList = async ({
+  const fetchUnifiedOrders = async ({
+    first,
+    filters,
+    sortBy,
+  }: {
+    first: number;
+    filters: OrdersFiltersInput;
+    sortBy: OrdersSortInput;
+  }): Promise<{ edges: ListItem[]; totalCount: number }> => {
+    const result = await getCustomerOrders({ first, filters, sortBy });
+    const edges = (result.data?.customer?.orders?.edges || []).map((edge) =>
+      mapSfGqlOrderToListItem(edge.node),
+    );
+    return { edges, totalCount: -1 };
+  };
+
+  const fetchLegacyOrders = async ({
     createdBy,
     ...params
   }: Partial<FilterSearchProps>): Promise<{ edges: ListItem[]; totalCount: number }> => {
-    if (isUnifiedOrdersNonCompanyOrderPath) {
-      const result = await getCustomerOrders({
-        first: params.first as number,
-        filters: customerFilterState.filters,
-        sortBy: customerFilterState.sortBy,
-      });
-
-      const orders = result.data?.customer?.orders;
-      const edges = (orders?.edges || []).map((edge) => mapSfGqlOrderToListItem(edge.node));
-
-      return { edges, totalCount: -1 };
-    }
-
     const { edges = [], totalCount } = isB2BUser
       ? await getB2BAllOrders({
           ...params,
@@ -288,9 +295,18 @@ function Order({ isCompanyOrder = false }: OrderProps) {
   const columnItems = getColumnItems();
 
   const { data, isFetching } = useQuery({
-    queryKey: ['orderList', filterData, pagination, orderBy],
-    enabled: Boolean(filterData),
-    queryFn: () => fetchList({ ...filterData, ...pagination, orderBy }),
+    queryKey: isUnifiedOrdersNonCompanyOrderPath
+      ? ['orderList:unified', customerFilterState.filters, customerFilterState.sortBy, pagination]
+      : ['orderList:legacy', filterData, pagination, orderBy],
+    enabled: isUnifiedOrdersNonCompanyOrderPath ? true : Boolean(filterData),
+    queryFn: () =>
+      isUnifiedOrdersNonCompanyOrderPath
+        ? fetchUnifiedOrders({
+            first: pagination.first,
+            filters: customerFilterState.filters,
+            sortBy: customerFilterState.sortBy,
+          })
+        : fetchLegacyOrders({ ...filterData, ...pagination, orderBy }),
   });
 
   const listItems = useMemo(

--- a/apps/storefront/src/pages/order/adaptUnifiedToLegacyFilterParams.ts
+++ b/apps/storefront/src/pages/order/adaptUnifiedToLegacyFilterParams.ts
@@ -1,0 +1,41 @@
+/**
+ * TEMPORARY, needs to be removed
+ *
+ * Bridges the unified filter state (OrdersFiltersInput + activeSort) back to the
+ * legacy FilterSearchProps + orderBy shape consumed by getB2BAllOrders /
+ * getBCAllOrders, so the new filter hook can drive the existing data-fetch path
+ * before the data source itself is switched to getCustomerOrders.
+ *
+ * Once Order.tsx calls getCustomerOrders directly, delete this file.
+ */
+
+import { FilterSearchProps, sortKeys } from './config';
+import type { UseCustomerOrdersFilterStateResult } from './useCustomerOrdersFilterState';
+
+export type AdaptUnifiedToLegacyFilterParamsArgs = Pick<
+  UseCustomerOrdersFilterStateResult,
+  'filters' | 'activeSort'
+> & {
+  isB2BUser: boolean;
+};
+
+export const adaptUnifiedToLegacyFilterParams = ({
+  filters,
+  activeSort,
+  isB2BUser,
+}: AdaptUnifiedToLegacyFilterParamsArgs): {
+  filterData: Partial<FilterSearchProps>;
+  orderBy: string;
+} => ({
+  filterData: {
+    q: filters.search ?? '',
+    statusCode: filters.status ?? '',
+    beginDateAt: filters.dateRange?.from ?? null,
+    endDateAt: filters.dateRange?.to ?? null,
+    companyName: filters.companyName ?? '',
+    // Legacy emits `companyIds: []` for "All"; restore that for B2B users.
+    companyIds: filters.companyIds?.map(Number) ?? (isB2BUser ? [] : undefined),
+    isShowMy: isB2BUser ? 1 : undefined,
+  },
+  orderBy: activeSort.dir === 'desc' ? `-${sortKeys[activeSort.key]}` : sortKeys[activeSort.key],
+});

--- a/apps/storefront/src/pages/order/adaptUnifiedToLegacyParams.test.ts
+++ b/apps/storefront/src/pages/order/adaptUnifiedToLegacyParams.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from 'vitest';
+
+import { OrdersSortInput } from '@/shared/service/bc/graphql/orders';
+
+import {
+  adaptUnifiedToLegacyFilterParams,
+  AdaptUnifiedToLegacyFilterParamsArgs,
+} from './adaptUnifiedToLegacyFilterParams';
+
+const baseArgs: AdaptUnifiedToLegacyFilterParamsArgs = {
+  filters: {},
+  activeSort: { key: 'orderId', dir: 'desc' },
+  isB2BUser: false,
+};
+
+describe('adaptUnifiedToLegacyFilterParams', () => {
+  describe('filterData', () => {
+    it('maps all unified filter fields to the legacy shape', () => {
+      const { filterData } = adaptUnifiedToLegacyFilterParams({
+        ...baseArgs,
+        filters: {
+          search: 'widget',
+          status: 'AWAITING_FULFILLMENT',
+          dateRange: { from: '2026-01-01', to: '2026-02-01' },
+          companyName: 'Acme',
+          companyIds: ['1', '2', '3'],
+        },
+      });
+
+      expect(filterData).toEqual({
+        q: 'widget',
+        statusCode: 'AWAITING_FULFILLMENT',
+        beginDateAt: '2026-01-01',
+        endDateAt: '2026-02-01',
+        companyName: 'Acme',
+        companyIds: [1, 2, 3],
+        isShowMy: undefined,
+      });
+    });
+
+    it('defaults missing search to an empty string', () => {
+      const { filterData } = adaptUnifiedToLegacyFilterParams(baseArgs);
+
+      expect(filterData.q).toBe('');
+    });
+
+    it('defaults missing companyName to an empty string', () => {
+      const { filterData } = adaptUnifiedToLegacyFilterParams(baseArgs);
+
+      expect(filterData.companyName).toBe('');
+    });
+
+    it('passes status through, defaulting undefined to an empty string', () => {
+      const { filterData: withStatus } = adaptUnifiedToLegacyFilterParams({
+        ...baseArgs,
+        filters: { status: 'COMPLETED' },
+      });
+      const { filterData: noStatus } = adaptUnifiedToLegacyFilterParams(baseArgs);
+
+      expect(withStatus.statusCode).toBe('COMPLETED');
+      expect(noStatus.statusCode).toBe('');
+    });
+
+    it('sets beginDateAt/endDateAt to null when dateRange is missing', () => {
+      const { filterData } = adaptUnifiedToLegacyFilterParams(baseArgs);
+
+      expect(filterData.beginDateAt).toBeNull();
+      expect(filterData.endDateAt).toBeNull();
+    });
+
+    it('sets endDateAt to null when dateRange.to is missing', () => {
+      const { filterData } = adaptUnifiedToLegacyFilterParams({
+        ...baseArgs,
+        filters: { dateRange: { from: '2026-01-01' } },
+      });
+
+      expect(filterData.beginDateAt).toBe('2026-01-01');
+      expect(filterData.endDateAt).toBeNull();
+    });
+
+    it('converts companyIds from strings to numbers', () => {
+      const { filterData } = adaptUnifiedToLegacyFilterParams({
+        ...baseArgs,
+        filters: { companyIds: ['10', '20'] },
+      });
+
+      expect(filterData.companyIds).toEqual([10, 20]);
+    });
+
+    it('leaves companyIds undefined when not provided for non-B2B users', () => {
+      const { filterData } = adaptUnifiedToLegacyFilterParams(baseArgs);
+
+      expect(filterData.companyIds).toBeUndefined();
+    });
+
+    it('falls back to an empty array for B2B users when companyIds is undefined', () => {
+      // Legacy "All companies" sets companyIds to []; the unified hook represents
+      // the same state as undefined. Adapter must restore the empty array so the
+      // GraphQL template still emits `companyIds: []` instead of omitting the field.
+      const { filterData } = adaptUnifiedToLegacyFilterParams({ ...baseArgs, isB2BUser: true });
+
+      expect(filterData.companyIds).toEqual([]);
+    });
+
+    it('sets isShowMy to 1 for B2B users', () => {
+      const { filterData } = adaptUnifiedToLegacyFilterParams({ ...baseArgs, isB2BUser: true });
+
+      expect(filterData.isShowMy).toBe(1);
+    });
+
+    it('leaves isShowMy undefined for non-B2B users', () => {
+      const { filterData } = adaptUnifiedToLegacyFilterParams({ ...baseArgs, isB2BUser: false });
+
+      expect(filterData.isShowMy).toBeUndefined();
+    });
+  });
+
+  describe('orderBy', () => {
+    it.each([
+      ['orderId', 'bcOrderId'],
+      ['poNumber', 'poNumber'],
+      ['totalIncTax', 'totalIncTax'],
+      ['status', 'status'],
+      ['createdAt', 'createdAt'],
+    ] as const)('maps %s asc to the legacy sort key without a leading dash', (key, expected) => {
+      const { orderBy } = adaptUnifiedToLegacyFilterParams({
+        ...baseArgs,
+        activeSort: { key, dir: 'asc' },
+      });
+
+      expect(orderBy).toBe(expected);
+    });
+
+    it('prefixes the sort key with a dash when dir is desc', () => {
+      const { orderBy } = adaptUnifiedToLegacyFilterParams({
+        ...baseArgs,
+        activeSort: { key: 'orderId', dir: 'desc' },
+      });
+
+      expect(orderBy).toBe('-bcOrderId');
+    });
+
+    it('works with a sort mapped from a unified OrdersSortInput round-trip', () => {
+      // Sanity check that the legacy string survives after a consumer converts
+      // activeSort → OrdersSortInput (via COLUMN_KEY_TO_SORT_INPUT) and back.
+      expect(OrdersSortInput.ID_Z_TO_A).toBeDefined();
+
+      const { orderBy } = adaptUnifiedToLegacyFilterParams({
+        ...baseArgs,
+        activeSort: { key: 'totalIncTax', dir: 'desc' },
+      });
+
+      expect(orderBy).toBe('-totalIncTax');
+    });
+  });
+});

--- a/apps/storefront/src/pages/order/config.ts
+++ b/apps/storefront/src/pages/order/config.ts
@@ -1,6 +1,8 @@
 import { CustomerRole } from '@/types';
 import { OrderStatusType } from '@/types/gql/graphql';
 
+import { orderStatusTranslationVariables } from './shared/getOrderStatus';
+
 export interface FilterSearchProps {
   [key: string]: string | number | number[] | null;
   beginDateAt: string | null;
@@ -140,3 +142,31 @@ export const getCompanyInitFilter = (
 
 export const getOrderStatusText = (status: number | string, getOrderStatuses: any) =>
   getOrderStatuses.find((item: any) => item.systemLabel === status)?.customLabel || '';
+
+type B3LangFn = (key: string) => string;
+
+type FilterMoreItem = ReturnType<typeof getFilterMoreData>[number];
+
+export const translateFilterMoreData = (
+  filterInfo: FilterMoreItem[],
+  b3Lang: B3LangFn,
+): FilterMoreItem[] =>
+  filterInfo.map((element) => {
+    const label = b3Lang(element.idLang);
+
+    if (element.name !== 'orderStatus') {
+      return { ...element, label };
+    }
+
+    const options = (element.options ?? []).map(
+      (option: { customLabel: string; systemLabel: string }) => {
+        const translated = b3Lang(orderStatusTranslationVariables[option.systemLabel]);
+        return {
+          ...option,
+          customLabel: translated === option.systemLabel ? option.customLabel : translated,
+        };
+      },
+    );
+
+    return { ...element, label, options };
+  });

--- a/apps/storefront/src/pages/order/orders.ts
+++ b/apps/storefront/src/pages/order/orders.ts
@@ -143,7 +143,7 @@ export const getBcOrderStatusType = (): Promise<OrderStatusItem[]> =>
     query: getOrderStatusTypeQl('bcOrderStatuses'),
   }).then((res) => res.bcOrderStatuses);
 
-export const getOrdersCreatedByUser = (companyId: number) =>
+export const getCreatedByUserForOrders = (companyId: number) =>
   B3Request.graphqlB2B({
     query: getCreatedByUser(companyId),
   });

--- a/apps/storefront/src/pages/order/unifiedApiFiltersHelper.ts
+++ b/apps/storefront/src/pages/order/unifiedApiFiltersHelper.ts
@@ -1,0 +1,20 @@
+import { OrderDateRangeFilterInput, OrdersFiltersInput } from '@/shared/service/bc/graphql/orders';
+
+export const getCustomerOrdersInitFilter = (companyId: number): OrdersFiltersInput => {
+  return {
+    status: undefined,
+    dateRange: undefined,
+    search: undefined,
+    companyName: undefined,
+    companyIds: companyId ? [String(companyId)] : undefined,
+  };
+};
+
+export const packDateRange = (
+  start: string | null | undefined,
+  end: string | null | undefined,
+): OrderDateRangeFilterInput | undefined => {
+  if (!start) return undefined;
+  if (!end) return { from: start };
+  return { from: start, to: end };
+};

--- a/apps/storefront/src/pages/order/useCustomerOrdersFilterState.ts
+++ b/apps/storefront/src/pages/order/useCustomerOrdersFilterState.ts
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 
+import { useFeatureFlag } from '@/hooks/useFeatureFlag';
 import { OrdersFiltersInput, OrdersSortInput } from '@/shared/service/bc/graphql/orders';
 // Status list still comes from the legacy `orderStatuses` query — the unified
 // schema doesn't expose one yet, so we depend on the legacy type here.
@@ -46,6 +47,7 @@ const DEFAULT_SORT: { key: SortableColumnKey; dir: SortDir } = { key: 'orderId',
 interface UseCustomerOrdersFilterStateArgs {
   companyId: number;
   orderStatuses: OrderStatusItem[];
+  isCompanyOrder: boolean;
 }
 
 export interface UseCustomerOrdersFilterStateResult {
@@ -61,15 +63,18 @@ export interface UseCustomerOrdersFilterStateResult {
 export const useCustomerOrdersFilterState = ({
   companyId,
   orderStatuses,
+  isCompanyOrder,
 }: UseCustomerOrdersFilterStateArgs): UseCustomerOrdersFilterStateResult => {
   const [filters, setFilters] = useState<OrdersFiltersInput>(() =>
     getCustomerOrdersInitFilter(companyId),
   );
   const [activeSort, setActiveSort] = useState(DEFAULT_SORT);
+  const isUnifiedOrdersNonCompanyOrderPath =
+    useFeatureFlag('B2B-4613.buyer_portal_unified_sf_gql_orders') && !isCompanyOrder;
 
   useEffect(() => {
-    setFilters(getCustomerOrdersInitFilter(companyId));
-  }, [companyId]);
+    if (isUnifiedOrdersNonCompanyOrderPath) setFilters(getCustomerOrdersInitFilter(companyId));
+  }, [companyId, isUnifiedOrdersNonCompanyOrderPath]);
 
   const sortBy = useMemo(
     () => COLUMN_KEY_TO_SORT_INPUT[activeSort.key][activeSort.dir],

--- a/apps/storefront/src/pages/order/useCustomerOrdersFilterState.ts
+++ b/apps/storefront/src/pages/order/useCustomerOrdersFilterState.ts
@@ -1,0 +1,125 @@
+import { useEffect, useMemo, useState } from 'react';
+
+import { OrdersFiltersInput, OrdersSortInput } from '@/shared/service/bc/graphql/orders';
+// Status list still comes from the legacy `orderStatuses` query — the unified
+// schema doesn't expose one yet, so we depend on the legacy type here.
+import { OrderStatusItem } from '@/types';
+
+import { getCustomerOrdersInitFilter, packDateRange } from './unifiedApiFiltersHelper';
+
+type SortableColumnKey = 'orderId' | 'poNumber' | 'totalIncTax' | 'status' | 'createdAt';
+type SortDir = 'asc' | 'desc';
+
+interface AppliedFilters {
+  startValue?: string;
+  endValue?: string;
+  orderStatus?: string | number;
+  company?: string;
+}
+
+const COLUMN_KEY_TO_SORT_INPUT: Record<SortableColumnKey, Record<SortDir, OrdersSortInput>> = {
+  orderId: { asc: OrdersSortInput.ID_A_TO_Z, desc: OrdersSortInput.ID_Z_TO_A },
+  poNumber: { asc: OrdersSortInput.REFERENCE_A_TO_Z, desc: OrdersSortInput.REFERENCE_Z_TO_A },
+  totalIncTax: {
+    asc: OrdersSortInput.LOWEST_TOTAL_INC_TAX,
+    desc: OrdersSortInput.HIGHEST_TOTAL_INC_TAX,
+  },
+  status: { asc: OrdersSortInput.STATUS_A_TO_Z, desc: OrdersSortInput.STATUS_Z_TO_A },
+  createdAt: { asc: OrdersSortInput.CREATED_AT_OLDEST, desc: OrdersSortInput.CREATED_AT_NEWEST },
+};
+
+const SORTABLE_KEYS: ReadonlySet<SortableColumnKey> = new Set(
+  Object.keys(COLUMN_KEY_TO_SORT_INPUT) as SortableColumnKey[],
+);
+
+const isSortableKey = (key: string): key is SortableColumnKey =>
+  SORTABLE_KEYS.has(key as SortableColumnKey);
+
+const normalizeString = (value: string | number | null | undefined): string | undefined => {
+  if (value === null || value === undefined) return undefined;
+  const str = String(value);
+  return str === '' ? undefined : str;
+};
+
+const DEFAULT_SORT: { key: SortableColumnKey; dir: SortDir } = { key: 'orderId', dir: 'desc' };
+
+interface UseCustomerOrdersFilterStateArgs {
+  companyId: number;
+  orderStatuses: OrderStatusItem[];
+}
+
+export interface UseCustomerOrdersFilterStateResult {
+  filters: OrdersFiltersInput;
+  sortBy: OrdersSortInput;
+  activeSort: { key: SortableColumnKey; dir: SortDir };
+  handleSearchChange: (key: string, value: string) => void;
+  handleFilterChange: (value: AppliedFilters) => void;
+  handleCompanyIdsChange: (companyIds: number[]) => void;
+  handleSetOrderBy: (key: string) => void;
+}
+
+export const useCustomerOrdersFilterState = ({
+  companyId,
+  orderStatuses,
+}: UseCustomerOrdersFilterStateArgs): UseCustomerOrdersFilterStateResult => {
+  const [filters, setFilters] = useState<OrdersFiltersInput>(() =>
+    getCustomerOrdersInitFilter(companyId),
+  );
+  const [activeSort, setActiveSort] = useState(DEFAULT_SORT);
+
+  useEffect(() => {
+    setFilters(getCustomerOrdersInitFilter(companyId));
+  }, [companyId]);
+
+  const sortBy = useMemo(
+    () => COLUMN_KEY_TO_SORT_INPUT[activeSort.key][activeSort.dir],
+    [activeSort],
+  );
+
+  const handleSearchChange = (key: string, value: string) => {
+    if (key !== 'search') return;
+    setFilters((prev) => ({ ...prev, search: value || undefined }));
+  };
+
+  const handleFilterChange = (value: AppliedFilters) => {
+    let currentStatus = normalizeString(value.orderStatus);
+    if (currentStatus) {
+      const originalStatus = orderStatuses.find(
+        (status) => status.customLabel === currentStatus || status.systemLabel === currentStatus,
+      );
+      // Drop the filter on miss — never send a display label as the API status code.
+      currentStatus = originalStatus?.systemLabel || undefined;
+    }
+    setFilters((prev) => ({
+      ...prev,
+      companyName: normalizeString(value.company),
+      status: currentStatus,
+      dateRange: packDateRange(value.startValue, value.endValue),
+    }));
+  };
+
+  const handleCompanyIdsChange = (companyIds: number[]) => {
+    const isAll = companyIds.length === 0 || companyIds.includes(-1);
+    setFilters((prev) => ({
+      ...prev,
+      companyIds: isAll ? undefined : companyIds.map(String),
+    }));
+  };
+
+  const handleSetOrderBy = (key: string) => {
+    if (!isSortableKey(key)) return;
+    setActiveSort((prev) =>
+      prev.key === key ? { key, dir: prev.dir === 'asc' ? 'desc' : 'asc' } : { key, dir: 'desc' },
+    );
+  };
+
+  return {
+    filters,
+    sortBy,
+    activeSort,
+    handleSearchChange,
+    handleFilterChange,
+    handleCompanyIdsChange,
+    handleSetOrderBy,
+  };
+};

--- a/apps/storefront/src/pages/order/useLegacyOrdersFilterState.ts
+++ b/apps/storefront/src/pages/order/useLegacyOrdersFilterState.ts
@@ -1,0 +1,114 @@
+import { useEffect, useState } from 'react';
+
+import { OrderStatusItem } from '@/types';
+
+import {
+  assertSortKey,
+  FilterSearchProps,
+  getCompanyInitFilter,
+  getCustomerInitFilter,
+  sortKeys,
+} from './config';
+
+type SortDir = 'asc' | 'desc';
+
+interface LegacyAppliedFilters {
+  startValue?: string;
+  endValue?: string;
+  PlacedBy?: string;
+  orderStatus?: string | number;
+  company?: string;
+}
+
+type LegacySortableColumnKey = keyof typeof sortKeys;
+
+interface UseLegacyOrdersFilterStateArgs {
+  isB2BUser: boolean;
+  isCompanyOrder: boolean;
+  selectedCompanyId: number;
+  orderStatuses: OrderStatusItem[];
+}
+
+interface UseLegacyOrdersFilterStateResult {
+  filterData: Partial<FilterSearchProps> | undefined;
+  orderBy: string;
+  activeSort: { key: LegacySortableColumnKey; dir: SortDir };
+  handleSearchChange: (key: string, value: string) => void;
+  handleFilterChange: (value: LegacyAppliedFilters) => void;
+  handleCompanyIdsChange: (companyIds: number[]) => void;
+  handleSetOrderBy: (key: string) => void;
+}
+
+const DEFAULT_SORT: { key: LegacySortableColumnKey; dir: SortDir } = {
+  key: 'orderId',
+  dir: 'desc',
+};
+
+export const useLegacyOrdersFilterState = ({
+  isB2BUser,
+  isCompanyOrder,
+  selectedCompanyId,
+  orderStatuses,
+}: UseLegacyOrdersFilterStateArgs): UseLegacyOrdersFilterStateResult => {
+  const [filterData, setFilterData] = useState<Partial<FilterSearchProps>>();
+  const [activeSort, setActiveSort] = useState(DEFAULT_SORT);
+
+  useEffect(() => {
+    const initial = isB2BUser
+      ? getCompanyInitFilter(isCompanyOrder, selectedCompanyId)
+      : getCustomerInitFilter();
+    setFilterData(initial);
+  }, [isB2BUser, isCompanyOrder, selectedCompanyId]);
+
+  const orderBy =
+    activeSort.dir === 'desc' ? `-${sortKeys[activeSort.key]}` : sortKeys[activeSort.key];
+
+  const handleSearchChange = (key: string, value: string) => {
+    if (key !== 'search') return;
+    setFilterData((data) => ({ ...data, q: value }));
+  };
+
+  const handleFilterChange = (value: LegacyAppliedFilters) => {
+    let currentStatus = String(value?.orderStatus || '');
+    if (currentStatus) {
+      const originalStatus = orderStatuses.find(
+        (status) => status.customLabel === currentStatus || status.systemLabel === currentStatus,
+      );
+      currentStatus = originalStatus?.systemLabel || currentStatus;
+    }
+
+    setFilterData((data) => ({
+      ...data,
+      beginDateAt: value?.startValue || null,
+      endDateAt: value?.endValue || null,
+      createdBy: value?.PlacedBy || '',
+      statusCode: currentStatus,
+      companyName: value?.company || '',
+    }));
+  };
+
+  const handleCompanyIdsChange = (companyIds: number[]) => {
+    const newCompanyIds = companyIds.includes(-1) ? [] : companyIds;
+    setFilterData((data) => ({ ...data, companyIds: newCompanyIds }));
+  };
+
+  const handleSetOrderBy = (key: string) => {
+    assertSortKey(key);
+    setActiveSort((prev) => {
+      if (prev.key === key) {
+        return { key, dir: prev.dir === 'asc' ? 'desc' : 'asc' };
+      }
+      return { key, dir: 'desc' };
+    });
+  };
+
+  return {
+    filterData,
+    orderBy,
+    activeSort,
+    handleSearchChange,
+    handleFilterChange,
+    handleCompanyIdsChange,
+    handleSetOrderBy,
+  };
+};

--- a/apps/storefront/src/pages/order/useLegacyOrdersFilterState.ts
+++ b/apps/storefront/src/pages/order/useLegacyOrdersFilterState.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 
+import { useFeatureFlag } from '@/hooks/useFeatureFlag';
 import { OrderStatusItem } from '@/types';
 
 import {
@@ -52,13 +53,17 @@ export const useLegacyOrdersFilterState = ({
 }: UseLegacyOrdersFilterStateArgs): UseLegacyOrdersFilterStateResult => {
   const [filterData, setFilterData] = useState<Partial<FilterSearchProps>>();
   const [activeSort, setActiveSort] = useState(DEFAULT_SORT);
+  const isUnifiedOrdersNonCompanyOrderPath =
+    useFeatureFlag('B2B-4613.buyer_portal_unified_sf_gql_orders') && !isCompanyOrder;
 
   useEffect(() => {
+    if (isUnifiedOrdersNonCompanyOrderPath) return;
+
     const initial = isB2BUser
       ? getCompanyInitFilter(isCompanyOrder, selectedCompanyId)
       : getCustomerInitFilter();
     setFilterData(initial);
-  }, [isB2BUser, isCompanyOrder, selectedCompanyId]);
+  }, [isB2BUser, isCompanyOrder, selectedCompanyId, isUnifiedOrdersNonCompanyOrderPath]);
 
   const orderBy =
     activeSort.dir === 'desc' ? `-${sortKeys[activeSort.key]}` : sortKeys[activeSort.key];


### PR DESCRIPTION
Jira: [B2B-4614](https://bigcommercecloud.atlassian.net/browse/B2B-4614)

## What/Why?

This PR migrates My Orders filter / search / sort state to the SF unified GraphQL `OrdersFiltersInput` + `OrdersSortInput` shape, gated behind `B2B-4613.buyer_portal_unified_sf_gql_orders`. It's the first half of a two-step migration — the filter state shape is unified now; the data source itself swaps to `customer.orders` in ticket 2a.

A temporary `adaptUnifiedToLegacyFilterParams` bridge maps the unified filter shape back to the legacy `FilterSearchProps` / `orderBy` strings the existing `getB2BAllOrders` / `getBCAllOrders` fetcher consumes, so the wire shape is identical with the flag on or off.

### Commit-by-commit

**1. `feat(orders): B2B-4614 add useCustomerOrdersFilterState for the unified customer.orders query`**
Adds the new hook holding search / status / date-range / sort state in the unified `OrdersFiltersInput` + `OrdersSortInput` shape. Includes the customLabel → systemLabel translation so storefront-renamed order statuses still send canonical codes to the API. Pure addition — not wired into the page yet, no user-facing change.

**2. `refactor(orders): B2B-4614 extract legacy filter state into useLegacyOrdersFilterState`**
Pulls the existing legacy filter state out of `Order.tsx` into a sibling hook with the same shape as commit 1, and extracts a pure `translateFilterMoreData` helper into `config.ts`. Also renames `getOrdersCreatedByUser` → `getCreatedByUserForOrders` for clarity. Pure refactor — page behaves identically. Sets up the symmetry the FF gate needs.

**3. `feat(orders): B2B-4614 wire unified filter state into My Orders behind the FF`**
Connects the new filter hook to the page under `B2B-4613.buyer_portal_unified_sf_gql_orders`. The temporary `adaptUnifiedToLegacyFilterParams` adapter maps the unified filter shape to the legacy params, so filter / search / sort changes go through the new state but still hit the legacy data path.

**4. `test(orders): B2B-4614 run My Orders tests under both legacy and unified filter paths`**
Wraps the personal / company / masquerade `/orders` describe blocks in `describe.each` so every scenario runs twice — once with the FF off, once with it on. No new test cases, just a new axis. Locks in the adapter's "wire-shape unchanged" guarantee.

## Rollout/Rollback

**Rollout:** Behind feature flag `B2B-4613.buyer_portal_unified_sf_gql_orders` (registered in PR #838). Flag defaults to off.

**Success signal:** GraphQL request shape on `/orders` is identical with the flag off vs on (validated by the parameterized tests in commit 4). If a store sees no behavior change after we flip the flag, the unified state shape is working end-to-end.

**Rollback:** Flip the FF off. No code revert, no migration. Because the adapter produces wire-identical GraphQL, the off-state matches `main` exactly.

## Testing

**Automated:**
- `MyOrders/index.test.tsx` — every existing scenario (personal customer, company customer, masquerading super admin) now runs under both `ffOn: false` (legacy filter path) and `ffOn: true` (unified filter path). Same GraphQL assertions hold both ways.
- `adaptUnifiedToLegacyParams.test.ts` — unit tests covering all field mappings, sort key/direction translation, B2B `isShowMy` flag, default values for missing fields.



[B2B-4614]: https://bigcommercecloud.atlassian.net/browse/B2B-4614?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: refactors `Order.tsx` filter/sort/search state and query-key logic and introduces a new unified code path (behind `B2B-4613...`) that could change request params or caching behavior when enabled.
> 
> **Overview**
> Migrates **My Orders** filter/search/sort state to the unified SF GraphQL shapes (`OrdersFiltersInput` + `OrdersSortInput`) behind `B2B-4613.buyer_portal_unified_sf_gql_orders`, while keeping the legacy fetch path intact via a temporary `adaptUnifiedToLegacyFilterParams` bridge.
> 
> Refactors `Order.tsx` to use new `useCustomerOrdersFilterState`/`useLegacyOrdersFilterState` hooks, extracts translation of “more filters” metadata into `translateFilterMoreData`, and renames `getOrdersCreatedByUser` to `getCreatedByUserForOrders`.
> 
> Expands test coverage to assert unified-path filter behavior (search, status/date ranges, customLabel→systemLabel mapping) and adds unit tests validating the adapter’s field/sort conversions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df6f8bc2fae307c26d2088e009560da35a5fd961. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->