### PR TITLE
[B2B-4620] Surface total count in Company Orders pagination

### DIFF
--- a/apps/storefront/src/pages/CompanyOrderList/unified-company-orders.test.tsx
+++ b/apps/storefront/src/pages/CompanyOrderList/unified-company-orders.test.tsx
@@ -637,7 +637,7 @@ describe('Company Orders — unified SF GQL orders (B2B-4616)', () => {
             startCursor: 'cursor-1001',
             endCursor: 'cursor-1002',
           },
-          4,
+          20,
         );
 
         const getOrders = vi.fn().mockReturnValue(page1Response);
@@ -653,7 +653,7 @@ describe('Company Orders — unified SF GQL orders (B2B-4616)', () => {
                 startCursor: 'cursor-2001',
                 endCursor: 'cursor-2002',
               },
-              4,
+              20,
             ),
           );
 
@@ -707,7 +707,7 @@ describe('Company Orders — unified SF GQL orders (B2B-4616)', () => {
             startCursor: 'cursor-1001',
             endCursor: 'cursor-1001',
           },
-          2,
+          20,
         );
 
         const getOrders = vi.fn().mockReturnValue(page1Response);
@@ -723,7 +723,7 @@ describe('Company Orders — unified SF GQL orders (B2B-4616)', () => {
                 startCursor: 'cursor-2001',
                 endCursor: 'cursor-2001',
               },
-              2,
+              20,
             ),
           );
 

--- a/apps/storefront/src/pages/CompanyOrderList/unified-company-orders.test.tsx
+++ b/apps/storefront/src/pages/CompanyOrderList/unified-company-orders.test.tsx
@@ -675,6 +675,29 @@ describe('Company Orders — unified SF GQL orders (B2B-4616)', () => {
         });
       });
 
