### PR TITLE
[B2B-4617] Implement Company Orders status and date range filters

### DIFF
--- a/apps/storefront/src/pages/CompanyOrderList/unified-company-orders.test.tsx
+++ b/apps/storefront/src/pages/CompanyOrderList/unified-company-orders.test.tsx
@@ -160,6 +160,25 @@ const superAdminMasqueradingState = (featureFlags: Record<string, boolean>) => (
 // Tests
 // ---------------------------------------------------------------------------
 
+const filteredCompanyOrdersResponse = (entityId: number): GetCompanyOrdersResponse => ({
+  data: {
+    customer: {
+      activeCompany: {
+        orders: {
+          edges: [{ node: buildSfGqlOrderWith({ entityId }), cursor: 'filtered' }],
+          pageInfo: {
+            hasNextPage: false,
+            hasPreviousPage: false,
+            startCursor: 'filtered',
+            endCursor: 'filtered',
+          },
+          collectionInfo: { totalItems: 1 },
+        },
+      },
+    },
+  },
+});
+
 describe('Company Orders — unified SF GQL orders (B2B-4616)', () => {
   beforeEach(() => {
     server.use(
@@ -358,42 +377,226 @@ describe('Company Orders — unified SF GQL orders (B2B-4616)', () => {
 
         await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
 
-        const filteredResponse: GetCompanyOrdersResponse = {
-          data: {
-            customer: {
-              activeCompany: {
-                orders: {
-                  edges: [
-                    {
-                      node: buildSfGqlOrderWith({ entityId: 66996 }),
-                      cursor: 'filtered',
-                    },
-                  ],
-                  pageInfo: {
-                    hasNextPage: false,
-                    hasPreviousPage: false,
-                    startCursor: 'filtered',
-                    endCursor: 'filtered',
-                  },
-                  collectionInfo: { totalItems: 1 },
-                },
-              },
-            },
-          },
-        };
-
         when(getOrders)
           .calledWith(
             expect.objectContaining({
               filters: expect.objectContaining({ search: '66996' }),
             }),
           )
-          .thenReturn(filteredResponse);
+          .thenReturn(filteredCompanyOrdersResponse(66996));
 
         await userEvent.type(screen.getByPlaceholderText('Search'), '66996');
 
         await waitFor(() => {
           expect(screen.getByText('66996').closest('tr')!).toBeInTheDocument();
+        });
+      });
+
+      it('filters by status', async () => {
+        const getOrders = vi
+          .fn()
+          .mockReturnValue(buildCompanyOrdersResponseWith('WHATEVER_VALUES'));
+
+        server.use(
+          graphql.query('GetOrderStatuses', () =>
+            HttpResponse.json(
+              buildLegacyB2BOrderStatusesResponseWith({
+                data: {
+                  orderStatuses: [
+                    buildLegacyOrderStatusWith({
+                      systemLabel: 'Completed',
+                      customLabel: 'Completed',
+                    }),
+                  ],
+                },
+              }),
+            ),
+          ),
+          graphql.query('GetCompanyOrders', ({ variables }) =>
+            HttpResponse.json(getOrders(variables)),
+          ),
+        );
+
+        renderWithProviders(<CompanyOrders />, { preloadedState: b2bStateWithFlag(flagOn) });
+
+        await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+        when(getOrders)
+          .calledWith(
+            expect.objectContaining({
+              filters: expect.objectContaining({ status: ['Completed'] }),
+            }),
+          )
+          .thenReturn(filteredCompanyOrdersResponse(66996));
+
+        await userEvent.click(screen.getByRole('button', { name: /edit/ }));
+
+        const dialog = await screen.findByRole('dialog', { name: 'Filters' });
+
+        await userEvent.click(within(dialog).getByRole('combobox', { name: 'Order status' }));
+        await userEvent.click(screen.getByRole('option', { name: 'Completed' }));
+
+        await userEvent.click(screen.getByRole('button', { name: 'Apply' }));
+
+        await waitFor(() => {
+          expect(screen.getByRole('row', { name: /66996/ })).toBeInTheDocument();
+        });
+      });
+
+      it('resolves custom status label to systemLabel before sending', async () => {
+        const getOrders = vi
+          .fn()
+          .mockReturnValue(buildCompanyOrdersResponseWith('WHATEVER_VALUES'));
+
+        server.use(
+          graphql.query('GetOrderStatuses', () =>
+            HttpResponse.json(
+              buildLegacyB2BOrderStatusesResponseWith({
+                data: {
+                  orderStatuses: [
+                    buildLegacyOrderStatusWith({
+                      systemLabel: 'Completed',
+                      customLabel: 'All Done',
+                    }),
+                  ],
+                },
+              }),
+            ),
+          ),
+          graphql.query('GetCompanyOrders', ({ variables }) =>
+            HttpResponse.json(getOrders(variables)),
+          ),
+        );
+
+        renderWithProviders(<CompanyOrders />, { preloadedState: b2bStateWithFlag(flagOn) });
+
+        await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+        when(getOrders)
+          .calledWith(
+            expect.objectContaining({
+              filters: expect.objectContaining({ status: ['Completed'] }),
+            }),
+          )
+          .thenReturn(filteredCompanyOrdersResponse(66996));
+
+        await userEvent.click(screen.getByRole('button', { name: /edit/ }));
+
+        const dialog = await screen.findByRole('dialog', { name: 'Filters' });
+
+        await userEvent.click(within(dialog).getByRole('combobox', { name: 'Order status' }));
+        await userEvent.click(screen.getByRole('option', { name: 'All Done' }));
+
+        await userEvent.click(screen.getByRole('button', { name: 'Apply' }));
+
+        await waitFor(() => {
+          expect(screen.getByRole('row', { name: /66996/ })).toBeInTheDocument();
+        });
+      });
+
+      it('filters by date range', async () => {
+        vi.setSystemTime(new Date('21 November 2022'));
+
+        const getOrders = vi
+          .fn()
+          .mockReturnValue(buildCompanyOrdersResponseWith('WHATEVER_VALUES'));
+
+        server.use(
+          graphql.query('GetCompanyOrders', ({ variables }) =>
+            HttpResponse.json(getOrders(variables)),
+          ),
+        );
+
+        renderWithProviders(<CompanyOrders />, { preloadedState: b2bStateWithFlag(flagOn) });
+
+        await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+        when(getOrders)
+          .calledWith(
+            expect.objectContaining({
+              filters: expect.objectContaining({
+                dateRange: { from: '2022-11-15', to: '2022-11-26' },
+              }),
+            }),
+          )
+          .thenReturn(filteredCompanyOrdersResponse(66996));
+
+        await userEvent.click(screen.getByRole('button', { name: /edit/ }));
+
+        const dialog = await screen.findByRole('dialog', { name: 'Filters' });
+
+        await userEvent.click(within(dialog).getByRole('textbox', { name: 'From' }));
+        await userEvent.click(screen.getByRole('gridcell', { name: /15/ }));
+
+        await userEvent.click(within(dialog).getByRole('textbox', { name: 'To' }));
+        await userEvent.click(screen.getByRole('gridcell', { name: /26/ }));
+
+        await userEvent.click(screen.getByRole('button', { name: 'Apply' }));
+
+        await waitFor(() => {
+          expect(screen.getByRole('row', { name: /66996/ })).toBeInTheDocument();
+        });
+      });
+
+      it('filters by status and date range together', async () => {
+        vi.setSystemTime(new Date('21 November 2022'));
+
+        const getOrders = vi
+          .fn()
+          .mockReturnValue(buildCompanyOrdersResponseWith('WHATEVER_VALUES'));
+
+        server.use(
+          graphql.query('GetOrderStatuses', () =>
+            HttpResponse.json(
+              buildLegacyB2BOrderStatusesResponseWith({
+                data: {
+                  orderStatuses: [
+                    buildLegacyOrderStatusWith({
+                      systemLabel: 'Pending',
+                      customLabel: 'Pending',
+                    }),
+                  ],
+                },
+              }),
+            ),
+          ),
+          graphql.query('GetCompanyOrders', ({ variables }) =>
+            HttpResponse.json(getOrders(variables)),
+          ),
+        );
+
+        renderWithProviders(<CompanyOrders />, { preloadedState: b2bStateWithFlag(flagOn) });
+
+        await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+        when(getOrders)
+          .calledWith(
+            expect.objectContaining({
+              filters: expect.objectContaining({
+                status: ['Pending'],
+                dateRange: { from: '2022-11-15', to: '2022-11-26' },
+              }),
+            }),
+          )
+          .thenReturn(filteredCompanyOrdersResponse(66996));
+
+        await userEvent.click(screen.getByRole('button', { name: /edit/ }));
+
+        const dialog = await screen.findByRole('dialog', { name: 'Filters' });
+
+        await userEvent.click(within(dialog).getByRole('combobox', { name: 'Order status' }));
+        await userEvent.click(screen.getByRole('option', { name: 'Pending' }));
+
+        await userEvent.click(within(dialog).getByRole('textbox', { name: 'From' }));
+        await userEvent.click(screen.getByRole('gridcell', { name: /15/ }));
+
+        await userEvent.click(within(dialog).getByRole('textbox', { name: 'To' }));
+        await userEvent.click(screen.getByRole('gridcell', { name: /26/ }));
+
+        await userEvent.click(screen.getByRole('button', { name: 'Apply' }));
+
+        await waitFor(() => {
+          expect(screen.getByRole('row', { name: /66996/ })).toBeInTheDocument();
         });
       });
     });

--- a/apps/storefront/src/pages/CompanyOrderList/unified-company-orders.test.tsx
+++ b/apps/storefront/src/pages/CompanyOrderList/unified-company-orders.test.tsx
@@ -388,7 +388,7 @@ describe('Company Orders — unified SF GQL orders (B2B-4616)', () => {
         await userEvent.type(screen.getByPlaceholderText('Search'), '66996');
 
         await waitFor(() => {
-          expect(screen.getByText('66996').closest('tr')!).toBeInTheDocument();
+          expect(screen.getByText('66996').closest('tr')!).toBeVisible();
         });
       });
 
@@ -429,7 +429,7 @@ describe('Company Orders — unified SF GQL orders (B2B-4616)', () => {
           )
           .thenReturn(filteredCompanyOrdersResponse(66996));
 
-        await userEvent.click(screen.getByRole('button', { name: /edit/ }));
+        await userEvent.click(screen.getByRole('button', { name: 'edit' }));
 
         const dialog = await screen.findByRole('dialog', { name: 'Filters' });
 
@@ -439,7 +439,7 @@ describe('Company Orders — unified SF GQL orders (B2B-4616)', () => {
         await userEvent.click(screen.getByRole('button', { name: 'Apply' }));
 
         await waitFor(() => {
-          expect(screen.getByRole('row', { name: /66996/ })).toBeInTheDocument();
+          expect(screen.getByText('66996').closest('tr')!).toBeVisible();
         });
       });
 
@@ -480,7 +480,7 @@ describe('Company Orders — unified SF GQL orders (B2B-4616)', () => {
           )
           .thenReturn(filteredCompanyOrdersResponse(66996));
 
-        await userEvent.click(screen.getByRole('button', { name: /edit/ }));
+        await userEvent.click(screen.getByRole('button', { name: 'edit' }));
 
         const dialog = await screen.findByRole('dialog', { name: 'Filters' });
 
@@ -490,7 +490,7 @@ describe('Company Orders — unified SF GQL orders (B2B-4616)', () => {
         await userEvent.click(screen.getByRole('button', { name: 'Apply' }));
 
         await waitFor(() => {
-          expect(screen.getByRole('row', { name: /66996/ })).toBeInTheDocument();
+          expect(screen.getByText('66996').closest('tr')!).toBeVisible();
         });
       });
 
@@ -521,20 +521,20 @@ describe('Company Orders — unified SF GQL orders (B2B-4616)', () => {
           )
           .thenReturn(filteredCompanyOrdersResponse(66996));
 
-        await userEvent.click(screen.getByRole('button', { name: /edit/ }));
+        await userEvent.click(screen.getByRole('button', { name: 'edit' }));
 
         const dialog = await screen.findByRole('dialog', { name: 'Filters' });
 
         await userEvent.click(within(dialog).getByRole('textbox', { name: 'From' }));
-        await userEvent.click(screen.getByRole('gridcell', { name: /15/ }));
+        await userEvent.click(screen.getByRole('gridcell', { name: '15' }));
 
         await userEvent.click(within(dialog).getByRole('textbox', { name: 'To' }));
-        await userEvent.click(screen.getByRole('gridcell', { name: /26/ }));
+        await userEvent.click(screen.getByRole('gridcell', { name: '26' }));
 
         await userEvent.click(screen.getByRole('button', { name: 'Apply' }));
 
         await waitFor(() => {
-          expect(screen.getByRole('row', { name: /66996/ })).toBeInTheDocument();
+          expect(screen.getByText('66996').closest('tr')!).toBeVisible();
         });
       });
 
@@ -580,7 +580,7 @@ describe('Company Orders — unified SF GQL orders (B2B-4616)', () => {
           )
           .thenReturn(filteredCompanyOrdersResponse(66996));
 
-        await userEvent.click(screen.getByRole('button', { name: /edit/ }));
+        await userEvent.click(screen.getByRole('button', { name: 'edit' }));
 
         const dialog = await screen.findByRole('dialog', { name: 'Filters' });
 
@@ -588,15 +588,15 @@ describe('Company Orders — unified SF GQL orders (B2B-4616)', () => {
         await userEvent.click(screen.getByRole('option', { name: 'Pending' }));
 
         await userEvent.click(within(dialog).getByRole('textbox', { name: 'From' }));
-        await userEvent.click(screen.getByRole('gridcell', { name: /15/ }));
+        await userEvent.click(screen.getByRole('gridcell', { name: '15' }));
 
         await userEvent.click(within(dialog).getByRole('textbox', { name: 'To' }));
-        await userEvent.click(screen.getByRole('gridcell', { name: /26/ }));
+        await userEvent.click(screen.getByRole('gridcell', { name: '26' }));
 
         await userEvent.click(screen.getByRole('button', { name: 'Apply' }));
 
         await waitFor(() => {
-          expect(screen.getByRole('row', { name: /66996/ })).toBeInTheDocument();
+          expect(screen.getByText('66996').closest('tr')!).toBeVisible();
         });
       });
     });


### PR DESCRIPTION
Jira: [B2B-4617](https://bigcommercecloud.atlassian.net/browse/B2B-4617)

## What/Why?

Adds verified test coverage for Company Orders status and date range filtering on the unified SF GQL path.

The filter logic was implemented in B2B-4616 via `useCompanyOrdersState.handleFilterChange`:
- **Status filter**: Resolves the selected status from the dropdown (which may be a custom merchant label) to `systemLabel`, wraps it in an array, and passes it as `CompanyOrdersFiltersInput.status: [String!]` — matching the gist contract which specifies "merchant-configured status labels, multiple values ORed"
- **Date range filter**: Packs `startValue`/`endValue` into `CompanyOrdersFiltersInput.dateRange: OrderDateRangeFilterInput` (`from` required, `to` optional) via `packDateRange()`
- **Status dropdown**: Continues to use legacy `getOrderStatusType()` B2B GQL query (no SF GQL equivalent yet — spike decision)
- **Pagination reset**: Automatically resets cursor pagination on any filter change

### Tests added (4 new)
- **Filters by status** — selects "Completed" from dropdown, verifies `filters.status: ['Completed']` sent to API
- **Resolves custom status label** — merchant displays "All Done", API receives `['Completed']` (systemLabel)
- **Filters by date range** — selects from/to dates, verifies `filters.dateRange: { from, to }` sent
- **Filters by status and date range together** — both filters combined in single request

## Rollout/Rollback

Behind existing feature flag `B2B-4613.buyer_portal_unified_sf_gql_orders`. When flag is off, Company Orders uses the legacy B2B Edition API path — fully unchanged. Rollback is disabling the flag.

## Testing

- All 12 unified company orders tests pass (8 from 3a + 4 new)
- All 32 legacy company orders tests pass (unchanged)
- All 87 My Orders tests pass (legacy + unified)
- TypeScript compiles cleanly (`tsc --noEmit`)
- ESLint passes with 0 warnings

**Stacks on:** PR #850 (`b2b-4616`)

[B2B-4617]: https://bigcommercecloud.atlassian.net/browse/B2B-4617?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes are confined to test code, expanding coverage for existing filtering behavior without altering production logic.
> 
> **Overview**
> Adds expanded test coverage for the **unified SF GQL Company Orders** path to verify filter requests are constructed correctly.
> 
> New tests assert `GetCompanyOrders` receives `filters.status` (including resolving a custom status label back to `systemLabel`) and `filters.dateRange` (and the combination of both), and refactors the existing search-filter test to reuse a shared `filteredCompanyOrdersResponse` fixture.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e3cfbf011779baa4026678483688d12ab6659b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->