### PR TITLE
feat(common): LOCAL-3190 Multi-lang dropdown implementation

### DIFF
--- a/apps/storefront/src/components/layout/B3AccountInfo.tsx
+++ b/apps/storefront/src/components/layout/B3AccountInfo.tsx
@@ -63,7 +63,6 @@ export default function B3AccountInfo({ closeSidebar }: B3AccountInfoProps) {
   return (
     <Box
       sx={{
-        minWidth: '150px',
         display: 'flex',
         justifyContent: isMobile ? 'start' : 'end',
         mr: '-5px',

--- a/apps/storefront/src/components/layout/B3LocaleSwitcher.test.tsx
+++ b/apps/storefront/src/components/layout/B3LocaleSwitcher.test.tsx
@@ -1,0 +1,131 @@
+import { buildGlobalStateWith } from 'tests/storeStateBuilders';
+import { renderWithProviders, screen } from 'tests/test-utils';
+
+import B3LocaleSwitcher from './B3LocaleSwitcher';
+
+const LOCALES = [
+  { code: 'en', isDefault: true, fullPath: 'https://store.example.com/' },
+  { code: 'fr', isDefault: false, fullPath: 'https://store.example.com/fr' },
+];
+
+const withFlagEnabled = {
+  global: buildGlobalStateWith({
+    featureFlags: { 'LOCAL-3191.B2B_multi_language': true },
+    availableLocales: LOCALES,
+  }),
+};
+
+describe('when the multi-language feature flag is disabled', () => {
+  it('renders nothing', () => {
+    const { result } = renderWithProviders(<B3LocaleSwitcher />, {
+      preloadedState: {
+        global: buildGlobalStateWith({
+          featureFlags: { 'LOCAL-3191.B2B_multi_language': false },
+          availableLocales: LOCALES,
+        }),
+      },
+    });
+
+    expect(result.container).toBeEmptyDOMElement();
+  });
+});
+
+describe('when there are 0 available locales', () => {
+  it('renders nothing', () => {
+    const { result } = renderWithProviders(<B3LocaleSwitcher />, {
+      preloadedState: {
+        global: buildGlobalStateWith({
+          featureFlags: { 'LOCAL-3191.B2B_multi_language': true },
+          availableLocales: [],
+        }),
+      },
+    });
+
+    expect(result.container).toBeEmptyDOMElement();
+  });
+});
+
+describe('when there is only 1 available locale', () => {
+  it('renders nothing', () => {
+    const { result } = renderWithProviders(<B3LocaleSwitcher />, {
+      preloadedState: {
+        global: buildGlobalStateWith({
+          featureFlags: { 'LOCAL-3191.B2B_multi_language': true },
+          availableLocales: [
+            { code: 'en', isDefault: true, fullPath: 'https://store.example.com/' },
+          ],
+        }),
+      },
+    });
+
+    expect(result.container).toBeEmptyDOMElement();
+  });
+});
+
+describe('when the flag is enabled and multiple locales are available', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('renders a dropdown button showing the default language in uppercase when URL does not match any locale', () => {
+    renderWithProviders(<B3LocaleSwitcher />, {
+      preloadedState: withFlagEnabled,
+    });
+
+    expect(screen.getByRole('button', { name: /EN/i })).toBeInTheDocument();
+  });
+
+  it('shows the active locale derived from the current URL', () => {
+    vi.stubGlobal('location', { href: 'https://store.example.com/fr/some-page' });
+
+    renderWithProviders(<B3LocaleSwitcher />, {
+      preloadedState: withFlagEnabled,
+    });
+
+    expect(screen.getByRole('button', { name: /FR/i })).toBeInTheDocument();
+  });
+
+  it('does not match a locale whose prefix is a substring of another path segment', () => {
+    vi.stubGlobal('location', { href: 'https://store.example.com/frozen' });
+
+    renderWithProviders(<B3LocaleSwitcher />, {
+      preloadedState: withFlagEnabled,
+    });
+
+    expect(screen.getByRole('button', { name: /EN/i })).toBeInTheDocument();
+  });
+
+  it('matches locale when URL ends exactly at the fullPath', () => {
+    vi.stubGlobal('location', { href: 'https://store.example.com/fr' });
+
+    renderWithProviders(<B3LocaleSwitcher />, {
+      preloadedState: withFlagEnabled,
+    });
+
+    expect(screen.getByRole('button', { name: /FR/i })).toBeInTheDocument();
+  });
+
+  it('matches locale when URL has a query string after the fullPath', () => {
+    vi.stubGlobal('location', { href: 'https://store.example.com/fr?ref=email' });
+
+    renderWithProviders(<B3LocaleSwitcher />, {
+      preloadedState: withFlagEnabled,
+    });
+
+    expect(screen.getByRole('button', { name: /FR/i })).toBeInTheDocument();
+  });
+
+  it('navigates to the selected locale fullPath on change', async () => {
+    const location = { href: 'https://store.example.com/#/orders', hash: '#/orders' };
+    vi.stubGlobal('location', location);
+
+    const { user } = renderWithProviders(<B3LocaleSwitcher />, {
+      preloadedState: withFlagEnabled,
+    });
+
+    await user.click(screen.getByRole('button', { name: /EN/i }));
+    await user.click(screen.getByRole('menuitem', { name: 'FR' }));
+
+    expect(location.href).toBe('https://store.example.com/fr#/orders');
+  });
+});

--- a/apps/storefront/src/components/layout/B3LocaleSwitcher.test.tsx
+++ b/apps/storefront/src/components/layout/B3LocaleSwitcher.test.tsx
@@ -51,9 +51,7 @@ describe('when there is only 1 available locale', () => {
       preloadedState: {
         global: buildGlobalStateWith({
           featureFlags: { 'LOCAL-3191.B2B_multi_language': true },
-          locales: [
-            { code: 'en', isDefault: true, fullPath: 'https://store.example.com/' },
-          ],
+          locales: [{ code: 'en', isDefault: true, fullPath: 'https://store.example.com/' }],
         }),
       },
     });

--- a/apps/storefront/src/components/layout/B3LocaleSwitcher.test.tsx
+++ b/apps/storefront/src/components/layout/B3LocaleSwitcher.test.tsx
@@ -11,7 +11,7 @@ const LOCALES = [
 const withFlagEnabled = {
   global: buildGlobalStateWith({
     featureFlags: { 'LOCAL-3191.B2B_multi_language': true },
-    availableLocales: LOCALES,
+    locales: LOCALES,
   }),
 };
 
@@ -21,7 +21,7 @@ describe('when the multi-language feature flag is disabled', () => {
       preloadedState: {
         global: buildGlobalStateWith({
           featureFlags: { 'LOCAL-3191.B2B_multi_language': false },
-          availableLocales: LOCALES,
+          locales: LOCALES,
         }),
       },
     });
@@ -36,7 +36,7 @@ describe('when there are 0 available locales', () => {
       preloadedState: {
         global: buildGlobalStateWith({
           featureFlags: { 'LOCAL-3191.B2B_multi_language': true },
-          availableLocales: [],
+          locales: [],
         }),
       },
     });
@@ -51,7 +51,7 @@ describe('when there is only 1 available locale', () => {
       preloadedState: {
         global: buildGlobalStateWith({
           featureFlags: { 'LOCAL-3191.B2B_multi_language': true },
-          availableLocales: [
+          locales: [
             { code: 'en', isDefault: true, fullPath: 'https://store.example.com/' },
           ],
         }),

--- a/apps/storefront/src/components/layout/B3LocaleSwitcher.tsx
+++ b/apps/storefront/src/components/layout/B3LocaleSwitcher.tsx
@@ -1,10 +1,10 @@
 import { useFeatureFlag } from '@/hooks/useFeatureFlag';
 import { useAppSelector } from '@/store';
-import { Locale } from '@/store/slices/global';
+import { Locales } from '@/store/slices/global';
 
 import B3DropDown from '../B3DropDown';
 
-const getActiveLocale = (locales: Locale[]) =>
+const getActiveLocale = (locales: Locales) =>
   [...locales]
     .sort((a, b) => b.fullPath.length - a.fullPath.length)
     .find((l) => {

--- a/apps/storefront/src/components/layout/B3LocaleSwitcher.tsx
+++ b/apps/storefront/src/components/layout/B3LocaleSwitcher.tsx
@@ -24,10 +24,7 @@ export default function B3LocaleSwitcher() {
     return null;
   }
 
-  const activeLocale =
-    getActiveLocale(locales) ??
-    locales.find((l) => l.isDefault) ??
-    locales[0];
+  const activeLocale = getActiveLocale(locales) ?? locales.find((l) => l.isDefault) ?? locales[0];
 
   const list = locales.map(({ code }) => ({ key: code, name: code.toUpperCase() }));
 

--- a/apps/storefront/src/components/layout/B3LocaleSwitcher.tsx
+++ b/apps/storefront/src/components/layout/B3LocaleSwitcher.tsx
@@ -9,7 +9,9 @@ const getActiveLocale = (locales: Locale[]) =>
     .sort((a, b) => b.fullPath.length - a.fullPath.length)
     .find((l) => {
       const { href } = window.location;
-      if (!href.startsWith(l.fullPath)) return false;
+      if (!href.startsWith(l.fullPath)) {
+        return false;
+      }
       const next = href[l.fullPath.length];
       return next === undefined || next === '/' || next === '#' || next === '?';
     });

--- a/apps/storefront/src/components/layout/B3LocaleSwitcher.tsx
+++ b/apps/storefront/src/components/layout/B3LocaleSwitcher.tsx
@@ -18,21 +18,21 @@ const getActiveLocale = (locales: Locale[]) =>
 
 export default function B3LocaleSwitcher() {
   const isMultiLocaleEnabled = useFeatureFlag('LOCAL-3191.B2B_multi_language');
-  const availableLocales = useAppSelector(({ global }) => global.availableLocales);
+  const locales = useAppSelector(({ global }) => global.locales);
 
-  if (!isMultiLocaleEnabled || availableLocales.length <= 1) {
+  if (!isMultiLocaleEnabled || locales.length <= 1) {
     return null;
   }
 
   const activeLocale =
-    getActiveLocale(availableLocales) ??
-    availableLocales.find((l) => l.isDefault) ??
-    availableLocales[0];
+    getActiveLocale(locales) ??
+    locales.find((l) => l.isDefault) ??
+    locales[0];
 
-  const list = availableLocales.map(({ code }) => ({ key: code, name: code.toUpperCase() }));
+  const list = locales.map(({ code }) => ({ key: code, name: code.toUpperCase() }));
 
   const handleLocaleChange = (code: string | number) => {
-    const nextLocale = availableLocales.find((l) => l.code === String(code));
+    const nextLocale = locales.find((l) => l.code === String(code));
     if (nextLocale && nextLocale.fullPath !== activeLocale.fullPath) {
       window.location.href = nextLocale.fullPath + window.location.hash;
     }

--- a/apps/storefront/src/components/layout/B3LocaleSwitcher.tsx
+++ b/apps/storefront/src/components/layout/B3LocaleSwitcher.tsx
@@ -1,0 +1,47 @@
+import { useFeatureFlag } from '@/hooks/useFeatureFlag';
+import { useAppSelector } from '@/store';
+import { Locale } from '@/store/slices/global';
+
+import B3DropDown from '../B3DropDown';
+
+const getActiveLocale = (locales: Locale[]) =>
+  [...locales]
+    .sort((a, b) => b.fullPath.length - a.fullPath.length)
+    .find((l) => {
+      const { href } = window.location;
+      if (!href.startsWith(l.fullPath)) return false;
+      const next = href[l.fullPath.length];
+      return next === undefined || next === '/' || next === '#' || next === '?';
+    });
+
+export default function B3LocaleSwitcher() {
+  const isMultiLocaleEnabled = useFeatureFlag('LOCAL-3191.B2B_multi_language');
+  const availableLocales = useAppSelector(({ global }) => global.availableLocales);
+
+  if (!isMultiLocaleEnabled || availableLocales.length <= 1) {
+    return null;
+  }
+
+  const activeLocale =
+    getActiveLocale(availableLocales) ??
+    availableLocales.find((l) => l.isDefault) ??
+    availableLocales[0];
+
+  const list = availableLocales.map(({ code }) => ({ key: code, name: code.toUpperCase() }));
+
+  const handleLocaleChange = (code: string | number) => {
+    const nextLocale = availableLocales.find((l) => l.code === String(code));
+    if (nextLocale && nextLocale.fullPath !== activeLocale.fullPath) {
+      window.location.href = nextLocale.fullPath + window.location.hash;
+    }
+  };
+
+  return (
+    <B3DropDown
+      title={activeLocale.code.toUpperCase()}
+      list={list}
+      value={activeLocale.code}
+      handleItemClick={handleLocaleChange}
+    />
+  );
+}

--- a/apps/storefront/src/components/layout/B3MainHeader.tsx
+++ b/apps/storefront/src/components/layout/B3MainHeader.tsx
@@ -14,6 +14,7 @@ import { getContrastColor } from '../outSideComponents/utils/b3CustomStyles';
 
 import B3AccountInfo from './B3AccountInfo';
 import B3CompanyHierarchy from './B3CompanyHierarchy';
+import B3LocaleSwitcher from './B3LocaleSwitcher';
 import B3StatusNotification from './B3StatusNotification';
 
 export default function MainHeader({ title }: { title: string }) {
@@ -96,6 +97,7 @@ export default function MainHeader({ title }: { title: string }) {
             alignItems: 'center',
           }}
         >
+          <B3LocaleSwitcher />
           {role !== 100 && <B3AccountInfo />}
           <Box sx={{ marginLeft: '8px' }}>
             {role === 100 && (

--- a/apps/storefront/src/shared/service/bc/graphql/locales.ts
+++ b/apps/storefront/src/shared/service/bc/graphql/locales.ts
@@ -31,11 +31,9 @@ query GetLocales {
   }
 }`;
 
-export const getLocales = (): Promise<Locale[]> => {
-  const request =
-    platform === 'bigcommerce'
-      ? B3Request.graphqlBC<LocalesResponse>({ query: getLocalesQuery })
-      : B3Request.graphqlBCProxy<LocalesResponse>({ query: getLocalesQuery });
+const getLocales = () =>
+  platform === 'bigcommerce'
+    ? B3Request.graphqlBC<LocalesResponse>({ query: getLocalesQuery })
+    : B3Request.graphqlBCProxy<LocalesResponse>({ query: getLocalesQuery });
 
-  return request.then((res) => res.data.site.settings.locales);
-};
+export default getLocales;

--- a/apps/storefront/src/shared/service/bc/graphql/locales.ts
+++ b/apps/storefront/src/shared/service/bc/graphql/locales.ts
@@ -1,0 +1,41 @@
+import { platform } from '@/utils/basicConfig';
+
+import B3Request from '../../request/b3Fetch';
+
+interface Locale {
+  code: string;
+  isDefault: boolean;
+  fullPath: string;
+}
+
+interface LocalesResponse {
+  data: {
+    site: {
+      settings: {
+        locales: Locale[];
+      };
+    };
+  };
+}
+
+const getLocalesQuery = `
+query GetLocales {
+  site {
+    settings {
+      locales {
+        code
+        isDefault
+        fullPath
+      }
+    }
+  }
+}`;
+
+export const getLocales = (): Promise<Locale[]> => {
+  const request =
+    platform === 'bigcommerce'
+      ? B3Request.graphqlBC<LocalesResponse>({ query: getLocalesQuery })
+      : B3Request.graphqlBCProxy<LocalesResponse>({ query: getLocalesQuery });
+
+  return request.then((res) => res.data.site.settings.locales);
+};

--- a/apps/storefront/src/shared/service/bc/index.ts
+++ b/apps/storefront/src/shared/service/bc/index.ts
@@ -1,6 +1,6 @@
 export * from './api/login';
 export { default as getActiveBcCurrency } from './graphql/currency';
-export * from './graphql/locales';
+export { default as getLocales } from './graphql/locales';
 export * from './graphql/login';
 export * from './graphql/company';
 export * from './graphql/user';

--- a/apps/storefront/src/shared/service/bc/index.ts
+++ b/apps/storefront/src/shared/service/bc/index.ts
@@ -1,5 +1,6 @@
 export * from './api/login';
 export { default as getActiveBcCurrency } from './graphql/currency';
+export * from './graphql/locales';
 export * from './graphql/login';
 export * from './graphql/company';
 export * from './graphql/user';

--- a/apps/storefront/src/store/slices/global.ts
+++ b/apps/storefront/src/store/slices/global.ts
@@ -48,6 +48,12 @@ export interface BackorderDisplaySettings {
   defaultShippingExpectationPrompt: string;
 }
 
+export interface Locale {
+  code: string;
+  isDefault: boolean;
+  fullPath: string;
+}
+
 export interface GlobalState {
   isClickEnterBtn: boolean;
   currentClickedUrl: string;
@@ -65,6 +71,7 @@ export interface GlobalState {
   quoteSubmissionResponse: QuoteSubmissionResponseProps;
   isOpenCompanyHierarchyDropDown: boolean;
   featureFlags: FeatureFlags;
+  availableLocales: Locale[];
   backorderEnabled: boolean;
   backorderDisplaySettings: BackorderDisplaySettings;
 }
@@ -118,6 +125,7 @@ export const initialState: GlobalState = {
   },
   isOpenCompanyHierarchyDropDown: false,
   featureFlags: {},
+  availableLocales: [],
 };
 
 export const globalSlice = createSlice({
@@ -174,6 +182,9 @@ export const globalSlice = createSlice({
         ...payload,
       };
     },
+    setLocales: (state, { payload }: PayloadAction<Locale[]>) => {
+      state.availableLocales = payload;
+    },
     setBackorderEnabled: (state, { payload }: PayloadAction<boolean>) => {
       state.backorderEnabled = payload;
     },
@@ -202,6 +213,7 @@ export const {
   setQuoteSubmissionResponse,
   setOpenCompanyHierarchyDropDown,
   setFeatureFlags,
+  setLocales,
   setBackorderEnabled,
   setBackorderDisplaySettings,
 } = globalSlice.actions;

--- a/apps/storefront/src/store/slices/global.ts
+++ b/apps/storefront/src/store/slices/global.ts
@@ -54,6 +54,8 @@ export interface Locale {
   fullPath: string;
 }
 
+export type Locales = Locale[];
+
 export interface GlobalState {
   isClickEnterBtn: boolean;
   currentClickedUrl: string;
@@ -71,7 +73,7 @@ export interface GlobalState {
   quoteSubmissionResponse: QuoteSubmissionResponseProps;
   isOpenCompanyHierarchyDropDown: boolean;
   featureFlags: FeatureFlags;
-  locales: Locale[];
+  locales: Locales;
   backorderEnabled: boolean;
   backorderDisplaySettings: BackorderDisplaySettings;
 }
@@ -182,7 +184,7 @@ export const globalSlice = createSlice({
         ...payload,
       };
     },
-    setLocales: (state, { payload }: PayloadAction<Locale[]>) => {
+    setLocales: (state, { payload }: PayloadAction<Locales>) => {
       state.locales = payload;
     },
     setBackorderEnabled: (state, { payload }: PayloadAction<boolean>) => {

--- a/apps/storefront/src/store/slices/global.ts
+++ b/apps/storefront/src/store/slices/global.ts
@@ -71,7 +71,7 @@ export interface GlobalState {
   quoteSubmissionResponse: QuoteSubmissionResponseProps;
   isOpenCompanyHierarchyDropDown: boolean;
   featureFlags: FeatureFlags;
-  availableLocales: Locale[];
+  locales: Locale[];
   backorderEnabled: boolean;
   backorderDisplaySettings: BackorderDisplaySettings;
 }
@@ -125,7 +125,7 @@ export const initialState: GlobalState = {
   },
   isOpenCompanyHierarchyDropDown: false,
   featureFlags: {},
-  availableLocales: [],
+  locales: [],
 };
 
 export const globalSlice = createSlice({
@@ -183,7 +183,7 @@ export const globalSlice = createSlice({
       };
     },
     setLocales: (state, { payload }: PayloadAction<Locale[]>) => {
-      state.availableLocales = payload;
+      state.locales = payload;
     },
     setBackorderEnabled: (state, { payload }: PayloadAction<boolean>) => {
       state.backorderEnabled = payload;

--- a/apps/storefront/src/utils/featureFlags.ts
+++ b/apps/storefront/src/utils/featureFlags.ts
@@ -35,6 +35,10 @@ export const featureFlags = [
     key: 'B2B-4613.buyer_portal_unified_sf_gql_orders',
     name: 'unifiedStorefrontGraphqlOrders',
   },
+  {
+    key: 'LOCAL-3191.B2B_multi_language',
+    name: 'b2bMultiLanguage',
+  },
 ] as const;
 
 export type FeatureFlagKey = (typeof featureFlags)[number]['key'];

--- a/apps/storefront/src/utils/storefrontConfig.ts
+++ b/apps/storefront/src/utils/storefrontConfig.ts
@@ -325,10 +325,9 @@ const setStorefrontConfig = async (dispatch: DispatchProps) => {
   const useCombinedQuery = featureFlags['B2B-3817.disable_masquerading_cleanup_on_login'] ?? false;
 
   if (featureFlags['LOCAL-3191.B2B_multi_language']) {
-    const locales = await getLocales()
-      .then((res) => res.data.site.settings.locales)
-      .catch(() => []);
-    store.dispatch(setLocales(locales));
+    getLocales()
+      .then((res) => store.dispatch(setLocales(res.data.site.settings.locales)))
+      .catch(() => {});
   }
 
   if (useCombinedQuery) {

--- a/apps/storefront/src/utils/storefrontConfig.ts
+++ b/apps/storefront/src/utils/storefrontConfig.ts
@@ -13,7 +13,7 @@ import {
   getStorefrontConfigWithCompanyHierarchy,
   getStorefrontDefaultLanguages,
 } from '@/shared/service/b2b';
-import { getActiveBcCurrency } from '@/shared/service/bc';
+import { getActiveBcCurrency, getLocales } from '@/shared/service/bc';
 import { getStorefrontTaxDisplayType } from '@/shared/service/bc/graphql/tax';
 import { store } from '@/store';
 import { setCompanyHierarchyInfoModules } from '@/store/slices/company';
@@ -21,6 +21,7 @@ import {
   setBlockPendingAccountViewPrice,
   setBlockPendingQuoteNonPurchasableOOS,
   setFeatureFlags,
+  setLocales,
   setLoginLandingLocation,
   setQuoteSubmissionResponse,
   setShowInclusiveTaxPrice,
@@ -322,6 +323,11 @@ export const getAccountHierarchyIsEnabled = async () => {
 const setStorefrontConfig = async (dispatch: DispatchProps) => {
   const { featureFlags } = store.getState().global;
   const useCombinedQuery = featureFlags['B2B-3817.disable_masquerading_cleanup_on_login'] ?? false;
+
+  if (featureFlags['LOCAL-3191.B2B_multi_language']) {
+    const locales = await getLocales().catch(() => []);
+    store.dispatch(setLocales(locales));
+  }
 
   if (useCombinedQuery) {
     const hasCompanyHierarchyPermission = checkEveryPermissionsCode(

--- a/apps/storefront/src/utils/storefrontConfig.ts
+++ b/apps/storefront/src/utils/storefrontConfig.ts
@@ -325,7 +325,9 @@ const setStorefrontConfig = async (dispatch: DispatchProps) => {
   const useCombinedQuery = featureFlags['B2B-3817.disable_masquerading_cleanup_on_login'] ?? false;
 
   if (featureFlags['LOCAL-3191.B2B_multi_language']) {
-    const locales = await getLocales().catch(() => []);
+    const locales = await getLocales()
+      .then((res) => res.data.site.settings.locales)
+      .catch(() => []);
     store.dispatch(setLocales(locales));
   }
 

--- a/apps/storefront/tests/storeStateBuilders/globalStateBuilder.ts
+++ b/apps/storefront/tests/storeStateBuilders/globalStateBuilder.ts
@@ -57,5 +57,5 @@ export const buildGlobalStateWith = builder<GlobalState & PersistPartial>(() => 
     rehydrated: true,
   },
   featureFlags: {},
-  availableLocales: [],
+  locales: [],
 }));

--- a/apps/storefront/tests/storeStateBuilders/globalStateBuilder.ts
+++ b/apps/storefront/tests/storeStateBuilders/globalStateBuilder.ts
@@ -57,4 +57,5 @@ export const buildGlobalStateWith = builder<GlobalState & PersistPartial>(() => 
     rehydrated: true,
   },
   featureFlags: {},
+  availableLocales: [],
 }));


### PR DESCRIPTION
Jira: [LOCAL-3191](https://bigcommercecloud.atlassian.net/browse/LOCAL-3191)

## What/Why?
Implements a locale switcher dropdown in the storefront header, allowing users to switch between available store languages. All changes are gated behind the **LOCAL-3191.B2B_multi_language** feature flag - when disabled, the component renders nothing and no additional network requests are made.
                                                                                                                                                                                     
**Changes:**                                                                                           
New component — B3LocaleSwitcher     
  - Renders a dropdown (reusing B3DropDown) in the main header showing the active locale code
  - Determines the active locale by matching window.location.href against each locale's fullPath, with path-boundary verification to prevent partial prefix matches (e.g. /fr does not match /frozen)                                                                                    
  - Falls back to the default locale when no URL match is found   
  - Switches locale by navigating to nextLocale.fullPath + window.location.hash, preserving the current SPA route
  - Selected language persists across page reloads since the locale is derived from the URL                                                                                                                                                                                                                  
Redux store (global slice)                                                                                                                                                         
  - Added Locale type and availableLocales: Locale[] field to GlobalState                                                                                                            
  - Added setLocales action                                                                                                                                                                                                                                                            
Storefront config initialization
  - When the flag is enabled, fetches available locales via getLocales() (new GraphQL query against site.settings.locales) and dispatches setLocales 
  - Fetch failure is silently caught (.catch(() => [])) so a locale API error does not break the rest of storefront config initialization 
 
 
## Rollout/Rollback
Disable experiments:
1. LOCAL-3191.B2B_multi_language (Control of language switcher display and management of data retrieval for building the language switcher)
2. LOCAL-3235.Available_locale_fullPath (Managing the addition of a new fullPath field in Storefront GraphQL)

If disabling the experiments didn’t help.
1. Revert PR
2. Revert storefront [PR](https://github.com/bigcommerce/storefront/pull/4900)

## Testing
1. Unit tests
2. Manual test

https://github.com/user-attachments/assets/f421376f-9039-4e27-ba9f-3884b764b9b0





[LOCAL-3191]: https://bigcommercecloud.atlassian.net/browse/LOCAL-3191?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new header dropdown that changes `window.location.href` based on BigCommerce locale `fullPath`, plus a new config-time locales fetch; navigation/URL-matching bugs or misconfigured locales could affect routing when the flag is enabled.
> 
> **Overview**
> Adds a **feature-flagged** (`LOCAL-3191.B2B_multi_language`) locale switcher dropdown to the main storefront header, showing the active locale code and navigating to the selected locale while preserving the current `window.location.hash`.
> 
> Introduces a new BigCommerce GraphQL `getLocales` query and stores the returned locales in Redux (`global.locales`) via a new `setLocales` action; locales are fetched during storefront config initialization only when the flag is enabled (errors are silently ignored). Adds unit tests covering render gating, URL-to-locale matching edge cases, and navigation behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0493d90ee7dfe024064b79d01e04e19e00283ca5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->