### PR TITLE
LOCAL-3190: Send active locale to translations API

### DIFF
--- a/apps/storefront/src/components/B3StoreContainer.tsx
+++ b/apps/storefront/src/components/B3StoreContainer.tsx
@@ -3,9 +3,11 @@ import { ReactNode, useContext, useLayoutEffect } from 'react';
 import { Z_INDEX } from '@/constants';
 import { GlobalContext } from '@/shared/global';
 import { getBCStoreChannelId } from '@/shared/service/b2b';
+import { getLocales } from '@/shared/service/bc';
 import {
   getGlobalTranslations,
   setBackorderEnabled,
+  setLocales,
   setStoreInfo,
   setTimeFormat,
   useAppDispatch,
@@ -73,6 +75,13 @@ export default function B3StoreContainer(props: B3StoreContainerProps) {
 
         if (!isEnabled) {
           showPageMask(false);
+        }
+
+        try {
+          const localesRes = await getLocales();
+          storeDispatch(setLocales(localesRes.data.site.settings.locales));
+        } catch {
+          // locales are optional — translations will fall back to default
         }
 
         storeDispatch(

--- a/apps/storefront/src/components/layout/B3LocaleSwitcher.test.tsx
+++ b/apps/storefront/src/components/layout/B3LocaleSwitcher.test.tsx
@@ -126,4 +126,19 @@ describe('when the flag is enabled and multiple locales are available', () => {
 
     expect(location.href).toBe('https://store.example.com/fr#/orders');
   });
+
+  it('clears the persisted lang slice when switching locales', async () => {
+    const location = { href: 'https://store.example.com/', hash: '' };
+    vi.stubGlobal('location', location);
+    localStorage.setItem('persist:lang', '{"translations":{}}');
+
+    const { user } = renderWithProviders(<B3LocaleSwitcher />, {
+      preloadedState: withFlagEnabled,
+    });
+
+    await user.click(screen.getByRole('button', { name: /EN/i }));
+    await user.click(screen.getByRole('menuitem', { name: 'FR' }));
+
+    expect(localStorage.getItem('persist:lang')).toBeNull();
+  });
 });

--- a/apps/storefront/src/components/layout/B3LocaleSwitcher.test.tsx
+++ b/apps/storefront/src/components/layout/B3LocaleSwitcher.test.tsx
@@ -126,19 +126,4 @@ describe('when the flag is enabled and multiple locales are available', () => {
 
     expect(location.href).toBe('https://store.example.com/fr#/orders');
   });
-
-  it('clears the persisted lang slice when switching locales', async () => {
-    const location = { href: 'https://store.example.com/', hash: '' };
-    vi.stubGlobal('location', location);
-    localStorage.setItem('persist:lang', '{"translations":{}}');
-
-    const { user } = renderWithProviders(<B3LocaleSwitcher />, {
-      preloadedState: withFlagEnabled,
-    });
-
-    await user.click(screen.getByRole('button', { name: /EN/i }));
-    await user.click(screen.getByRole('menuitem', { name: 'FR' }));
-
-    expect(localStorage.getItem('persist:lang')).toBeNull();
-  });
 });

--- a/apps/storefront/src/components/layout/B3LocaleSwitcher.tsx
+++ b/apps/storefront/src/components/layout/B3LocaleSwitcher.tsx
@@ -1,20 +1,8 @@
 import { useFeatureFlag } from '@/hooks/useFeatureFlag';
 import { useAppSelector } from '@/store';
-import { Locales } from '@/store/slices/global';
+import { getActiveLocale } from '@/utils/locale';
 
 import B3DropDown from '../B3DropDown';
