### PR TITLE
docs(agents): B2B-4863 Minimize public repo exposure for Claude Code users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,10 @@ slack-message.json
 
 # generated graphql POC schema
 supergraph.graphql
+
+# Claude Code setup
+docs/**
+!docs/headless.md
+!docs/stencil.md
+.claude/settings.local.json
+.claude/**/personal-*.md

--- a/.gitignore
+++ b/.gitignore
@@ -38,10 +38,3 @@ slack-message.json
 
 # generated graphql POC schema
 supergraph.graphql
-
-# Claude Code setup
-docs/**
-!docs/headless.md
-!docs/stencil.md
-.claude/settings.local.json
-.claude/**/personal-*.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,19 @@
 
 ---
 
+## 🤖 AI Coding Agent Setup (BigCommerce Team)
+
+For full architecture context, testing patterns, and engineering workflow guidelines, install the internal Claude Code plugin:
+
+```bash
+/plugin marketplace add bigcommerce/cc-plugins-marketplace  # one-time, if not already done
+/plugin install b2b-buyer-portal@cc-plugins-marketplace
+```
+
+Once installed, Claude Code automatically loads project-specific context when you work in this repo.
+
+---
+
 ## 🎯 Project Overview
 
 **B2B Buyer Portal** is a React-based frontend application for BigCommerce's B2B Edition buyer experience.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,14 +26,7 @@
 
 ## 🤖 AI Coding Agent Setup (BigCommerce Team)
 
-For full architecture context, testing patterns, and engineering workflow guidelines, install the internal Claude Code plugin:
-
-```bash
-/plugin marketplace add bigcommerce/cc-plugins-marketplace  # one-time, if not already done
-/plugin install b2b-buyer-portal@cc-plugins-marketplace
-```
-
-Once installed, Claude Code automatically loads project-specific context when you work in this repo.
+Install the internal `b2b-buyer-portal` plugin from the internal plugin repository to get the full context.
 
 ---
 
@@ -91,6 +84,7 @@ yarn build
 This project uses Turborepo as a monorepo structure, even though it currently contains only one package (`storefront`). All package dependencies, scripts, and configurations are defined at the `apps/storefront/` level, not at the root.
 
 **Running commands from the wrong directory will cause:**
+
 - ❌ Commands not found
 - ❌ Wrong dependencies loaded
 - ❌ Incorrect build outputs
@@ -105,6 +99,7 @@ This project uses Turborepo as a monorepo structure, even though it currently co
 When writing new code, follow these principles:
 
 #### 1. **Matroska-Style Structure**
+
 Each component/page owns its domain-specific dependencies. Group related files together.
 
 ```
@@ -120,13 +115,14 @@ src/pages/Invoice/
 ```
 
 #### 2. **Prefer Props Over Context/Redux**
+
 Pass data through component props whenever possible. This makes data flow explicit and components more testable.
 
 ```typescript
 // ✅ GOOD: Explicit props
 interface Props {
-  orderId: string;
-  customerId: string;
+  orderId: string
+  customerId: string
 }
 
 function OrderDetails({ orderId, customerId }: Props) {
@@ -135,13 +131,14 @@ function OrderDetails({ orderId, customerId }: Props) {
 
 // ❌ BAD: Hidden dependencies
 function OrderDetails() {
-  const orderId = useAppSelector(state => state.order.id);
-  const customerId = useContext(CustomerContext);
+  const orderId = useAppSelector((state) => state.order.id)
+  const customerId = useContext(CustomerContext)
   // ...
 }
 ```
 
 #### 3. **Co-located Files**
+
 Keep related files together. Tests live next to the code they test.
 
 ```
@@ -153,6 +150,7 @@ InvoiceList/
 ```
 
 #### 4. **URL-Driven State**
+
 Use route parameters and query strings for state that should persist across page loads.
 
 ```typescript
@@ -161,7 +159,7 @@ function ProductList() {
   const [searchParams, setSearchParams] = useSearchParams();
   const page = Number(searchParams.get('page')) || 1;
   const category = searchParams.get('category') || 'all';
-  
+
   return (
     <button onClick={() => setSearchParams({ page: page + 1, category })}>
       Next Page
@@ -178,32 +176,34 @@ function ProductList() {
 ```
 
 #### 5. **Local Component State**
+
 Use React hooks (`useState`, `useReducer`) for component-specific state.
 
 ```typescript
 function InvoiceForm() {
-  const [formData, setFormData] = useState({ amount: '', note: '' });
-  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [formData, setFormData] = useState({ amount: '', note: '' })
+  const [isSubmitting, setIsSubmitting] = useState(false)
   // ...
 }
 ```
 
 #### 6. **Domain-Agnostic Helpers Only**
+
 Shared utilities (`src/utils/`, `src/hooks/`) should contain pure functions with no business logic.
 
 ```typescript
 // ✅ GOOD: Pure utility
 export function formatCurrency(amount: number, currency: string): string {
-  return new Intl.NumberFormat('en-US', { 
-    style: 'currency', 
-    currency 
-  }).format(amount);
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency,
+  }).format(amount)
 }
 
 // ❌ BAD: Business logic in utility
 export function getInvoiceTotal(invoice: Invoice): number {
   // This belongs in the Invoice domain, not shared utils
-  return invoice.items.reduce((sum, item) => sum + item.price, 0);
+  return invoice.items.reduce((sum, item) => sum + item.price, 0)
 }
 ```
 
