### PR TITLE
test(orders): B2B-4618 add Company Orders full-text search tests

### DIFF
--- a/apps/storefront/src/pages/CompanyOrderList/unified-company-orders.test.tsx
+++ b/apps/storefront/src/pages/CompanyOrderList/unified-company-orders.test.tsx
@@ -425,7 +425,7 @@ describe('Company Orders — unified SF GQL orders (B2B-4616)', () => {
         await userEvent.clear(searchInput);
 
         await waitFor(() => {
-          const calls = getOrders.mock.calls;
+          const { calls } = getOrders.mock;
           const lastCall = calls[calls.length - 1]?.[0];
           expect(lastCall?.filters).not.toHaveProperty('search');
         });

--- a/apps/storefront/src/pages/CompanyOrderList/unified-company-orders.test.tsx
+++ b/apps/storefront/src/pages/CompanyOrderList/unified-company-orders.test.tsx
@@ -392,6 +392,109 @@ describe('Company Orders — unified SF GQL orders (B2B-4616)', () => {
         });
       });
 
+      it('clears search and removes the filter from the query', async () => {
+        const getOrders = vi
+          .fn()
+          .mockReturnValue(buildCompanyOrdersResponseWith('WHATEVER_VALUES'));
+
+        server.use(
+          graphql.query('GetCompanyOrders', ({ variables }) =>
+            HttpResponse.json(getOrders(variables)),
+          ),
+        );
+
+        renderWithProviders(<CompanyOrders />, { preloadedState: b2bStateWithFlag(flagOn) });
+
+        await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+        when(getOrders)
+          .calledWith(
+            expect.objectContaining({
+              filters: expect.objectContaining({ search: 'temp' }),
+            }),
+          )
+          .thenReturn(filteredCompanyOrdersResponse(11111));
+
+        const searchInput = screen.getByPlaceholderText('Search');
+        await userEvent.type(searchInput, 'temp');
+
+        await waitFor(() => {
+          expect(screen.getByText('11111').closest('tr')!).toBeVisible();
+        });
+
+        await userEvent.clear(searchInput);
+
+        await waitFor(() => {
+          const lastCall = getOrders.mock.calls.at(-1)?.[0];
+          expect(lastCall?.filters).not.toHaveProperty('search');
+        });
+      });
+
+      it('composes search with status and date range filters', async () => {
+        vi.setSystemTime(new Date('21 November 2022'));
+
+        const getOrders = vi
+          .fn()
+          .mockReturnValue(buildCompanyOrdersResponseWith('WHATEVER_VALUES'));
+
+        server.use(
+          graphql.query('GetOrderStatuses', () =>
+            HttpResponse.json(
+              buildLegacyB2BOrderStatusesResponseWith({
+                data: {
+                  orderStatuses: [
+                    buildLegacyOrderStatusWith({
+                      systemLabel: 'Completed',
+                      customLabel: 'Completed',
+                    }),
+                  ],
+                },
+              }),
+            ),
+          ),
+          graphql.query('GetCompanyOrders', ({ variables }) =>
+            HttpResponse.json(getOrders(variables)),
+          ),
+        );
+
+        renderWithProviders(<CompanyOrders />, { preloadedState: b2bStateWithFlag(flagOn) });
+
+        await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+        when(getOrders)
+          .calledWith(
+            expect.objectContaining({
+              filters: expect.objectContaining({
+                search: 'PO-42',
+                status: ['Completed'],
+                dateRange: { from: '2022-11-15', to: '2022-11-26' },
+              }),
+            }),
+          )
+          .thenReturn(filteredCompanyOrdersResponse(99999));
+
+        await userEvent.type(screen.getByPlaceholderText('Search'), 'PO-42');
+
+        await userEvent.click(screen.getByRole('button', { name: 'edit' }));
+
+        const dialog = await screen.findByRole('dialog', { name: 'Filters' });
+
+        await userEvent.click(within(dialog).getByRole('combobox', { name: 'Order status' }));
+        await userEvent.click(screen.getByRole('option', { name: 'Completed' }));
+
+        await userEvent.click(within(dialog).getByRole('textbox', { name: 'From' }));
+        await userEvent.click(screen.getByRole('gridcell', { name: '15' }));
+
+        await userEvent.click(within(dialog).getByRole('textbox', { name: 'To' }));
+        await userEvent.click(screen.getByRole('gridcell', { name: '26' }));
+
+        await userEvent.click(screen.getByRole('button', { name: 'Apply' }));
+
+        await waitFor(() => {
+          expect(screen.getByText('99999').closest('tr')!).toBeVisible();
+        });
+      });
+
       it('filters by status', async () => {
         const getOrders = vi
           .fn()

--- a/apps/storefront/src/pages/CompanyOrderList/unified-company-orders.test.tsx
+++ b/apps/storefront/src/pages/CompanyOrderList/unified-company-orders.test.tsx
@@ -425,7 +425,8 @@ describe('Company Orders — unified SF GQL orders (B2B-4616)', () => {
         await userEvent.clear(searchInput);
 
         await waitFor(() => {
-          const lastCall = getOrders.mock.calls.at(-1)?.[0];
+          const calls = getOrders.mock.calls;
+          const lastCall = calls[calls.length - 1]?.[0];
           expect(lastCall?.filters).not.toHaveProperty('search');
         });
       });


### PR DESCRIPTION
Jira: [B2B-4618](https://bigcommercecloud.atlassian.net/browse/B2B-4618)

## What/Why?

Adds dedicated functional tests for Company Orders full-text search, completing the test coverage for B2B-4618 (3c).

The search wiring (`CompanyOrdersFiltersInput.search`) was already implemented as part of B2B-4616 (3a) and the basic happy-path test shipped with B2B-4617 (3b). This PR adds two edge-case tests that validate:

- **Search clearing** — verifies that clearing the search input removes `search` from the query filters (sends `undefined`, not empty string)
- **Filter composition** — verifies search composes correctly with status and date range filters in a single query, confirming all three filter types are AND-composed

### Test summary

| # | Test | Validates |
|---|---|---|
| 1 | `clears search and removes the filter from the query` | `handleSearchChange` sets `search: undefined` when input is cleared |
| 2 | `composes search with status and date range filters` | All three filter types compose correctly in `CompanyOrdersFiltersInput` |

Total Company Orders tests: 14 (12 existing + 2 new)

## Rollout/Rollback

Test-only change. No runtime impact. Behind feature flag `B2B-4613.buyer_portal_unified_sf_gql_orders`.

## Testing

```
cd apps/storefront
npx vitest run src/pages/CompanyOrderList/unified-company-orders.test.tsx
```

All 14 tests pass.

[B2B-4618]: https://bigcommercecloud.atlassian.net/browse/B2B-4618?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to frontend Vitest coverage and do not affect runtime behavior. Risk is mainly around potential test flakiness due to timer/date handling and mocked GraphQL variable assertions.
> 
> **Overview**
> Adds two new functional tests for the unified SF GQL Company Orders list to validate **search edge cases**.
> 
> The suite now verifies that clearing the search input removes `filters.search` from the `GetCompanyOrders` query (rather than sending an empty string) and that `search` correctly composes with `status` and `dateRange` filters in a single request.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a40d5c7733ff01b4ef87b7fec4aaf2ff32fd205. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->