+      it('displays total count from collectionInfo.totalItems', async () => {
+        const response = buildPagedResponse(
+          [{ entityId: 3001 }, { entityId: 3002 }],
+          {
+            hasNextPage: true,
+            hasPreviousPage: false,
+            startCursor: 'cursor-3001',
+            endCursor: 'cursor-3002',
+          },
+          42,
+        );
+
+        server.use(graphql.query('GetCompanyOrders', () => HttpResponse.json(response)));
+
+        renderWithProviders(<CompanyOrders />, { preloadedState: b2bStateWithFlag(flagOn) });
+
+        await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+        await waitFor(() => {
+          expect(screen.getByText(/of 42/)).toBeInTheDocument();
+        });
+      });
+
       it('passes before cursor when navigating to the previous page', async () => {
         const page1Response = buildPagedResponse(
           [{ entityId: 1001 }],

--- a/apps/storefront/src/pages/order/Order.tsx
+++ b/apps/storefront/src/pages/order/Order.tsx
@@ -412,6 +412,9 @@ function Order({ isCompanyOrder = false }: OrderProps) {
     if (!data || !isUnifiedOrders) return;
     const pageInfo = 'pageInfo' in data ? (data as { pageInfo: PageInfo | null }).pageInfo : null;
     if (pageInfo) unifiedState.updatePageInfo(pageInfo);
+    if (isUnifiedCompanyPath && 'totalCount' in data && typeof data.totalCount === 'number') {
+      unifiedState.updateTotalCount(data.totalCount);
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [dataUpdatedAt, isUnifiedOrders]);
 

--- a/apps/storefront/src/pages/order/useUnifiedOrdersPagination.ts
+++ b/apps/storefront/src/pages/order/useUnifiedOrdersPagination.ts
@@ -31,6 +31,7 @@ export interface UseUnifiedOrdersPaginationResult {
   handlePageChange: (direction: 'next' | 'prev') => void;
   handlePageSizeChange: (size: number) => void;
   updatePageInfo: (info: PageInfo) => void;
+  updateTotalCount: (count: number) => void;
 }
 
 export const useUnifiedOrdersPagination = (): UseUnifiedOrdersPaginationResult => {
@@ -38,6 +39,7 @@ export const useUnifiedOrdersPagination = (): UseUnifiedOrdersPaginationResult =
   const [pageSize, setPageSize] = useState(DEFAULT_PAGE_SIZE);
   const [pageInfo, setPageInfo] = useState<PageInfo | null>(null);
   const [currentPage, setCurrentPage] = useState(0);
+  const [totalCount, setTotalCount] = useState(-1);
 
   const paginationVariables = useMemo<PaginationVariables>(
     () =>
@@ -51,6 +53,7 @@ export const useUnifiedOrdersPagination = (): UseUnifiedOrdersPaginationResult =
     setCursors({});
     setCurrentPage(0);
     setPageInfo(null);
+    setTotalCount(-1);
   }, []);
 
   const handlePageChange = useCallback(
@@ -80,9 +83,13 @@ export const useUnifiedOrdersPagination = (): UseUnifiedOrdersPaginationResult =
     setPageInfo(info);
   }, []);
 
+  const updateTotalCount = useCallback((count: number) => {
+    setTotalCount(count);
+  }, []);
+
   const b3TablePaginationProps = useMemo(
     () => ({
-      pagination: { offset: currentPage * pageSize, first: pageSize, count: -1 },
+      pagination: { offset: currentPage * pageSize, first: pageSize, count: totalCount },
       cursorPageInfo: {
         hasNextPage: pageInfo?.hasNextPage ?? false,
         hasPreviousPage: pageInfo?.hasPreviousPage ?? false,
@@ -98,7 +105,7 @@ export const useUnifiedOrdersPagination = (): UseUnifiedOrdersPaginationResult =
         }
       },
     }),
-    [currentPage, pageSize, pageInfo, handlePageChange, handlePageSizeChange],
+    [currentPage, pageSize, pageInfo, totalCount, handlePageChange, handlePageSizeChange],
   );
 
   return {
@@ -111,5 +118,6 @@ export const useUnifiedOrdersPagination = (): UseUnifiedOrdersPaginationResult =
     handlePageChange,
     handlePageSizeChange,
     updatePageInfo,
+    updateTotalCount,
   };
 };


### PR DESCRIPTION
Jira: [B2B-4620](https://bigcommercecloud.atlassian.net/browse/B2B-4620)

## What/Why?

Surfaces `collectionInfo.totalItems` from the `CompanyOrdersConnection` into the pagination display for Company Orders.

The cursor pagination hook (`useUnifiedOrdersPagination`) was built for My Orders which lacks `collectionInfo`, so it hardcoded `count: -1` — hiding the total count even on Company Orders where the API provides it. This PR:

- Adds `updateTotalCount` to the pagination hook, making `count` dynamic
- Wires `data.totalCount` from `fetchUnifiedCompanyOrders` into the hook via `Order.tsx`
- Resets total count on pagination reset (filter/sort changes)
- Company Orders now shows "1–10 of 42" instead of just "1–10"
- My Orders is unaffected (still shows range-only since `collectionInfo` isn't available)

### AC verification

| # | AC | Status |
|---|---|---|
| 1 | `first`/`after` forward, `last`/`before` backward | Already met (B2B-4616) |
| 2 | Page size selector maps to `first`/`last` | Already met (B2B-4616) |
| 3 | `endCursor`/`startCursor` for cursor args | Already met (B2B-4616) |
| 4 | `hasNextPage`/`hasPreviousPage` control buttons | Already met (B2B-4616) |
| 5 | Total count from `collectionInfo.totalItems` | **This PR** |
| 6 | Filter/sort changes reset pagination | Already met (B2B-4616) |
| 7 | Shared pagination with My Orders (2c) | Already met — same hook |
| 8 | Consistent UI behavior | Already met |

## Rollout/Rollback

Behind feature flag `B2B-4613.buyer_portal_unified_sf_gql_orders`. No runtime impact when flag is off.

## Testing

```
cd apps/storefront
npx vitest run src/pages/CompanyOrderList/unified-company-orders.test.tsx
```

All 13 tests pass. New test: "displays total count from collectionInfo.totalItems" verifies pagination shows "of 42" when `totalItems: 42`.

[B2B-4620]: https://bigcommercecloud.atlassian.net/browse/B2B-4620?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: wires an additional `totalCount` field into existing pagination state and UI, with changes scoped to unified company orders plus a test update.
> 
> **Overview**
> Company Orders pagination now surfaces the backend-provided total via `collectionInfo.totalItems` (shown as `of N`), instead of always hiding the count.
> 
> This extends `useUnifiedOrdersPagination` to track/reset a dynamic `count` and updates `Order.tsx` to push `data.totalCount` into pagination state on the unified company-orders path. Tests are updated to use a realistic `totalItems` value and add coverage asserting the total count display.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6267df665fd23a383a2b3a386652b4599c405c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->