### PR TITLE
feat(quotes): BACK-593 ordered quote backorder display

### DIFF
--- a/apps/storefront/src/pages/QuoteDetail/index.tsx
+++ b/apps/storefront/src/pages/QuoteDetail/index.tsx
@@ -50,6 +50,7 @@ import {
   QUOTE_VALIDATION_ERROR_CODES,
   QUOTE_VALIDATION_MESSAGE_CONTEXTS,
 } from '../quote/shared/getQuoteValidationErrorMessage';
+import { applyOrderedQuoteBackorderSnapshot } from '../quote/utils/applyOrderedQuoteBackorderSnapshot';
 import getB2BQuoteExtraFields from '../quote/utils/getQuoteExtraFields';
 import { handleQuoteCheckout } from '../quote/utils/quoteCheckout';
 
@@ -81,6 +82,7 @@ interface ProductInfoProps {
   updatedAt: number;
   variantId: number;
   variantSku: string;
+  sku?: string;
   productsSearch: CustomFieldItems;
   backorderMessage?: string;
   totalOnHand?: number;
@@ -564,7 +566,11 @@ function QuoteDetail() {
         totalAmount: quote.totalAmount,
       });
 
-      const productListResponse = productsWithMoreInfo ?? [];
+      const productListResponse = applyOrderedQuoteBackorderSnapshot(
+        productsWithMoreInfo ?? [],
+        quote.orderSnapshot,
+        quote.status,
+      );
       setProductList(productListResponse);
 
       const { salesRep, salesRepEmail } = quote;