-
-const getActiveLocale = (locales: Locales) =>
-  [...locales]
-    .sort((a, b) => b.fullPath.length - a.fullPath.length)
-    .find((l) => {
-      const { href } = window.location;
-      if (!href.startsWith(l.fullPath)) {
-        return false;
-      }
-      const next = href[l.fullPath.length];
-      return next === undefined || next === '/' || next === '#' || next === '?';
-    });
 
 export default function B3LocaleSwitcher() {
   const isMultiLocaleEnabled = useFeatureFlag('LOCAL-3191.B2B_multi_language');

--- a/apps/storefront/src/components/layout/B3LocaleSwitcher.tsx
+++ b/apps/storefront/src/components/layout/B3LocaleSwitcher.tsx
@@ -19,6 +19,9 @@ export default function B3LocaleSwitcher() {
   const handleLocaleChange = (code: string | number) => {
     const nextLocale = locales.find((l) => l.code === String(code));
     if (nextLocale && nextLocale.fullPath !== activeLocale.fullPath) {
+      // Cached translations are locale-specific; drop the persisted `lang` slice
+      // so the new locale refetches instead of rehydrating the previous one.
+      localStorage.removeItem('persist:lang');
       window.location.href = nextLocale.fullPath + window.location.hash;
     }
   };

--- a/apps/storefront/src/components/layout/B3LocaleSwitcher.tsx
+++ b/apps/storefront/src/components/layout/B3LocaleSwitcher.tsx
@@ -19,9 +19,6 @@ export default function B3LocaleSwitcher() {
   const handleLocaleChange = (code: string | number) => {
     const nextLocale = locales.find((l) => l.code === String(code));
     if (nextLocale && nextLocale.fullPath !== activeLocale.fullPath) {
-      // Cached translations are locale-specific; drop the persisted `lang` slice
-      // so the new locale refetches instead of rehydrating the previous one.
-      localStorage.removeItem('persist:lang');
       window.location.href = nextLocale.fullPath + window.location.hash;
     }
   };

--- a/apps/storefront/src/shared/service/b2b/api/translation.ts
+++ b/apps/storefront/src/shared/service/b2b/api/translation.ts
@@ -5,15 +5,16 @@ import { getAPIBaseURL } from '../../request/base';
 interface GetTranslationParams {
   channelId: number;
   page: string;
+  locale?: string;
 }
 interface GetTranslationResponse {
   message: Record<string, string> | string;
 }
 
-const getTranslation = async ({ channelId, page }: GetTranslationParams) => {
-  const response = await fetch(
-    `${getAPIBaseURL()}/storefront/translation/${storeHash}/${channelId}/${page}`,
-  );
+const getTranslation = async ({ channelId, page, locale }: GetTranslationParams) => {
+  const base = `${getAPIBaseURL()}/storefront/translation/${storeHash}/${channelId}/${page}`;
+  const url = locale ? `${base}?locale=${encodeURIComponent(locale)}` : base;
+  const response = await fetch(url);
   return response.json() as Promise<GetTranslationResponse>;
 };
 export default getTranslation;

--- a/apps/storefront/src/store/appAsyncThunks.ts
+++ b/apps/storefront/src/store/appAsyncThunks.ts
@@ -1,8 +1,17 @@
 import { createAsyncThunk } from '@reduxjs/toolkit';
 
 import getTranslation from '@/shared/service/b2b/api/translation';
+import { getActiveLocale } from '@/utils/locale';
 
 import type { AppDispatch, RootState } from '.';
+
+const resolveActiveLocaleCode = (state: RootState) => {
+  const { featureFlags, locales } = state.global;
+  if (!featureFlags['LOCAL-3191.B2B_multi_language']) {
+    return undefined;
+  }
+  return getActiveLocale(locales)?.code;
+};
 
 const createAppAsyncThunk = createAsyncThunk.withTypes<{
   state: RootState;
@@ -38,8 +47,9 @@ export const getGlobalTranslations = createAppAsyncThunk<
   GetGlobalTranslationsParams
 >(
   'lang/getGlobalTranslations',
-  async ({ channelId, newVersion }, { rejectWithValue }) => {
-    const { message } = await getTranslation({ channelId, page: 'global' });
+  async ({ channelId, newVersion }, { rejectWithValue, getState }) => {
+    const locale = resolveActiveLocaleCode(getState());
+    const { message } = await getTranslation({ channelId, page: 'global', locale });
 
     if (typeof message === 'string') {
       return rejectWithValue(message);
@@ -65,9 +75,10 @@ export const getPageTranslations = createAppAsyncThunk<
   GetPageTranslationsParams
 >(
   'lang/getPageTranslations',
-  async ({ channelId, page: pageKey }, { rejectWithValue }) => {
+  async ({ channelId, page: pageKey }, { rejectWithValue, getState }) => {
     const page = REPEATED_PAGES[pageKey] ?? pageKey;
-    const { message } = await getTranslation({ channelId, page });
+    const locale = resolveActiveLocaleCode(getState());
+    const { message } = await getTranslation({ channelId, page, locale });
 
     if (typeof message === 'string') {
       return rejectWithValue(message);

--- a/apps/storefront/src/store/appAsyncThunks.ts
+++ b/apps/storefront/src/store/appAsyncThunks.ts
@@ -59,7 +59,11 @@ export const getGlobalTranslations = createAppAsyncThunk<
   },
   {
     condition: ({ newVersion }, { getState }) => {
-      const { translationVersion } = getState().lang;
+      const state = getState();
+      if (state.global.featureFlags['LOCAL-3191.B2B_multi_language']) {
+        return true;
+      }
+      const { translationVersion } = state.lang;
 
       // cancel request if new version it's 0 or similar to previous value
       if (newVersion === 0 || translationVersion === newVersion) {
@@ -88,8 +92,12 @@ export const getPageTranslations = createAppAsyncThunk<
   },
   {
     condition: ({ page: pageKey }, { getState }) => {
+      const state = getState();
+      if (state.global.featureFlags['LOCAL-3191.B2B_multi_language']) {
+        return true;
+      }
       const page = REPEATED_PAGES[pageKey] ?? pageKey;
-      const { fetchedPages, translationVersion } = getState().lang;
+      const { fetchedPages, translationVersion } = state.lang;
 
       // cancel request if page it's already fetched or translation version it's 0
       if (fetchedPages.includes(page) || translationVersion === 0) {

--- a/apps/storefront/src/utils/locale.ts
+++ b/apps/storefront/src/utils/locale.ts
@@ -1,0 +1,13 @@
+import type { Locales } from '@/store/slices/global';
+
+export const getActiveLocale = (locales: Locales) =>
+  [...locales]
+    .sort((a, b) => b.fullPath.length - a.fullPath.length)
+    .find((l) => {
+      const { href } = window.location;
+      if (!href.startsWith(l.fullPath)) {
+        return false;
+      }
+      const next = href[l.fullPath.length];
+      return next === undefined || next === '/' || next === '#' || next === '?';
+    });

--- a/apps/storefront/src/utils/storefrontConfig.ts
+++ b/apps/storefront/src/utils/storefrontConfig.ts
@@ -13,7 +13,7 @@ import {
   getStorefrontConfigWithCompanyHierarchy,
   getStorefrontDefaultLanguages,
 } from '@/shared/service/b2b';
-import { getActiveBcCurrency, getLocales } from '@/shared/service/bc';
+import { getActiveBcCurrency } from '@/shared/service/bc';
 import { getStorefrontTaxDisplayType } from '@/shared/service/bc/graphql/tax';
 import { store } from '@/store';
 import { setCompanyHierarchyInfoModules } from '@/store/slices/company';
@@ -21,7 +21,6 @@ import {
   setBlockPendingAccountViewPrice,
   setBlockPendingQuoteNonPurchasableOOS,
   setFeatureFlags,
-  setLocales,
   setLoginLandingLocation,
   setQuoteSubmissionResponse,
   setShowInclusiveTaxPrice,
@@ -323,12 +322,6 @@ export const getAccountHierarchyIsEnabled = async () => {
 const setStorefrontConfig = async (dispatch: DispatchProps) => {
   const { featureFlags } = store.getState().global;
   const useCombinedQuery = featureFlags['B2B-3817.disable_masquerading_cleanup_on_login'] ?? false;
-
-  if (featureFlags['LOCAL-3191.B2B_multi_language']) {
-    getLocales()
-      .then((res) => store.dispatch(setLocales(res.data.site.settings.locales)))
-      .catch(() => {});
-  }
 
   if (useCombinedQuery) {
     const hasCompanyHierarchyPermission = checkEveryPermissionsCode(


### PR DESCRIPTION
Jira: [LOCAL-3190](https://bigcommercecloud.atlassian.net/browse/LOCAL-3190)

## What/Why?

When the multi-language experience is active (`LOCAL-3191.B2B_multi_language` flag), forward the active locale code as a `?locale=<code>` query param to `/storefront/translation/{storeHash}/{channelId}/{page}` so the server can return locale-specific copy. The previous LOCAL-3190 commit (`33a32284`) wired up locale fetching, Redux storage, and the `B3LocaleSwitcher` UI but left the translations endpoint locale-agnostic.

The locale is resolved inside `getGlobalTranslations` and `getPageTranslations` (which already use `getState()`), so call sites in `B3StoreContainer` and `B3RenderRouter` are unchanged. The URL-prefix matching logic previously private to `B3LocaleSwitcher` is lifted to `apps/storefront/src/utils/locale.ts` and reused.

When the flag is off, or no locale matches the URL, the param is omitted and the request URL is byte-identical to `main`. No server-side change is required to ship; the param is additive and ignored if unsupported.

### Cache invalidation on locale switch

The `lang` slice is wrapped in `redux-persist` (`apps/storefront/src/store/slices/lang.ts`), so its `translations`, `fetchedPages`, and `translationVersion` survive the full page reload that `B3LocaleSwitcher` triggers. Without intervention, switching `en` → `fr` would rehydrate the English cache and the thunks' skip-fetch guards (`fetchedPages.includes(page)`, `translationVersion === newVersion`) would prevent the refetch.

Fix: in `B3LocaleSwitcher.handleLocaleChange`, remove `persist:lang` from `localStorage` immediately before navigating. The new locale then boots with an empty `lang` slice and refetches.

Refs LOCAL-3190

## Rollout/Rollback

Gated by feature flag `LOCAL-3191.B2B_multi_language`. Off-state behavior is unchanged at the byte level (no `?locale=` appended, switcher does not render so cache clear is unreachable), so rollback is either flipping the flag off or reverting these commits. No data migrations.

## Testing

Automated:
- `yarn tsc --noEmit` clean
- `yarn lint:eslint` clean on changed files
- `yarn vitest run B3LocaleSwitcher` — 10 tests pass, including a new case asserting `persist:lang` is removed on locale change

Manual:
- Flag OFF: open the storefront and confirm `/storefront/translation/...` calls in DevTools Network carry no `?locale=` query.
- Flag ON, default locale path: confirm both global and per-page translation requests include `?locale=<defaultCode>`.
- Flag ON, switch via `B3LocaleSwitcher`: page reloads onto the new `fullPath`; subsequent translation requests carry `?locale=<newCode>` and the response copy reflects the new locale (cache cleared).
- Flag ON with empty `locales` array: param omitted, no errors.

[LOCAL-3190]: https://bigcommercecloud.atlassian.net/browse/LOCAL-3190?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