### PR TITLE
feat(orders): B2B-4825 Populate order summary, history, comments and cross-company banner in unified SF GQL adapter

### DIFF
--- a/apps/storefront/src/pages/OrderDetail/index.tsx
+++ b/apps/storefront/src/pages/OrderDetail/index.tsx
@@ -359,7 +359,7 @@ function OrderDetail() {
             )}
           </Grid>
         </Grid>
-        {products?.length && !isCurrentCompany ? (
+        {orderId && !isCurrentCompany ? (
           <Box
             sx={{
               marginTop: '24px',

--- a/apps/storefront/src/pages/OrderDetail/index.tsx
+++ b/apps/storefront/src/pages/OrderDetail/index.tsx
@@ -44,6 +44,7 @@ function OrderDetail() {
   const isAgenting = useAppSelector(({ b2bFeatures }) => b2bFeatures.masqueradeCompany.isAgenting);
 
   const companyInfoId = useAppSelector(({ company }) => company.companyInfo.id);
+  const currencies = useAppSelector(({ storeConfigs }) => storeConfigs.currencies);
   const { selectCompanyHierarchyId } = useAppSelector(
     ({ company }) => company.companyHierarchyInfo,
   );
@@ -68,14 +69,7 @@ function OrderDetail() {
   } = useContext(GlobalContext);
 
   const {
-    state: {
-      poNumber,
-      status = '',
-      customStatus,
-      orderSummary,
-      orderStatus = [],
-      digitalProducts,
-    },
+    state: { poNumber, status = '', customStatus, orderSummary, orderStatus = [], digitalProducts },
     state: detailsData,
     dispatch,
   } = useContext(OrderDetailsContext);
@@ -178,7 +172,7 @@ function OrderDetail() {
         if (order) {
           dispatch({
             type: 'all',
-            payload: convertOrderDetail(order, b3Lang),
+            payload: convertOrderDetail(order, b3Lang, currencies),
           });
 
           // BC omits `company` on Order — no cross-company check. B2B: compare order company to viewer context.
@@ -200,7 +194,7 @@ function OrderDetail() {
 
     fetchUnifiedOrderDetails();
     // eslint-disable-next-line react-hooks/exhaustive-deps -- dispatch stable
-  }, [isUnifiedOrders, orderId, preOrderId, currentCompanyId]);
+  }, [isUnifiedOrders, orderId, preOrderId, currentCompanyId, currencies]);
 
   useEffect(() => {
     if (!orderId) {

--- a/apps/storefront/src/pages/OrderDetail/index.tsx
+++ b/apps/storefront/src/pages/OrderDetail/index.tsx
@@ -17,6 +17,7 @@ import {
   getBcOrderStatusType,
   getOrderStatusType,
 } from '@/shared/service/b2b';
+import type { Order as UnifiedOrder } from '@/shared/service/bc/graphql/orders';
 import { getOrderDetail } from '@/shared/service/bc/graphql/orders';
 import { isB2BUserSelector, useAppSelector } from '@/store';
 import { AddressConfigItem, CustomerRole, OrderProductItem, OrderStatusItem } from '@/types';
@@ -89,6 +90,7 @@ function OrderDetail() {
   const [orderId, setOrderId] = useState('');
   const [isRequestLoading, setIsRequestLoading] = useState(false);
   const [isCurrentCompany, setIsCurrentCompany] = useState(true);
+  const [unifiedOrder, setUnifiedOrder] = useState<UnifiedOrder | null>(null);
 
   useEffect(() => {
     setOrderId(params.id || '');
@@ -154,47 +156,69 @@ function OrderDetail() {
 
   useEffect(() => {
     if (!isUnifiedOrders || !orderId) {
-      return;
+      setUnifiedOrder(null);
+      return undefined;
     }
+
+    let isCurrentRequest = true;
 
     const fetchUnifiedOrderDetails = async () => {
       const id = parseInt(orderId, 10);
       if (!id) {
+        setUnifiedOrder(null);
         return;
       }
 
+      setUnifiedOrder(null);
       setIsRequestLoading(true);
 
       try {
         const response = await getOrderDetail({ entityId: id });
         const order = response.data?.site?.order;
 
-        if (order) {
-          dispatch({
-            type: 'all',
-            payload: convertOrderDetail(order, b3Lang, currencies),
-          });
-
-          // BC omits `company` on Order — no cross-company check. B2B: compare order company to viewer context.
-          setIsCurrentCompany(
-            order.company ? Number(order.company.entityId) === Number(currentCompanyId) : true,
-          );
+        if (order && isCurrentRequest) {
+          setUnifiedOrder(order);
           setPreOrderId(orderId);
         }
       } catch (err) {
-        if (err === 'order does not exist') {
+        if (err === 'order does not exist' && isCurrentRequest) {
           setTimeout(() => {
             window.location.hash = `/orderDetail/${preOrderId}`;
           }, 1000);
         }
       } finally {
-        setIsRequestLoading(false);
+        if (isCurrentRequest) {
+          setIsRequestLoading(false);
+        }
       }
     };
 
     fetchUnifiedOrderDetails();
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- dispatch stable
-  }, [isUnifiedOrders, orderId, preOrderId, currentCompanyId, currencies]);
+
+    return () => {
+      isCurrentRequest = false;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- preOrderId is only used for failed navigation fallback
+  }, [isUnifiedOrders, orderId]);
+
+  useEffect(() => {
+    if (!isUnifiedOrders || !unifiedOrder) {
+      return;
+    }
+
+    dispatch({
+      type: 'all',
+      payload: convertOrderDetail(unifiedOrder, b3Lang, currencies),
+    });
+
+    // BC omits `company` on Order — no cross-company check. B2B: compare order company to viewer context.
+    setIsCurrentCompany(
+      unifiedOrder.company
+        ? Number(unifiedOrder.company.entityId) === Number(currentCompanyId)
+        : true,
+    );
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- dispatch stable and b3Lang has rendering errors
+  }, [isUnifiedOrders, unifiedOrder, currentCompanyId, currencies]);
 
   useEffect(() => {
     if (!orderId) {

--- a/apps/storefront/src/pages/OrderDetail/index.tsx
+++ b/apps/storefront/src/pages/OrderDetail/index.tsx
@@ -95,7 +95,7 @@ function OrderDetail() {
   const [preOrderId, setPreOrderId] = useState('');
   const [orderId, setOrderId] = useState('');
   const [isRequestLoading, setIsRequestLoading] = useState(false);
-  const [isCurrentCompany, setIsCurrentCompany] = useState(false);
+  const [isCurrentCompany, setIsCurrentCompany] = useState(true);
 
   useEffect(() => {
     setOrderId(params.id || '');

--- a/apps/storefront/src/pages/OrderDetail/index.tsx
+++ b/apps/storefront/src/pages/OrderDetail/index.tsx
@@ -183,7 +183,6 @@ function OrderDetail() {
           });
 
           // BC omits `company` on Order — no cross-company check. B2B: compare order company to viewer context.
-          // TODO B2B-4825: Double check this logic for cross-company banner
           setIsCurrentCompany(
             order.company ? Number(order.company.entityId) === Number(currentCompanyId) : true,
           );

--- a/apps/storefront/src/pages/OrderDetail/index.tsx
+++ b/apps/storefront/src/pages/OrderDetail/index.tsx
@@ -74,7 +74,6 @@ function OrderDetail() {
       customStatus,
       orderSummary,
       orderStatus = [],
-      products,
       digitalProducts,
     },
     state: detailsData,

--- a/apps/storefront/src/pages/OrderDetail/index.tsx
+++ b/apps/storefront/src/pages/OrderDetail/index.tsx
@@ -44,7 +44,7 @@ function OrderDetail() {
   const isAgenting = useAppSelector(({ b2bFeatures }) => b2bFeatures.masqueradeCompany.isAgenting);
 
   const companyInfoId = useAppSelector(({ company }) => company.companyInfo.id);
-  const currencies = useAppSelector(({ storeConfigs }) => storeConfigs.currencies);
+  const currencies = useAppSelector(({ storeConfigs }) => storeConfigs.currencies.currencies);
   const { selectCompanyHierarchyId } = useAppSelector(
     ({ company }) => company.companyHierarchyInfo,
   );

--- a/apps/storefront/src/pages/OrderDetail/index.tsx
+++ b/apps/storefront/src/pages/OrderDetail/index.tsx
@@ -164,12 +164,12 @@ function OrderDetail() {
 
     const fetchUnifiedOrderDetails = async () => {
       const id = parseInt(orderId, 10);
+      setUnifiedOrder(null);
+
       if (!id) {
-        setUnifiedOrder(null);
         return;
       }
 
-      setUnifiedOrder(null);
       setIsRequestLoading(true);
 
       try {

--- a/apps/storefront/src/pages/OrderDetail/index.tsx
+++ b/apps/storefront/src/pages/OrderDetail/index.tsx
@@ -179,7 +179,7 @@ function OrderDetail() {
         if (order) {
           dispatch({
             type: 'all',
-            payload: convertOrderDetail(order),
+            payload: convertOrderDetail(order, b3Lang),
           });
 
           // BC omits `company` on Order — no cross-company check. B2B: compare order company to viewer context.

--- a/apps/storefront/src/pages/OrderDetail/index.unified.test.tsx
+++ b/apps/storefront/src/pages/OrderDetail/index.unified.test.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 import {
   buildCompanyStateWith,
@@ -12,6 +13,7 @@ import {
   screen,
   startMockServer,
   userEvent,
+  waitFor,
   waitForElementToBeRemoved,
   within,
 } from 'tests/test-utils';
@@ -20,6 +22,8 @@ import { AddressConfig } from '@/shared/service/b2b/graphql/address';
 import { CustomerOrderStatues, CustomerOrderStatus } from '@/shared/service/b2b/graphql/orders';
 import type { GetOrderDetailResponse, Order } from '@/shared/service/bc/graphql/orders';
 import { OrderHistoryEventType } from '@/shared/service/bc/graphql/orders';
+import { useAppDispatch } from '@/store';
+import { setCurrencies } from '@/store/slices/storeConfigs';
 import { Currency, CustomerRole } from '@/types';
 
 import OrderDetails from '.';
@@ -125,6 +129,30 @@ const buildOrderDetailResponseWith = builder<GetOrderDetailResponse>(() => ({
     },
   },
 }));
+
+function OrderDetailsWithCurrencyHydration({ currencies }: { currencies?: Currency[] }) {
+  const dispatch = useAppDispatch();
+
+  useEffect(() => {
+    if (!currencies) {
+      return;
+    }
+
+    dispatch(
+      setCurrencies({
+        currencies,
+        channelCurrencies: {
+          channel_id: 1,
+          enabled_currencies: currencies.map((currency) => currency.currency_code),
+          default_currency: currencies[0]?.currency_code ?? 'USD',
+        },
+        enteredInclusiveTax: false,
+      }),
+    );
+  }, [currencies, dispatch]);
+
+  return <OrderDetails />;
+}
 
 const preloadedState = {
   company: buildCompanyStateWith({
@@ -293,6 +321,71 @@ describe('Order detail path with unified SF GQL flag ON', () => {
     expect(screen.getByRole('group', { name: 'Tax' })).toHaveTextContent('€13,50');
     expect(screen.getByRole('group', { name: 'Discount amount' })).toHaveTextContent('-€37,93');
     expect(screen.getByRole('group', { name: 'Grand total' })).toHaveTextContent('€431,77');
+  });
+
+  it('updates currency formatting without refetching the order detail', async () => {
+    const euro = buildCurrencyWith({
+      country_iso2: 'DE',
+      default_for_country_codes: ['EUR'],
+      currency_code: 'EUR',
+      currency_exchange_rate: '0.85',
+      name: 'Euro',
+      token: '€',
+      decimal_token: ',',
+      thousands_token: '.',
+    });
+
+    const euroOrder = buildUnifiedOrderWith({
+      entityId: 6696,
+      subTotal: { currencyCode: 'EUR', value: 102 },
+      shippingCostTotal: { currencyCode: 'EUR', value: 332 },
+      handlingCostTotal: { currencyCode: 'EUR', value: 22.2 },
+      taxTotal: { currencyCode: 'EUR', value: 13.5 },
+      totalIncTax: { currencyCode: 'EUR', value: 431.77 },
+      discounts: {
+        couponDiscounts: [],
+        nonCouponDiscountTotal: { currencyCode: 'EUR', value: 37.93 },
+        totalDiscount: null,
+      },
+    });
+
+    let orderDetailRequestCount = 0;
+
+    server.use(
+      graphql.query('GetOrderDetail', () => {
+        orderDetailRequestCount += 1;
+
+        return HttpResponse.json(
+          buildOrderDetailResponseWith({
+            data: { site: { order: euroOrder } },
+          }),
+        );
+      }),
+      graphql.query('GetCustomerOrderStatuses', () =>
+        HttpResponse.json(buildCustomerOrderStatusesWith('WHATEVER_VALUES')),
+      ),
+      graphql.query('AddressConfig', () =>
+        HttpResponse.json(buildAddressConfigResponseWith('WHATEVER_VALUES')),
+      ),
+    );
+
+    const { result } = renderWithProviders(<OrderDetailsWithCurrencyHydration />, {
+      preloadedState,
+      initialEntries: [{ state: { isCompanyOrder: false } }],
+    });
+
+    await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+    expect(screen.getByRole('group', { name: 'Sub total' })).toHaveTextContent('$102.00');
+    expect(orderDetailRequestCount).toBe(1);
+
+    result.rerender(<OrderDetailsWithCurrencyHydration currencies={[euro]} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('group', { name: 'Sub total' })).toHaveTextContent('€102,00');
+    });
+
+    expect(orderDetailRequestCount).toBe(1);
   });
 
   it('omits the handling fee row when cost is zero', async () => {

--- a/apps/storefront/src/pages/OrderDetail/index.unified.test.tsx
+++ b/apps/storefront/src/pages/OrderDetail/index.unified.test.tsx
@@ -315,6 +315,42 @@ describe('Order detail path with unified SF GQL flag ON', () => {
     });
   });
 
+  describe('when it is a Purchase Order (includes reference/poNumber)', () => {
+    it('renders the poNumber in the header', async () => {
+      server.use(
+        graphql.query('GetOrderDetail', () =>
+          HttpResponse.json(
+            buildOrderDetailResponseWith({
+              data: {
+                site: {
+                  order: buildUnifiedOrderWith({
+                    entityId: 6696,
+                    reference: '3405',
+                  }),
+                },
+              },
+            }),
+          ),
+        ),
+        graphql.query('GetCustomerOrderStatuses', () =>
+          HttpResponse.json(buildCustomerOrderStatusesWith('WHATEVER_VALUES')),
+        ),
+        graphql.query('AddressConfig', () =>
+          HttpResponse.json(buildAddressConfigResponseWith('WHATEVER_VALUES')),
+        ),
+      );
+
+      renderWithProviders(<OrderDetails />, {
+        preloadedState,
+        initialEntries: [{ state: { isCompanyOrder: false } }],
+      });
+
+      await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+      expect(screen.getByRole('heading', { name: 'Order #6696, 3405' })).toBeVisible();
+    });
+  });
+
   describe('when there are order history events', () => {
     it('renders the order history section', async () => {
       server.use(

--- a/apps/storefront/src/pages/OrderDetail/index.unified.test.tsx
+++ b/apps/storefront/src/pages/OrderDetail/index.unified.test.tsx
@@ -378,7 +378,7 @@ describe('Order detail path with unified SF GQL flag ON', () => {
     const crossCompanyState = {
       ...preloadedState,
       company: buildCompanyStateWith({
-        customer: { role: CustomerRole.B2B },
+        customer: { role: CustomerRole.ADMIN },
         companyInfo: { id: '100' },
       }),
       global: buildGlobalStateWith({

--- a/apps/storefront/src/pages/OrderDetail/index.unified.test.tsx
+++ b/apps/storefront/src/pages/OrderDetail/index.unified.test.tsx
@@ -13,10 +13,12 @@ import {
   startMockServer,
   userEvent,
   waitForElementToBeRemoved,
+  within,
 } from 'tests/test-utils';
 
 import { AddressConfig } from '@/shared/service/b2b/graphql/address';
 import { CustomerOrderStatues, CustomerOrderStatus } from '@/shared/service/b2b/graphql/orders';
+import { OrderHistoryEventType } from '@/shared/service/bc/graphql/orders';
 import type { GetOrderDetailResponse, Order } from '@/shared/service/bc/graphql/orders';
 import { CustomerRole } from '@/types';
 
@@ -185,5 +187,96 @@ describe('Order detail path with unified SF GQL flag ON', () => {
     await userEvent.click(screen.getByText('Back to orders'));
 
     expect(view.navigation).toHaveBeenCalledWith('/orders');
+  });
+
+  it('renders the order summary', async () => {
+    server.use(
+      graphql.query('GetOrderDetail', () =>
+        HttpResponse.json(
+          buildOrderDetailResponseWith({
+            data: {
+              site: {
+                order: buildUnifiedOrderWith({
+                  entityId: 6696,
+                  orderedAt: { utc: '2025-05-04T00:00:00.000Z' },
+                  placedBy: {
+                    entityId: 1,
+                    firstName: 'Mike',
+                    lastName: 'Wazowski',
+                    email: 'mike@monstersinc.com',
+                  },
+                  subTotal: { currencyCode: 'USD', value: 102 },
+                  shippingCostTotal: { currencyCode: 'USD', value: 332 },
+                  handlingCostTotal: { currencyCode: 'USD', value: 22.2 },
+                  taxTotal: { currencyCode: 'USD', value: 13.5 },
+                  totalIncTax: { currencyCode: 'USD', value: 100 },
+                  discounts: {
+                    couponDiscounts: [],
+                    nonCouponDiscountTotal: { currencyCode: 'USD', value: 37.93 },
+                    totalDiscount: null,
+                  },
+                }),
+              },
+            },
+          }),
+        ),
+      ),
+      graphql.query('GetCustomerOrderStatuses', () =>
+        HttpResponse.json(buildCustomerOrderStatusesWith('WHATEVER_VALUES')),
+      ),
+      graphql.query('AddressConfig', () =>
+        HttpResponse.json(buildAddressConfigResponseWith('WHATEVER_VALUES')),
+      ),
+    );
+
+    renderWithProviders(<OrderDetails />, {
+      preloadedState,
+      initialEntries: [{ state: { isCompanyOrder: false } }],
+    });
+
+    await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+    expect(screen.getByRole('heading', { name: 'Summary' })).toBeVisible();
+    expect(screen.getByText(/Purchased by Mike Wazowski on/)).toBeVisible();
+
+    expect(screen.getByRole('group', { name: 'Sub total' })).toHaveTextContent('102.00');
+    expect(screen.getByRole('group', { name: 'Shipping' })).toHaveTextContent('332.00');
+    expect(screen.getByRole('group', { name: 'Handling Fee' })).toHaveTextContent('22.20');
+    expect(screen.getByRole('group', { name: 'Tax' })).toHaveTextContent('13.50');
+    expect(screen.getByRole('group', { name: 'Discount amount' })).toHaveTextContent('37.93');
+    expect(screen.getByRole('group', { name: 'Grand total' })).toHaveTextContent('100.00');
+  });
+
+  it('omits the handling fee row when cost is zero', async () => {
+    server.use(
+      graphql.query('GetOrderDetail', () =>
+        HttpResponse.json(
+          buildOrderDetailResponseWith({
+            data: {
+              site: {
+                order: buildUnifiedOrderWith({
+                  handlingCostTotal: { currencyCode: 'USD', value: 0 },
+                }),
+              },
+            },
+          }),
+        ),
+      ),
+      graphql.query('GetCustomerOrderStatuses', () =>
+        HttpResponse.json(buildCustomerOrderStatusesWith('WHATEVER_VALUES')),
+      ),
+      graphql.query('AddressConfig', () =>
+        HttpResponse.json(buildAddressConfigResponseWith('WHATEVER_VALUES')),
+      ),
+    );
+
+    renderWithProviders(<OrderDetails />, {
+      preloadedState,
+      initialEntries: [{ state: { isCompanyOrder: false } }],
+    });
+
+    await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+    expect(screen.queryByRole('group', { name: 'Handling Fee' })).not.toBeInTheDocument();
   });
 });

--- a/apps/storefront/src/pages/OrderDetail/index.unified.test.tsx
+++ b/apps/storefront/src/pages/OrderDetail/index.unified.test.tsx
@@ -220,34 +220,33 @@ describe('Order detail path with unified SF GQL flag ON', () => {
       thousands_token: '.',
     });
 
+    const euroOrder = buildUnifiedOrderWith({
+      entityId: 6696,
+      orderedAt: { utc: '2025-05-04T00:00:00.000Z' },
+      placedBy: {
+        entityId: 1,
+        firstName: 'Mike',
+        lastName: 'Wazowski',
+        email: 'mike@monstersinc.com',
+      },
+      subTotal: { currencyCode: 'EUR', value: 102 },
+      shippingCostTotal: { currencyCode: 'EUR', value: 332 },
+      handlingCostTotal: { currencyCode: 'EUR', value: 22.2 },
+      taxTotal: { currencyCode: 'EUR', value: 13.5 },
+      // 102 + 332 + 22.2 − 37.93 + 13.5
+      totalIncTax: { currencyCode: 'EUR', value: 431.77 },
+      discounts: {
+        couponDiscounts: [],
+        nonCouponDiscountTotal: { currencyCode: 'EUR', value: 37.93 },
+        totalDiscount: null,
+      },
+    });
+
     server.use(
       graphql.query('GetOrderDetail', () =>
         HttpResponse.json(
           buildOrderDetailResponseWith({
-            data: {
-              site: {
-                order: buildUnifiedOrderWith({
-                  entityId: 6696,
-                  orderedAt: { utc: '2025-05-04T00:00:00.000Z' },
-                  placedBy: {
-                    entityId: 1,
-                    firstName: 'Mike',
-                    lastName: 'Wazowski',
-                    email: 'mike@monstersinc.com',
-                  },
-                  subTotal: { currencyCode: 'EUR', value: 102 },
-                  shippingCostTotal: { currencyCode: 'EUR', value: 332 },
-                  handlingCostTotal: { currencyCode: 'EUR', value: 22.2 },
-                  taxTotal: { currencyCode: 'EUR', value: 13.5 },
-                  totalIncTax: { currencyCode: 'EUR', value: 100 },
-                  discounts: {
-                    couponDiscounts: [],
-                    nonCouponDiscountTotal: { currencyCode: 'EUR', value: 37.93 },
-                    totalDiscount: null,
-                  },
-                }),
-              },
-            },
+            data: { site: { order: euroOrder } },
           }),
         ),
       ),
@@ -280,14 +279,20 @@ describe('Order detail path with unified SF GQL flag ON', () => {
     await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
 
     expect(screen.getByRole('heading', { name: 'Summary' })).toBeVisible();
-    expect(screen.getByText(/Purchased by Mike Wazowski on/)).toBeVisible();
+    expect(
+      screen.getByText(
+        new RegExp(
+          `Purchased by ${euroOrder.placedBy!.firstName} ${euroOrder.placedBy!.lastName} on`,
+        ),
+      ),
+    ).toBeVisible();
 
     expect(screen.getByRole('group', { name: 'Sub total' })).toHaveTextContent('€102,00');
     expect(screen.getByRole('group', { name: 'Shipping' })).toHaveTextContent('€332,00');
     expect(screen.getByRole('group', { name: 'Handling Fee' })).toHaveTextContent('€22,20');
     expect(screen.getByRole('group', { name: 'Tax' })).toHaveTextContent('€13,50');
     expect(screen.getByRole('group', { name: 'Discount amount' })).toHaveTextContent('-€37,93');
-    expect(screen.getByRole('group', { name: 'Grand total' })).toHaveTextContent('€100,00');
+    expect(screen.getByRole('group', { name: 'Grand total' })).toHaveTextContent('€431,77');
   });
 
   it('omits the handling fee row when cost is zero', async () => {

--- a/apps/storefront/src/pages/OrderDetail/index.unified.test.tsx
+++ b/apps/storefront/src/pages/OrderDetail/index.unified.test.tsx
@@ -13,7 +13,6 @@ import {
   startMockServer,
   userEvent,
   waitForElementToBeRemoved,
-  within,
 } from 'tests/test-utils';
 
 import { AddressConfig } from '@/shared/service/b2b/graphql/address';

--- a/apps/storefront/src/pages/OrderDetail/index.unified.test.tsx
+++ b/apps/storefront/src/pages/OrderDetail/index.unified.test.tsx
@@ -13,6 +13,7 @@ import {
   startMockServer,
   userEvent,
   waitForElementToBeRemoved,
+  within,
 } from 'tests/test-utils';
 
 import { AddressConfig } from '@/shared/service/b2b/graphql/address';
@@ -277,5 +278,105 @@ describe('Order detail path with unified SF GQL flag ON', () => {
     await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
 
     expect(screen.queryByRole('group', { name: 'Handling Fee' })).not.toBeInTheDocument();
+  });
+
+  describe('when there is no order history', () => {
+    it('does not render the order history section', async () => {
+      server.use(
+        graphql.query('GetOrderDetail', () =>
+          HttpResponse.json(
+            buildOrderDetailResponseWith({
+              data: {
+                site: {
+                  order: buildUnifiedOrderWith({
+                    history: [],
+                  }),
+                },
+              },
+            }),
+          ),
+        ),
+        graphql.query('GetCustomerOrderStatuses', () =>
+          HttpResponse.json(buildCustomerOrderStatusesWith('WHATEVER_VALUES')),
+        ),
+        graphql.query('AddressConfig', () =>
+          HttpResponse.json(buildAddressConfigResponseWith('WHATEVER_VALUES')),
+        ),
+      );
+
+      renderWithProviders(<OrderDetails />, { preloadedState });
+
+      await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+      expect(screen.queryByRole('heading', { name: 'History' })).not.toBeInTheDocument();
+    });
+  });
+
+  describe('when there are order history events', () => {
+    it('renders the order history section', async () => {
+      server.use(
+        graphql.query('GetOrderDetail', () =>
+          HttpResponse.json(
+            buildOrderDetailResponseWith({
+              data: {
+                site: {
+                  order: buildUnifiedOrderWith({
+                    history: [
+                      {
+                        id: '1',
+                        eventType: OrderHistoryEventType.ORDER_CREATED,
+                        status: 'Pending',
+                        source: null,
+                        createdBy: null,
+                        details: null,
+                        createdAt: '2025-05-01T03:44:00.000Z',
+                      },
+                      {
+                        id: '2',
+                        eventType: OrderHistoryEventType.ORDER_UPDATED,
+                        status: 'Shipped',
+                        source: null,
+                        createdBy: null,
+                        details: null,
+                        createdAt: '2025-05-04T07:22:00.000Z',
+                      },
+                    ],
+                  }),
+                },
+              },
+            }),
+          ),
+        ),
+        graphql.query('GetCustomerOrderStatuses', () =>
+          HttpResponse.json(
+            buildCustomerOrderStatusesWith({
+              data: {
+                bcOrderStatuses: [
+                  buildOrderStatusWith({ systemLabel: 'Pending', customLabel: 'Pending' }),
+                  buildOrderStatusWith({ systemLabel: 'Shipped', customLabel: 'Shipped' }),
+                ],
+              },
+            }),
+          ),
+        ),
+        graphql.query('AddressConfig', () =>
+          HttpResponse.json(buildAddressConfigResponseWith('WHATEVER_VALUES')),
+        ),
+      );
+
+      renderWithProviders(<OrderDetails />, { preloadedState });
+
+      await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+      expect(screen.getByRole('heading', { name: 'History' })).toBeVisible();
+
+      const table = screen.getByRole('table');
+      const columnHeaders = within(table).getAllByRole('columnheader');
+      expect(columnHeaders[0]).toHaveTextContent('Date');
+      expect(columnHeaders[1]).toHaveTextContent('Status');
+
+      expect(within(table).getByRole('cell', { name: 'Pending' })).toBeVisible();
+      expect(within(table).getByRole('cell', { name: 'Shipped' })).toBeVisible();
+    });
   });
 });

--- a/apps/storefront/src/pages/OrderDetail/index.unified.test.tsx
+++ b/apps/storefront/src/pages/OrderDetail/index.unified.test.tsx
@@ -18,9 +18,9 @@ import {
 
 import { AddressConfig } from '@/shared/service/b2b/graphql/address';
 import { CustomerOrderStatues, CustomerOrderStatus } from '@/shared/service/b2b/graphql/orders';
-import { OrderHistoryEventType } from '@/shared/service/bc/graphql/orders';
 import type { GetOrderDetailResponse, Order } from '@/shared/service/bc/graphql/orders';
-import { CustomerRole } from '@/types';
+import { OrderHistoryEventType } from '@/shared/service/bc/graphql/orders';
+import { Currency, CustomerRole } from '@/types';
 
 import OrderDetails from '.';
 
@@ -53,6 +53,25 @@ const buildAddressConfigResponseWith = builder(() => {
     },
   };
 });
+
+const buildCurrencyWith = builder<Currency>(() => ({
+  id: faker.string.uuid(),
+  is_default: true,
+  last_updated: faker.date.past().toUTCString(),
+  country_iso2: 'US',
+  default_for_country_codes: ['USD'],
+  currency_code: 'USD',
+  currency_exchange_rate: '1.0000000000',
+  name: 'United States Dollar',
+  token: '$',
+  auto_update: false,
+  decimal_token: '.',
+  decimal_places: 2,
+  enabled: true,
+  is_transactional: true,
+  token_location: 'left',
+  thousands_token: ',',
+}));
 
 const buildUnifiedOrderWith = builder<Order>(() => ({
   entityId: faker.number.int({ min: 1000, max: 99999 }),
@@ -190,6 +209,17 @@ describe('Order detail path with unified SF GQL flag ON', () => {
   });
 
   it('renders the order summary', async () => {
+    const euro = buildCurrencyWith({
+      country_iso2: 'DE',
+      default_for_country_codes: ['EUR'],
+      currency_code: 'EUR',
+      currency_exchange_rate: '0.85',
+      name: 'Euro',
+      token: '€',
+      decimal_token: ',',
+      thousands_token: '.',
+    });
+
     server.use(
       graphql.query('GetOrderDetail', () =>
         HttpResponse.json(
@@ -205,14 +235,14 @@ describe('Order detail path with unified SF GQL flag ON', () => {
                     lastName: 'Wazowski',
                     email: 'mike@monstersinc.com',
                   },
-                  subTotal: { currencyCode: 'USD', value: 102 },
-                  shippingCostTotal: { currencyCode: 'USD', value: 332 },
-                  handlingCostTotal: { currencyCode: 'USD', value: 22.2 },
-                  taxTotal: { currencyCode: 'USD', value: 13.5 },
-                  totalIncTax: { currencyCode: 'USD', value: 100 },
+                  subTotal: { currencyCode: 'EUR', value: 102 },
+                  shippingCostTotal: { currencyCode: 'EUR', value: 332 },
+                  handlingCostTotal: { currencyCode: 'EUR', value: 22.2 },
+                  taxTotal: { currencyCode: 'EUR', value: 13.5 },
+                  totalIncTax: { currencyCode: 'EUR', value: 100 },
                   discounts: {
                     couponDiscounts: [],
-                    nonCouponDiscountTotal: { currencyCode: 'USD', value: 37.93 },
+                    nonCouponDiscountTotal: { currencyCode: 'EUR', value: 37.93 },
                     totalDiscount: null,
                   },
                 }),
@@ -230,7 +260,20 @@ describe('Order detail path with unified SF GQL flag ON', () => {
     );
 
     renderWithProviders(<OrderDetails />, {
-      preloadedState,
+      preloadedState: {
+        ...preloadedState,
+        storeConfigs: {
+          currencies: {
+            currencies: [euro],
+            channelCurrencies: {
+              channel_id: 1,
+              enabled_currencies: ['EUR'],
+              default_currency: 'EUR',
+            },
+            enteredInclusiveTax: false,
+          },
+        },
+      },
       initialEntries: [{ state: { isCompanyOrder: false } }],
     });
 
@@ -239,12 +282,12 @@ describe('Order detail path with unified SF GQL flag ON', () => {
     expect(screen.getByRole('heading', { name: 'Summary' })).toBeVisible();
     expect(screen.getByText(/Purchased by Mike Wazowski on/)).toBeVisible();
 
-    expect(screen.getByRole('group', { name: 'Sub total' })).toHaveTextContent('102.00');
-    expect(screen.getByRole('group', { name: 'Shipping' })).toHaveTextContent('332.00');
-    expect(screen.getByRole('group', { name: 'Handling Fee' })).toHaveTextContent('22.20');
-    expect(screen.getByRole('group', { name: 'Tax' })).toHaveTextContent('13.50');
-    expect(screen.getByRole('group', { name: 'Discount amount' })).toHaveTextContent('37.93');
-    expect(screen.getByRole('group', { name: 'Grand total' })).toHaveTextContent('100.00');
+    expect(screen.getByRole('group', { name: 'Sub total' })).toHaveTextContent('€102,00');
+    expect(screen.getByRole('group', { name: 'Shipping' })).toHaveTextContent('€332,00');
+    expect(screen.getByRole('group', { name: 'Handling Fee' })).toHaveTextContent('€22,20');
+    expect(screen.getByRole('group', { name: 'Tax' })).toHaveTextContent('€13,50');
+    expect(screen.getByRole('group', { name: 'Discount amount' })).toHaveTextContent('-€37,93');
+    expect(screen.getByRole('group', { name: 'Grand total' })).toHaveTextContent('€100,00');
   });
 
   it('omits the handling fee row when cost is zero', async () => {
@@ -400,6 +443,41 @@ describe('Order detail path with unified SF GQL flag ON', () => {
         'This order is related to another company. To reorder, add to a shopping list, or perform other actions, you need to switch to that company.',
       ),
     ).toBeVisible();
+  });
+
+  it('renders customer message comments', async () => {
+    server.use(
+      graphql.query('GetOrderDetail', () =>
+        HttpResponse.json(
+          buildOrderDetailResponseWith({
+            data: {
+              site: {
+                order: buildUnifiedOrderWith({
+                  customerMessage: 'Customer note: leave at reception\nPlease call before delivery',
+                }),
+              },
+            },
+          }),
+        ),
+      ),
+      graphql.query('GetCustomerOrderStatuses', () =>
+        HttpResponse.json(buildCustomerOrderStatusesWith('WHATEVER_VALUES')),
+      ),
+      graphql.query('AddressConfig', () =>
+        HttpResponse.json(buildAddressConfigResponseWith('WHATEVER_VALUES')),
+      ),
+    );
+
+    renderWithProviders(<OrderDetails />, {
+      preloadedState,
+      initialEntries: [{ state: { isCompanyOrder: false } }],
+    });
+
+    await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+    expect(screen.getByRole('heading', { name: 'Comments' })).toBeVisible();
+    expect(screen.getByText('Customer note: leave at reception')).toBeVisible();
+    expect(screen.getByText('Comments: Please call before delivery')).toBeVisible();
   });
 
   describe('when there are order history events', () => {

--- a/apps/storefront/src/pages/OrderDetail/index.unified.test.tsx
+++ b/apps/storefront/src/pages/OrderDetail/index.unified.test.tsx
@@ -351,6 +351,57 @@ describe('Order detail path with unified SF GQL flag ON', () => {
     });
   });
 
+  it('shows the cross-company banner when the order belongs to a different company', async () => {
+    server.use(
+      graphql.query('GetOrderDetail', () =>
+        HttpResponse.json(
+          buildOrderDetailResponseWith({
+            data: {
+              site: {
+                order: buildUnifiedOrderWith({
+                  // Active company in Redux state is 100; order belongs to company 200
+                  company: { entityId: 200, name: 'Other Company' },
+                }),
+              },
+            },
+          }),
+        ),
+      ),
+      graphql.query('GetCustomerOrderStatuses', () =>
+        HttpResponse.json(buildCustomerOrderStatusesWith('WHATEVER_VALUES')),
+      ),
+      graphql.query('AddressConfig', () =>
+        HttpResponse.json(buildAddressConfigResponseWith('WHATEVER_VALUES')),
+      ),
+    );
+
+    const crossCompanyState = {
+      ...preloadedState,
+      company: buildCompanyStateWith({
+        customer: { role: CustomerRole.B2B },
+        companyInfo: { id: '100' },
+      }),
+      global: buildGlobalStateWith({
+        featureFlags: {
+          'B2B-4613.buyer_portal_unified_sf_gql_orders': true,
+        },
+      }),
+    };
+
+    renderWithProviders(<OrderDetails />, {
+      preloadedState: crossCompanyState,
+      initialEntries: [{ state: { isCompanyOrder: false } }],
+    });
+
+    await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+    expect(
+      screen.getByText(
+        'This order is related to another company. To reorder, add to a shopping list, or perform other actions, you need to switch to that company.',
+      ),
+    ).toBeVisible();
+  });
+
   describe('when there are order history events', () => {
     it('renders the order history section', async () => {
       server.use(

--- a/apps/storefront/src/pages/OrderDetail/index.unified.test.tsx
+++ b/apps/storefront/src/pages/OrderDetail/index.unified.test.tsx
@@ -304,7 +304,10 @@ describe('Order detail path with unified SF GQL flag ON', () => {
         ),
       );
 
-      renderWithProviders(<OrderDetails />, { preloadedState });
+      renderWithProviders(<OrderDetails />, {
+        preloadedState,
+        initialEntries: [{ state: { isCompanyOrder: false } }],
+      });
 
       await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
 
@@ -364,19 +367,26 @@ describe('Order detail path with unified SF GQL flag ON', () => {
         ),
       );
 
-      renderWithProviders(<OrderDetails />, { preloadedState });
+      renderWithProviders(<OrderDetails />, {
+        preloadedState,
+        initialEntries: [{ state: { isCompanyOrder: false } }],
+      });
 
       await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
 
       expect(screen.getByRole('heading', { name: 'History' })).toBeVisible();
 
       const table = screen.getByRole('table');
-      const columnHeaders = within(table).getAllByRole('columnheader');
-      expect(columnHeaders[0]).toHaveTextContent('Date');
-      expect(columnHeaders[1]).toHaveTextContent('Status');
+      expect(within(table).getByRole('columnheader', { name: 'Date' })).toBeVisible();
+      expect(within(table).getByRole('columnheader', { name: 'Status' })).toBeVisible();
 
-      expect(within(table).getByRole('cell', { name: 'Pending' })).toBeVisible();
-      expect(within(table).getByRole('cell', { name: 'Shipped' })).toBeVisible();
+      const pendingRow = within(within(table).getByRole('row', { name: /Pending/ }));
+      expect(pendingRow.getByRole('cell', { name: 'Pending' })).toBeVisible();
+      expect(pendingRow.getByRole('cell', { name: 'May 1 2025 @ 3:44 AM' })).toBeVisible();
+
+      const shippedRow = within(within(table).getByRole('row', { name: /Shipped/ }));
+      expect(shippedRow.getByRole('cell', { name: 'Shipped' })).toBeVisible();
+      expect(shippedRow.getByRole('cell', { name: 'May 4 2025 @ 7:22 AM' })).toBeVisible();
     });
   });
 });

--- a/apps/storefront/src/pages/OrderDetail/shared/convertOrderDetail.ts
+++ b/apps/storefront/src/pages/OrderDetail/shared/convertOrderDetail.ts
@@ -1,14 +1,18 @@
 import type { LangFormatFunction } from '@/lib/lang';
-import { store } from '@/store';
-
 import type { Order } from '@/shared/service/bc/graphql/orders';
 import { OrderHistoryEventType } from '@/shared/service/bc/graphql/orders';
-import type { MoneyFormat, OrderHistoryItem, OrderPayment, OrderSummary } from '@/types';
+import type {
+  Currencies,
+  MoneyFormat,
+  OrderHistoryItem,
+  OrderPayment,
+  OrderSummary,
+} from '@/types';
 
 import type { OrderDetailsState } from '../context/OrderDetailsContext';
 
-function buildMoneyFormat(currencyCode: string): MoneyFormat {
-  const { currencies } = store.getState().storeConfigs.currencies;
+function buildMoneyFormat(storeCurrencies: Currencies, currencyCode: string): MoneyFormat {
+  const { currencies } = storeCurrencies;
   const currency = currencies.find((c) => c.currency_code === currencyCode);
   if (!currency) {
     return {
@@ -124,6 +128,7 @@ function buildPayment(order: Order): OrderPayment {
 export function convertOrderDetail(
   order: Order,
   b3Lang: LangFormatFunction,
+  currencies: Currencies,
 ): Pick<
   OrderDetailsState,
   | 'orderId'
@@ -137,7 +142,7 @@ export function convertOrderDetail(
   | 'orderComments'
   | 'payment'
 > {
-  const moneyFormat = buildMoneyFormat(order.totalIncTax.currencyCode);
+  const moneyFormat = buildMoneyFormat(currencies, order.totalIncTax.currencyCode);
 
   return {
     orderId: order.entityId,

--- a/apps/storefront/src/pages/OrderDetail/shared/convertOrderDetail.ts
+++ b/apps/storefront/src/pages/OrderDetail/shared/convertOrderDetail.ts
@@ -1,10 +1,126 @@
+import type { LangFormatFunction } from '@/lib/lang';
+import { store } from '@/store';
+import { getActiveCurrencyInfo } from '@/utils/currencyUtils';
+
 import type { Order } from '@/shared/service/bc/graphql/orders';
+import { OrderHistoryEventType } from '@/shared/service/bc/graphql/orders';
+import type { MoneyFormat, OrderHistoryItem, OrderPayment, OrderSummary } from '@/types';
 
 import type { OrderDetailsState } from '../context/OrderDetailsContext';
 
+function buildMoneyFormat(currencyCode: string): MoneyFormat {
+  const { currencies } = store.getState().storeConfigs.currencies;
+  const currency = currencies.find((c) => c.currency_code === currencyCode);
+  if (!currency) {
+    return {
+      currency_location: 'left',
+      currency_token: '$',
+      decimal_token: '.',
+      decimal_places: 2,
+      thousands_token: ',',
+      currency_exchange_rate: '1.0000000000',
+    };
+  }
+  return {
+    currency_location: currency.token_location,
+    currency_token: currency.token,
+    decimal_token: currency.decimal_token,
+    decimal_places: currency.decimal_places,
+    thousands_token: currency.thousands_token,
+    currency_exchange_rate: currency.currency_exchange_rate,
+  };
+}
+
+function formatPrice(value: number): string {
+  const { decimal_places: decimalPlaces = 2 } = getActiveCurrencyInfo();
+  return value.toFixed(decimalPlaces);
+}
+
+function buildOrderSummary(order: Order, b3Lang: LangFormatFunction): OrderSummary {
+  const labels = {
+    subTotal: b3Lang('orderDetail.summary.subTotal'),
+    shipping: b3Lang('orderDetail.summary.shipping'),
+    handlingFee: b3Lang('orderDetail.summary.handlingFee'),
+    discountAmount: b3Lang('orderDetail.summary.discountAmount'),
+    tax: b3Lang('orderDetail.summary.tax'),
+    grandTotal: b3Lang('orderDetail.summary.grandTotal'),
+  };
+
+  const hasHandlingFee = order.handlingCostTotal.value > 0;
+
+  const couponLabels: Record<string, string> = {};
+  const couponPrices: Record<string, string> = {};
+  const couponSymbols: Record<string, string> = {};
+
+  order.discounts.couponDiscounts.forEach((coupon) => {
+    const key = b3Lang('orderDetail.summary.coupon', {
+      couponCode: coupon.couponCode ? `(${coupon.couponCode})` : '',
+    });
+    couponLabels[key] = key;
+    couponPrices[key] = formatPrice(coupon.discountedAmount.value);
+    couponSymbols[key] = 'coupon';
+  });
+
+  const placedByName = order.placedBy
+    ? `${order.placedBy.firstName} ${order.placedBy.lastName}`.trim()
+    : '';
+
+  return {
+    createAt: order.orderedAt.utc,
+    name: placedByName,
+    priceData: {
+      [labels.subTotal]: formatPrice(order.subTotal.value),
+      [labels.shipping]: formatPrice(order.shippingCostTotal.value),
+      ...(hasHandlingFee && { [labels.handlingFee]: formatPrice(order.handlingCostTotal.value) }),
+      [labels.discountAmount]: formatPrice(order.discounts.nonCouponDiscountTotal.value),
+      ...couponPrices,
+      [labels.tax]: formatPrice(order.taxTotal.value),
+      [labels.grandTotal]: formatPrice(order.totalIncTax.value),
+    },
+    priceSymbol: {
+      [labels.subTotal]: 'subTotal',
+      [labels.shipping]: 'shipping',
+      ...(hasHandlingFee && { [labels.handlingFee]: 'handlingFee' }),
+      [labels.discountAmount]: 'discountAmount',
+      ...couponSymbols,
+      [labels.tax]: 'tax',
+      [labels.grandTotal]: 'grandTotal',
+    },
+  };
+}
+
+function mapHistoryEvents(history: Order['history']): OrderHistoryItem[] {
+  return history.map((e) => ({
+    id: Number(e.id),
+    eventType: e.eventType === OrderHistoryEventType.ORDER_CREATED ? 1 : 2,
+    status: e.status,
+    createdAt: Math.floor(new Date(e.createdAt).getTime() / 1000),
+  }));
+}
+
+function buildPayment(order: Order): OrderPayment {
+  const dateCreateAt = Math.floor(new Date(order.orderedAt.utc).getTime() / 1000);
+  return {
+    dateCreateAt: JSON.stringify(dateCreateAt),
+  };
+}
+
 export function convertOrderDetail(
   order: Order,
-): Pick<OrderDetailsState, 'orderId' | 'status' | 'customStatus' | 'poNumber'> {
+  b3Lang: LangFormatFunction,
+): Pick<
+  OrderDetailsState,
+  | 'orderId'
+  | 'status'
+  | 'customStatus'
+  | 'poNumber'
+  | 'currencyCode'
+  | 'money'
+  | 'orderSummary'
+  | 'history'
+  | 'orderComments'
+  | 'payment'
+> {
   return {
     orderId: order.entityId,
 
@@ -13,10 +129,16 @@ export function convertOrderDetail(
     // orderStatus list (getOrderStatusType / getBcOrderStatusType) to resolve
     status: order.status.label,
 
-    // customStatus is not yet exposed by the unified endpoint.
+    // customStatus is not exposed by the unified endpoint.
     // getOrderStatusLabel() falls back to the status label when this is empty.
     customStatus: '',
 
     poNumber: order.reference ?? '',
+    currencyCode: order.totalIncTax.currencyCode,
+    money: buildMoneyFormat(order.totalIncTax.currencyCode),
+    orderSummary: buildOrderSummary(order, b3Lang),
+    payment: buildPayment(order),
+    history: mapHistoryEvents(order.history),
+    orderComments: order.customerMessage ?? '',
   };
 }

--- a/apps/storefront/src/pages/OrderDetail/shared/convertOrderDetail.ts
+++ b/apps/storefront/src/pages/OrderDetail/shared/convertOrderDetail.ts
@@ -1,13 +1,7 @@
 import type { LangFormatFunction } from '@/lib/lang';
 import type { Order } from '@/shared/service/bc/graphql/orders';
 import { OrderHistoryEventType } from '@/shared/service/bc/graphql/orders';
-import type {
-  Currency,
-  MoneyFormat,
-  OrderHistoryItem,
-  OrderPayment,
-  OrderSummary,
-} from '@/types';
+import type { Currency, MoneyFormat, OrderHistoryItem, OrderPayment, OrderSummary } from '@/types';
 
 import type { OrderDetailsState } from '../context/OrderDetailsContext';
 

--- a/apps/storefront/src/pages/OrderDetail/shared/convertOrderDetail.ts
+++ b/apps/storefront/src/pages/OrderDetail/shared/convertOrderDetail.ts
@@ -48,7 +48,6 @@ function buildOrderSummary(order: Order, b3Lang: LangFormatFunction): OrderSumma
 
   const hasHandlingFee = order.handlingCostTotal.value > 0;
 
-  const couponLabels: Record<string, string> = {};
   const couponPrices: Record<string, string> = {};
   const couponSymbols: Record<string, string> = {};
 
@@ -56,7 +55,6 @@ function buildOrderSummary(order: Order, b3Lang: LangFormatFunction): OrderSumma
     const key = b3Lang('orderDetail.summary.coupon', {
       couponCode: coupon.couponCode ? `(${coupon.couponCode})` : '',
     });
-    couponLabels[key] = key;
     couponPrices[key] = formatPrice(coupon.discountedAmount.value);
     couponSymbols[key] = 'coupon';
   });
@@ -101,7 +99,7 @@ function mapHistoryEvents(history: Order['history']): OrderHistoryItem[] {
 function buildPayment(order: Order): OrderPayment {
   const dateCreateAt = Math.floor(new Date(order.orderedAt.utc).getTime() / 1000);
   return {
-    dateCreateAt: JSON.stringify(dateCreateAt),
+    dateCreateAt: String(dateCreateAt),
   };
 }
 

--- a/apps/storefront/src/pages/OrderDetail/shared/convertOrderDetail.ts
+++ b/apps/storefront/src/pages/OrderDetail/shared/convertOrderDetail.ts
@@ -1,6 +1,5 @@
 import type { LangFormatFunction } from '@/lib/lang';
 import { store } from '@/store';
-import { getActiveCurrencyInfo } from '@/utils/currencyUtils';
 
 import type { Order } from '@/shared/service/bc/graphql/orders';
 import { OrderHistoryEventType } from '@/shared/service/bc/graphql/orders';
@@ -31,12 +30,15 @@ function buildMoneyFormat(currencyCode: string): MoneyFormat {
   };
 }
 
-function formatPrice(value: number): string {
-  const { decimal_places: decimalPlaces = 2 } = getActiveCurrencyInfo();
+function formatPrice(value: number, decimalPlaces: number): string {
   return value.toFixed(decimalPlaces);
 }
 
-function buildOrderSummary(order: Order, b3Lang: LangFormatFunction): OrderSummary {
+function buildOrderSummary(
+  order: Order,
+  b3Lang: LangFormatFunction,
+  decimalPlaces: number,
+): OrderSummary {
   const labels = {
     subTotal: b3Lang('orderDetail.summary.subTotal'),
     shipping: b3Lang('orderDetail.summary.shipping'),
@@ -55,7 +57,7 @@ function buildOrderSummary(order: Order, b3Lang: LangFormatFunction): OrderSumma
     const key = b3Lang('orderDetail.summary.coupon', {
       couponCode: coupon.couponCode ? `(${coupon.couponCode})` : '',
     });
-    couponPrices[key] = formatPrice(coupon.discountedAmount.value);
+    couponPrices[key] = formatPrice(coupon.discountedAmount.value, decimalPlaces);
     couponSymbols[key] = 'coupon';
   });
 
@@ -67,13 +69,18 @@ function buildOrderSummary(order: Order, b3Lang: LangFormatFunction): OrderSumma
     createAt: order.orderedAt.utc,
     name: placedByName,
     priceData: {
-      [labels.subTotal]: formatPrice(order.subTotal.value),
-      [labels.shipping]: formatPrice(order.shippingCostTotal.value),
-      ...(hasHandlingFee && { [labels.handlingFee]: formatPrice(order.handlingCostTotal.value) }),
-      [labels.discountAmount]: formatPrice(order.discounts.nonCouponDiscountTotal.value),
+      [labels.subTotal]: formatPrice(order.subTotal.value, decimalPlaces),
+      [labels.shipping]: formatPrice(order.shippingCostTotal.value, decimalPlaces),
+      ...(hasHandlingFee && {
+        [labels.handlingFee]: formatPrice(order.handlingCostTotal.value, decimalPlaces),
+      }),
+      [labels.discountAmount]: formatPrice(
+        order.discounts.nonCouponDiscountTotal.value,
+        decimalPlaces,
+      ),
       ...couponPrices,
-      [labels.tax]: formatPrice(order.taxTotal.value),
-      [labels.grandTotal]: formatPrice(order.totalIncTax.value),
+      [labels.tax]: formatPrice(order.taxTotal.value, decimalPlaces),
+      [labels.grandTotal]: formatPrice(order.totalIncTax.value, decimalPlaces),
     },
     priceSymbol: {
       [labels.subTotal]: 'subTotal',
@@ -87,10 +94,21 @@ function buildOrderSummary(order: Order, b3Lang: LangFormatFunction): OrderSumma
   };
 }
 
+function toNumericEventType(type: OrderHistoryEventType): number {
+  switch (type) {
+    case OrderHistoryEventType.ORDER_CREATED:
+      return 1;
+    case OrderHistoryEventType.ORDER_UPDATED:
+      return 2;
+    default:
+      return 2;
+  }
+}
+
 function mapHistoryEvents(history: Order['history']): OrderHistoryItem[] {
   return history.map((e) => ({
     id: Number(e.id),
-    eventType: e.eventType === OrderHistoryEventType.ORDER_CREATED ? 1 : 2,
+    eventType: toNumericEventType(e.eventType),
     status: e.status,
     createdAt: Math.floor(new Date(e.createdAt).getTime() / 1000),
   }));
@@ -119,6 +137,8 @@ export function convertOrderDetail(
   | 'orderComments'
   | 'payment'
 > {
+  const moneyFormat = buildMoneyFormat(order.totalIncTax.currencyCode);
+
   return {
     orderId: order.entityId,
 
@@ -133,8 +153,8 @@ export function convertOrderDetail(
 
     poNumber: order.reference ?? '',
     currencyCode: order.totalIncTax.currencyCode,
-    money: buildMoneyFormat(order.totalIncTax.currencyCode),
-    orderSummary: buildOrderSummary(order, b3Lang),
+    money: moneyFormat,
+    orderSummary: buildOrderSummary(order, b3Lang, moneyFormat.decimal_places),
     payment: buildPayment(order),
     history: mapHistoryEvents(order.history),
     orderComments: order.customerMessage ?? '',

--- a/apps/storefront/src/pages/OrderDetail/shared/convertOrderDetail.ts
+++ b/apps/storefront/src/pages/OrderDetail/shared/convertOrderDetail.ts
@@ -2,7 +2,7 @@ import type { LangFormatFunction } from '@/lib/lang';
 import type { Order } from '@/shared/service/bc/graphql/orders';
 import { OrderHistoryEventType } from '@/shared/service/bc/graphql/orders';
 import type {
-  Currencies,
+  Currency,
   MoneyFormat,
   OrderHistoryItem,
   OrderPayment,
@@ -11,8 +11,7 @@ import type {
 
 import type { OrderDetailsState } from '../context/OrderDetailsContext';
 
-function buildMoneyFormat(storeCurrencies: Currencies, currencyCode: string): MoneyFormat {
-  const { currencies } = storeCurrencies;
+function buildMoneyFormat(currencies: Currency[], currencyCode: string): MoneyFormat {
   const currency = currencies.find((c) => c.currency_code === currencyCode);
   if (!currency) {
     return {
@@ -128,7 +127,7 @@ function buildPayment(order: Order): OrderPayment {
 export function convertOrderDetail(
   order: Order,
   b3Lang: LangFormatFunction,
-  currencies: Currencies,
+  currencies: Currency[],
 ): Pick<
   OrderDetailsState,
   | 'orderId'


### PR DESCRIPTION
Jira: [B2B-4825](https://bigcommercecloud.atlassian.net/browse/B2B-4825)

## What/Why?

Extends the unified SF GQL order detail adapter (`convertOrderDetail`) to populate the second tier of fields left blank after Task 1 (B2B-4824):

- **Order summary** (`orderSummary`, `money`, `currencyCode`) — subtotal, shipping, handling fee, discounts, tax, grand total; handling fee row omitted when zero; decimal places derived from the order's own currency
- **Order history** (`history`) — maps SF GQL `OrderHistoryEvent` to the legacy `OrderHistoryItem` shape including Unix timestamp conversion
- **Customer comments** (`orderComments`)
- **PO number** (`poNumber`) — already mapped in Task 1, end-to-end test added here
- **Cross-company banner** — fixed guard from `products?.length` to `orderId`; `isCurrentCompany` initialised to `true` to prevent banner flash before fetch resolves; uses `order.company.entityId` (SF GQL) instead of legacy `companyInfo.companyId`

All changes are gated behind the `B2B-4613.buyer_portal_unified_sf_gql_orders` feature flag. Legacy path is unaffected.

## Rollout/Rollback

Feature flagged via `B2B-4613.buyer_portal_unified_sf_gql_orders`. Rollback by disabling the flag.

## Testing
I use random mocking data to show what has been done and is available under the detail page
<img width="1433" height="798" alt="Screenshot 2026-05-14 at 1 36 37 pm" src="https://github.com/user-attachments/assets/ef912ca9-cff9-46cc-9645-323594763e4a" />


SF GQL backend is not yet available in dev, so testing is via the unified test file:

- `src/pages/OrderDetail/index.unified.test.tsx` — 8 tests covering:
  - Order summary renders with correct price rows
  - Handling fee row omitted when cost is zero
  - Order history section hidden when empty
  - Order history renders date, status rows when events present
  - PO number rendered in header
  - Cross-company banner shown when order belongs to a different company
- `src/pages/OrderDetail/index.test.tsx` — 35 existing legacy tests, all passing

All 43 tests pass.

[B2B-4825]: https://bigcommercecloud.atlassian.net/browse/B2B-4825?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes unified order-detail fetching and state mapping (currency formatting, history timestamps, cross-company detection), which can affect what buyers see on order detail pages, though it is gated behind a feature flag.
> 
> **Overview**
> When `B2B-4613.buyer_portal_unified_sf_gql_orders` is enabled, the unified order-detail adapter now populates previously-empty fields: **currency-aware `orderSummary`** (including optional handling fee/coupon rows), `money`/`currencyCode`, `payment.dateCreateAt`, `orderComments`, and **mapped `history` events** (with event type normalization and Unix timestamps).
> 
> `OrderDetail` refactors the unified fetch to store the raw `order` separately and then dispatch converted state when either the order or currencies change, preventing stale updates and enabling currency formatting updates without a refetch; it also initializes `isCurrentCompany` to `true` and fixes the cross-company banner guard to use `orderId` (reducing banner flash / incorrect gating). Comprehensive unified-path tests were added to cover summary formatting, handling-fee omission, history visibility/rows, PO number display, cross-company banner, comments rendering, and currency reformatting without reloading.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b71247293206717968a180e40b5c176b4b61d028. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->