@@ -623,7 +629,7 @@ function QuoteDetail() {
 
       setFileList(newFileList);
 
-      return quote;
+      return { quote, mergedProductList: productListResponse };
     } catch (error: unknown) {
       if (error instanceof Error) {
         snackbar.error(error.message);
@@ -703,8 +709,8 @@ function QuoteDetail() {
     let allProductsList = productList;
 
     if (allProductsList.length === 0) {
-      const quote = await getQuoteDetail();
-      allProductsList = quote?.productsList || [];
+      const { mergedProductList } = await getQuoteDetail();
+      allProductsList = mergedProductList;
     }
 
     const startIndex = Number(params.offset);
@@ -918,7 +924,6 @@ function QuoteDetail() {
                 getQuoteTableDetails={getQuoteTableDetails}
                 getTaxRate={getTaxRate}
                 displayDiscount={quoteDetail.displayDiscount}
-                status={quoteDetail.status}
               />
             </Box>
           </Grid>

--- a/apps/storefront/src/pages/quote/components/QuoteDetailSummary.test.tsx
+++ b/apps/storefront/src/pages/quote/components/QuoteDetailSummary.test.tsx
@@ -43,8 +43,17 @@ describe('QuoteDetailSummary shipping expectation prompt', () => {
     expect(screen.getByText(expectationMessage)).toBeVisible();
   });
 
-  it('hides the prompt when the quote has been converted to an order', () => {
+  it('shows the prompt for ordered quotes when there are backordered items', () => {
     renderWithProviders(<QuoteDetailSummary {...defaultProps} status="4" />, withPromptEnabled);
+
+    expect(screen.getByText(expectationMessage)).toBeVisible();
+  });
+
+  it('hides the prompt for ordered quotes when there are no backordered items', () => {
+    renderWithProviders(
+      <QuoteDetailSummary {...defaultProps} status="4" hasBackorderedItems={false} />,
+      withPromptEnabled,
+    );
 
     expect(screen.queryByText(expectationMessage)).toBeNull();
   });

--- a/apps/storefront/src/pages/quote/components/QuoteDetailSummary.tsx
+++ b/apps/storefront/src/pages/quote/components/QuoteDetailSummary.tsx
@@ -199,7 +199,7 @@ export default function QuoteDetailSummary({
                   </Typography>
                   <Typography>{showPrice(shippingAndTax.shippingVal)}</Typography>
                 </Grid>
-                {Number(status) !== 4 && isBackorderMessagingEnabled && (
+                {isBackorderMessagingEnabled && (
                   <ShippingExpectationPrompt
                     backorderEnabled={backorderEnabled}
                     hasBackorderedItems={hasBackorderedItems}

--- a/apps/storefront/src/pages/quote/components/QuoteDetailTable.tsx
+++ b/apps/storefront/src/pages/quote/components/QuoteDetailTable.tsx
@@ -50,7 +50,6 @@ interface ShoppingDetailTableProps {
   getTaxRate: (taxClassId: number, variants: any) => number;
   displayDiscount: boolean;
   currency: CurrencyProps;
-  status: string | number;
 }
 
 interface SearchProps {
@@ -113,9 +112,7 @@ function QuoteDetailTable(props: ShoppingDetailTableProps, ref: Ref<unknown>) {
     quoteReviewedBySalesRep,
     displayDiscount,
     currency,
-    status,
   } = props;
-  const isOrdered = Number(status) === 4;
 
   const isEnableProduct = useAppSelector(
     ({ global }) => global.blockPendingQuoteNonPurchasableOOS.isEnableProduct,
@@ -315,7 +312,7 @@ function QuoteDetailTable(props: ShoppingDetailTableProps, ref: Ref<unknown>) {
       render: (row) => (
         <Box>
           <Typography sx={{ padding: '12px 0' }}>{row.quantity}</Typography>
-          {isBackorderEnabled && isBackorderMessagingEnabled && !isOrdered && (
+          {isBackorderEnabled && isBackorderMessagingEnabled && (
             <BackorderMessage
               totalOnHand={row.totalOnHand}
               quantityBackordered={row.quantityBackordered}
@@ -420,7 +417,6 @@ function QuoteDetailTable(props: ShoppingDetailTableProps, ref: Ref<unknown>) {
         </Typography>
         {isBackorderEnabled &&
           isBackorderMessagingEnabled &&
-          !isOrdered &&
           hasAnyBackorderDisplay &&
           hasBackorderedItems && (
             <FormControlLabel
@@ -459,7 +455,6 @@ function QuoteDetailTable(props: ShoppingDetailTableProps, ref: Ref<unknown>) {
             displayDiscount={displayDiscount}
             getTaxRate={getTaxRate}
             showBackorderDetails={showBackorderDetails}
-            status={status}
           />
         )}
       />

--- a/apps/storefront/src/pages/quote/components/QuoteDetailTableCard.tsx
+++ b/apps/storefront/src/pages/quote/components/QuoteDetailTableCard.tsx
@@ -17,7 +17,6 @@ interface QuoteTableCardProps {
   displayDiscount: boolean;
   currency: CurrencyProps;
   showBackorderDetails?: boolean;
-  status?: string | number;
 }
 
 const StyledImage = styled('img')(() => ({
@@ -36,9 +35,7 @@ function QuoteDetailTableCard(props: QuoteTableCardProps) {
     currency,
     displayDiscount,
     showBackorderDetails = false,
-    status,
   } = props;
-  const isOrdered = Number(status) === 4;
   const b3Lang = useB3Lang();
   const enteredInclusiveTax = useAppSelector(
     ({ storeConfigs }) => storeConfigs.currencies.enteredInclusiveTax,
@@ -149,7 +146,7 @@ function QuoteDetailTableCard(props: QuoteTableCardProps) {
           <Typography variant="body1" color="#616161">
             {notes}
           </Typography>
-          {isBackorderEnabled && isBackorderMessagingEnabled && !isOrdered && (
+          {isBackorderEnabled && isBackorderMessagingEnabled && (
             <BackorderMessage
               totalOnHand={totalOnHand}
               quantityBackordered={quantityBackordered}

--- a/apps/storefront/src/pages/quote/utils/applyOrderedQuoteBackorderSnapshot.test.ts
+++ b/apps/storefront/src/pages/quote/utils/applyOrderedQuoteBackorderSnapshot.test.ts
@@ -1,0 +1,174 @@
+import { QuoteStatus } from '@/shared/service/b2b/graphql/quote';
+
+import {
+  applyOrderedQuoteBackorderSnapshot,
+  type OrderSnapshotProduct,
+} from './applyOrderedQuoteBackorderSnapshot';
+
+describe('applyOrderedQuoteBackorderSnapshot', () => {
+  const baseLine = {
+    productId: 42,
+    sku: 'SKU-42',
+    quantityBackordered: 99,
+    totalOnHand: 99,
+    backorderMessage: 'live',
+  };
+
+  it('returns items unchanged when status is not ordered', () => {
+    const items = [{ ...baseLine }];
+    const snapshot = {
+      products: [
+        {
+          productId: 42,
+          sku: 'SKU-42',
+          totalOnHand: 2,
+          quantityBackordered: 3,
+          backorderMessage: 'Ships later',
+        } satisfies OrderSnapshotProduct,
+      ],
+    };
+
+    const result = applyOrderedQuoteBackorderSnapshot(items, snapshot, QuoteStatus.OPEN);
+
+    expect(result).toEqual(items);
+    expect(result[0]).toBe(items[0]);
+  });
+
+  it('clears backorder fields when ordered and backorder snapshot is missing or empty', () => {
+    expect(
+      applyOrderedQuoteBackorderSnapshot([{ ...baseLine }], null, QuoteStatus.ORDERED)[0],
+    ).toEqual({
+      ...baseLine,
+      totalOnHand: undefined,
+      quantityBackordered: undefined,
+      backorderMessage: undefined,
+    });
+
+    expect(
+      applyOrderedQuoteBackorderSnapshot(
+        [{ ...baseLine }],
+        { products: [] },
+        QuoteStatus.ORDERED,
+      )[0],
+    ).toEqual({
+      ...baseLine,
+      totalOnHand: undefined,
+      quantityBackordered: undefined,
+      backorderMessage: undefined,
+    });
+  });
+
+  it('merges order backorder snapshot onto line items matched by productId and sku', () => {
+    const snapshot = {
+      products: [
+        {
+          productId: 42,
+          sku: 'SKU-42',
+          totalOnHand: 2,
+          quantityBackordered: 3,
+          backorderMessage: 'Ships later',
+        } satisfies OrderSnapshotProduct,
+      ],
+    };
+
+    const result = applyOrderedQuoteBackorderSnapshot(
+      [{ ...baseLine }],
+      snapshot,
+      QuoteStatus.ORDERED,
+    );
+
+    expect(result[0]).toMatchObject({
+      productId: 42,
+      sku: 'SKU-42',
+      totalOnHand: 2,
+      quantityBackordered: 3,
+      backorderMessage: 'Ships later',
+    });
+  });
+
+  it('matches order backorder snapshot using variantSku when line item sku is absent', () => {
+    const snapshot = {
+      products: [
+        {
+          productId: 10,
+          sku: 'VAR-SKU',
+          totalOnHand: 1,
+          quantityBackordered: 2,
+          backorderMessage: 'Soon',
+        } satisfies OrderSnapshotProduct,
+      ],
+    };
+
+    const result = applyOrderedQuoteBackorderSnapshot(
+      [
+        {
+          productId: 10,
+          variantSku: 'VAR-SKU',
+          quantityBackordered: 0,
+        },
+      ],
+      snapshot,
+      QuoteStatus.ORDERED,
+    );
+
+    expect(result[0]).toMatchObject({
+      quantityBackordered: 2,
+      backorderMessage: 'Soon',
+    });
+  });
+
+  it('merges each line item to the next matching snapshot row when productId and sku repeat', () => {
+    const snapshot = {
+      products: [
+        {
+          productId: 1,
+          sku: 'S',
+          totalOnHand: 1,
+          quantityBackordered: 1,
+          backorderMessage: 'A',
+        },
+        {
+          productId: 1,
+          sku: 'S',
+          totalOnHand: 2,
+          quantityBackordered: 2,
+          backorderMessage: 'B',
+        },
+      ] satisfies OrderSnapshotProduct[],
+    };
+
+    const result = applyOrderedQuoteBackorderSnapshot(
+      [
+        { productId: 1, sku: 'S' },
+        { productId: 1, sku: 'S' },
+      ],
+      snapshot,
+      QuoteStatus.ORDERED,
+    );
+
+    expect(result[0]).toMatchObject({ quantityBackordered: 1 });
+    expect(result[1]).toMatchObject({ quantityBackordered: 2 });
+  });
+
+  it('clears backorder fields on line items with no matching backorder snapshot row', () => {
+    const snapshot = {
+      products: [
+        {
+          productId: 1,
+          sku: 'A',
+          totalOnHand: 1,
+          quantityBackordered: 1,
+          backorderMessage: 'x',
+        } satisfies OrderSnapshotProduct,
+      ],
+    };
+
+    const result = applyOrderedQuoteBackorderSnapshot(
+      [{ productId: 2, sku: 'B', quantityBackordered: 5 }],
+      snapshot,
+      QuoteStatus.ORDERED,
+    );
+
+    expect(result[0]?.quantityBackordered).toBeUndefined();
+  });
+});

--- a/apps/storefront/src/pages/quote/utils/applyOrderedQuoteBackorderSnapshot.ts
+++ b/apps/storefront/src/pages/quote/utils/applyOrderedQuoteBackorderSnapshot.ts
@@ -1,0 +1,85 @@
+import { QuoteStatus } from '@/shared/service/b2b/graphql/quote';
+
+export type OrderSnapshotProduct = {
+  productId: number;
+  sku: string;
+  totalOnHand: number | null;
+  quantityBackordered: number;
+  backorderMessage: string | null;
+};
+
+type BackorderFields = {
+  totalOnHand?: number;
+  quantityBackordered?: number;
+  backorderMessage?: string;
+};
+
+function getSkuFromLineItem(item: { sku?: string; variantSku?: string }): string {
+  return String(item.sku ?? item.variantSku ?? '').trim();
+}
+
+function buildLineItemKey(productId: number | string, sku: string): string {
+  return `${Number(productId)}|${sku}`;
+}
+
+export function applyOrderedQuoteBackorderSnapshot<
+  T extends { productId: number | string } & Partial<{ sku: string; variantSku: string }> &
+    BackorderFields,
+>(
+  items: T[],
+  orderSnapshot: { products: OrderSnapshotProduct[] } | null | undefined,
+  status: number | string,
+): T[] {
+  if (Number(status) !== QuoteStatus.ORDERED) {
+    return items;
+  }
+
+  if (!orderSnapshot?.products?.length) {
+    return items.map((item) => ({
+      ...item,
+      totalOnHand: undefined,
+      quantityBackordered: undefined,
+      backorderMessage: undefined,
+    }));
+  }
+
+  const snapshotQueuesByLineItemKey = new Map<
+    string,
+    { rows: OrderSnapshotProduct[]; nextRowIndex: number }
+  >();
+  orderSnapshot.products.forEach((snapshotProduct) => {
+    const lineItemKey = buildLineItemKey(
+      snapshotProduct.productId,
+      String(snapshotProduct.sku ?? '').trim(),
+    );
+    const queueForLineItemKey = snapshotQueuesByLineItemKey.get(lineItemKey) ?? {
+      rows: [],
+      nextRowIndex: 0,
+    };
+    queueForLineItemKey.rows.push(snapshotProduct);
+    snapshotQueuesByLineItemKey.set(lineItemKey, queueForLineItemKey);
+  });
+
+  return items.map((lineItem) => {
+    const lineItemKey = buildLineItemKey(lineItem.productId, getSkuFromLineItem(lineItem));
+    const snapshotQueue = snapshotQueuesByLineItemKey.get(lineItemKey);
+    if (!snapshotQueue || snapshotQueue.nextRowIndex >= snapshotQueue.rows.length) {
+      return {
+        ...lineItem,
+        totalOnHand: undefined,
+        quantityBackordered: undefined,
+        backorderMessage: undefined,
+      };
+    }
+
+    const matchedSnapshotRow = snapshotQueue.rows[snapshotQueue.nextRowIndex];
+    snapshotQueue.nextRowIndex += 1;
+
+    return {
+      ...lineItem,
+      totalOnHand: matchedSnapshotRow.totalOnHand ?? undefined,
+      quantityBackordered: matchedSnapshotRow.quantityBackordered,
+      backorderMessage: matchedSnapshotRow.backorderMessage ?? undefined,
+    };
+  });
+}

--- a/apps/storefront/src/shared/service/b2b/graphql/quote.ts
+++ b/apps/storefront/src/shared/service/b2b/graphql/quote.ts
@@ -276,6 +276,15 @@ const getQuoteInfo = `
       allowCheckout,
       displayDiscount,
       uuid,
+      orderSnapshot {
+        products {
+          productId,
+          sku,
+          totalOnHand,
+          quantityBackordered,
+          backorderMessage,
+        }
+      }
     }
   }
 `;
@@ -654,6 +663,15 @@ export interface B2BQuoteDetail {
       allowCheckout: boolean;
       displayDiscount: boolean;
       uuid?: string;
+      orderSnapshot?: {
+        products: {
+          productId: number;
+          sku: string;
+          totalOnHand: number | null;
+          quantityBackordered: number;
+          backorderMessage: string | null;
+        }[];
+      } | null;
     };
   };
 }


### PR DESCRIPTION
Jira: [BACK-593](https://bigcommercecloud.atlassian.net/browse/BACK-593)

## What/Why?
Adding backorder display to quotes with ordered status (on hand, backorder amount, backorder message, shipping expectation). Requests `orderSnapshot` from the API, merges `orderSnapshot.products` onto line items (order-time snapshot from `orders.backorder_snapshot`).

>[!NOTE]
> Requires backend PR to receive backorder snapshot - https://github.com/bigcommerce/b2b-edition-api/compare/BACK-592

## Rollout/Rollback
Backorder display is gated by `Feature_Backorder && BACK-134.backorders_phase_1_1_control_messaging_on_storefront`.

## Testing
Expected backorder display for a variety of scenarios (some on-hand, none on-hand, with and without backorder message, products with no backordering).

https://github.com/user-attachments/assets/beb2fc2b-776e-435e-9880-2a6d048eeac1

No backorder display/toggle for quotes with no backordered quantity.

<img width="1153" height="452" alt="Screenshot 2026-04-29 at 11 37 43 am" src="https://github.com/user-attachments/assets/f34a4951-be8d-4e25-ac2b-1e8a5bb5f5c2" />

Backorder display does not appear for disabled `Feature_Backorder` or `BACK-134.backorders_phase_1_1_control_messaging_on_storefront`.

<img width="1153" height="649" alt="Screenshot 2026-04-29 at 11 39 34 am" src="https://github.com/user-attachments/assets/77dea67d-5ffe-4668-915d-82e030c27b28" />

[BACK-593]: https://bigcommercecloud.atlassian.net/browse/BACK-593?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Ping @benpratt77 @animesh1987 @bigcommerce/team-b2b 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the quote detail data-fetch path and GraphQL contract by introducing `orderSnapshot` and merging it into line items, which could affect backorder display correctness for ordered quotes. Changes are feature-flagged and covered by targeted unit tests, limiting blast radius.
> 
> **Overview**
> Enables backorder messaging on *ordered* quotes by fetching an `orderSnapshot` from the quote GraphQL query and using it to populate line-item `totalOnHand`/`quantityBackordered`/`backorderMessage` on the Quote Detail page.
> 
> Adds `applyOrderedQuoteBackorderSnapshot` (with unit tests) to merge snapshot rows onto products (and clear backorder fields when snapshot data is missing/unmatched), and updates Quote Detail UI to always render the backorder message/toggle and shipping expectation prompt when the feature flag is enabled (driven by whether any items are actually backordered, not by quote status).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5d56f72b721a4ee43ffabd51f8f63b872e0c31d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->