@@ -213,12 +213,13 @@ export function getInvoiceTotal(invoice: Invoice): number {
 
 The codebase contains these patterns, but **do not add more**:
 
-❌ **DO NOT** add new React Context providers  
-❌ **DO NOT** store state in Redux unless absolutely necessary  
-❌ **DO NOT** use `localStorage` or `sessionStorage` for state  
+❌ **DO NOT** add new React Context providers
+❌ **DO NOT** store state in Redux unless absolutely necessary
+❌ **DO NOT** use `localStorage` or `sessionStorage` for state
 ❌ **DO NOT** create global contexts like `GlobalContext`, `DynamicallyVariableContext`, or `CustomStyleContext`
 
 **Why avoid these?**
+
 - Hidden dependencies make code harder to understand
 - Difficult to test in isolation
 - Unclear data flow
@@ -334,27 +335,27 @@ Import from `tests/test-utils.tsx`:
 
 ```typescript
 import {
-  renderWithProviders,      // Render components with Redux/Router
-  screen,                    // Query rendered elements
-  userEvent,                 // Simulate user interactions
-  waitFor,                   // Async assertions
+  renderWithProviders, // Render components with Redux/Router
+  screen, // Query rendered elements
+  userEvent, // Simulate user interactions
+  waitFor, // Async assertions
   waitForElementToBeRemoved, // Wait for loading states
-  within,                    // Scope queries to a container
-  faker,                     // Generate fake data
-  builder,                   // Build test objects
-  bulk,                      // Build multiple test objects
-  graphql,                   // Mock GraphQL requests
-  http,                      // Mock HTTP requests
-  HttpResponse,              // Create mock responses
-  startMockServer,           // Start MSW server
-  stringContainingAll,       // Assert multiple substrings
-} from 'tests/test-utils';
+  within, // Scope queries to a container
+  faker, // Generate fake data
+  builder, // Build test objects
+  bulk, // Build multiple test objects
+  graphql, // Mock GraphQL requests
+  http, // Mock HTTP requests
+  HttpResponse, // Create mock responses
+  startMockServer, // Start MSW server
+  stringContainingAll, // Assert multiple substrings
+} from 'tests/test-utils'
 ```
 
 For hook testing: (hooks should rarely be tested in isolation)
 
 ```typescript
-import { renderHookWithProviders } from 'tests/utils/hook-test-utils';
+import { renderHookWithProviders } from 'tests/utils/hook-test-utils'
 ```
 
 ---
@@ -366,7 +367,7 @@ import { renderHookWithProviders } from 'tests/utils/hook-test-utils';
 #### Basic Builder Pattern
 
 ```typescript
-import { builder, bulk, faker } from 'tests/test-utils';
+import { builder, bulk, faker } from 'tests/test-utils'
 
 // Define a builder
 const buildInvoiceWith = builder(() => ({
@@ -375,15 +376,16 @@ const buildInvoiceWith = builder(() => ({
   amount: faker.commerce.price(),
   status: faker.helpers.enumValue(InvoiceStatus),
   dueDate: faker.date.future(),
-}));
+}))
 
 // Use it in tests
-const invoice = buildInvoiceWith({ status: 'PAID' });
+const invoice = buildInvoiceWith({ status: 'PAID' })
 // Use 'WHATEVER_VALUES' to explicitly indicate "any values will do"
-const invoices = bulk(buildInvoiceWith, 'WHATEVER_VALUES').times(5);
+const invoices = bulk(buildInvoiceWith, 'WHATEVER_VALUES').times(5)
 ```
 
 **Key Points:**
+
 - `builder()` creates a factory function that generates random test data
 - Override specific properties by passing an object: `buildInvoiceWith({ status: 'PAID' })`
 - `bulk()` generates multiple items: `bulk(buildInvoiceWith, 'WHATEVER_VALUES').times(5)`
@@ -400,7 +402,7 @@ import {
   buildB2BFeaturesStateWith,
 } from 'tests/test-utils';
 
-const loggedInUser = buildCompanyStateWith({ 
+const loggedInUser = buildCompanyStateWith({
   tokens: { B2BToken: faker.string.uuid() },
   customer: { role: CustomerRole.ADMIN }
 });
@@ -417,30 +419,30 @@ renderWithProviders(<Invoice />, {
 Use Mock Service Worker (MSW) for API mocking:
 
 ```typescript
-import { graphql, http, HttpResponse, startMockServer } from 'tests/test-utils';
+import { graphql, http, HttpResponse, startMockServer } from 'tests/test-utils'
 
-const { server } = startMockServer();
+const { server } = startMockServer()
 
 // Mock GraphQL queries
 server.use(
   graphql.query('GetInvoice', () => {
-    return HttpResponse.json({ 
-      data: { 
-        invoice: buildInvoiceWith({ id: '123' })
-      } 
-    });
-  })
-);
+    return HttpResponse.json({
+      data: {
+        invoice: buildInvoiceWith({ id: '123' }),
+      },
+    })
+  }),
+)
 
 // Mock REST endpoints
 server.use(
   http.get('/api/invoices/:id', ({ params }) => {
-    return HttpResponse.json({ 
+    return HttpResponse.json({
       id: params.id,
-      amount: '100.00'
-    });
-  })
-);
+      amount: '100.00',
+    })
+  }),
+)
 ```
 
 ---
@@ -450,23 +452,24 @@ server.use(
 Use `vitest-when` for argument-based mock behavior:
 
 ```typescript
-import { when } from 'vitest-when';
+import { when } from 'vitest-when'
 
 // Mock different returns based on arguments
 when(vi.mocked(fetchInvoice))
   .calledWith('invoice-123')
-  .thenReturn({ id: 'invoice-123', status: 'PAID' });
+  .thenReturn({ id: 'invoice-123', status: 'PAID' })
 
 when(vi.mocked(fetchInvoice))
   .calledWith('invoice-456')
-  .thenReturn({ id: 'invoice-456', status: 'PENDING' });
+  .thenReturn({ id: 'invoice-456', status: 'PENDING' })
 
 // Calls return different values
-await fetchInvoice('invoice-123'); // { status: 'PAID' }
-await fetchInvoice('invoice-456'); // { status: 'PENDING' }
+await fetchInvoice('invoice-123') // { status: 'PAID' }
+await fetchInvoice('invoice-456') // { status: 'PENDING' }
 ```
 
 **Benefits:**
+
 - Clearer test intentions than `mockImplementation`
 - Multiple test scenarios with one mock
 - Type-safe conditional behavior
@@ -476,14 +479,16 @@ await fetchInvoice('invoice-456'); // { status: 'PENDING' }
 ### Assertion Helpers
 
 ```typescript
-import { stringContainingAll } from 'tests/test-utils';
+import { stringContainingAll } from 'tests/test-utils'
 
 when(getOrders)
-    // Assert GraphQL queries contain specific strings
-  .calledWith(stringContainingAll(['query', 'GetInvoice', 'invoiceNumber', 'dueDate']))
+  // Assert GraphQL queries contain specific strings
+  .calledWith(
+    stringContainingAll(['query', 'GetInvoice', 'invoiceNumber', 'dueDate']),
+  )
   .thenReturn({
     orders: [],
-  })  
+  })
 ```
 
 ---
@@ -512,7 +517,7 @@ describe('Invoice Page', () => {
     // Arrange
     const invoice = buildInvoiceWith({ status: 'PAID' });
     server.use(
-      graphql.query('GetInvoice', () => 
+      graphql.query('GetInvoice', () =>
         HttpResponse.json({ data: { invoice } })
       )
     );
@@ -547,10 +552,10 @@ it('calls handleSubmit when form is submitted', () => {
 it('submits invoice payment when user clicks Pay button', async () => {
   const user = userEvent.setup();
   renderWithProviders(<InvoicePayment />);
-  
+
   await user.type(screen.getByLabelText('Amount'), '100');
   await user.click(screen.getByRole('button', { name: 'Pay' }));
-  
+
   await waitFor(() => {
     expect(screen.getByText('Payment successful')).toBeInTheDocument();
   });
@@ -592,8 +597,8 @@ const buildInvoiceWith = builder(() => ({
 }));
 
 describe('Invoice Page', () => {
-  const loggedInUser = buildCompanyStateWith({ 
-    tokens: { B2BToken: faker.string.uuid() } 
+  const loggedInUser = buildCompanyStateWith({
+    tokens: { B2BToken: faker.string.uuid() }
   });
 
   beforeEach(() => {
@@ -602,7 +607,7 @@ describe('Invoice Page', () => {
 
   it('displays invoice details after loading', async () => {
     const invoice = buildInvoiceWith({ status: 'PAID' });
-    
+
     server.use(
       graphql.query('GetInvoice', () => {
         return HttpResponse.json({ data: { invoice } });
@@ -615,7 +620,7 @@ describe('Invoice Page', () => {
     });
 
     await waitForElementToBeRemoved(() => screen.queryByText('Loading'));
-    
+
     expect(screen.getByText(invoice.invoiceNumber)).toBeInTheDocument();
     expect(screen.getByText('PAID')).toBeInTheDocument();
   });
@@ -632,15 +637,15 @@ Enforced by ESLint - these will cause build failures if violated:
 
 ```typescript
 // ✅ CORRECT
-import { debounce, groupBy } from 'lodash-es';
-import { Add, Delete } from '@mui/icons-material';
-import { renderWithProviders } from 'tests/test-utils';
-import { formatCurrency } from '@/utils/formatters';
+import { debounce, groupBy } from 'lodash-es'
+import { Add, Delete } from '@mui/icons-material'
+import { renderWithProviders } from 'tests/test-utils'
+import { formatCurrency } from '@/utils/formatters'
 
 // ❌ WRONG - Will fail linting
-import debounce from 'lodash/debounce';           // Use lodash-es
-import Add from '@mui/icons-material/Add';         // Use named imports
-import { formatCurrency } from '../utils/formatters'; // Use path alias
+import debounce from 'lodash/debounce' // Use lodash-es
+import Add from '@mui/icons-material/Add' // Use named imports
+import { formatCurrency } from '../utils/formatters' // Use path alias
 ```
 
 ### Path Aliases
@@ -654,12 +659,12 @@ Configured in `tsconfig.json` and `vite.config.ts`:
 
 ```typescript
 // ✅ Use path aliases
-import { Invoice } from '@/types/invoice';
-import { useInvoiceData } from '@/pages/Invoice/hooks/useInvoiceData';
-import { buildInvoiceWith } from 'tests/builders/invoiceBuilder';
+import { Invoice } from '@/types/invoice'
+import { useInvoiceData } from '@/pages/Invoice/hooks/useInvoiceData'
+import { buildInvoiceWith } from 'tests/builders/invoiceBuilder'
 
 // ❌ Don't use relative paths for cross-directory imports
-import { Invoice } from '../../../types/invoice';
+import { Invoice } from '../../../types/invoice'
 ```
 
 ---
@@ -713,15 +718,15 @@ function Invoice({ invoice, className, onClose }: InvoiceProps) {
 ```typescript
 // ✅ PRIORITY 1: URL state
 function ProductList() {
-  const [searchParams, setSearchParams] = useSearchParams();
-  const page = Number(searchParams.get('page')) || 1;
-  const sort = searchParams.get('sort') || 'name';
+  const [searchParams, setSearchParams] = useSearchParams()
+  const page = Number(searchParams.get('page')) || 1
+  const sort = searchParams.get('sort') || 'name'
 }
 
 // ✅ PRIORITY 2: Local state
 function InvoiceForm() {
-  const [formData, setFormData] = useState({ amount: '', note: '' });
-  const [errors, setErrors] = useState<ValidationErrors>({});
+  const [formData, setFormData] = useState({ amount: '', note: '' })
+  const [errors, setErrors] = useState<ValidationErrors>({})
 }
 
 // ✅ PRIORITY 3: Props
@@ -731,8 +736,8 @@ function InvoiceList({ customerId, filters }: Props) {
 
 // ❌ AVOID: Redux (use only when absolutely necessary)
 function InvoiceList() {
-  const invoices = useAppSelector(state => state.invoices.list);
-  const dispatch = useAppDispatch();
+  const invoices = useAppSelector((state) => state.invoices.list)
+  const dispatch = useAppDispatch()
 }
 ```
 
@@ -756,13 +761,15 @@ The store contains these slices (avoid adding to them):
 ### Accessing Redux State (If You Must)
 
 ```typescript
-import { useAppSelector, useAppDispatch } from '@/store';
+import { useAppSelector, useAppDispatch } from '@/store'
 
 function Component() {
-  const dispatch = useAppDispatch();
-  const customerId = useAppSelector(({ company }) => company.customer.id);
-  const isAdmin = useAppSelector(({ company }) => company.customer.role === 'ADMIN');
-  
+  const dispatch = useAppDispatch()
+  const customerId = useAppSelector(({ company }) => company.customer.id)
+  const isAdmin = useAppSelector(
+    ({ company }) => company.customer.role === 'ADMIN',
+  )
+
   // Avoid dispatching actions - use local state instead
   // dispatch(updateInvoice(invoice)); // ❌
 }
@@ -774,14 +781,14 @@ function Component() {
 // ✅ Pass data via props from a parent that has access to Redux
 function InvoicePage() {
   const customerId = useAppSelector(({ company }) => company.customer.id);
-  
+
   return <InvoiceList customerId={customerId} />;
 }
 
 function InvoiceList({ customerId }: { customerId: number }) {
   // No Redux dependency here!
   const [invoices, setInvoices] = useState<Invoice[]>([]);
-  
+
   useEffect(() => {
     fetchInvoices(customerId).then(setInvoices);
   }, [customerId]);
@@ -857,11 +864,11 @@ function InvoiceList() {
   const dispatch = useContext(SomeContext);
   const invoices = useAppSelector(state => state.invoices.list);
   const filters = useContext(FilterContext);
-  
+
   useEffect(() => {
     dispatch(fetchInvoices());
   }, []);
-  
+
   return (
     <div>
       {invoices.map(invoice => (
@@ -873,6 +880,7 @@ function InvoiceList() {
 ```
 
 **Problems:**
+
 - Hidden dependencies (Context, Redux)
 - Side effects in wrong place
 - Hard to test
@@ -889,14 +897,14 @@ function InvoiceList({ companyId }: { companyId: number }) {
   const [searchParams] = useSearchParams();
   const page = Number(searchParams.get('page')) || 1;
   const status = searchParams.get('status') || 'all';
-  
+
   const { data: invoices = [], isLoading } = useQuery({
     queryKey: ['invoices', companyId, page, status],
     queryFn: () => fetchInvoices(companyId, { page, status }),
   });
-  
+
   if (isLoading) return <Loading />;
-  
+
   return (
     <div>
       <InvoiceFilters status={status} />
@@ -910,6 +918,7 @@ function InvoiceList({ companyId }: { companyId: number }) {
 ```
 
 **Benefits:**
+
 - Explicit dependencies via props
 - State in URL (survives refresh)
 - Local component state
@@ -925,7 +934,7 @@ Browser APIs are mocked in `tests/setup-test-environment.ts`:
 
 ```typescript
 // These are set up automatically for all tests
-window.URL.createObjectURL = vi.fn();
+window.URL.createObjectURL = vi.fn()
 window.matchMedia = vi.fn().mockImplementation((query) => ({
   matches: false,
   media: query,
@@ -935,7 +944,7 @@ window.matchMedia = vi.fn().mockImplementation((query) => ({
   addEventListener: vi.fn(),
   removeEventListener: vi.fn(),
   dispatchEvent: vi.fn(),
-}));
+}))
 ```
 
 **If you need additional global mocks**, add them to `tests/setup-test-environment.ts`.
@@ -961,15 +970,17 @@ Use this checklist when writing tests:
 ## 🎓 Learning Resources
 
 - **Testing Library Docs**: https://testing-library.com/docs/react-testing-library/intro
-    - **Common mistakes**: https://kentcdodds.com/blog/common-mistakes-with-react-testing-library
+  - **Common mistakes**: https://kentcdodds.com/blog/common-mistakes-with-react-testing-library
 - **Vitest Docs**: https://vitest.dev/
 - **MSW Docs**: https://mswjs.io/docs/
 - **vitest-when**: https://github.com/mcous/vitest-when
+
 ---
 
 ## 📞 Questions?
 
 For questions or clarifications:
+
 - Review `CONTRIBUTING.md` for detailed contribution guidelines
 - Check existing tests for patterns (`src/pages/Invoice/index.mobile.test.tsx`)
 - Create an issue or ask in any of the b2b channels

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,7 +84,6 @@ yarn build
 This project uses Turborepo as a monorepo structure, even though it currently contains only one package (`storefront`). All package dependencies, scripts, and configurations are defined at the `apps/storefront/` level, not at the root.
 
 **Running commands from the wrong directory will cause:**
-
 - ❌ Commands not found
 - ❌ Wrong dependencies loaded
 - ❌ Incorrect build outputs
@@ -99,7 +98,6 @@ This project uses Turborepo as a monorepo structure, even though it currently co
 When writing new code, follow these principles:
 
 #### 1. **Matroska-Style Structure**
-
 Each component/page owns its domain-specific dependencies. Group related files together.
 
 ```
@@ -115,7 +113,6 @@ src/pages/Invoice/
 ```
 
 #### 2. **Prefer Props Over Context/Redux**
-
 Pass data through component props whenever possible. This makes data flow explicit and components more testable.
 
 ```typescript
@@ -131,14 +128,13 @@ function OrderDetails({ orderId, customerId }: Props) {
 
 // ❌ BAD: Hidden dependencies
 function OrderDetails() {
-  const orderId = useAppSelector((state) => state.order.id);
+  const orderId = useAppSelector(state => state.order.id);
   const customerId = useContext(CustomerContext);
   // ...
 }
 ```
 
 #### 3. **Co-located Files**
-
 Keep related files together. Tests live next to the code they test.
 
 ```
@@ -150,7 +146,6 @@ InvoiceList/
 ```
 
 #### 4. **URL-Driven State**
-
 Use route parameters and query strings for state that should persist across page loads.
 
 ```typescript
@@ -159,7 +154,7 @@ function ProductList() {
   const [searchParams, setSearchParams] = useSearchParams();
   const page = Number(searchParams.get('page')) || 1;
   const category = searchParams.get('category') || 'all';
-
+  
   return (
     <button onClick={() => setSearchParams({ page: page + 1, category })}>
       Next Page
@@ -176,7 +171,6 @@ function ProductList() {
 ```
 
 #### 5. **Local Component State**
-
 Use React hooks (`useState`, `useReducer`) for component-specific state.
 
 ```typescript
@@ -188,15 +182,14 @@ function InvoiceForm() {
 ```
 
 #### 6. **Domain-Agnostic Helpers Only**
-
 Shared utilities (`src/utils/`, `src/hooks/`) should contain pure functions with no business logic.
 
 ```typescript
 // ✅ GOOD: Pure utility
 export function formatCurrency(amount: number, currency: string): string {
-  return new Intl.NumberFormat('en-US', {
-    style: 'currency',
-    currency,
+  return new Intl.NumberFormat('en-US', { 
+    style: 'currency', 
+    currency 
   }).format(amount);
 }
 
@@ -213,13 +206,12 @@ export function getInvoiceTotal(invoice: Invoice): number {
 
 The codebase contains these patterns, but **do not add more**:
 
-❌ **DO NOT** add new React Context providers
-❌ **DO NOT** store state in Redux unless absolutely necessary
-❌ **DO NOT** use `localStorage` or `sessionStorage` for state
+❌ **DO NOT** add new React Context providers  
+❌ **DO NOT** store state in Redux unless absolutely necessary  
+❌ **DO NOT** use `localStorage` or `sessionStorage` for state  
 ❌ **DO NOT** create global contexts like `GlobalContext`, `DynamicallyVariableContext`, or `CustomStyleContext`
 
 **Why avoid these?**
-
 - Hidden dependencies make code harder to understand
 - Difficult to test in isolation
 - Unclear data flow
@@ -335,20 +327,20 @@ Import from `tests/test-utils.tsx`:
 
 ```typescript
 import {
-  renderWithProviders, // Render components with Redux/Router
-  screen, // Query rendered elements
-  userEvent, // Simulate user interactions
-  waitFor, // Async assertions
+  renderWithProviders,      // Render components with Redux/Router
+  screen,                    // Query rendered elements
+  userEvent,                 // Simulate user interactions
+  waitFor,                   // Async assertions
   waitForElementToBeRemoved, // Wait for loading states
-  within, // Scope queries to a container
-  faker, // Generate fake data
-  builder, // Build test objects
-  bulk, // Build multiple test objects
-  graphql, // Mock GraphQL requests
-  http, // Mock HTTP requests
-  HttpResponse, // Create mock responses
-  startMockServer, // Start MSW server
-  stringContainingAll, // Assert multiple substrings
+  within,                    // Scope queries to a container
+  faker,                     // Generate fake data
+  builder,                   // Build test objects
+  bulk,                      // Build multiple test objects
+  graphql,                   // Mock GraphQL requests
+  http,                      // Mock HTTP requests
+  HttpResponse,              // Create mock responses
+  startMockServer,           // Start MSW server
+  stringContainingAll,       // Assert multiple substrings
 } from 'tests/test-utils';
 ```
 
@@ -385,7 +377,6 @@ const invoices = bulk(buildInvoiceWith, 'WHATEVER_VALUES').times(5);
 ```
 
 **Key Points:**
-
 - `builder()` creates a factory function that generates random test data
 - Override specific properties by passing an object: `buildInvoiceWith({ status: 'PAID' })`
 - `bulk()` generates multiple items: `bulk(buildInvoiceWith, 'WHATEVER_VALUES').times(5)`
@@ -402,7 +393,7 @@ import {
   buildB2BFeaturesStateWith,
 } from 'tests/test-utils';
 
-const loggedInUser = buildCompanyStateWith({
+const loggedInUser = buildCompanyStateWith({ 
   tokens: { B2BToken: faker.string.uuid() },
   customer: { role: CustomerRole.ADMIN }
 });
@@ -426,22 +417,22 @@ const { server } = startMockServer();
 // Mock GraphQL queries
 server.use(
   graphql.query('GetInvoice', () => {
-    return HttpResponse.json({
-      data: {
-        invoice: buildInvoiceWith({ id: '123' }),
-      },
-    })
-  }),
+    return HttpResponse.json({ 
+      data: { 
+        invoice: buildInvoiceWith({ id: '123' })
+      } 
+    });
+  })
 );
 
 // Mock REST endpoints
 server.use(
   http.get('/api/invoices/:id', ({ params }) => {
-    return HttpResponse.json({
+    return HttpResponse.json({ 
       id: params.id,
-      amount: '100.00',
-    })
-  }),
+      amount: '100.00'
+    });
+  })
 );
 ```
 
@@ -469,7 +460,6 @@ await fetchInvoice('invoice-456'); // { status: 'PENDING' }
 ```
 
 **Benefits:**
-
 - Clearer test intentions than `mockImplementation`
 - Multiple test scenarios with one mock
 - Type-safe conditional behavior
@@ -482,13 +472,11 @@ await fetchInvoice('invoice-456'); // { status: 'PENDING' }
 import { stringContainingAll } from 'tests/test-utils';
 
 when(getOrders)
-  // Assert GraphQL queries contain specific strings
-  .calledWith(
-    stringContainingAll(['query', 'GetInvoice', 'invoiceNumber', 'dueDate']),
-  )
+    // Assert GraphQL queries contain specific strings
+  .calledWith(stringContainingAll(['query', 'GetInvoice', 'invoiceNumber', 'dueDate']))
   .thenReturn({
     orders: [],
-  })
+  })  
 ```
 
 ---
@@ -517,7 +505,7 @@ describe('Invoice Page', () => {
     // Arrange
     const invoice = buildInvoiceWith({ status: 'PAID' });
     server.use(
-      graphql.query('GetInvoice', () =>
+      graphql.query('GetInvoice', () => 
         HttpResponse.json({ data: { invoice } })
       )
     );
@@ -552,10 +540,10 @@ it('calls handleSubmit when form is submitted', () => {
 it('submits invoice payment when user clicks Pay button', async () => {
   const user = userEvent.setup();
   renderWithProviders(<InvoicePayment />);
-
+  
   await user.type(screen.getByLabelText('Amount'), '100');
   await user.click(screen.getByRole('button', { name: 'Pay' }));
-
+  
   await waitFor(() => {
     expect(screen.getByText('Payment successful')).toBeInTheDocument();
   });
@@ -597,8 +585,8 @@ const buildInvoiceWith = builder(() => ({
 }));
 
 describe('Invoice Page', () => {
-  const loggedInUser = buildCompanyStateWith({
-    tokens: { B2BToken: faker.string.uuid() }
+  const loggedInUser = buildCompanyStateWith({ 
+    tokens: { B2BToken: faker.string.uuid() } 
   });
 
   beforeEach(() => {
@@ -607,7 +595,7 @@ describe('Invoice Page', () => {
 
   it('displays invoice details after loading', async () => {
     const invoice = buildInvoiceWith({ status: 'PAID' });
-
+    
     server.use(
       graphql.query('GetInvoice', () => {
         return HttpResponse.json({ data: { invoice } });
@@ -620,7 +608,7 @@ describe('Invoice Page', () => {
     });
 
     await waitForElementToBeRemoved(() => screen.queryByText('Loading'));
-
+    
     expect(screen.getByText(invoice.invoiceNumber)).toBeInTheDocument();
     expect(screen.getByText('PAID')).toBeInTheDocument();
   });
@@ -643,8 +631,8 @@ import { renderWithProviders } from 'tests/test-utils';
 import { formatCurrency } from '@/utils/formatters';
 
 // ❌ WRONG - Will fail linting
-import debounce from 'lodash/debounce'; // Use lodash-es
-import Add from '@mui/icons-material/Add'; // Use named imports
+import debounce from 'lodash/debounce';           // Use lodash-es
+import Add from '@mui/icons-material/Add';         // Use named imports
 import { formatCurrency } from '../utils/formatters'; // Use path alias
 ```
 
@@ -736,8 +724,8 @@ function InvoiceList({ customerId, filters }: Props) {
 
 // ❌ AVOID: Redux (use only when absolutely necessary)
 function InvoiceList() {
-  const invoices = useAppSelector((state) => state.invoices.list)
-  const dispatch = useAppDispatch()
+  const invoices = useAppSelector(state => state.invoices.list);
+  const dispatch = useAppDispatch();
 }
 ```
 
@@ -766,10 +754,8 @@ import { useAppSelector, useAppDispatch } from '@/store';
 function Component() {
   const dispatch = useAppDispatch();
   const customerId = useAppSelector(({ company }) => company.customer.id);
-  const isAdmin = useAppSelector(
-    ({ company }) => company.customer.role === 'ADMIN',
-  );
-
+  const isAdmin = useAppSelector(({ company }) => company.customer.role === 'ADMIN');
+  
   // Avoid dispatching actions - use local state instead
   // dispatch(updateInvoice(invoice)); // ❌
 }
@@ -781,14 +767,14 @@ function Component() {
 // ✅ Pass data via props from a parent that has access to Redux
 function InvoicePage() {
   const customerId = useAppSelector(({ company }) => company.customer.id);
-
+  
   return <InvoiceList customerId={customerId} />;
 }
 
 function InvoiceList({ customerId }: { customerId: number }) {
   // No Redux dependency here!
   const [invoices, setInvoices] = useState<Invoice[]>([]);
-
+  
   useEffect(() => {
     fetchInvoices(customerId).then(setInvoices);
   }, [customerId]);
@@ -864,11 +850,11 @@ function InvoiceList() {
   const dispatch = useContext(SomeContext);
   const invoices = useAppSelector(state => state.invoices.list);
   const filters = useContext(FilterContext);
-
+  
   useEffect(() => {
     dispatch(fetchInvoices());
   }, []);
-
+  
   return (
     <div>
       {invoices.map(invoice => (
@@ -880,7 +866,6 @@ function InvoiceList() {
 ```
 
 **Problems:**
-
 - Hidden dependencies (Context, Redux)
 - Side effects in wrong place
 - Hard to test
@@ -897,14 +882,14 @@ function InvoiceList({ companyId }: { companyId: number }) {
   const [searchParams] = useSearchParams();
   const page = Number(searchParams.get('page')) || 1;
   const status = searchParams.get('status') || 'all';
-
+  
   const { data: invoices = [], isLoading } = useQuery({
     queryKey: ['invoices', companyId, page, status],
     queryFn: () => fetchInvoices(companyId, { page, status }),
   });
-
+  
   if (isLoading) return <Loading />;
-
+  
   return (
     <div>
       <InvoiceFilters status={status} />
@@ -918,7 +903,6 @@ function InvoiceList({ companyId }: { companyId: number }) {
 ```
 
 **Benefits:**
-
 - Explicit dependencies via props
 - State in URL (survives refresh)
 - Local component state
@@ -970,17 +954,15 @@ Use this checklist when writing tests:
 ## 🎓 Learning Resources
 
 - **Testing Library Docs**: https://testing-library.com/docs/react-testing-library/intro
-  - **Common mistakes**: https://kentcdodds.com/blog/common-mistakes-with-react-testing-library
+    - **Common mistakes**: https://kentcdodds.com/blog/common-mistakes-with-react-testing-library
 - **Vitest Docs**: https://vitest.dev/
 - **MSW Docs**: https://mswjs.io/docs/
 - **vitest-when**: https://github.com/mcous/vitest-when
-
 ---
 
 ## 📞 Questions?
 
 For questions or clarifications:
-
 - Review `CONTRIBUTING.md` for detailed contribution guidelines
 - Check existing tests for patterns (`src/pages/Invoice/index.mobile.test.tsx`)
 - Create an issue or ask in any of the b2b channels

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,8 +121,8 @@ Pass data through component props whenever possible. This makes data flow explic
 ```typescript
 // ✅ GOOD: Explicit props
 interface Props {
-  orderId: string
-  customerId: string
+  orderId: string;
+  customerId: string;
 }
 
 function OrderDetails({ orderId, customerId }: Props) {
@@ -131,8 +131,8 @@ function OrderDetails({ orderId, customerId }: Props) {
 
 // ❌ BAD: Hidden dependencies
 function OrderDetails() {
-  const orderId = useAppSelector((state) => state.order.id)
-  const customerId = useContext(CustomerContext)
+  const orderId = useAppSelector((state) => state.order.id);
+  const customerId = useContext(CustomerContext);
   // ...
 }
 ```
@@ -181,8 +181,8 @@ Use React hooks (`useState`, `useReducer`) for component-specific state.
 
 ```typescript
 function InvoiceForm() {
-  const [formData, setFormData] = useState({ amount: '', note: '' })
-  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [formData, setFormData] = useState({ amount: '', note: '' });
+  const [isSubmitting, setIsSubmitting] = useState(false);
   // ...
 }
 ```
@@ -197,13 +197,13 @@ export function formatCurrency(amount: number, currency: string): string {
   return new Intl.NumberFormat('en-US', {
     style: 'currency',
     currency,
-  }).format(amount)
+  }).format(amount);
 }
 
 // ❌ BAD: Business logic in utility
 export function getInvoiceTotal(invoice: Invoice): number {
   // This belongs in the Invoice domain, not shared utils
-  return invoice.items.reduce((sum, item) => sum + item.price, 0)
+  return invoice.items.reduce((sum, item) => sum + item.price, 0);
 }
 ```
 
@@ -349,13 +349,13 @@ import {
   HttpResponse, // Create mock responses
   startMockServer, // Start MSW server
   stringContainingAll, // Assert multiple substrings
-} from 'tests/test-utils'
+} from 'tests/test-utils';
 ```
 
 For hook testing: (hooks should rarely be tested in isolation)
 
 ```typescript
-import { renderHookWithProviders } from 'tests/utils/hook-test-utils'
+import { renderHookWithProviders } from 'tests/utils/hook-test-utils';
 ```
 
 ---
@@ -367,7 +367,7 @@ import { renderHookWithProviders } from 'tests/utils/hook-test-utils'
 #### Basic Builder Pattern
 
 ```typescript
-import { builder, bulk, faker } from 'tests/test-utils'
+import { builder, bulk, faker } from 'tests/test-utils';
 
 // Define a builder
 const buildInvoiceWith = builder(() => ({
@@ -376,12 +376,12 @@ const buildInvoiceWith = builder(() => ({
   amount: faker.commerce.price(),
   status: faker.helpers.enumValue(InvoiceStatus),
   dueDate: faker.date.future(),
-}))
+}));
 
 // Use it in tests
-const invoice = buildInvoiceWith({ status: 'PAID' })
+const invoice = buildInvoiceWith({ status: 'PAID' });
 // Use 'WHATEVER_VALUES' to explicitly indicate "any values will do"
-const invoices = bulk(buildInvoiceWith, 'WHATEVER_VALUES').times(5)
+const invoices = bulk(buildInvoiceWith, 'WHATEVER_VALUES').times(5);
 ```
 
 **Key Points:**
@@ -419,9 +419,9 @@ renderWithProviders(<Invoice />, {
 Use Mock Service Worker (MSW) for API mocking:
 
 ```typescript
-import { graphql, http, HttpResponse, startMockServer } from 'tests/test-utils'
+import { graphql, http, HttpResponse, startMockServer } from 'tests/test-utils';
 
-const { server } = startMockServer()
+const { server } = startMockServer();
 
 // Mock GraphQL queries
 server.use(
@@ -432,7 +432,7 @@ server.use(
       },
     })
   }),
-)
+);
 
 // Mock REST endpoints
 server.use(
@@ -442,7 +442,7 @@ server.use(
       amount: '100.00',
     })
   }),
-)
+);
 ```
 
 ---
@@ -452,20 +452,20 @@ server.use(
 Use `vitest-when` for argument-based mock behavior:
 
 ```typescript
-import { when } from 'vitest-when'
+import { when } from 'vitest-when';
 
 // Mock different returns based on arguments
 when(vi.mocked(fetchInvoice))
   .calledWith('invoice-123')
-  .thenReturn({ id: 'invoice-123', status: 'PAID' })
+  .thenReturn({ id: 'invoice-123', status: 'PAID' });
 
 when(vi.mocked(fetchInvoice))
   .calledWith('invoice-456')
-  .thenReturn({ id: 'invoice-456', status: 'PENDING' })
+  .thenReturn({ id: 'invoice-456', status: 'PENDING' });
 
 // Calls return different values
-await fetchInvoice('invoice-123') // { status: 'PAID' }
-await fetchInvoice('invoice-456') // { status: 'PENDING' }
+await fetchInvoice('invoice-123'); // { status: 'PAID' }
+await fetchInvoice('invoice-456'); // { status: 'PENDING' }
 ```
 
 **Benefits:**
@@ -479,7 +479,7 @@ await fetchInvoice('invoice-456') // { status: 'PENDING' }
 ### Assertion Helpers
 
 ```typescript
-import { stringContainingAll } from 'tests/test-utils'
+import { stringContainingAll } from 'tests/test-utils';
 
 when(getOrders)
   // Assert GraphQL queries contain specific strings
@@ -637,15 +637,15 @@ Enforced by ESLint - these will cause build failures if violated:
 
 ```typescript
 // ✅ CORRECT
-import { debounce, groupBy } from 'lodash-es'
-import { Add, Delete } from '@mui/icons-material'
-import { renderWithProviders } from 'tests/test-utils'
-import { formatCurrency } from '@/utils/formatters'
+import { debounce, groupBy } from 'lodash-es';
+import { Add, Delete } from '@mui/icons-material';
+import { renderWithProviders } from 'tests/test-utils';
+import { formatCurrency } from '@/utils/formatters';
 
 // ❌ WRONG - Will fail linting
-import debounce from 'lodash/debounce' // Use lodash-es
-import Add from '@mui/icons-material/Add' // Use named imports
-import { formatCurrency } from '../utils/formatters' // Use path alias
+import debounce from 'lodash/debounce'; // Use lodash-es
+import Add from '@mui/icons-material/Add'; // Use named imports
+import { formatCurrency } from '../utils/formatters'; // Use path alias
 ```
 
 ### Path Aliases
@@ -659,12 +659,12 @@ Configured in `tsconfig.json` and `vite.config.ts`:
 
 ```typescript
 // ✅ Use path aliases
-import { Invoice } from '@/types/invoice'
-import { useInvoiceData } from '@/pages/Invoice/hooks/useInvoiceData'
-import { buildInvoiceWith } from 'tests/builders/invoiceBuilder'
+import { Invoice } from '@/types/invoice';
+import { useInvoiceData } from '@/pages/Invoice/hooks/useInvoiceData';
+import { buildInvoiceWith } from 'tests/builders/invoiceBuilder';
 
 // ❌ Don't use relative paths for cross-directory imports
-import { Invoice } from '../../../types/invoice'
+import { Invoice } from '../../../types/invoice';
 ```
 
 ---
@@ -718,15 +718,15 @@ function Invoice({ invoice, className, onClose }: InvoiceProps) {
 ```typescript
 // ✅ PRIORITY 1: URL state
 function ProductList() {
-  const [searchParams, setSearchParams] = useSearchParams()
-  const page = Number(searchParams.get('page')) || 1
-  const sort = searchParams.get('sort') || 'name'
+  const [searchParams, setSearchParams] = useSearchParams();
+  const page = Number(searchParams.get('page')) || 1;
+  const sort = searchParams.get('sort') || 'name';
 }
 
 // ✅ PRIORITY 2: Local state
 function InvoiceForm() {
-  const [formData, setFormData] = useState({ amount: '', note: '' })
-  const [errors, setErrors] = useState<ValidationErrors>({})
+  const [formData, setFormData] = useState({ amount: '', note: '' });
+  const [errors, setErrors] = useState<ValidationErrors>({});
 }
 
 // ✅ PRIORITY 3: Props
@@ -761,14 +761,14 @@ The store contains these slices (avoid adding to them):
 ### Accessing Redux State (If You Must)
 
 ```typescript
-import { useAppSelector, useAppDispatch } from '@/store'
+import { useAppSelector, useAppDispatch } from '@/store';
 
 function Component() {
-  const dispatch = useAppDispatch()
-  const customerId = useAppSelector(({ company }) => company.customer.id)
+  const dispatch = useAppDispatch();
+  const customerId = useAppSelector(({ company }) => company.customer.id);
   const isAdmin = useAppSelector(
     ({ company }) => company.customer.role === 'ADMIN',
-  )
+  );
 
   // Avoid dispatching actions - use local state instead
   // dispatch(updateInvoice(invoice)); // ❌
@@ -934,7 +934,7 @@ Browser APIs are mocked in `tests/setup-test-environment.ts`:
 
 ```typescript
 // These are set up automatically for all tests
-window.URL.createObjectURL = vi.fn()
+window.URL.createObjectURL = vi.fn();
 window.matchMedia = vi.fn().mockImplementation((query) => ({
   matches: false,
   media: query,
@@ -944,7 +944,7 @@ window.matchMedia = vi.fn().mockImplementation((query) => ({
   addEventListener: vi.fn(),
   removeEventListener: vi.fn(),
   dispatchEvent: vi.fn(),
-}))
+}));
 ```
 
 **If you need additional global mocks**, add them to `tests/setup-test-environment.ts`.


### PR DESCRIPTION
## Jira

[B2B-4863](https://bigcommercecloud.atlassian.net/browse/B2B-4863)

## What / Why?

This PR reduces internal engineering detail exposed in this public repository while still giving internal team members a first-class Claude Code experience.

**Changes:**

1. **`AGENTS.md` — plugin install section added**
   Directs internal BigCommerce engineers to install the private `b2b-buyer-portal` plugin from `cc-plugins-marketplace`. That plugin delivers full project context (architecture, testing patterns, PR review checklist, engineering workflow, repo map) directly into Claude Code sessions without exposing the detail in this public repo.

2. **`.gitignore` — Claude Code artefacts excluded**
   Prevents `docs/agents/`, `.claude/settings.local.json`, and personal Claude config files from being accidentally committed. The public-facing integration guides (`docs/stencil.md`, `docs/headless.md`) are explicitly allowed.

## Rollout / Rollback

- No runtime changes — documentation and gitignore only.
- Rollback: revert this PR; no downstream impact.

## Testing

- Verified `AGENTS.md` renders correctly on GitHub.
- Verified `.gitignore` rules with `git check-ignore -v` on representative paths.
- Internal plugin lives at `cc-plugins-marketplace` and was reviewed separately (PR #52).

[B2B-4863]: https://bigcommercecloud.atlassian.net/browse/B2B-4863?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no impact to runtime behavior, build, or tests.
> 
> **Overview**
> Adds a short **internal-only** “AI Coding Agent Setup” section to `AGENTS.md` directing BigCommerce engineers to install the private `b2b-buyer-portal` plugin for full Claude/agent context.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b26bf288c31c3ec5efbf02d8301122cfa4ce83e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->