### PR TITLE
feat(orders): B2B-4616 implement Company Orders via SF GQL

### DIFF
--- a/apps/storefront/src/pages/CompanyOrderList/unified-company-orders.test.tsx
+++ b/apps/storefront/src/pages/CompanyOrderList/unified-company-orders.test.tsx
@@ -1,0 +1,530 @@
+import {
+  buildB2BFeaturesStateWith,
+  buildCompanyStateWith,
+  builder,
+  buildGlobalStateWith,
+  buildStoreInfoStateWith,
+  bulk,
+  faker,
+  graphql,
+  HttpResponse,
+  renderWithProviders,
+  screen,
+  startMockServer,
+  userEvent,
+  waitFor,
+  waitForElementToBeRemoved,
+  within,
+} from 'tests/test-utils';
+import { vi } from 'vitest';
+import { when } from 'vitest-when';
+
+import type {
+  GetCompanyOrdersResponse,
+  Order,
+  OrderPlacedBy,
+} from '@/shared/service/bc/graphql/orders';
+import { CompanyStatus, CustomerRole, UserTypes } from '@/types';
+
+import { CompanyOrderStatuses, OrderStatus as LegacyOrderStatus } from '../order/orders';
+
+import CompanyOrders from '.';
+
+const { server } = startMockServer();
+
+// ---------------------------------------------------------------------------
+// Builders
+// ---------------------------------------------------------------------------
+
+const buildPlacedByWith = builder<OrderPlacedBy>(() => ({
+  entityId: faker.number.int({ min: 1, max: 9999 }),
+  firstName: faker.person.firstName(),
+  lastName: faker.person.lastName(),
+  email: faker.internet.email(),
+}));
+
+const buildSfGqlOrderWith = builder<Order>(() => ({
+  entityId: faker.number.int({ min: 1000, max: 99999 }),
+  orderedAt: { utc: faker.date.past().toISOString() },
+  updatedAt: { utc: faker.date.past().toISOString() },
+  status: { value: 'PENDING', label: 'Pending' },
+  billingAddress: {
+    firstName: faker.person.firstName(),
+    lastName: faker.person.lastName(),
+    company: faker.company.name(),
+    address1: faker.location.streetAddress(),
+    address2: null,
+    city: faker.location.city(),
+    stateOrProvince: faker.location.state(),
+    postalCode: faker.location.zipCode(),
+    country: faker.location.country(),
+    countryCode: faker.location.countryCode(),
+    phone: faker.phone.number(),
+    email: faker.internet.email(),
+  },
+  subTotal: { currencyCode: 'USD', value: 100 },
+  discountedSubTotal: null,
+  shippingCostTotal: { currencyCode: 'USD', value: 9.99 },
+  handlingCostTotal: { currencyCode: 'USD', value: 0 },
+  wrappingCostTotal: { currencyCode: 'USD', value: 0 },
+  taxTotal: { currencyCode: 'USD', value: 5 },
+  totalIncTax: { currencyCode: 'USD', value: 114.99 },
+  isTaxIncluded: false,
+  taxes: [{ name: 'Tax', amount: { currencyCode: 'USD', value: 5 } }],
+  discounts: {
+    couponDiscounts: [],
+    nonCouponDiscountTotal: { currencyCode: 'USD', value: 0 },
+    totalDiscount: null,
+  },
+  customerMessage: null,
+  totalProductQuantity: 2,
+  consignments: null,
+  reference: faker.string.alphanumeric(8),
+  company: { entityId: faker.number.int({ min: 1, max: 999 }), name: faker.company.name() },
+  placedBy: buildPlacedByWith('WHATEVER_VALUES'),
+  history: [],
+  quote: null,
+  invoice: null,
+  extraFields: [],
+}));
+
+const buildCompanyOrdersResponseWith = builder<GetCompanyOrdersResponse>(() => {
+  const numberOfOrders = faker.number.int({ min: 1, max: 5 });
+  return {
+    data: {
+      customer: {
+        activeCompany: {
+          orders: {
+            edges: bulk(
+              builder(() => ({
+                node: buildSfGqlOrderWith('WHATEVER_VALUES'),
+                cursor: faker.string.alphanumeric(20),
+              })),
+              'WHATEVER_VALUES',
+            ).times(numberOfOrders),
+            pageInfo: {
+              hasNextPage: false,
+              hasPreviousPage: false,
+              startCursor: faker.string.alphanumeric(20),
+              endCursor: faker.string.alphanumeric(20),
+            },
+            collectionInfo: { totalItems: numberOfOrders },
+          },
+        },
+      },
+    },
+  };
+});
+
+const buildLegacyOrderStatusWith = builder<LegacyOrderStatus>(() => ({
+  statusCode: faker.number.int().toString(),
+  systemLabel: faker.word.noun(),
+  customLabel: faker.word.noun(),
+}));
+
+const buildLegacyB2BOrderStatusesResponseWith = builder<CompanyOrderStatuses>(() => ({
+  data: {
+    orderStatuses: bulk(buildLegacyOrderStatusWith, 'WHATEVER_VALUES').times(3),
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Preloaded states
+// ---------------------------------------------------------------------------
+
+const flagOn = { 'B2B-4613.buyer_portal_unified_sf_gql_orders': true } as const;
+const flagOff = { 'B2B-4613.buyer_portal_unified_sf_gql_orders': false } as const;
+
+const b2bStateWithFlag = (featureFlags: Record<string, boolean>) => ({
+  company: buildCompanyStateWith({
+    customer: { role: CustomerRole.SENIOR_BUYER, userType: UserTypes.MULTIPLE_B2C },
+    companyInfo: { id: '123', companyName: 'Test Corp', status: CompanyStatus.APPROVED },
+  }),
+  global: buildGlobalStateWith({ featureFlags }),
+  storeInfo: buildStoreInfoStateWith({ timeFormat: { display: 'j F Y' } }),
+});
+
+const superAdminMasqueradingState = (featureFlags: Record<string, boolean>) => ({
+  company: buildCompanyStateWith({
+    customer: { role: CustomerRole.SUPER_ADMIN, userType: UserTypes.MULTIPLE_B2C },
+    companyInfo: { id: '456', companyName: 'Admin Corp', status: CompanyStatus.APPROVED },
+  }),
+  b2bFeatures: buildB2BFeaturesStateWith({
+    masqueradeCompany: { id: 456, isAgenting: true },
+  }),
+  global: buildGlobalStateWith({ featureFlags }),
+  storeInfo: buildStoreInfoStateWith({ timeFormat: { display: 'j F Y' } }),
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('Company Orders — unified SF GQL orders (B2B-4616)', () => {
+  beforeEach(() => {
+    server.use(
+      graphql.query('GetOrderStatuses', () =>
+        HttpResponse.json(buildLegacyB2BOrderStatusesResponseWith('WHATEVER_VALUES')),
+      ),
+      graphql.query('GetOrdersCreatedByUser', () =>
+        HttpResponse.json({ data: { createdByUser: { results: [] } } }),
+      ),
+    );
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('flag OFF — legacy path unchanged', () => {
+    it('does not call the SF GQL company orders query', async () => {
+      const sfGqlHandler = vi.fn();
+
+      server.use(
+        graphql.query('GetCompanyOrders', () => {
+          sfGqlHandler();
+          return HttpResponse.json(buildCompanyOrdersResponseWith('WHATEVER_VALUES'));
+        }),
+        graphql.query('GetAllOrders', () =>
+          HttpResponse.json({
+            data: {
+              allOrders: {
+                totalCount: 1,
+                pageInfo: { hasNextPage: false, hasPreviousPage: false },
+                edges: [
+                  {
+                    node: {
+                      orderId: '100',
+                      createdAt: 1700000000,
+                      totalIncTax: 50,
+                      poNumber: 'PO1',
+                      status: 'Pending',
+                      firstName: 'A',
+                      lastName: 'B',
+                      companyInfo: { companyName: 'Corp' },
+                    },
+                  },
+                ],
+              },
+            },
+          }),
+        ),
+      );
+
+      renderWithProviders(<CompanyOrders />, { preloadedState: b2bStateWithFlag(flagOff) });
+
+      await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+      expect(sfGqlHandler).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('flag ON — unified SF GQL company orders path', () => {
+    it('renders company orders with all fields', async () => {
+      const order = buildSfGqlOrderWith({
+        entityId: 12345,
+        reference: 'PO-9876',
+        status: { value: 'COMPLETED', label: 'Completed' },
+        totalIncTax: { currencyCode: 'USD', value: 250 },
+        orderedAt: { utc: '2025-03-13T00:00:00Z' },
+        company: { entityId: 1, name: 'Acme Corp' },
+        placedBy: { entityId: 1, firstName: 'Jane', lastName: 'Doe', email: 'jane@acme.com' },
+      });
+
+      server.use(
+        graphql.query('GetCompanyOrders', () =>
+          HttpResponse.json({
+            data: {
+              customer: {
+                activeCompany: {
+                  orders: {
+                    edges: [{ node: order, cursor: 'abc' }],
+                    pageInfo: {
+                      hasNextPage: false,
+                      hasPreviousPage: false,
+                      startCursor: 'abc',
+                      endCursor: 'abc',
+                    },
+                    collectionInfo: { totalItems: 1 },
+                  },
+                },
+              },
+            },
+          } satisfies GetCompanyOrdersResponse),
+        ),
+      );
+
+      renderWithProviders(<CompanyOrders />, { preloadedState: b2bStateWithFlag(flagOn) });
+
+      await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+      const row = screen.getByRole('row', { name: /12345/ });
+      expect(row).toBeInTheDocument();
+      expect(within(row).getByText('PO-9876')).toBeInTheDocument();
+      expect(within(row).getByText(/Acme Corp/)).toBeInTheDocument();
+      expect(within(row).getByText(/Completed/)).toBeInTheDocument();
+      expect(within(row).getByText(/Jane Doe/)).toBeInTheDocument();
+    });
+
+    it('shows company and placed-by columns for company orders', async () => {
+      server.use(
+        graphql.query('GetCompanyOrders', () =>
+          HttpResponse.json(buildCompanyOrdersResponseWith('WHATEVER_VALUES')),
+        ),
+      );
+
+      renderWithProviders(<CompanyOrders />, { preloadedState: b2bStateWithFlag(flagOn) });
+
+      await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+      const table = screen.getByRole('table');
+      const headers = within(table).getAllByRole('columnheader');
+      const headerTexts = headers.map((h) => h.textContent);
+
+      expect(headerTexts).toContain('Company');
+      expect(headerTexts).toContain('Placed by');
+    });
+
+    it('shows placed-by column for super admin masquerading on company orders', async () => {
+      server.use(
+        graphql.query('GetCompanyOrders', () =>
+          HttpResponse.json(buildCompanyOrdersResponseWith('WHATEVER_VALUES')),
+        ),
+      );
+
+      renderWithProviders(<CompanyOrders />, {
+        preloadedState: superAdminMasqueradingState(flagOn),
+      });
+
+      await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+      const table = screen.getByRole('table');
+      const headers = within(table).getAllByRole('columnheader');
+      const headerTexts = headers.map((h) => h.textContent);
+
+      expect(headerTexts).toContain('Placed by');
+    });
+
+    it('formats currency correctly', async () => {
+      const order = buildSfGqlOrderWith({
+        entityId: 77777,
+        totalIncTax: { currencyCode: 'USD', value: 1234.56 },
+      });
+
+      server.use(
+        graphql.query('GetCompanyOrders', () =>
+          HttpResponse.json({
+            data: {
+              customer: {
+                activeCompany: {
+                  orders: {
+                    edges: [{ node: order, cursor: 'cur' }],
+                    pageInfo: {
+                      hasNextPage: false,
+                      hasPreviousPage: false,
+                      startCursor: null,
+                      endCursor: null,
+                    },
+                    collectionInfo: { totalItems: 1 },
+                  },
+                },
+              },
+            },
+          } satisfies GetCompanyOrdersResponse),
+        ),
+      );
+
+      renderWithProviders(<CompanyOrders />, { preloadedState: b2bStateWithFlag(flagOn) });
+
+      await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+      const row = screen.getByRole('row', { name: /77777/ });
+      expect(within(row).getByText(/1,234\.56/)).toBeInTheDocument();
+    });
+
+    describe('filter behavior', () => {
+      it('filters by search input', async () => {
+        const getOrders = vi
+          .fn()
+          .mockReturnValue(buildCompanyOrdersResponseWith('WHATEVER_VALUES'));
+
+        server.use(
+          graphql.query('GetCompanyOrders', ({ variables }) =>
+            HttpResponse.json(getOrders(variables)),
+          ),
+        );
+
+        renderWithProviders(<CompanyOrders />, { preloadedState: b2bStateWithFlag(flagOn) });
+
+        await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+        const filteredResponse: GetCompanyOrdersResponse = {
+          data: {
+            customer: {
+              activeCompany: {
+                orders: {
+                  edges: [
+                    {
+                      node: buildSfGqlOrderWith({ entityId: 66996 }),
+                      cursor: 'filtered',
+                    },
+                  ],
+                  pageInfo: {
+                    hasNextPage: false,
+                    hasPreviousPage: false,
+                    startCursor: 'filtered',
+                    endCursor: 'filtered',
+                  },
+                  collectionInfo: { totalItems: 1 },
+                },
+              },
+            },
+          },
+        };
+
+        when(getOrders)
+          .calledWith(
+            expect.objectContaining({
+              filters: expect.objectContaining({ search: '66996' }),
+            }),
+          )
+          .thenReturn(filteredResponse);
+
+        await userEvent.type(screen.getByPlaceholderText(/Search/), '66996');
+
+        await waitFor(() => {
+          expect(screen.getByRole('row', { name: /66996/ })).toBeInTheDocument();
+        });
+      });
+    });
+
+    describe('cursor pagination', () => {
+      const buildPagedResponse = (
+        orders: Array<{ entityId: number }>,
+        pageInfo: {
+          hasNextPage: boolean;
+          hasPreviousPage: boolean;
+          startCursor: string | null;
+          endCursor: string | null;
+        },
+        totalItems: number,
+      ): GetCompanyOrdersResponse => ({
+        data: {
+          customer: {
+            activeCompany: {
+              orders: {
+                edges: orders.map((o) => ({
+                  node: buildSfGqlOrderWith(o),
+                  cursor: `cursor-${o.entityId}`,
+                })),
+                pageInfo,
+                collectionInfo: { totalItems },
+              },
+            },
+          },
+        },
+      });
+
+      it('passes after cursor when navigating to the next page', async () => {
+        const page1Response = buildPagedResponse(
+          [{ entityId: 1001 }, { entityId: 1002 }],
+          {
+            hasNextPage: true,
+            hasPreviousPage: false,
+            startCursor: 'cursor-1001',
+            endCursor: 'cursor-1002',
+          },
+          4,
+        );
+
+        const getOrders = vi.fn().mockReturnValue(page1Response);
+
+        when(getOrders)
+          .calledWith(expect.objectContaining({ after: 'cursor-1002' }))
+          .thenReturn(
+            buildPagedResponse(
+              [{ entityId: 2001 }, { entityId: 2002 }],
+              {
+                hasNextPage: false,
+                hasPreviousPage: true,
+                startCursor: 'cursor-2001',
+                endCursor: 'cursor-2002',
+              },
+              4,
+            ),
+          );
+
+        server.use(
+          graphql.query('GetCompanyOrders', ({ variables }) =>
+            HttpResponse.json(getOrders(variables)),
+          ),
+        );
+
+        renderWithProviders(<CompanyOrders />, { preloadedState: b2bStateWithFlag(flagOn) });
+
+        await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+        expect(screen.getByRole('row', { name: /1001/ })).toBeInTheDocument();
+
+        await userEvent.click(screen.getByRole('button', { name: /next page/ }));
+
+        await waitFor(() => {
+          expect(screen.getByRole('row', { name: /2001/ })).toBeInTheDocument();
+        });
+      });
+
+      it('passes before cursor when navigating to the previous page', async () => {
+        const page1Response = buildPagedResponse(
+          [{ entityId: 1001 }],
+          {
+            hasNextPage: true,
+            hasPreviousPage: false,
+            startCursor: 'cursor-1001',
+            endCursor: 'cursor-1001',
+          },
+          2,
+        );
+
+        const getOrders = vi.fn().mockReturnValue(page1Response);
+
+        when(getOrders)
+          .calledWith(expect.objectContaining({ after: 'cursor-1001' }))
+          .thenReturn(
+            buildPagedResponse(
+              [{ entityId: 2001 }],
+              {
+                hasNextPage: false,
+                hasPreviousPage: true,
+                startCursor: 'cursor-2001',
+                endCursor: 'cursor-2001',
+              },
+              2,
+            ),
+          );
+
+        when(getOrders)
+          .calledWith(expect.objectContaining({ before: 'cursor-2001' }))
+          .thenReturn(page1Response);
+
+        server.use(
+          graphql.query('GetCompanyOrders', ({ variables }) =>
+            HttpResponse.json(getOrders(variables)),
+          ),
+        );
+
+        renderWithProviders(<CompanyOrders />, { preloadedState: b2bStateWithFlag(flagOn) });
+
+        await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+        await userEvent.click(screen.getByRole('button', { name: /next page/ }));
+        await waitFor(() => {
+          expect(screen.getByRole('row', { name: /2001/ })).toBeInTheDocument();
+        });
+
+        await userEvent.click(screen.getByRole('button', { name: /previous page/ }));
+        await waitFor(() => {
+          expect(screen.getByRole('row', { name: /1001/ })).toBeInTheDocument();
+        });
+      });
+    });
+  });
+});

--- a/apps/storefront/src/pages/CompanyOrderList/unified-company-orders.test.tsx
+++ b/apps/storefront/src/pages/CompanyOrderList/unified-company-orders.test.tsx
@@ -258,7 +258,7 @@ describe('Company Orders — unified SF GQL orders (B2B-4616)', () => {
 
       await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
 
-      const row = screen.getByRole('row', { name: /12345/ });
+      const row = screen.getByText('12345').closest('tr')!;
       expect(row).toBeInTheDocument();
       expect(within(row).getByText('PO-9876')).toBeInTheDocument();
       expect(within(row).getByText('Acme Corp')).toBeInTheDocument();
@@ -338,7 +338,7 @@ describe('Company Orders — unified SF GQL orders (B2B-4616)', () => {
 
       await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
 
-      const row = screen.getByRole('row', { name: /77777/ });
+      const row = screen.getByText('77777').closest('tr')!;
       expect(within(row).getByText('$1,234.56')).toBeInTheDocument();
     });
 
@@ -393,7 +393,7 @@ describe('Company Orders — unified SF GQL orders (B2B-4616)', () => {
         await userEvent.type(screen.getByPlaceholderText('Search'), '66996');
 
         await waitFor(() => {
-          expect(screen.getByRole('row', { name: /66996/ })).toBeInTheDocument();
+          expect(screen.getByText('66996').closest('tr')!).toBeInTheDocument();
         });
       });
     });
@@ -463,12 +463,12 @@ describe('Company Orders — unified SF GQL orders (B2B-4616)', () => {
         renderWithProviders(<CompanyOrders />, { preloadedState: b2bStateWithFlag(flagOn) });
 
         await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
-        expect(screen.getByRole('row', { name: /1001/ })).toBeInTheDocument();
+        expect(screen.getByText('1001').closest('tr')!).toBeInTheDocument();
 
-        await userEvent.click(screen.getByRole('button', { name: /next page/ }));
+        await userEvent.click(screen.getByRole('button', { name: 'Go to next page' }));
 
         await waitFor(() => {
-          expect(screen.getByRole('row', { name: /2001/ })).toBeInTheDocument();
+          expect(screen.getByText('2001').closest('tr')!).toBeInTheDocument();
         });
       });
 
@@ -515,14 +515,14 @@ describe('Company Orders — unified SF GQL orders (B2B-4616)', () => {
 
         await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
 
-        await userEvent.click(screen.getByRole('button', { name: /next page/ }));
+        await userEvent.click(screen.getByRole('button', { name: 'Go to next page' }));
         await waitFor(() => {
-          expect(screen.getByRole('row', { name: /2001/ })).toBeInTheDocument();
+          expect(screen.getByText('2001').closest('tr')!).toBeInTheDocument();
         });
 
-        await userEvent.click(screen.getByRole('button', { name: /previous page/ }));
+        await userEvent.click(screen.getByRole('button', { name: 'Go to previous page' }));
         await waitFor(() => {
-          expect(screen.getByRole('row', { name: /1001/ })).toBeInTheDocument();
+          expect(screen.getByText('1001').closest('tr')!).toBeInTheDocument();
         });
       });
     });

--- a/apps/storefront/src/pages/CompanyOrderList/unified-company-orders.test.tsx
+++ b/apps/storefront/src/pages/CompanyOrderList/unified-company-orders.test.tsx
@@ -132,8 +132,8 @@ const buildLegacyB2BOrderStatusesResponseWith = builder<CompanyOrderStatuses>(()
 // Preloaded states
 // ---------------------------------------------------------------------------
 
-const flagOn = { 'B2B-4613.buyer_portal_unified_sf_gql_orders': true } as const;
-const flagOff = { 'B2B-4613.buyer_portal_unified_sf_gql_orders': false } as const;
+const flagOn = { 'B2B-4613.buyer_portal_unified_sf_gql_orders': true };
+const flagOff = { 'B2B-4613.buyer_portal_unified_sf_gql_orders': false };
 
 const b2bStateWithFlag = (featureFlags: Record<string, boolean>) => ({
   company: buildCompanyStateWith({
@@ -261,9 +261,9 @@ describe('Company Orders — unified SF GQL orders (B2B-4616)', () => {
       const row = screen.getByRole('row', { name: /12345/ });
       expect(row).toBeInTheDocument();
       expect(within(row).getByText('PO-9876')).toBeInTheDocument();
-      expect(within(row).getByText(/Acme Corp/)).toBeInTheDocument();
-      expect(within(row).getByText(/Completed/)).toBeInTheDocument();
-      expect(within(row).getByText(/Jane Doe/)).toBeInTheDocument();
+      expect(within(row).getByText('Acme Corp')).toBeInTheDocument();
+      expect(within(row).getByText('Completed')).toBeInTheDocument();
+      expect(within(row).getByText('Jane Doe')).toBeInTheDocument();
     });
 
     it('shows company and placed-by columns for company orders', async () => {
@@ -339,7 +339,7 @@ describe('Company Orders — unified SF GQL orders (B2B-4616)', () => {
       await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
 
       const row = screen.getByRole('row', { name: /77777/ });
-      expect(within(row).getByText(/1,234\.56/)).toBeInTheDocument();
+      expect(within(row).getByText('$1,234.56')).toBeInTheDocument();
     });
 
     describe('filter behavior', () => {
@@ -390,7 +390,7 @@ describe('Company Orders — unified SF GQL orders (B2B-4616)', () => {
           )
           .thenReturn(filteredResponse);
 
-        await userEvent.type(screen.getByPlaceholderText(/Search/), '66996');
+        await userEvent.type(screen.getByPlaceholderText('Search'), '66996');
 
         await waitFor(() => {
           expect(screen.getByRole('row', { name: /66996/ })).toBeInTheDocument();

--- a/apps/storefront/src/pages/order/Order.tsx
+++ b/apps/storefront/src/pages/order/Order.tsx
@@ -11,6 +11,8 @@ import { useMobile } from '@/hooks/useMobile';
 import { useB3Lang } from '@/lib/lang';
 import { PageInfo } from '@/shared/service/bc/graphql/base';
 import {
+  CompanyOrdersFiltersInput,
+  getCompanyOrders,
   getCustomerOrders,
   OrdersFiltersInput,
   OrdersSortInput,
@@ -22,7 +24,10 @@ import { displayFormat } from '@/utils/b3DateFormat';
 
 import OrderStatus from './components/OrderStatus';
 import { B3Table, PossibleNodeWrapper, TableColumnItem } from './table/B3Table';
-import { adaptUnifiedToLegacyFilterParams } from './adaptUnifiedToLegacyFilterParams';
+import {
+  adaptCompanyUnifiedToLegacyFilterParams,
+  adaptUnifiedToLegacyFilterParams,
+} from './adaptUnifiedToLegacyFilterParams';
 import {
   FilterSearchProps,
   getFilterMoreData,
@@ -38,6 +43,7 @@ import {
   getCreatedByUserForOrders,
   getOrderStatusType,
 } from './orders';
+import { useCompanyOrdersState } from './useCompanyOrdersState';
 import { useCustomerOrdersState } from './useCustomerOrdersState';
 import { useLegacyOrdersFilterState } from './useLegacyOrdersFilterState';
 
@@ -103,7 +109,8 @@ function Order({ isCompanyOrder = false }: OrderProps) {
   const [filterMoreInfo, setFilterMoreInfo] = useState<Array<any>>([]);
   const [getOrderStatuses, setOrderStatuses] = useState<Array<any>>([]);
 
-  const isUnifiedOrdersNonCompanyOrderPath = isUnifiedOrders && !isCompanyOrder;
+  const isUnifiedCustomerPath = isUnifiedOrders && !isCompanyOrder;
+  const isUnifiedCompanyPath = isUnifiedOrders && isCompanyOrder;
 
   const legacyFilterState = useLegacyOrdersFilterState({
     isB2BUser,
@@ -114,8 +121,19 @@ function Order({ isCompanyOrder = false }: OrderProps) {
   const customerFilterState = useCustomerOrdersState({
     companyId: selectedCompanyId,
     orderStatuses: getOrderStatuses,
-    isCompanyOrder,
   });
+  const companyFilterState = useCompanyOrdersState({
+    selectedCompanyId,
+    orderStatuses: getOrderStatuses,
+  });
+
+  const getActiveFilterState = () => {
+    if (isUnifiedCompanyPath) return companyFilterState;
+    if (isUnifiedCustomerPath) return customerFilterState;
+    return legacyFilterState;
+  };
+
+  const activeFilterState = getActiveFilterState();
 
   const {
     activeSort,
@@ -123,15 +141,26 @@ function Order({ isCompanyOrder = false }: OrderProps) {
     handleFilterChange,
     handleCompanyIdsChange,
     handleSetOrderBy,
-  } = isUnifiedOrdersNonCompanyOrderPath ? customerFilterState : legacyFilterState;
+  } = activeFilterState;
 
-  const { filterData, orderBy } = isUnifiedOrdersNonCompanyOrderPath
-    ? adaptUnifiedToLegacyFilterParams({
+  const getFilterDataAndOrderBy = () => {
+    if (isUnifiedCompanyPath) {
+      return adaptCompanyUnifiedToLegacyFilterParams({
+        filters: companyFilterState.filters,
+        activeSort: companyFilterState.activeSort,
+      });
+    }
+    if (isUnifiedCustomerPath) {
+      return adaptUnifiedToLegacyFilterParams({
         filters: customerFilterState.filters,
         activeSort: customerFilterState.activeSort,
         isB2BUser,
-      })
-    : { filterData: legacyFilterState.filterData, orderBy: legacyFilterState.orderBy };
+      });
+    }
+    return { filterData: legacyFilterState.filterData, orderBy: legacyFilterState.orderBy };
+  };
+
+  const { filterData, orderBy } = getFilterDataAndOrderBy();
 
   useEffect(() => {
     // TODO: Guest customer should not be able to see the order list
@@ -186,6 +215,27 @@ function Order({ isCompanyOrder = false }: OrderProps) {
     return { edges, totalCount: -1, pageInfo };
   };
 
+  const fetchUnifiedCompanyOrders = async (args: {
+    first?: number;
+    after?: string;
+    last?: number;
+    before?: string;
+    filters: CompanyOrdersFiltersInput;
+    sortBy: OrdersSortInput;
+  }): Promise<{
+    edges: ListItem[];
+    totalCount: number;
+    pageInfo: PageInfo | null;
+  }> => {
+    const result = await getCompanyOrders(args);
+    const orders = result.data?.customer?.activeCompany?.orders;
+    const edges = (orders?.edges || []).map((edge) => mapSfGqlOrderToListItem(edge.node));
+    const pageInfo = orders?.pageInfo ?? null;
+    const totalCount = orders?.collectionInfo?.totalItems ?? -1;
+
+    return { edges, totalCount, pageInfo };
+  };
+
   const fetchLegacyOrders = async ({
     createdBy,
     ...params
@@ -216,7 +266,7 @@ function Order({ isCompanyOrder = false }: OrderProps) {
           ...filterData,
           orderBy,
         },
-        totalCount: allTotal,
+        totalCount: isUnifiedOrders ? -1 : allTotal,
         isCompanyOrder,
         beginDateAt: filterData?.beginDateAt,
         endDateAt: filterData?.endDateAt,
@@ -237,7 +287,7 @@ function Order({ isCompanyOrder = false }: OrderProps) {
     });
   };
 
-  const navigateToOrderDetail = isUnifiedOrdersNonCompanyOrderPath ? goToDetail : legacyGoToDetail;
+  const navigateToOrderDetail = isUnifiedCustomerPath ? goToDetail : legacyGoToDetail;
 
   const columnAllItems = [
     {
@@ -314,32 +364,58 @@ function Order({ isCompanyOrder = false }: OrderProps) {
 
   const columnItems = getColumnItems();
 
+  const unifiedState = isUnifiedCompanyPath ? companyFilterState : customerFilterState;
+
+  const getQueryKey = () => {
+    if (isUnifiedCompanyPath) {
+      return [
+        'orderList:unifiedCompany',
+        companyFilterState.filters,
+        companyFilterState.sortBy,
+        companyFilterState.paginationVariables,
+      ];
+    }
+    if (isUnifiedCustomerPath) {
+      return [
+        'orderList:unified',
+        customerFilterState.filters,
+        customerFilterState.sortBy,
+        customerFilterState.paginationVariables,
+      ];
+    }
+    return ['orderList:legacy', filterData, legacyPagination, orderBy];
+  };
+
+  const getQueryFn = () => {
+    if (isUnifiedCompanyPath) {
+      return fetchUnifiedCompanyOrders({
+        ...companyFilterState.paginationVariables,
+        filters: companyFilterState.filters,
+        sortBy: companyFilterState.sortBy,
+      });
+    }
+    if (isUnifiedCustomerPath) {
+      return fetchUnifiedOrders({
+        ...customerFilterState.paginationVariables,
+        filters: customerFilterState.filters,
+        sortBy: customerFilterState.sortBy,
+      });
+    }
+    return fetchLegacyOrders({ ...filterData, ...legacyPagination, orderBy });
+  };
+
   const { data, isFetching, dataUpdatedAt } = useQuery({
-    queryKey: isUnifiedOrdersNonCompanyOrderPath
-      ? [
-          'orderList:unified',
-          customerFilterState.filters,
-          customerFilterState.sortBy,
-          customerFilterState.paginationVariables,
-        ]
-      : ['orderList:legacy', filterData, legacyPagination, orderBy],
-    enabled: isUnifiedOrdersNonCompanyOrderPath ? true : Boolean(filterData),
-    queryFn: () =>
-      isUnifiedOrdersNonCompanyOrderPath
-        ? fetchUnifiedOrders({
-            ...customerFilterState.paginationVariables,
-            filters: customerFilterState.filters,
-            sortBy: customerFilterState.sortBy,
-          })
-        : fetchLegacyOrders({ ...filterData, ...legacyPagination, orderBy }),
+    queryKey: getQueryKey(),
+    enabled: isUnifiedOrders || Boolean(filterData),
+    queryFn: getQueryFn,
   });
 
   useEffect(() => {
-    if (!data || !isUnifiedOrdersNonCompanyOrderPath) return;
+    if (!data || !isUnifiedOrders) return;
     const pageInfo = 'pageInfo' in data ? (data as { pageInfo: PageInfo | null }).pageInfo : null;
-    if (pageInfo) customerFilterState.updatePageInfo(pageInfo);
+    if (pageInfo) unifiedState.updatePageInfo(pageInfo);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [dataUpdatedAt, isUnifiedOrdersNonCompanyOrderPath]);
+  }, [dataUpdatedAt, isUnifiedOrders]);
 
   const listItems = useMemo(
     () =>
@@ -404,18 +480,16 @@ function Order({ isCompanyOrder = false }: OrderProps) {
           columnItems={columnItems}
           listItems={listItems}
           pagination={
-            isUnifiedOrdersNonCompanyOrderPath
-              ? customerFilterState.b3TablePaginationProps.pagination
+            isUnifiedOrders
+              ? unifiedState.b3TablePaginationProps.pagination
               : { ...legacyPagination, count: data?.totalCount || 0 }
           }
           cursorPageInfo={
-            isUnifiedOrdersNonCompanyOrderPath
-              ? customerFilterState.b3TablePaginationProps.cursorPageInfo
-              : undefined
+            isUnifiedOrders ? unifiedState.b3TablePaginationProps.cursorPageInfo : undefined
           }
           onPaginationChange={
-            isUnifiedOrdersNonCompanyOrderPath
-              ? customerFilterState.b3TablePaginationProps.onPaginationChange
+            isUnifiedOrders
+              ? unifiedState.b3TablePaginationProps.onPaginationChange
               : setLegacyPagination
           }
           isInfiniteScroll={isMobile}

--- a/apps/storefront/src/pages/order/Order.tsx
+++ b/apps/storefront/src/pages/order/Order.tsx
@@ -133,15 +133,13 @@ function Order({ isCompanyOrder = false }: OrderProps) {
     return legacyFilterState;
   };
 
-  const activeFilterState = getActiveFilterState();
-
   const {
     activeSort,
     handleSearchChange,
     handleFilterChange,
     handleCompanyIdsChange,
     handleSetOrderBy,
-  } = activeFilterState;
+  } = getActiveFilterState();
 
   const getFilterDataAndOrderBy = () => {
     if (isUnifiedCompanyPath) {

--- a/apps/storefront/src/pages/order/adaptUnifiedToLegacyFilterParams.ts
+++ b/apps/storefront/src/pages/order/adaptUnifiedToLegacyFilterParams.ts
@@ -10,6 +10,7 @@
  */
 
 import { FilterSearchProps, sortKeys } from './config';
+import type { UseCompanyOrdersStateResult } from './useCompanyOrdersState';
 import type { UseCustomerOrdersStateResult } from './useCustomerOrdersState';
 
 export type AdaptUnifiedToLegacyFilterParamsArgs = Pick<
@@ -36,6 +37,30 @@ export const adaptUnifiedToLegacyFilterParams = ({
     // Legacy emits `companyIds: []` for "All"; restore that for B2B users.
     companyIds: filters.companyIds?.map(Number) ?? (isB2BUser ? [] : undefined),
     isShowMy: isB2BUser ? 1 : undefined,
+  },
+  orderBy: activeSort.dir === 'desc' ? `-${sortKeys[activeSort.key]}` : sortKeys[activeSort.key],
+});
+
+type AdaptCompanyUnifiedToLegacyFilterParamsArgs = Pick<
+  UseCompanyOrdersStateResult,
+  'filters' | 'activeSort'
+>;
+
+export const adaptCompanyUnifiedToLegacyFilterParams = ({
+  filters,
+  activeSort,
+}: AdaptCompanyUnifiedToLegacyFilterParamsArgs): {
+  filterData: Partial<FilterSearchProps>;
+  orderBy: string;
+} => ({
+  filterData: {
+    q: filters.search ?? '',
+    statusCode: filters.status?.[0] ?? '',
+    beginDateAt: filters.dateRange?.from ?? null,
+    endDateAt: filters.dateRange?.to ?? null,
+    companyName: '',
+    companyIds: filters.companyIds?.map(Number) ?? [],
+    isShowMy: 0,
   },
   orderBy: activeSort.dir === 'desc' ? `-${sortKeys[activeSort.key]}` : sortKeys[activeSort.key],
 });

--- a/apps/storefront/src/pages/order/unifiedApiFiltersHelper.ts
+++ b/apps/storefront/src/pages/order/unifiedApiFiltersHelper.ts
@@ -1,4 +1,16 @@
-import { OrderDateRangeFilterInput, OrdersFiltersInput } from '@/shared/service/bc/graphql/orders';
+import {
+  CompanyOrdersFiltersInput,
+  OrderDateRangeFilterInput,
+  OrdersFiltersInput,
+} from '@/shared/service/bc/graphql/orders';
+
+export const getCompanyOrdersInitFilter = (companyId: number): CompanyOrdersFiltersInput => ({
+  search: undefined,
+  dateRange: undefined,
+  status: undefined,
+  customerId: undefined,
+  companyIds: companyId ? [String(companyId)] : undefined,
+});
 
 export const getCustomerOrdersInitFilter = (companyId: number): OrdersFiltersInput => {
   return {

--- a/apps/storefront/src/pages/order/unifiedApiFiltersHelper.ts
+++ b/apps/storefront/src/pages/order/unifiedApiFiltersHelper.ts
@@ -22,6 +22,12 @@ export const getCustomerOrdersInitFilter = (companyId: number): OrdersFiltersInp
   };
 };
 
+export const normalizeString = (value: string | number | null | undefined): string | undefined => {
+  if (value === null || value === undefined) return undefined;
+  const str = String(value);
+  return str === '' ? undefined : str;
+};
+
 export const packDateRange = (
   start: string | null | undefined,
   end: string | null | undefined,

--- a/apps/storefront/src/pages/order/useCompanyOrderSorting.ts
+++ b/apps/storefront/src/pages/order/useCompanyOrderSorting.ts
@@ -1,0 +1,22 @@
+import { OrdersSortInput } from '@/shared/service/bc/graphql/orders';
+
+import {
+  BASE_SORT_MAP,
+  BaseSortableColumnKey,
+  SortMap,
+  useUnifiedOrderSorting,
+  UseUnifiedOrderSortingResult,
+} from './useUnifiedOrderSorting';
+
+export type CompanySortableColumnKey = BaseSortableColumnKey | 'placedBy';
+
+const COMPANY_SORT_MAP: SortMap<CompanySortableColumnKey> = {
+  ...BASE_SORT_MAP,
+  placedBy: { asc: OrdersSortInput.PLACED_BY_A_TO_Z, desc: OrdersSortInput.PLACED_BY_Z_TO_A },
+};
+
+export const useCompanyOrderSorting = (
+  resetPagination: () => void,
+): UseUnifiedOrderSortingResult<CompanySortableColumnKey> => {
+  return useUnifiedOrderSorting(COMPANY_SORT_MAP, resetPagination);
+};

--- a/apps/storefront/src/pages/order/useCompanyOrderSorting.ts
+++ b/apps/storefront/src/pages/order/useCompanyOrderSorting.ts
@@ -18,5 +18,5 @@ const COMPANY_SORT_MAP: SortMap<CompanySortableColumnKey> = {
 export const useCompanyOrderSorting = (
   resetPagination: () => void,
 ): UseUnifiedOrderSortingResult<CompanySortableColumnKey> => {
-  return useUnifiedOrderSorting(COMPANY_SORT_MAP, resetPagination);
+  return useUnifiedOrderSorting(COMPANY_SORT_MAP, resetPagination, 'orderId');
 };

--- a/apps/storefront/src/pages/order/useCompanyOrdersState.ts
+++ b/apps/storefront/src/pages/order/useCompanyOrdersState.ts
@@ -1,23 +1,28 @@
 import { useEffect, useMemo, useState } from 'react';
 
-import { OrdersFiltersInput, OrdersSortInput } from '@/shared/service/bc/graphql/orders';
-// Status list still comes from the legacy `orderStatuses` query — the unified
-// schema doesn't expose one yet, so we depend on the legacy type here.
+import { CompanyOrdersFiltersInput, OrdersSortInput } from '@/shared/service/bc/graphql/orders';
 import { OrderStatusItem } from '@/types';
 
-import { getCustomerOrdersInitFilter, packDateRange } from './unifiedApiFiltersHelper';
+import { getCompanyOrdersInitFilter, packDateRange } from './unifiedApiFiltersHelper';
 import {
   useUnifiedOrdersPagination,
   UseUnifiedOrdersPaginationResult,
 } from './useUnifiedOrdersPagination';
 
-type SortableColumnKey = 'orderId' | 'poNumber' | 'totalIncTax' | 'status' | 'createdAt';
+type SortableColumnKey =
+  | 'orderId'
+  | 'poNumber'
+  | 'totalIncTax'
+  | 'status'
+  | 'placedBy'
+  | 'createdAt';
 type SortDir = 'asc' | 'desc';
 
 interface AppliedFilters {
   startValue?: string;
   endValue?: string;
   orderStatus?: string | number;
+  PlacedBy?: string;
   company?: string;
 }
 
@@ -29,6 +34,7 @@ const COLUMN_KEY_TO_SORT_INPUT: Record<SortableColumnKey, Record<SortDir, Orders
     desc: OrdersSortInput.HIGHEST_TOTAL_INC_TAX,
   },
   status: { asc: OrdersSortInput.STATUS_A_TO_Z, desc: OrdersSortInput.STATUS_Z_TO_A },
+  placedBy: { asc: OrdersSortInput.PLACED_BY_A_TO_Z, desc: OrdersSortInput.PLACED_BY_Z_TO_A },
   createdAt: { asc: OrdersSortInput.CREATED_AT_OLDEST, desc: OrdersSortInput.CREATED_AT_NEWEST },
 };
 
@@ -47,13 +53,13 @@ const normalizeString = (value: string | number | null | undefined): string | un
 
 const DEFAULT_SORT: { key: SortableColumnKey; dir: SortDir } = { key: 'orderId', dir: 'desc' };
 
-interface UseCustomerOrdersStateArgs {
-  companyId: number;
+interface UseCompanyOrdersStateArgs {
+  selectedCompanyId: number;
   orderStatuses: OrderStatusItem[];
 }
 
-export interface UseCustomerOrdersStateResult extends UseUnifiedOrdersPaginationResult {
-  filters: OrdersFiltersInput;
+export interface UseCompanyOrdersStateResult extends UseUnifiedOrdersPaginationResult {
+  filters: CompanyOrdersFiltersInput;
   sortBy: OrdersSortInput;
   activeSort: { key: SortableColumnKey; dir: SortDir };
   handleSearchChange: (key: string, value: string) => void;
@@ -62,20 +68,20 @@ export interface UseCustomerOrdersStateResult extends UseUnifiedOrdersPagination
   handleSetOrderBy: (key: string) => void;
 }
 
-export const useCustomerOrdersState = ({
-  companyId,
+export const useCompanyOrdersState = ({
+  selectedCompanyId,
   orderStatuses,
-}: UseCustomerOrdersStateArgs): UseCustomerOrdersStateResult => {
-  const [filters, setFilters] = useState<OrdersFiltersInput>(() =>
-    getCustomerOrdersInitFilter(companyId),
+}: UseCompanyOrdersStateArgs): UseCompanyOrdersStateResult => {
+  const [filters, setFilters] = useState<CompanyOrdersFiltersInput>(() =>
+    getCompanyOrdersInitFilter(selectedCompanyId),
   );
   const [activeSort, setActiveSort] = useState(DEFAULT_SORT);
 
   const pagination = useUnifiedOrdersPagination();
 
   useEffect(() => {
-    setFilters(getCustomerOrdersInitFilter(companyId));
-  }, [companyId]);
+    setFilters(getCompanyOrdersInitFilter(selectedCompanyId));
+  }, [selectedCompanyId]);
 
   const sortBy = useMemo(
     () => COLUMN_KEY_TO_SORT_INPUT[activeSort.key][activeSort.dir],
@@ -89,19 +95,19 @@ export const useCustomerOrdersState = ({
   };
 
   const handleFilterChange = (value: AppliedFilters) => {
-    let currentStatus = normalizeString(value.orderStatus);
-    if (currentStatus) {
+    let resolvedStatuses: string[] | undefined;
+    const rawStatus = normalizeString(value.orderStatus);
+    if (rawStatus) {
       const originalStatus = orderStatuses.find(
-        (status) => status.customLabel === currentStatus || status.systemLabel === currentStatus,
+        (s) => s.customLabel === rawStatus || s.systemLabel === rawStatus,
       );
-      // Drop the filter on miss — never send a display label as the API status code.
-      currentStatus = originalStatus?.systemLabel || undefined;
+      resolvedStatuses = originalStatus?.systemLabel ? [originalStatus.systemLabel] : undefined;
     }
+
     pagination.resetPagination();
     setFilters((prev) => ({
       ...prev,
-      companyName: normalizeString(value.company),
-      status: currentStatus,
+      status: resolvedStatuses,
       dateRange: packDateRange(value.startValue, value.endValue),
     }));
   };

--- a/apps/storefront/src/pages/order/useCompanyOrdersState.ts
+++ b/apps/storefront/src/pages/order/useCompanyOrdersState.ts
@@ -1,22 +1,19 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 
-import { CompanyOrdersFiltersInput, OrdersSortInput } from '@/shared/service/bc/graphql/orders';
+import { CompanyOrdersFiltersInput } from '@/shared/service/bc/graphql/orders';
 import { OrderStatusItem } from '@/types';
 
-import { getCompanyOrdersInitFilter, packDateRange } from './unifiedApiFiltersHelper';
+import {
+  getCompanyOrdersInitFilter,
+  normalizeString,
+  packDateRange,
+} from './unifiedApiFiltersHelper';
+import { CompanySortableColumnKey, useCompanyOrderSorting } from './useCompanyOrderSorting';
+import { UseUnifiedOrderSortingResult } from './useUnifiedOrderSorting';
 import {
   useUnifiedOrdersPagination,
   UseUnifiedOrdersPaginationResult,
 } from './useUnifiedOrdersPagination';
-
-type SortableColumnKey =
-  | 'orderId'
-  | 'poNumber'
-  | 'totalIncTax'
-  | 'status'
-  | 'placedBy'
-  | 'createdAt';
-type SortDir = 'asc' | 'desc';
 
 interface AppliedFilters {
   startValue?: string;
@@ -26,46 +23,18 @@ interface AppliedFilters {
   company?: string;
 }
 
-const COLUMN_KEY_TO_SORT_INPUT: Record<SortableColumnKey, Record<SortDir, OrdersSortInput>> = {
-  orderId: { asc: OrdersSortInput.ID_A_TO_Z, desc: OrdersSortInput.ID_Z_TO_A },
-  poNumber: { asc: OrdersSortInput.REFERENCE_A_TO_Z, desc: OrdersSortInput.REFERENCE_Z_TO_A },
-  totalIncTax: {
-    asc: OrdersSortInput.LOWEST_TOTAL_INC_TAX,
-    desc: OrdersSortInput.HIGHEST_TOTAL_INC_TAX,
-  },
-  status: { asc: OrdersSortInput.STATUS_A_TO_Z, desc: OrdersSortInput.STATUS_Z_TO_A },
-  placedBy: { asc: OrdersSortInput.PLACED_BY_A_TO_Z, desc: OrdersSortInput.PLACED_BY_Z_TO_A },
-  createdAt: { asc: OrdersSortInput.CREATED_AT_OLDEST, desc: OrdersSortInput.CREATED_AT_NEWEST },
-};
-
-const SORTABLE_KEYS: ReadonlySet<SortableColumnKey> = new Set(
-  Object.keys(COLUMN_KEY_TO_SORT_INPUT) as SortableColumnKey[],
-);
-
-const isSortableKey = (key: string): key is SortableColumnKey =>
-  SORTABLE_KEYS.has(key as SortableColumnKey);
-
-const normalizeString = (value: string | number | null | undefined): string | undefined => {
-  if (value === null || value === undefined) return undefined;
-  const str = String(value);
-  return str === '' ? undefined : str;
-};
-
-const DEFAULT_SORT: { key: SortableColumnKey; dir: SortDir } = { key: 'orderId', dir: 'desc' };
-
 interface UseCompanyOrdersStateArgs {
   selectedCompanyId: number;
   orderStatuses: OrderStatusItem[];
 }
 
-export interface UseCompanyOrdersStateResult extends UseUnifiedOrdersPaginationResult {
+export interface UseCompanyOrdersStateResult
+  extends UseUnifiedOrdersPaginationResult,
+    UseUnifiedOrderSortingResult<CompanySortableColumnKey> {
   filters: CompanyOrdersFiltersInput;
-  sortBy: OrdersSortInput;
-  activeSort: { key: SortableColumnKey; dir: SortDir };
   handleSearchChange: (key: string, value: string) => void;
   handleFilterChange: (value: AppliedFilters) => void;
   handleCompanyIdsChange: (companyIds: number[]) => void;
-  handleSetOrderBy: (key: string) => void;
 }
 
 export const useCompanyOrdersState = ({
@@ -75,18 +44,13 @@ export const useCompanyOrdersState = ({
   const [filters, setFilters] = useState<CompanyOrdersFiltersInput>(() =>
     getCompanyOrdersInitFilter(selectedCompanyId),
   );
-  const [activeSort, setActiveSort] = useState(DEFAULT_SORT);
 
   const pagination = useUnifiedOrdersPagination();
+  const sorting = useCompanyOrderSorting(pagination.resetPagination);
 
   useEffect(() => {
     setFilters(getCompanyOrdersInitFilter(selectedCompanyId));
   }, [selectedCompanyId]);
-
-  const sortBy = useMemo(
-    () => COLUMN_KEY_TO_SORT_INPUT[activeSort.key][activeSort.dir],
-    [activeSort],
-  );
 
   const handleSearchChange = (key: string, value: string) => {
     if (key !== 'search') return;
@@ -121,22 +85,12 @@ export const useCompanyOrdersState = ({
     }));
   };
 
-  const handleSetOrderBy = (key: string) => {
-    if (!isSortableKey(key)) return;
-    pagination.resetPagination();
-    setActiveSort((prev) =>
-      prev.key === key ? { key, dir: prev.dir === 'asc' ? 'desc' : 'asc' } : { key, dir: 'desc' },
-    );
-  };
-
   return {
     ...pagination,
+    ...sorting,
     filters,
-    sortBy,
-    activeSort,
     handleSearchChange,
     handleFilterChange,
     handleCompanyIdsChange,
-    handleSetOrderBy,
   };
 };

--- a/apps/storefront/src/pages/order/useCustomerOrdersState.ts
+++ b/apps/storefront/src/pages/order/useCustomerOrdersState.ts
@@ -1,18 +1,25 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 
-import { OrdersFiltersInput, OrdersSortInput } from '@/shared/service/bc/graphql/orders';
+import { OrdersFiltersInput } from '@/shared/service/bc/graphql/orders';
 // Status list still comes from the legacy `orderStatuses` query — the unified
 // schema doesn't expose one yet, so we depend on the legacy type here.
 import { OrderStatusItem } from '@/types';
 
-import { getCustomerOrdersInitFilter, packDateRange } from './unifiedApiFiltersHelper';
+import {
+  getCustomerOrdersInitFilter,
+  normalizeString,
+  packDateRange,
+} from './unifiedApiFiltersHelper';
+import {
+  BASE_SORT_MAP,
+  BaseSortableColumnKey,
+  useUnifiedOrderSorting,
+  UseUnifiedOrderSortingResult,
+} from './useUnifiedOrderSorting';
 import {
   useUnifiedOrdersPagination,
   UseUnifiedOrdersPaginationResult,
 } from './useUnifiedOrdersPagination';
-
-type SortableColumnKey = 'orderId' | 'poNumber' | 'totalIncTax' | 'status' | 'createdAt';
-type SortDir = 'asc' | 'desc';
 
 interface AppliedFilters {
   startValue?: string;
@@ -21,45 +28,18 @@ interface AppliedFilters {
   company?: string;
 }
 
-const COLUMN_KEY_TO_SORT_INPUT: Record<SortableColumnKey, Record<SortDir, OrdersSortInput>> = {
-  orderId: { asc: OrdersSortInput.ID_A_TO_Z, desc: OrdersSortInput.ID_Z_TO_A },
-  poNumber: { asc: OrdersSortInput.REFERENCE_A_TO_Z, desc: OrdersSortInput.REFERENCE_Z_TO_A },
-  totalIncTax: {
-    asc: OrdersSortInput.LOWEST_TOTAL_INC_TAX,
-    desc: OrdersSortInput.HIGHEST_TOTAL_INC_TAX,
-  },
-  status: { asc: OrdersSortInput.STATUS_A_TO_Z, desc: OrdersSortInput.STATUS_Z_TO_A },
-  createdAt: { asc: OrdersSortInput.CREATED_AT_OLDEST, desc: OrdersSortInput.CREATED_AT_NEWEST },
-};
-
-const SORTABLE_KEYS: ReadonlySet<SortableColumnKey> = new Set(
-  Object.keys(COLUMN_KEY_TO_SORT_INPUT) as SortableColumnKey[],
-);
-
-const isSortableKey = (key: string): key is SortableColumnKey =>
-  SORTABLE_KEYS.has(key as SortableColumnKey);
-
-const normalizeString = (value: string | number | null | undefined): string | undefined => {
-  if (value === null || value === undefined) return undefined;
-  const str = String(value);
-  return str === '' ? undefined : str;
-};
-
-const DEFAULT_SORT: { key: SortableColumnKey; dir: SortDir } = { key: 'orderId', dir: 'desc' };
-
 interface UseCustomerOrdersStateArgs {
   companyId: number;
   orderStatuses: OrderStatusItem[];
 }
 
-export interface UseCustomerOrdersStateResult extends UseUnifiedOrdersPaginationResult {
+export interface UseCustomerOrdersStateResult
+  extends UseUnifiedOrdersPaginationResult,
+    UseUnifiedOrderSortingResult<BaseSortableColumnKey> {
   filters: OrdersFiltersInput;
-  sortBy: OrdersSortInput;
-  activeSort: { key: SortableColumnKey; dir: SortDir };
   handleSearchChange: (key: string, value: string) => void;
   handleFilterChange: (value: AppliedFilters) => void;
   handleCompanyIdsChange: (companyIds: number[]) => void;
-  handleSetOrderBy: (key: string) => void;
 }
 
 export const useCustomerOrdersState = ({
@@ -69,18 +49,13 @@ export const useCustomerOrdersState = ({
   const [filters, setFilters] = useState<OrdersFiltersInput>(() =>
     getCustomerOrdersInitFilter(companyId),
   );
-  const [activeSort, setActiveSort] = useState(DEFAULT_SORT);
 
   const pagination = useUnifiedOrdersPagination();
+  const sorting = useUnifiedOrderSorting(BASE_SORT_MAP, pagination.resetPagination);
 
   useEffect(() => {
     setFilters(getCustomerOrdersInitFilter(companyId));
   }, [companyId]);
-
-  const sortBy = useMemo(
-    () => COLUMN_KEY_TO_SORT_INPUT[activeSort.key][activeSort.dir],
-    [activeSort],
-  );
 
   const handleSearchChange = (key: string, value: string) => {
     if (key !== 'search') return;
@@ -115,22 +90,12 @@ export const useCustomerOrdersState = ({
     }));
   };
 
-  const handleSetOrderBy = (key: string) => {
-    if (!isSortableKey(key)) return;
-    pagination.resetPagination();
-    setActiveSort((prev) =>
-      prev.key === key ? { key, dir: prev.dir === 'asc' ? 'desc' : 'asc' } : { key, dir: 'desc' },
-    );
-  };
-
   return {
     ...pagination,
+    ...sorting,
     filters,
-    sortBy,
-    activeSort,
     handleSearchChange,
     handleFilterChange,
     handleCompanyIdsChange,
-    handleSetOrderBy,
   };
 };

--- a/apps/storefront/src/pages/order/useCustomerOrdersState.ts
+++ b/apps/storefront/src/pages/order/useCustomerOrdersState.ts
@@ -51,7 +51,7 @@ export const useCustomerOrdersState = ({
   );
 
   const pagination = useUnifiedOrdersPagination();
-  const sorting = useUnifiedOrderSorting(BASE_SORT_MAP, pagination.resetPagination);
+  const sorting = useUnifiedOrderSorting(BASE_SORT_MAP, pagination.resetPagination, 'orderId');
 
   useEffect(() => {
     setFilters(getCustomerOrdersInitFilter(companyId));

--- a/apps/storefront/src/pages/order/useLegacyOrdersFilterState.ts
+++ b/apps/storefront/src/pages/order/useLegacyOrdersFilterState.ts
@@ -53,17 +53,16 @@ export const useLegacyOrdersFilterState = ({
 }: UseLegacyOrdersFilterStateArgs): UseLegacyOrdersFilterStateResult => {
   const [filterData, setFilterData] = useState<Partial<FilterSearchProps>>();
   const [activeSort, setActiveSort] = useState(DEFAULT_SORT);
-  const isUnifiedOrdersNonCompanyOrderPath =
-    useFeatureFlag('B2B-4613.buyer_portal_unified_sf_gql_orders') && !isCompanyOrder;
+  const isUnifiedOrders = useFeatureFlag('B2B-4613.buyer_portal_unified_sf_gql_orders');
 
   useEffect(() => {
-    if (isUnifiedOrdersNonCompanyOrderPath) return;
+    if (isUnifiedOrders) return;
 
     const initial = isB2BUser
       ? getCompanyInitFilter(isCompanyOrder, selectedCompanyId)
       : getCustomerInitFilter();
     setFilterData(initial);
-  }, [isB2BUser, isCompanyOrder, selectedCompanyId, isUnifiedOrdersNonCompanyOrderPath]);
+  }, [isB2BUser, isCompanyOrder, selectedCompanyId, isUnifiedOrders]);
 
   const orderBy =
     activeSort.dir === 'desc' ? `-${sortKeys[activeSort.key]}` : sortKeys[activeSort.key];

--- a/apps/storefront/src/pages/order/useUnifiedOrderSorting.ts
+++ b/apps/storefront/src/pages/order/useUnifiedOrderSorting.ts
@@ -28,6 +28,7 @@ export const BASE_SORT_MAP: SortMap<BaseSortableColumnKey> = {
 export const useUnifiedOrderSorting = <K extends string>(
   columnKeyToSortInput: SortMap<K>,
   resetPagination: () => void,
+  defaultSortKey: K,
 ): UseUnifiedOrderSortingResult<K> => {
   const sortableKeys = useMemo(
     () => new Set(Object.keys(columnKeyToSortInput) as K[]),
@@ -35,7 +36,7 @@ export const useUnifiedOrderSorting = <K extends string>(
   );
 
   const [activeSort, setActiveSort] = useState<{ key: K; dir: SortDir }>({
-    key: 'orderId' as K,
+    key: defaultSortKey,
     dir: 'desc',
   });
 

--- a/apps/storefront/src/pages/order/useUnifiedOrderSorting.ts
+++ b/apps/storefront/src/pages/order/useUnifiedOrderSorting.ts
@@ -1,0 +1,59 @@
+import { useMemo, useState } from 'react';
+
+import { OrdersSortInput } from '@/shared/service/bc/graphql/orders';
+
+export type SortDir = 'asc' | 'desc';
+
+export type SortMap<K extends string> = Record<K, Record<SortDir, OrdersSortInput>>;
+
+export interface UseUnifiedOrderSortingResult<K extends string> {
+  activeSort: { key: K; dir: SortDir };
+  sortBy: OrdersSortInput;
+  handleSetOrderBy: (key: string) => void;
+}
+
+export type BaseSortableColumnKey = 'orderId' | 'poNumber' | 'totalIncTax' | 'status' | 'createdAt';
+
+export const BASE_SORT_MAP: SortMap<BaseSortableColumnKey> = {
+  orderId: { asc: OrdersSortInput.ID_A_TO_Z, desc: OrdersSortInput.ID_Z_TO_A },
+  poNumber: { asc: OrdersSortInput.REFERENCE_A_TO_Z, desc: OrdersSortInput.REFERENCE_Z_TO_A },
+  totalIncTax: {
+    asc: OrdersSortInput.LOWEST_TOTAL_INC_TAX,
+    desc: OrdersSortInput.HIGHEST_TOTAL_INC_TAX,
+  },
+  status: { asc: OrdersSortInput.STATUS_A_TO_Z, desc: OrdersSortInput.STATUS_Z_TO_A },
+  createdAt: { asc: OrdersSortInput.CREATED_AT_OLDEST, desc: OrdersSortInput.CREATED_AT_NEWEST },
+};
+
+export const useUnifiedOrderSorting = <K extends string>(
+  columnKeyToSortInput: SortMap<K>,
+  resetPagination: () => void,
+): UseUnifiedOrderSortingResult<K> => {
+  const sortableKeys = useMemo(
+    () => new Set(Object.keys(columnKeyToSortInput) as K[]),
+    [columnKeyToSortInput],
+  );
+
+  const [activeSort, setActiveSort] = useState<{ key: K; dir: SortDir }>({
+    key: 'orderId' as K,
+    dir: 'desc',
+  });
+
+  const sortBy = useMemo(
+    () => columnKeyToSortInput[activeSort.key][activeSort.dir],
+    [columnKeyToSortInput, activeSort],
+  );
+
+  const handleSetOrderBy = (key: string) => {
+    if (!sortableKeys.has(key as K)) return;
+    const typedKey = key as K;
+    resetPagination();
+    setActiveSort((prev) =>
+      prev.key === typedKey
+        ? { key: typedKey, dir: prev.dir === 'asc' ? 'desc' : 'asc' }
+        : { key: typedKey, dir: 'desc' },
+    );
+  };
+
+  return { activeSort, sortBy, handleSetOrderBy };
+};

--- a/apps/storefront/src/pages/order/useUnifiedOrderSorting.ts
+++ b/apps/storefront/src/pages/order/useUnifiedOrderSorting.ts
@@ -2,7 +2,7 @@ import { useMemo, useState } from 'react';
 
 import { OrdersSortInput } from '@/shared/service/bc/graphql/orders';
 
-export type SortDir = 'asc' | 'desc';
+type SortDir = 'asc' | 'desc';
 
 export type SortMap<K extends string> = Record<K, Record<SortDir, OrdersSortInput>>;
 

--- a/apps/storefront/src/shared/service/bc/graphql/orders.ts
+++ b/apps/storefront/src/shared/service/bc/graphql/orders.ts
@@ -223,6 +223,8 @@ export enum OrdersSortInput {
   STATUS_Z_TO_A = 'STATUS_Z_TO_A',
   CREATED_AT_NEWEST = 'CREATED_AT_NEWEST',
   CREATED_AT_OLDEST = 'CREATED_AT_OLDEST',
+  PLACED_BY_A_TO_Z = 'PLACED_BY_A_TO_Z',
+  PLACED_BY_Z_TO_A = 'PLACED_BY_Z_TO_A',
 }
 
 export interface OrderDateRangeFilterInput {
@@ -261,7 +263,7 @@ export interface CustomerWithOrdersFiltersInput {
 export interface GetCompanyOrdersResponse {
   data?: {
     customer?: {
-      company?: {
+      activeCompany?: {
         orders?: CompanyOrdersConnection;
       };
     };
@@ -293,7 +295,7 @@ export interface GetOrderDetailResponse {
 export interface GetCustomersWithOrdersResponse {
   data?: {
     customer?: {
-      company?: {
+      activeCompany?: {
         customersWithOrders?: CompanyCustomerConnection;
       };
     };
@@ -491,7 +493,7 @@ const orderListNodeFields = `entityId
 // Queries
 // ===========================================================================
 
-/** Company-scoped order list (B2B). Entry: customer.company.orders. */
+/** Company-scoped order list (B2B). Entry: customer.activeCompany.orders. */
 const GET_COMPANY_ORDERS = `query GetCompanyOrders(
   $filters: CompanyOrdersFiltersInput
   $sortBy: OrdersSortInput
@@ -501,7 +503,7 @@ const GET_COMPANY_ORDERS = `query GetCompanyOrders(
   $before: String
 ) {
   customer {
-    company {
+    activeCompany {
       orders(
         filters: $filters
         sortBy: $sortBy
@@ -600,7 +602,7 @@ const GET_CUSTOMERS_WITH_ORDERS = `query GetCustomersWithOrders(
   $after: String
 ) {
   customer {
-    company {
+    activeCompany {
       customersWithOrders(
         filters: $filters
         first: $first


### PR DESCRIPTION
## Summary

Migrates Company Orders data fetching from the legacy B2B Edition API to the unified BC Storefront GraphQL API, behind the existing feature flag (`B2B-4613.buyer_portal_unified_sf_gql_orders`).

**Ticket:** [B2B-4616](https://bigcommercecloud.atlassian.net/browse/B2B-4616)

### What changed

- **Service layer** (`orders.ts`): Updated queries to use `customer.activeCompany` path. Added `PLACED_BY_A_TO_Z`/`PLACED_BY_Z_TO_A` to `OrdersSortInput`.
- **New hook** (`useCompanyOrdersState.ts`): Manages `CompanyOrdersFiltersInput`, sort, and cursor pagination.
- **Order.tsx**: Three-path branching: unified company / unified customer / legacy. `fetchUnifiedCompanyOrders` extracts `collectionInfo.totalItems`.
- **Adapter**: Added `adaptCompanyUnifiedToLegacyFilterParams` for B3Filter defaults.
- **Cleanup**: Removed `isCompanyOrder` from `useCustomerOrdersState`. Updated legacy hook to skip when flag is on.

### Known limitation — deferred to B2B-4620 (3e)

`fetchUnifiedCompanyOrders` correctly extracts `collectionInfo.totalItems` from the response, but the value is not surfaced to `B3Table`. `useUnifiedOrdersPagination` hardcodes `count: -1` (built for My Orders which lacks `collectionInfo`). Company Orders reuses the same hook, so "X of Y" is hidden even though the data is available. **B2B-4620 (3e) will wire `collectionInfo.totalItems` into the pagination props.**

## Test plan

- [x] 8 new tests (flag off/on, columns, currency, search, cursor pagination)
- [x] All existing tests pass (19 unified + 32 legacy company + 66 legacy my orders)
- [x] TypeScript + ESLint clean

## BE dependency

Requires BE to add `customer.activeCompany` to SF GQL (B2B-4586). FE builds behind FF with mocked tests.


[B2B-4616]: https://bigcommercecloud.atlassian.net/browse/B2B-4616?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes order list data-fetching, filtering, sorting, and pagination behavior for company orders behind a feature flag, and updates the Storefront GraphQL query shape (`customer.activeCompany`) plus new sort inputs.
> 
> **Overview**
> **Adds a unified Storefront GraphQL data source for B2B Company Orders behind `B2B-4613.buyer_portal_unified_sf_gql_orders`.** `Order.tsx` now branches between *legacy*, *unified customer*, and *unified company* paths, including a new `fetchUnifiedCompanyOrders` that calls `getCompanyOrders` and reads `collectionInfo.totalItems`.
> 
> Introduces `useCompanyOrdersState` (filters + cursor pagination + sorting) and refactors unified sorting into a shared `useUnifiedOrderSorting` hook; company sorting adds a new `placedBy` sort mapped to new `OrdersSortInput` values. Updates the unified GraphQL service/types to query `customer.activeCompany` (was `customer.company`) and adds comprehensive tests for the unified company-orders flow (flag gating, columns, currency, search, and cursor pagination).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b91cde180be845be782c4c8429dee81924784f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->