### PR TITLE
refactor(orders): B2B-4623 add hidden prop to B3Table for column visibility and update tests

### DIFF
--- a/apps/storefront/src/pages/order/Order.tsx
+++ b/apps/storefront/src/pages/order/Order.tsx
@@ -67,7 +67,7 @@ function useData() {
   );
 
   const currentCompanyId =
-    role === CustomerRole.SUPER_ADMIN && isAgenting
+    Number(role) === CustomerRole.SUPER_ADMIN && isAgenting
       ? Number(salesRepCompanyId)
       : Number(companyB2BId);
 
@@ -287,80 +287,70 @@ function Order({ isCompanyOrder = false }: OrderProps) {
 
   const navigateToOrderDetail = isUnifiedCustomerPath ? goToDetail : legacyGoToDetail;
 
-  const columnAllItems = [
-    {
-      key: 'orderId',
-      title: b3Lang('orders.order'),
-      width: '10%',
-      isSortable: true,
-      render: ({ orderId }) => orderId,
-    },
-    {
-      key: 'companyName',
-      title: b3Lang('orders.company'),
-      width: '10%',
-      isSortable: false,
-      render: ({ companyInfo }) => {
-        return <Box>{companyInfo?.companyName || '–'}</Box>;
+  const isSuperAdminNotAgenting = Number(role) === CustomerRole.SUPER_ADMIN && !isAgenting;
+
+  const columnItems: TableColumnItem<ListItem>[] = useMemo(
+    () => [
+      {
+        key: 'orderId',
+        title: b3Lang('orders.order'),
+        width: '10%',
+        isSortable: true,
+        render: ({ orderId }) => orderId,
       },
-    },
-    {
-      key: 'poNumber',
-      title: b3Lang('orders.poReference'),
-      render: ({ poNumber }) => <Box>{poNumber || '–'}</Box>,
-      width: '10%',
-      isSortable: true,
-    },
-    {
-      key: 'totalIncTax',
-      title: b3Lang('orders.grandTotal'),
-      render: ({ money, totalIncTax }) =>
-        money
-          ? ordersCurrencyFormat(JSON.parse(JSON.parse(money)), totalIncTax)
-          : currencyFormat(totalIncTax),
-      align: 'right',
-      width: '8%',
-      isSortable: true,
-    },
-    {
-      key: 'status',
-      title: b3Lang('orders.orderStatus'),
-      render: ({ status, statusText }) => <OrderStatus text={statusText} code={status} />,
-      width: '10%',
-      isSortable: true,
-    },
-    {
-      key: 'placedBy',
-      title: b3Lang('orders.placedBy'),
-      render: ({ firstName, lastName }) => `${firstName} ${lastName}`,
-      width: '10%',
-      isSortable: true,
-    },
-    {
-      key: 'createdAt',
-      title: b3Lang('orders.createdOn'),
-      render: ({ createdAt }) => `${displayFormat(Number(createdAt))}`,
-      width: '10%',
-      isSortable: true,
-    },
-  ] as const satisfies TableColumnItem<ListItem>[];
-
-  const getColumnItems = (): TableColumnItem<ListItem>[] => {
-    const getNewColumnItems = columnAllItems.filter((item) => {
-      const { key } = item;
-      if (!isB2BUser && key === 'companyName') return false;
-      if ((!isB2BUser || (Number(role) === 3 && !isAgenting)) && key === 'placedBy') return false;
-
-      if (key === 'placedBy' && !(Number(role) === 3 && !isAgenting) && !isCompanyOrder) {
-        return false;
-      }
-      return true;
-    });
-
-    return getNewColumnItems;
-  };
-
-  const columnItems = getColumnItems();
+      {
+        key: 'companyName',
+        title: b3Lang('orders.company'),
+        width: '10%',
+        isSortable: false,
+        render: ({ companyInfo }) => {
+          return <Box>{companyInfo?.companyName || '–'}</Box>;
+        },
+        hidden: !isB2BUser,
+      },
+      {
+        key: 'poNumber',
+        title: b3Lang('orders.poReference'),
+        render: ({ poNumber }) => <Box>{poNumber || '–'}</Box>,
+        width: '10%',
+        isSortable: true,
+      },
+      {
+        key: 'totalIncTax',
+        title: b3Lang('orders.grandTotal'),
+        render: ({ money, totalIncTax }) =>
+          money
+            ? ordersCurrencyFormat(JSON.parse(JSON.parse(money)), totalIncTax)
+            : currencyFormat(totalIncTax),
+        align: 'right',
+        width: '8%',
+        isSortable: true,
+      },
+      {
+        key: 'status',
+        title: b3Lang('orders.orderStatus'),
+        render: ({ status, statusText }) => <OrderStatus text={statusText} code={status} />,
+        width: '10%',
+        isSortable: true,
+      },
+      {
+        key: 'placedBy',
+        title: b3Lang('orders.placedBy'),
+        render: ({ firstName, lastName }) => `${firstName} ${lastName}`,
+        width: '10%',
+        isSortable: true,
+        hidden: !isB2BUser || isSuperAdminNotAgenting || !isCompanyOrder,
+      },
+      {
+        key: 'createdAt',
+        title: b3Lang('orders.createdOn'),
+        render: ({ createdAt }) => `${displayFormat(Number(createdAt))}`,
+        width: '10%',
+        isSortable: true,
+      },
+    ],
+    [b3Lang, isB2BUser, isSuperAdminNotAgenting, isCompanyOrder],
+  );
 
   const unifiedState = isUnifiedCompanyPath ? companyFilterState : customerFilterState;
 

--- a/apps/storefront/src/pages/order/order.test.tsx
+++ b/apps/storefront/src/pages/order/order.test.tsx
@@ -1,0 +1,359 @@
+import {
+  buildB2BFeaturesStateWith,
+  buildCompanyStateWith,
+  builder,
+  buildGlobalStateWith,
+  buildStoreInfoStateWith,
+  bulk,
+  faker,
+  getUnixTime,
+  graphql,
+  HttpResponse,
+  renderWithProviders,
+  screen,
+  startMockServer,
+  waitFor,
+  within,
+} from 'tests/test-utils';
+import { describe, expect, it, vi } from 'vitest';
+
+import { CompanyStatus, CustomerRole, LoginTypes, UserTypes } from '@/types';
+
+import Order from './Order';
+import {
+  CompanyOrderNode,
+  CompanyOrderStatuses,
+  CustomerOrderStatues,
+  GetCompanyOrders,
+  OrderStatus,
+} from './orders';
+
+vi.mock('@/hooks/useMobile', () => ({
+  useMobile: () => [false] as const,
+}));
+
+const { server } = startMockServer();
+
+function getBodyCellsForColumn(columnAccessibleName: string) {
+  const headers = screen.getAllByRole('columnheader');
+  const columnHeader = screen.getByRole('columnheader', { name: columnAccessibleName });
+  const columnIndex = headers.indexOf(columnHeader);
+
+  return screen
+    .getAllByRole('row')
+    .filter((row) => within(row).queryAllByRole('cell').length > 0)
+    .map((row) => within(row).getAllByRole('cell')[columnIndex]);
+}
+
+// ---------------------------------------------------------------------------
+// Builders
+// ---------------------------------------------------------------------------
+
+const buildOrderStatusWith = builder<OrderStatus>(() => ({
+  statusCode: faker.number.int().toString(),
+  systemLabel: faker.word.noun(),
+  customLabel: faker.word.noun(),
+}));
+
+const buildCompanyOrderNodeWith = builder<CompanyOrderNode>(() => ({
+  node: {
+    orderId: faker.number.int({ min: 1000, max: 9999 }).toString(),
+    firstName: faker.person.firstName(),
+    lastName: faker.person.lastName(),
+    createdAt: getUnixTime(faker.date.past()),
+    totalIncTax: faker.number.float({ min: 10, max: 1000 }),
+    money: '',
+    poNumber: faker.string.alphanumeric(6),
+    status: faker.word.noun(),
+    companyInfo: { companyName: faker.company.name() },
+  },
+}));
+
+const buildGetAllOrdersWith = builder<GetCompanyOrders>(() => ({
+  data: {
+    allOrders: {
+      totalCount: 3,
+      edges: bulk(buildCompanyOrderNodeWith, 'WHATEVER_VALUES').times(3),
+    },
+  },
+}));
+
+const buildCompanyOrderStatusesWith = builder<CompanyOrderStatuses>(() => ({
+  data: {
+    orderStatuses: bulk(buildOrderStatusWith, 'WHATEVER_VALUES').times(3),
+  },
+}));
+
+const buildBcOrderStatusesWith = builder<CustomerOrderStatues>(() => ({
+  data: {
+    bcOrderStatuses: bulk(buildOrderStatusWith, 'WHATEVER_VALUES').times(3),
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Preloaded states
+// ---------------------------------------------------------------------------
+
+const defaultCompanyState = buildCompanyStateWith('WHATEVER_VALUES');
+
+const approvedB2bBuyerCompany = buildCompanyStateWith({
+  permissions: [{ code: 'purchase_enable', permissionLevel: 1 }],
+  companyInfo: { id: '42', status: CompanyStatus.APPROVED, companyName: 'Co' },
+  customer: {
+    userType: UserTypes.MULTIPLE_B2C,
+    role: CustomerRole.SENIOR_BUYER,
+    loginType: LoginTypes.GENERAL_LOGIN,
+  },
+  pagesSubsidiariesPermission: {
+    ...defaultCompanyState.pagesSubsidiariesPermission,
+    order: true,
+  },
+  companyHierarchyInfo: {
+    ...defaultCompanyState.companyHierarchyInfo,
+    isEnabledCompanyHierarchy: false,
+  },
+});
+
+const superAdminCompany = buildCompanyStateWith({
+  ...approvedB2bBuyerCompany,
+  customer: {
+    ...approvedB2bBuyerCompany.customer,
+    role: CustomerRole.SUPER_ADMIN,
+  },
+});
+
+const bcCustomerCompany = buildCompanyStateWith({
+  companyInfo: { id: '1', status: CompanyStatus.DEFAULT, companyName: '' },
+  customer: {
+    userType: UserTypes.B2C,
+    role: CustomerRole.ADMIN,
+    loginType: LoginTypes.GENERAL_LOGIN,
+  },
+});
+
+const basePreloaded = {
+  company: approvedB2bBuyerCompany,
+  storeInfo: buildStoreInfoStateWith({ timeFormat: { display: 'j F Y' } }),
+  global: buildGlobalStateWith({
+    featureFlags: {
+      'B2B-4613.buyer_portal_unified_sf_gql_orders': false,
+    },
+  }),
+  b2bFeatures: buildB2BFeaturesStateWith({
+    masqueradeCompany: { id: 0, isAgenting: false, companyName: '', customerGroupId: 0 },
+  }),
+};
+
+const agentingPreloaded = {
+  ...basePreloaded,
+  company: superAdminCompany,
+  b2bFeatures: buildB2BFeaturesStateWith({
+    masqueradeCompany: { id: 1, isAgenting: true, companyName: 'Other', customerGroupId: 0 },
+  }),
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('Orders list (UI)', () => {
+  beforeEach(() => {
+    server.use(
+      // B2B order statuses (used when isB2BUser = true)
+      graphql.query('GetOrderStatuses', () =>
+        HttpResponse.json(buildCompanyOrderStatusesWith('WHATEVER_VALUES')),
+      ),
+      // BC order statuses (used when isB2BUser = false)
+      graphql.query('GetCustomerOrderStatuses', () =>
+        HttpResponse.json(buildBcOrderStatusesWith('WHATEVER_VALUES')),
+      ),
+      // B2B orders — legacy path (GetAllOrders operation name)
+      graphql.query('GetAllOrders', () =>
+        HttpResponse.json(buildGetAllOrdersWith('WHATEVER_VALUES')),
+      ),
+      // BC orders — legacy path (GetCustomerOrders operation name, distinct from SF GQL path
+      // because the flag is OFF for all tests in this file)
+      graphql.query('GetCustomerOrders', () =>
+        HttpResponse.json({
+          data: {
+            customerOrders: {
+              totalCount: 3,
+              edges: bulk(buildCompanyOrderNodeWith, 'WHATEVER_VALUES').times(3),
+            },
+          },
+        }),
+      ),
+      // Created-by lookup — only triggered for isB2BUser && isCompanyOrder
+      graphql.query('GetOrdersCreatedByUser', () =>
+        HttpResponse.json({ data: { createdByUser: { results: [] } } }),
+      ),
+    );
+  });
+
+  it('shows Company and Placed by columns on company orders for an approved B2B buyer', async () => {
+    const orderStatuses = [
+      buildOrderStatusWith({
+        systemLabel: 'Awaiting Fulfillment',
+        customLabel: 'Awaiting fulfillment',
+      }),
+      buildOrderStatusWith({ systemLabel: 'Shipped', customLabel: 'Shipped' }),
+      buildOrderStatusWith({ systemLabel: 'Completed', customLabel: 'Completed' }),
+      buildOrderStatusWith({ systemLabel: 'Awaiting Payment', customLabel: 'Awaiting payment' }),
+      buildOrderStatusWith({ systemLabel: 'Cancelled', customLabel: 'Order cancelled' }),
+      buildOrderStatusWith({ systemLabel: 'Pending', customLabel: 'On hold pending review' }),
+    ];
+
+    server.use(
+      graphql.query('GetOrderStatuses', () =>
+        HttpResponse.json({ data: { orderStatuses } } satisfies CompanyOrderStatuses),
+      ),
+      graphql.query('GetAllOrders', () =>
+        HttpResponse.json({
+          data: {
+            allOrders: {
+              totalCount: 6,
+              edges: [
+                buildCompanyOrderNodeWith({
+                  node: {
+                    orderId: '1001',
+                    firstName: 'Alex',
+                    lastName: 'Buyer',
+                    status: 'Awaiting Fulfillment',
+                  },
+                }),
+                buildCompanyOrderNodeWith({
+                  node: {
+                    orderId: '1002',
+                    firstName: 'Jordan',
+                    lastName: 'Lee',
+                    status: 'Shipped',
+                  },
+                }),
+                buildCompanyOrderNodeWith({
+                  node: {
+                    orderId: '1003',
+                    firstName: 'Morgan',
+                    lastName: 'Chen',
+                    status: 'Completed',
+                  },
+                }),
+                buildCompanyOrderNodeWith({
+                  node: {
+                    orderId: '1004',
+                    firstName: 'Riley',
+                    lastName: 'Patel',
+                    status: 'Awaiting Payment',
+                  },
+                }),
+                buildCompanyOrderNodeWith({
+                  node: {
+                    orderId: '1005',
+                    firstName: 'Sam',
+                    lastName: 'Rivera',
+                    status: 'Cancelled',
+                  },
+                }),
+                buildCompanyOrderNodeWith({
+                  node: {
+                    orderId: '1006',
+                    firstName: 'Taylor',
+                    lastName: 'Wong',
+                    status: 'Pending',
+                  },
+                }),
+              ],
+            },
+          },
+        }),
+      ),
+    );
+
+    renderWithProviders(<Order isCompanyOrder />, { preloadedState: basePreloaded });
+
+    await waitFor(() => {
+      expect(screen.getByRole('columnheader', { name: 'Order' })).toBeVisible();
+    });
+
+    expect(screen.getByRole('columnheader', { name: 'Company' })).toBeVisible();
+    expect(screen.getByRole('columnheader', { name: 'Placed by' })).toBeVisible();
+
+    expect(getBodyCellsForColumn('Placed by').map((cell) => cell.textContent?.trim())).toEqual([
+      'Alex Buyer',
+      'Jordan Lee',
+      'Morgan Chen',
+      'Riley Patel',
+      'Sam Rivera',
+      'Taylor Wong',
+    ]);
+
+    await waitFor(() => {
+      expect(getBodyCellsForColumn('Order status').map((cell) => cell.textContent?.trim())).toEqual(
+        [
+          'Awaiting fulfillment',
+          'Shipped',
+          'Completed',
+          'Awaiting payment',
+          'Order cancelled',
+          'On hold pending review',
+        ],
+      );
+    });
+  });
+
+  it('shows Company but not Placed by on the non-company orders list for an approved B2B buyer', async () => {
+    renderWithProviders(<Order isCompanyOrder={false} />, { preloadedState: basePreloaded });
+
+    await waitFor(() => {
+      expect(screen.getByRole('columnheader', { name: 'Order' })).toBeVisible();
+    });
+
+    expect(screen.getByRole('columnheader', { name: 'Company' })).toBeVisible();
+    expect(screen.queryByRole('columnheader', { name: 'Placed by' })).not.toBeInTheDocument();
+  });
+
+  it('does not show Placed by for a super admin who is not agenting, on company orders', async () => {
+    renderWithProviders(<Order isCompanyOrder />, {
+      preloadedState: { ...basePreloaded, company: superAdminCompany },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole('columnheader', { name: 'Order' })).toBeVisible();
+    });
+
+    expect(screen.queryByRole('columnheader', { name: 'Placed by' })).not.toBeInTheDocument();
+  });
+
+  it('does not show Company or Placed by for a BC shopper', async () => {
+    renderWithProviders(<Order isCompanyOrder={false} />, {
+      preloadedState: { ...basePreloaded, company: bcCustomerCompany },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole('columnheader', { name: 'Order' })).toBeVisible();
+    });
+
+    expect(screen.queryByRole('columnheader', { name: 'Company' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('columnheader', { name: 'Placed by' })).not.toBeInTheDocument();
+  });
+
+  it('shows Placed by for a super admin who is agenting, on company orders', async () => {
+    renderWithProviders(<Order isCompanyOrder />, { preloadedState: agentingPreloaded });
+
+    await waitFor(() => {
+      expect(screen.getByRole('columnheader', { name: 'Order' })).toBeVisible();
+    });
+
+    expect(screen.getByRole('columnheader', { name: 'Placed by' })).toBeVisible();
+  });
+
+  it('does not show Placed by for a super admin who is agenting, on My Orders', async () => {
+    // isCompanyOrder is false, which is sufficient to hide placedBy regardless of agenting status.
+    renderWithProviders(<Order isCompanyOrder={false} />, { preloadedState: agentingPreloaded });
+
+    await waitFor(() => {
+      expect(screen.getByRole('columnheader', { name: 'Order' })).toBeVisible();
+    });
+
+    expect(screen.queryByRole('columnheader', { name: 'Placed by' })).not.toBeInTheDocument();
+  });
+});

--- a/apps/storefront/src/pages/order/table/B3Table.tsx
+++ b/apps/storefront/src/pages/order/table/B3Table.tsx
@@ -49,6 +49,10 @@ export interface TableColumnItem<Row extends OrderIdRow> {
   width?: string;
   render: (row: Row) => ReactNode;
   isSortable?: boolean;
+  /**
+   * If true, the column will not be displayed in the table
+   */
+  hidden?: boolean;
 }
 
 interface RowProps<Row extends OrderIdRow> {
@@ -151,144 +155,145 @@ export function B3Table<Row extends OrderIdRow>({
     });
   };
 
-  return listItems.length > 0 ? (
-    <>
-      {isInfiniteScroll && (
-        <>
-          <Grid container spacing={2}>
-            {listItems.map((row, index) => {
-              return (
-                <Grid item xs={12} key={row.orderId}>
-                  {renderItem(row, index)}
-                </Grid>
-              );
-            })}
-          </Grid>
-          <TablePagination
-            labelDisplayedRows={({ from, to, count }) =>
-              count === -1
-                ? `${from}–${Math.min(to, from + listItems.length - 1)}`
-                : b3Lang('global.pagination.pageXOfY', { from, to, count })
-            }
-            rowsPerPageOptions={rowsPerPageOptions}
-            labelRowsPerPage={b3Lang('global.pagination.perPage')}
-            component="div"
-            sx={{
-              color: isMobile ? b3HexToRgb(customColor, 0.87) : 'rgba(0, 0, 0, 0.87)',
-              marginTop: '1.5rem',
-              '::-webkit-scrollbar': {
-                display: 'none',
-              },
-              '& svg': {
-                color: isMobile ? b3HexToRgb(customColor, 0.87) : 'rgba(0, 0, 0, 0.87)',
-              },
-            }}
-            count={count}
-            rowsPerPage={first}
-            page={first === 0 ? 0 : offset / first}
-            onPageChange={handleChangePage}
-            onRowsPerPageChange={handleChangeRowsPerPage}
-            {...(cursorPageInfo && {
-              slotProps: {
-                actions: {
-                  nextButton: { disabled: !cursorPageInfo.hasNextPage },
-                  previousButton: { disabled: !cursorPageInfo.hasPreviousPage },
-                },
-              },
-            })}
-          />
-        </>
-      )}
-      {!isInfiniteScroll && (
-        <Card
+  if (listItems.length === 0) return <B3NoData />;
+
+  if (isInfiniteScroll) {
+    return (
+      <>
+        <Grid container spacing={2}>
+          {listItems.map((row, index) => {
+            return (
+              <Grid item xs={12} key={row.orderId}>
+                {renderItem(row, index)}
+              </Grid>
+            );
+          })}
+        </Grid>
+        <TablePagination
+          labelDisplayedRows={({ from, to, count }) =>
+            count === -1
+              ? `${from}–${Math.min(to, from + listItems.length - 1)}`
+              : b3Lang('global.pagination.pageXOfY', { from, to, count })
+          }
+          rowsPerPageOptions={rowsPerPageOptions}
+          labelRowsPerPage={b3Lang('global.pagination.perPage')}
+          component="div"
           sx={{
-            height: '100%',
-            boxShadow:
-              '0px 2px 1px -1px rgb(0 0 0 / 20%), 0px 1px 1px 0px rgb(0 0 0 / 14%), 0px 1px 3px 0px rgb(0 0 0 / 12%)',
+            color: isMobile ? b3HexToRgb(customColor, 0.87) : 'rgba(0, 0, 0, 0.87)',
+            marginTop: '1.5rem',
+            '::-webkit-scrollbar': {
+              display: 'none',
+            },
+            '& svg': {
+              color: isMobile ? b3HexToRgb(customColor, 0.87) : 'rgba(0, 0, 0, 0.87)',
+            },
+          }}
+          count={count}
+          rowsPerPage={first}
+          page={first === 0 ? 0 : offset / first}
+          onPageChange={handleChangePage}
+          onRowsPerPageChange={handleChangeRowsPerPage}
+          {...(cursorPageInfo && {
+            slotProps: {
+              actions: {
+                nextButton: { disabled: !cursorPageInfo.hasNextPage },
+                previousButton: { disabled: !cursorPageInfo.hasPreviousPage },
+              },
+            },
+          })}
+        />
+      </>
+    );
+  }
+
+  const visibleColumnItems = columnItems.filter((column) => !column.hidden);
+
+  return (
+    <Card
+      sx={{
+        height: '100%',
+        boxShadow:
+          '0px 2px 1px -1px rgb(0 0 0 / 20%), 0px 1px 1px 0px rgb(0 0 0 / 14%), 0px 1px 3px 0px rgb(0 0 0 / 12%)',
+      }}
+    >
+      <TableContainer>
+        <Table
+          sx={{
+            tableLayout: 'initial',
           }}
         >
-          <TableContainer>
-            <Table
-              sx={{
-                tableLayout: 'initial',
-              }}
-            >
-              <TableHead>
-                <TableRow data-testid="tableHead-Row">
-                  {columnItems.map((column) => (
-                    <TableCell
-                      key={column.title}
-                      width={column.width}
-                      align={column.align ?? 'left'}
-                      sortDirection={column.key === orderBy ? sortDirection : false}
-                      data-testid={column.key ? `tableHead-${column.key}` : ''}
+          <TableHead>
+            <TableRow data-testid="tableHead-Row">
+              {visibleColumnItems.map((column) => (
+                <TableCell
+                  key={column.title}
+                  width={column.width}
+                  align={column.align ?? 'left'}
+                  sortDirection={column.key === orderBy ? sortDirection : false}
+                  data-testid={column.key ? `tableHead-${column.key}` : ''}
+                >
+                  {column.isSortable ? (
+                    <TableSortLabel
+                      active={column.key === orderBy}
+                      direction={column.key === orderBy ? sortDirection : 'desc'}
+                      hideSortIcon={column.key !== orderBy}
+                      onClick={() => sortByFn?.(column.key)}
                     >
-                      {column.isSortable ? (
-                        <TableSortLabel
-                          active={column.key === orderBy}
-                          direction={column.key === orderBy ? sortDirection : 'desc'}
-                          hideSortIcon={column.key !== orderBy}
-                          onClick={() => sortByFn?.(column.key)}
-                        >
-                          {column.title}
-                        </TableSortLabel>
-                      ) : (
-                        column.title
-                      )}
-                    </TableCell>
-                  ))}
-                </TableRow>
-              </TableHead>
+                      {column.title}
+                    </TableSortLabel>
+                  ) : (
+                    column.title
+                  )}
+                </TableCell>
+              ))}
+            </TableRow>
+          </TableHead>
 
-              <TableBody>
-                {listItems.map((row, index) => {
-                  const node = isNodeWrapper(row) ? row.node : row;
+          <TableBody>
+            {listItems.map((row, index) => {
+              const node = isNodeWrapper(row) ? row.node : row;
 
-                  return (
-                    <Row
-                      key={`row-${node.orderId}`}
-                      columnItems={columnItems}
-                      node={node}
-                      onClickRow={() => onClickRow(node, index)}
-                    />
-                  );
-                })}
-              </TableBody>
-            </Table>
-          </TableContainer>
-          <TablePagination
-            labelDisplayedRows={({ from, to, count }) =>
-              count === -1
-                ? `${from}–${Math.min(to, from + listItems.length - 1)}`
-                : b3Lang('global.pagination.pageXOfY', { from, to, count })
-            }
-            rowsPerPageOptions={rowsPerPageOptions}
-            labelRowsPerPage={b3Lang('global.pagination.rowsPerPage')}
-            component="div"
-            sx={{
-              marginTop: '1.5rem',
-              '::-webkit-scrollbar': {
-                display: 'none',
-              },
-            }}
-            count={count}
-            rowsPerPage={first}
-            page={first === 0 ? 0 : offset / first}
-            onPageChange={handleChangePage}
-            onRowsPerPageChange={handleChangeRowsPerPage}
-            {...(cursorPageInfo && {
-              slotProps: {
-                actions: {
-                  nextButton: { disabled: !cursorPageInfo.hasNextPage },
-                  previousButton: { disabled: !cursorPageInfo.hasPreviousPage },
-                },
-              },
+              return (
+                <Row
+                  key={`row-${node.orderId}`}
+                  columnItems={visibleColumnItems}
+                  node={node}
+                  onClickRow={() => onClickRow(node, index)}
+                />
+              );
             })}
-          />
-        </Card>
-      )}
-    </>
-  ) : (
-    <B3NoData />
+          </TableBody>
+        </Table>
+      </TableContainer>
+      <TablePagination
+        labelDisplayedRows={({ from, to, count }) =>
+          count === -1
+            ? `${from}–${Math.min(to, from + listItems.length - 1)}`
+            : b3Lang('global.pagination.pageXOfY', { from, to, count })
+        }
+        rowsPerPageOptions={rowsPerPageOptions}
+        labelRowsPerPage={b3Lang('global.pagination.rowsPerPage')}
+        component="div"
+        sx={{
+          marginTop: '1.5rem',
+          '::-webkit-scrollbar': {
+            display: 'none',
+          },
+        }}
+        count={count}
+        rowsPerPage={first}
+        page={first === 0 ? 0 : offset / first}
+        onPageChange={handleChangePage}
+        onRowsPerPageChange={handleChangeRowsPerPage}
+        {...(cursorPageInfo && {
+          slotProps: {
+            actions: {
+              nextButton: { disabled: !cursorPageInfo.hasNextPage },
+              previousButton: { disabled: !cursorPageInfo.hasPreviousPage },
+            },
+          },
+        })}
+      />
+    </Card>
   );
 }


### PR DESCRIPTION
Jira: [B2B-4623](https://bigcommercecloud.atlassian.net/browse/B2B-4623)

## What/Why?
<!--
  A description about what this pull request implements and its purpose.
  Try to be detailed and describe any technical details to simplify the job
  of the reviewer and the individual on production support.
-->
This pull request refactors how table columns are conditionally displayed in the Orders page and its table component, making the logic more declarative and easier to maintain. It moves the column visibility logic into the column definitions themselves and introduces a new `hidden` property to table columns, which is then respected by the table rendering logic. Additionally, comprehensive tests have been added to verify the correct visibility of columns for different user roles and order types.

**Refactoring and simplification of column visibility logic:**

- The conditional logic for displaying columns such as "Company" and "Placed by" in the `Order` page has been moved from a filtering function to the column definitions themselves, using a new `hidden` property for each column. This makes the code more readable and maintainable. [[1]](diffhunk://#diff-a558aaee2e7eddca900f59f36caed5dd4539500e9fafea8e50ae7bab8af60788L227-R229) [[2]](diffhunk://#diff-a558aaee2e7eddca900f59f36caed5dd4539500e9fafea8e50ae7bab8af60788R245) [[3]](diffhunk://#diff-a558aaee2e7eddca900f59f36caed5dd4539500e9fafea8e50ae7bab8af60788R278-R283) [[4]](diffhunk://#diff-a558aaee2e7eddca900f59f36caed5dd4539500e9fafea8e50ae7bab8af60788L283-R292)

**Enhancements to the table component:**

- The `TableColumnItem` type in `B3Table.tsx` now includes an optional `hidden` property, allowing columns to declare whether they should be displayed.
- The `B3Table` component filters out columns with `hidden: true` before rendering both the table headers and rows, ensuring that only visible columns are shown. [[1]](diffhunk://#diff-ba8be525ef880b3e7560a6eac2b0eb89bb9cd3c7a6f5e8829999438388146fc4R158-R159) [[2]](diffhunk://#diff-ba8be525ef880b3e7560a6eac2b0eb89bb9cd3c7a6f5e8829999438388146fc4L218-R224) [[3]](diffhunk://#diff-ba8be525ef880b3e7560a6eac2b0eb89bb9cd3c7a6f5e8829999438388146fc4L250-R256)

## Rollout/Rollback
<!--
Detail how this change will be rolled out. Include reference to any
experiments and how the success will be measured as the experiment is
ramped.

Document rollback procedures. Is rolling back the change as simple as
rolling back an experiment or does it require reverting code? Are there
database migrations that may change our decision to roll forward instead of
back?
-->
Revert the PR
## Testing
<!--
Provide as much information as you can about how you tested and how another
Engineer can test your change. Include screenshots, or test run output
where appropriate.
-->
- A new test suite for the `Order` page has been added, verifying that the correct columns are visible or hidden for various user roles (B2B buyer, super admin, BC shopper) and order types (company vs non-company orders). This ensures that the new column visibility logic works as intended.

[B2B-4623]: https://bigcommercecloud.atlassian.net/browse/B2B-4623?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared table rendering logic (`B3Table`) used across the storefront, so incorrect `hidden` handling could affect multiple tables; changes are mitigated by targeted Orders UI tests covering role/order-type permutations.
> 
> **Overview**
> Refactors Orders list column-visibility to be *declarative*: `Order.tsx` now defines `Company`/`Placed by` columns with a `hidden` flag (including clarified `SUPER_ADMIN` role casting and a dedicated `isSuperAdminNotAgenting` check) instead of filtering the column array.
> 
> Extends `B3Table` to support an optional `hidden` property on `TableColumnItem` and filters hidden columns out when rendering headers and row cells (non-infinite-scroll path), with a small early-return cleanup for the no-data case.
> 
> Adds a new `order.test.tsx` suite validating column visibility and key cell content across B2B buyer, super admin (agenting vs not), and B2C shopper scenarios for company vs non-company orders.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ddd309ca3b1b044482c3b3150f095964d1256a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->