### PR TITLE
chore(common): B2B-4614 exclude generated dirs from storefront tsconfig

### DIFF
--- a/apps/storefront/tsconfig.json
+++ b/apps/storefront/tsconfig.json
@@ -33,5 +33,5 @@
     },
   },
   "include": ["**/*.ts", "**/*.tsx", "**/*.js"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "dist", ".turbo", "coverage"]
 }


### PR DESCRIPTION
[B2B-4614](https://bigcommercecloud.atlassian.net/browse/B2B-4614)

## What
Add `dist, .turbo` and `coverage` to `apps/storefront/tsconfig.json` `exclude`.

## Why
Without these excludes, tsserver pulls generated/cache files (e.g. minified bundles in `dist`) into the program, producing bogus TS2554 errors on test framework globals like `it()` and bloating memory.

## Rollout / Rollback
No runtime impact — tsconfig affects editor/CI type-checking only. Revert the file to roll back.

## Testing
- [X] `yarn workspace @b3/store typecheck` passes
- [X] In VS Code, open `unified-orders.test.tsx` — no spurious "Expected 0 arguments" errors on `it(...)` / `describe(...)`


[B2B-4614]: https://bigcommercecloud.atlassian.net/browse/B2B-4614?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit a8467a1dab92226b7b4c307bd71f445fd814e64e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->