### PR TITLE
fix(register): B2B-4861 Buyer Portal: Add null check for stateRequired flag and remove FF

### DIFF
--- a/apps/storefront/src/hooks/useGetCountry.ts
+++ b/apps/storefront/src/hooks/useGetCountry.ts
@@ -1,7 +1,6 @@
 import { useContext, useEffect } from 'react';
 import { Control, FieldValues, UseFormGetValues, UseFormSetValue, useWatch } from 'react-hook-form';
 
-import { useFeatureFlag } from '@/hooks/useFeatureFlag';
 import { GlobalContext } from '@/shared/global';
 import { Country, State } from '@/shared/global/context/config';
 import { getB2BCountries } from '@/shared/service/b2b';
@@ -12,14 +11,10 @@ const useSetCountry = () => {
     dispatch,
   } = useContext(GlobalContext);
 
-  const grpcGeoForStateRequiredFlag = useFeatureFlag(
-    'B2B-4481.use_grpc_geo_for_state_required_flag',
-  );
-
   useEffect(() => {
     const init = async () => {
       if (countriesList && !countriesList.length) {
-        const { countries } = await getB2BCountries(grpcGeoForStateRequiredFlag);
+        const { countries } = await getB2BCountries();
 
         dispatch({
           type: 'common',

--- a/apps/storefront/src/hooks/useGetCountry.ts
+++ b/apps/storefront/src/hooks/useGetCountry.ts
@@ -1,6 +1,7 @@
 import { useContext, useEffect } from 'react';
 import { Control, FieldValues, UseFormGetValues, UseFormSetValue, useWatch } from 'react-hook-form';
 
+import { getIsStateRequired } from '@/pages/Registered/config';
 import { GlobalContext } from '@/shared/global';
 import { Country, State } from '@/shared/global/context/config';
 import { getB2BCountries } from '@/shared/service/b2b';
@@ -89,8 +90,11 @@ const useGetCountry = ({
   // Populate state array when the user change selected country
   useEffect(() => {
     if (!countryCode || !countriesList?.length) return;
-    const stateList =
-      countriesList.find((country: Country) => country.countryCode === countryCode)?.states || [];
+    const selectedCountry = countriesList.find(
+      (country: Country) => country.countryCode === countryCode,
+    );
+    const stateList = selectedCountry?.states || [];
+    const isStateRequired = getIsStateRequired(selectedCountry, stateList);
     const stateFieldIndex = addresses.findIndex(
       (formFields: FormFieldsProps) => formFields.name === 'state',
     );
@@ -103,10 +107,10 @@ const useGetCountry = ({
                 ...addressField,
                 fieldType: 'dropdown',
                 options: stateList,
-                required: true,
+                required: isStateRequired,
               };
             }
-            return { ...addressField, fieldType: 'text', options: [], required: false };
+            return { ...addressField, fieldType: 'text', options: [], required: isStateRequired };
           }
           return addressField;
         }),

--- a/apps/storefront/src/hooks/useGetCountry.ts
+++ b/apps/storefront/src/hooks/useGetCountry.ts
@@ -1,10 +1,10 @@
 import { useContext, useEffect } from 'react';
 import { Control, FieldValues, UseFormGetValues, UseFormSetValue, useWatch } from 'react-hook-form';
 
-import { getIsStateRequired } from '@/pages/Registered/config';
 import { GlobalContext } from '@/shared/global';
 import { Country, State } from '@/shared/global/context/config';
 import { getB2BCountries } from '@/shared/service/b2b';
+import { getIsStateRequired } from '@/utils/b2bGetIsStateRequired';
 
 const useSetCountry = () => {
   const {

--- a/apps/storefront/src/pages/AddressList/components/AddressForm.tsx
+++ b/apps/storefront/src/pages/AddressList/components/AddressForm.tsx
@@ -6,6 +6,7 @@ import cloneDeep from 'lodash-es/cloneDeep';
 import { B3CustomForm } from '@/components/B3CustomForm';
 import B3Dialog from '@/components/B3Dialog';
 import { useB3Lang } from '@/lib/lang';
+import { Country, getIsStateRequired } from '@/pages/Registered/config';
 import {
   createB2BAddress,
   createBcAddress,
@@ -476,9 +477,9 @@ function AddressForm(
 
   useEffect(() => {
     const handleCountryChange = (countryCode: string) => {
-      const stateList =
-        countries.find((country: CountryProps) => country.countryCode === countryCode)?.states ||
-        [];
+      const selectedCountry = countries.find((country) => country.countryCode === countryCode);
+      const stateList = selectedCountry?.states || [];
+      const isStateRequired = getIsStateRequired(selectedCountry as Country, stateList);
       const stateFields = allAddressFields.find(
         (formFields: CustomFieldItems) => formFields.name === 'state',
       );
@@ -487,11 +488,11 @@ function AddressForm(
         if (stateList.length > 0) {
           stateFields.fieldType = 'dropdown';
           stateFields.options = stateList;
-          stateFields.required = true;
+          stateFields.required = isStateRequired;
         } else {
           stateFields.fieldType = 'text';
           stateFields.options = [];
-          stateFields.required = false;
+          stateFields.required = isStateRequired;
         }
       }
 

--- a/apps/storefront/src/pages/AddressList/components/AddressForm.tsx
+++ b/apps/storefront/src/pages/AddressList/components/AddressForm.tsx
@@ -6,7 +6,6 @@ import cloneDeep from 'lodash-es/cloneDeep';
 import { B3CustomForm } from '@/components/B3CustomForm';
 import B3Dialog from '@/components/B3Dialog';
 import { useB3Lang } from '@/lib/lang';
-import { getIsStateRequired } from '@/pages/Registered/config';
 import {
   createB2BAddress,
   createBcAddress,
@@ -14,6 +13,7 @@ import {
   updateBcAddress,
   validateAddressExtraFields,
 } from '@/shared/service/b2b';
+import { getIsStateRequired } from '@/utils/b2bGetIsStateRequired';
 import { snackbar } from '@/utils/b3Tip';
 import { deCodeField } from '@/utils/registerUtils';
 

--- a/apps/storefront/src/pages/AddressList/components/AddressForm.tsx
+++ b/apps/storefront/src/pages/AddressList/components/AddressForm.tsx
@@ -6,7 +6,7 @@ import cloneDeep from 'lodash-es/cloneDeep';
 import { B3CustomForm } from '@/components/B3CustomForm';
 import B3Dialog from '@/components/B3Dialog';
 import { useB3Lang } from '@/lib/lang';
-import { Country, getIsStateRequired } from '@/pages/Registered/config';
+import { getIsStateRequired } from '@/pages/Registered/config';
 import {
   createB2BAddress,
   createBcAddress,
@@ -447,16 +447,16 @@ function AddressForm(
           setValue(field.name, stateCode || state);
           if (currentCountry[0]) {
             const { states } = currentCountry[0];
+            const isStateRequired = getIsStateRequired(currentCountry[0], states);
 
             if (states.length > 0) {
               field.options = states;
               field.fieldType = 'dropdown';
-              field.required = true;
             } else {
               field.options = [];
               field.fieldType = 'text';
-              field.required = false;
             }
+            field.required = isStateRequired;
           }
         } else {
           setValue(
@@ -479,7 +479,7 @@ function AddressForm(
     const handleCountryChange = (countryCode: string) => {
       const selectedCountry = countries.find((country) => country.countryCode === countryCode);
       const stateList = selectedCountry?.states || [];
-      const isStateRequired = getIsStateRequired(selectedCountry as Country, stateList);
+      const isStateRequired = getIsStateRequired(selectedCountry, stateList);
       const stateFields = allAddressFields.find(
         (formFields: CustomFieldItems) => formFields.name === 'state',
       );

--- a/apps/storefront/src/pages/AddressList/index.tsx
+++ b/apps/storefront/src/pages/AddressList/index.tsx
@@ -5,7 +5,6 @@ import B3Filter from '@/components/filter/B3Filter';
 import B3Spin from '@/components/spin/B3Spin';
 import { B3PaginationTable, GetRequestList } from '@/components/table/B3PaginationTable';
 import { useCardListColumn } from '@/hooks/useCardListColumn';
-import { useFeatureFlag } from '@/hooks/useFeatureFlag';
 import { useTableRef } from '@/hooks/useTableRef';
 import { useVerifyCreatePermission } from '@/hooks/useVerifyPermission';
 import { useB3Lang } from '@/lib/lang';
@@ -63,9 +62,6 @@ const isConfigEnabled = (configs: Config[] | undefined, key: string) => {
 };
 
 function Address() {
-  const grpcGeoForStateRequiredFlag = useFeatureFlag(
-    'B2B-4481.use_grpc_geo_for_state_required_flag',
-  );
   const isB2BUser = useAppSelector(isB2BUserSelector);
   const companyInfoId = useAppSelector(({ company }) => company.companyInfo.id);
   const role = useAppSelector(({ company }) => company.customer.role);
@@ -100,7 +96,7 @@ function Address() {
 
   useEffect(() => {
     const handleGetAddressFields = async () => {
-      const { countries } = await getB2BCountries(grpcGeoForStateRequiredFlag);
+      const { countries } = await getB2BCountries();
 
       setCountries(countries);
       setIsRequestLoading(true);
@@ -115,7 +111,7 @@ function Address() {
     };
 
     handleGetAddressFields();
-  }, [isBCPermission, grpcGeoForStateRequiredFlag]);
+  }, [isBCPermission]);
 
   const getAddressList: GetRequestList<FilterSearchProps, AddressItemType> = async (
     params = {},

--- a/apps/storefront/src/pages/AddressList/shared/getAddressFields.ts
+++ b/apps/storefront/src/pages/AddressList/shared/getAddressFields.ts
@@ -18,6 +18,7 @@ export interface CountryProps {
   countryName: string;
   id: string | number;
   states: StateProps[];
+  stateRequired?: boolean;
 }
 interface B2bExtraFieldsProps {
   defaultValue: string;

--- a/apps/storefront/src/pages/Registered/RegisterSteps/index.tsx
+++ b/apps/storefront/src/pages/Registered/RegisterSteps/index.tsx
@@ -1,6 +1,5 @@
 import { useContext, useEffect, useState } from 'react';
 
-import { useFeatureFlag } from '@/hooks/useFeatureFlag';
 import { useB3Lang } from '@/lib/lang';
 import { LoginConfig } from '@/pages/Login/helper';
 import { CustomStyleContext } from '@/shared/customStyleButton';
@@ -35,9 +34,6 @@ export function RegisterSteps({ backgroundColor, handleFinish }: RegisterStepsPr
   const [activeStep, setActiveStep] = useState(0);
 
   const IframeDocument = useAppSelector(themeFrameSelector);
-  const grpcGeoForStateRequiredFlag = useFeatureFlag(
-    'B2B-4481.use_grpc_geo_for_state_required_flag',
-  );
 
   const {
     state: { accountLoginRegistration },
@@ -86,7 +82,7 @@ export function RegisterSteps({ backgroundColor, handleFinish }: RegisterStepsPr
         );
         const b2bAccountFormFields = getAccountFormFields(newB2bAccountFormFields || []);
 
-        const { countries } = await getB2BCountries(grpcGeoForStateRequiredFlag);
+        const { countries } = await getB2BCountries();
 
         const newAddressInformationFields =
           b2bAccountFormFields.address?.map(

--- a/apps/storefront/src/pages/Registered/RegisterSteps/steps/DetailStep.tsx
+++ b/apps/storefront/src/pages/Registered/RegisterSteps/steps/DetailStep.tsx
@@ -5,7 +5,6 @@ import isEmpty from 'lodash-es/isEmpty';
 
 import { B3CustomForm } from '@/components/B3CustomForm';
 import { getContrastColor } from '@/components/outSideComponents/utils/b3CustomStyles';
-import { useFeatureFlag } from '@/hooks/useFeatureFlag';
 import { useB3Lang } from '@/lib/lang';
 import { CustomStyleContext } from '@/shared/customStyleButton';
 
@@ -32,9 +31,6 @@ export default function DetailStep({ handleBack, handleNext }: DetailStepProps) 
   } = useContext(CustomStyleContext);
 
   const customColor = getContrastColor(backgroundColor);
-  const grpcGeoForStateRequiredFlag = useFeatureFlag(
-    'B2B-4481.use_grpc_geo_for_state_required_flag',
-  );
 
   const [errorMessage, setErrorMessage] = useState('');
 
@@ -71,11 +67,7 @@ export default function DetailStep({ handleBack, handleNext }: DetailStepProps) 
         (c: Country) => c.countryCode === countryCode || c.countryName === countryCode,
       );
       const stateList = selectedCountry?.states || [];
-      const isStateRequired = getIsStateRequired(
-        selectedCountry,
-        stateList,
-        grpcGeoForStateRequiredFlag,
-      );
+      const isStateRequired = getIsStateRequired(selectedCountry, stateList);
       const stateFields = addressBasicList.find(
         (formFields: RegisterFields) => formFields.name === 'state',
       );
@@ -114,14 +106,7 @@ export default function DetailStep({ handleBack, handleNext }: DetailStepProps) 
     },
     // disabling as we don't need dispatchers here
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [
-      addressBasicFields,
-      addressBasicList,
-      addressBasicName,
-      bcAddressBasicFields,
-      countryList,
-      grpcGeoForStateRequiredFlag,
-    ],
+    [addressBasicFields, addressBasicList, addressBasicName, bcAddressBasicFields, countryList],
   );
 
   useEffect(() => {

--- a/apps/storefront/src/pages/Registered/RegisterSteps/steps/DetailStep.tsx
+++ b/apps/storefront/src/pages/Registered/RegisterSteps/steps/DetailStep.tsx
@@ -7,8 +7,9 @@ import { B3CustomForm } from '@/components/B3CustomForm';
 import { getContrastColor } from '@/components/outSideComponents/utils/b3CustomStyles';
 import { useB3Lang } from '@/lib/lang';
 import { CustomStyleContext } from '@/shared/customStyleButton';
+import { getIsStateRequired } from '@/utils/b2bGetIsStateRequired';
 
-import { Country, getIsStateRequired, State, validateExtraFields } from '../../config';
+import { Country, State, validateExtraFields } from '../../config';
 import { RegisteredContext } from '../../Context';
 import { RegisterFields } from '../../types';
 import { PrimaryButton } from '../PrimaryButton';

--- a/apps/storefront/src/pages/Registered/config.ts
+++ b/apps/storefront/src/pages/Registered/config.ts
@@ -50,9 +50,10 @@ export interface State {
 export function getIsStateRequired(
   country: Country | undefined,
   stateList: State[] | null | undefined,
-  grpcGeoForStateRequiredFlag: boolean,
 ): boolean {
-  return grpcGeoForStateRequiredFlag ? !!country?.stateRequired : (stateList?.length ?? 0) > 0;
+  return typeof country?.stateRequired === 'boolean'
+    ? country.stateRequired
+    : (stateList?.length ?? 0) > 0;
 }
 
 type EmailError = {

--- a/apps/storefront/src/pages/Registered/config.ts
+++ b/apps/storefront/src/pages/Registered/config.ts
@@ -48,8 +48,8 @@ export interface State {
 }
 
 export function getIsStateRequired(
-  country: Country | undefined,
-  stateList: State[] | null | undefined,
+  country: { stateRequired?: boolean } | undefined,
+  stateList: { length: number } | null | undefined,
 ): boolean {
   return typeof country?.stateRequired === 'boolean'
     ? country.stateRequired

--- a/apps/storefront/src/pages/Registered/config.ts
+++ b/apps/storefront/src/pages/Registered/config.ts
@@ -47,15 +47,6 @@ export interface State {
   id?: string;
 }
 
-export function getIsStateRequired(
-  country: { stateRequired?: boolean } | undefined,
-  stateList: { length: number } | null | undefined,
-): boolean {
-  return typeof country?.stateRequired === 'boolean'
-    ? country.stateRequired
-    : (stateList?.length ?? 0) > 0;
-}
-
 type EmailError = {
   [k: number]: string;
 };

--- a/apps/storefront/src/pages/RegisteredBCToB2B/Register.tsx
+++ b/apps/storefront/src/pages/RegisteredBCToB2B/Register.tsx
@@ -5,7 +5,6 @@ import { Box } from '@mui/material';
 import { B3Card } from '@/components/B3Card';
 import { getContrastColor } from '@/components/outSideComponents/utils/b3CustomStyles';
 import B3Spin from '@/components/spin/B3Spin';
-import { useFeatureFlag } from '@/hooks/useFeatureFlag';
 import { useMobile } from '@/hooks/useMobile';
 import { useB3Lang } from '@/lib/lang';
 import { CustomStyleContext } from '@/shared/customStyleButton';
@@ -44,9 +43,6 @@ export function Register({ logo, ...props }: RegisterProps) {
 
   const b3Lang = useB3Lang();
   const [isMobile] = useMobile();
-  const grpcGeoForStateRequiredFlag = useFeatureFlag(
-    'B2B-4481.use_grpc_geo_for_state_required_flag',
-  );
 
   const navigate = useNavigate();
 
@@ -98,7 +94,7 @@ export function Register({ logo, ...props }: RegisterProps) {
       });
 
       const bcToB2BAccountFormFields = getAccountFormFields(newAccountFormFields || []);
-      const { countries } = await getB2BCountries(grpcGeoForStateRequiredFlag);
+      const { countries } = await getB2BCountries();
 
       const newAddressInformationFields = (bcToB2BAccountFormFields.address ?? []).map(
         (addressFields: Partial<RegisterFieldsItems>): Partial<RegisterFieldsItems> => {
@@ -160,15 +156,7 @@ export function Register({ logo, ...props }: RegisterProps) {
     } finally {
       showLoading(false);
     }
-  }, [
-    dispatch,
-    emailAddress,
-    firstName,
-    grpcGeoForStateRequiredFlag,
-    lastName,
-    phoneNumber,
-    showLoading,
-  ]);
+  }, [dispatch, emailAddress, firstName, lastName, phoneNumber, showLoading]);
 
   useEffect(() => {
     getBCAdditionalFields();

--- a/apps/storefront/src/pages/RegisteredBCToB2B/RegistrationForm/useRegistrationForm.ts
+++ b/apps/storefront/src/pages/RegisteredBCToB2B/RegistrationForm/useRegistrationForm.ts
@@ -38,9 +38,6 @@ interface UseRegistrationFormParams {
 export function useRegistrationForm({ onRegistrationSuccess }: UseRegistrationFormParams) {
   const b3Lang = useB3Lang();
   const isRegisterCompanyFlowEnabled = useFeatureFlag('B2B-4466.use_register_company_flow');
-  const grpcGeoForStateRequiredFlag = useFeatureFlag(
-    'B2B-4481.use_grpc_geo_for_state_required_flag',
-  );
   const [isMobile] = useMobile();
   const [errorMessage, setErrorMessage] = useState('');
 
@@ -95,7 +92,7 @@ export function useRegistrationForm({ onRegistrationSuccess }: UseRegistrationFo
         (c: Country) => c.countryCode === countryCode || c.countryName === countryCode,
       );
       const stateList = country?.states || [];
-      const isStateRequired = getIsStateRequired(country, stateList, grpcGeoForStateRequiredFlag);
+      const isStateRequired = getIsStateRequired(country, stateList);
       const stateFields = bcTob2bAddressBasicFields.find(
         (formFields: RegisterFields) => formFields.name === 'state',
       );

--- a/apps/storefront/src/pages/RegisteredBCToB2B/RegistrationForm/useRegistrationForm.ts
+++ b/apps/storefront/src/pages/RegisteredBCToB2B/RegistrationForm/useRegistrationForm.ts
@@ -5,7 +5,7 @@ import isEmpty from 'lodash-es/isEmpty';
 import { useFeatureFlag } from '@/hooks/useFeatureFlag';
 import { useMobile } from '@/hooks/useMobile';
 import { useB3Lang } from '@/lib/lang';
-import { Country, getIsStateRequired, State } from '@/pages/Registered/config';
+import { Country, State } from '@/pages/Registered/config';
 import { RegisteredContext } from '@/pages/Registered/Context';
 import type { RegisterFields } from '@/pages/Registered/types';
 import { CustomStyleContext } from '@/shared/customStyleButton';
@@ -18,6 +18,7 @@ import {
 } from '@/shared/service/b2b';
 import { RegisterCompanyStatus } from '@/shared/service/bc/graphql/company';
 import { useAppSelector } from '@/store';
+import { getIsStateRequired } from '@/utils/b2bGetIsStateRequired';
 import b2bLogger from '@/utils/b3Logger';
 import { Base64 } from '@/utils/base64';
 import { getCurrentCustomerInfo } from '@/utils/loginInfo';

--- a/apps/storefront/src/shared/service/b2b/graphql/register.ts
+++ b/apps/storefront/src/shared/service/b2b/graphql/register.ts
@@ -101,12 +101,12 @@ const getCustomerInfo = () => `{
   }
 }`;
 
-const getCountries = (grpcGeoForStateRequiredFlag: boolean) => `query Countries {
+const getCountries = () => `query Countries {
   countries(storeHash:"${storeHash}") {
     id
     countryName
     countryCode
-    ${grpcGeoForStateRequiredFlag ? 'stateRequired' : ''}
+    stateRequired
     states {
       stateName
       stateCode
@@ -218,9 +218,9 @@ export const getB2BCompanyUserInfo = () =>
     query: getCustomerInfo(),
   });
 
-export const getB2BCountries = (grpcGeoForStateRequiredFlag = false) =>
+export const getB2BCountries = () =>
   B3Request.graphqlB2B({
-    query: getCountries(grpcGeoForStateRequiredFlag),
+    query: getCountries(),
   });
 
 export const createB2BCompanyUser = (data: CustomFieldItems) =>

--- a/apps/storefront/src/utils/b2bGetIsStateRequired.ts
+++ b/apps/storefront/src/utils/b2bGetIsStateRequired.ts
@@ -1,0 +1,8 @@
+export function getIsStateRequired(
+  country: { stateRequired?: boolean } | undefined,
+  stateList: { length: number } | null | undefined,
+): boolean {
+  return typeof country?.stateRequired === 'boolean'
+    ? country.stateRequired
+    : (stateList?.length ?? 0) > 0;
+}

--- a/apps/storefront/src/utils/featureFlags.ts
+++ b/apps/storefront/src/utils/featureFlags.ts
@@ -28,10 +28,6 @@ export const featureFlags = [
     name: 'useRegisterCompanyFlow',
   },
   {
-    key: 'B2B-4481.use_grpc_geo_for_state_required_flag',
-    name: 'grpcGeoForStateRequiredFlag',
-  },
-  {
     key: 'B2B-4613.buyer_portal_unified_sf_gql_orders',
     name: 'unifiedStorefrontGraphqlOrders',
   },


### PR DESCRIPTION
Jira: [B2B-4861](https://bigcommercecloud.atlassian.net/browse/B2B-4861)

## What/Why?
<!--
  A description about what this pull request implements and its purpose.
  Try to be detailed and describe any technical details to simplify the job
  of the reviewer and the individual on production support.
-->

Removed rolled-out feature flag B2B-4481.use_grpc_geo_for_state_required_flag and all its call sites.

Added null check for stateRequired in getIsStateRequired — falls back to stateList.length > 0 only when the flag is absent, correctly honoring false.

stateRequired is now always requested in the Countries GraphQL query.

Applied getIsStateRequired to the Address List form (previously bypassed the flag).



## Rollout/Rollback
<!--
Detail how this change will be rolled out. Include reference to any
experiments and how the success will be measured as the experiment is
ramped.

Document rollback procedures. Is rolling back the change as simple as
rolling back an experiment or does it require reverting code? Are there
database migrations that may change our decision to roll forward instead of
back?
-->

Rollback or Revert


## Testing
<!--
Provide as much information as you can about how you tested and how another
Engineer can test your change. Include screenshots, or test run output
where appropriate.
-->



https://github.com/user-attachments/assets/b1644bbf-3b31-49e0-9c1e-9108d78bd5d2


https://github.com/user-attachments/assets/943905d8-0896-4fa8-a96b-1bf9ff6c5c1f



https://github.com/user-attachments/assets/448e113d-91b0-4580-856c-3bbbee5f05d9

<img width="1910" height="1035" alt="After(Addresses)" src="https://github.com/user-attachments/assets/c7b93844-4a4a-4d35-9b76-ab529ce99def" />
<img width="1910" height="1035" alt="Before (Addresses)" src="https://github.com/user-attachments/assets/b56cd0bc-526b-478b-940f-b99eab017ef2" />
<img width="1910" height="1035" alt="registeredbctob2b" src="https://github.com/user-attachments/assets/e3b4ee9b-b5a1-427e-aba0-eaa899099331" />



[B2B-4861]: https://bigcommercecloud.atlassian.net/browse/B2B-4861?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `state` field required-ness is computed across registration and address forms and updates the countries GraphQL query shape, which can affect form validation/UX if backend data differs or is missing.
> 
> **Overview**
> Removes the rolled-out `B2B-4481.use_grpc_geo_for_state_required_flag` and updates all call sites to fetch countries without flag-gated behavior.
> 
> Introduces a shared `getIsStateRequired` helper that treats `country.stateRequired` as authoritative when present (including `false`), falling back to `states.length > 0` when absent, and applies this consistently to registration and address book forms so `state` required-ness matches backend data.
> 
> Updates the countries GraphQL query/response typing to always request `stateRequired` and removes the old `getIsStateRequired` implementation from `Registered/config.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e89e61b6d20c2bf79e62757b119952307705479f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->