### PR TITLE
test(orders): B2B-4619 Add tests for company orders sorting

### DIFF
--- a/apps/storefront/src/pages/CompanyOrderList/unified-company-orders.test.tsx
+++ b/apps/storefront/src/pages/CompanyOrderList/unified-company-orders.test.tsx
@@ -19,10 +19,11 @@ import {
 import { vi } from 'vitest';
 import { when } from 'vitest-when';
 
-import type {
-  GetCompanyOrdersResponse,
-  Order,
-  OrderPlacedBy,
+import {
+  type GetCompanyOrdersResponse,
+  type Order,
+  type OrderPlacedBy,
+  OrdersSortInput,
 } from '@/shared/service/bc/graphql/orders';
 import { CompanyStatus, CustomerRole, UserTypes } from '@/types';
 
@@ -173,6 +174,32 @@ const filteredCompanyOrdersResponse = (entityId: number): GetCompanyOrdersRespon
             endCursor: 'filtered',
           },
           collectionInfo: { totalItems: 1 },
+        },
+      },
+    },
+  },
+});
+
+const buildPagedCompanyOrdersResponse = (
+  orders: Array<{ entityId: number }>,
+  pageInfo: {
+    hasNextPage: boolean;
+    hasPreviousPage: boolean;
+    startCursor: string | null;
+    endCursor: string | null;
+  },
+  totalItems: number,
+): GetCompanyOrdersResponse => ({
+  data: {
+    customer: {
+      activeCompany: {
+        orders: {
+          edges: orders.map((o) => ({
+            node: buildSfGqlOrderWith(o),
+            cursor: `cursor-${o.entityId}`,
+          })),
+          pageInfo,
+          collectionInfo: { totalItems },
         },
       },
     },
@@ -359,6 +386,294 @@ describe('Company Orders — unified SF GQL orders (B2B-4616)', () => {
 
       const row = screen.getByText('77777').closest('tr')!;
       expect(within(row).getByText('$1,234.56')).toBeInTheDocument();
+    });
+
+    describe('sorting', () => {
+      describe('default Order ID sort', () => {
+        it('requests ID_Z_TO_A initially', async () => {
+          const getOrders = vi
+            .fn()
+            .mockReturnValue(buildCompanyOrdersResponseWith('WHATEVER_VALUES'));
+
+          server.use(
+            graphql.query('GetCompanyOrders', ({ variables }) =>
+              HttpResponse.json(getOrders(variables)),
+            ),
+          );
+
+          renderWithProviders(<CompanyOrders />, { preloadedState: b2bStateWithFlag(flagOn) });
+
+          await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+          expect(getOrders).toHaveBeenCalledWith(
+            expect.objectContaining({ sortBy: OrdersSortInput.ID_Z_TO_A }),
+          );
+        });
+
+        it('toggles to ID_A_TO_Z when the active Order column is clicked', async () => {
+          const getOrders = vi
+            .fn()
+            .mockReturnValue(buildCompanyOrdersResponseWith('WHATEVER_VALUES'));
+
+          server.use(
+            graphql.query('GetCompanyOrders', ({ variables }) =>
+              HttpResponse.json(getOrders(variables)),
+            ),
+          );
+
+          renderWithProviders(<CompanyOrders />, { preloadedState: b2bStateWithFlag(flagOn) });
+
+          await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+          const orderHeader = screen.getByRole('columnheader', { name: 'Order' });
+          expect(orderHeader).toHaveAttribute('aria-sort', 'descending');
+
+          when(getOrders)
+            .calledWith(expect.objectContaining({ sortBy: OrdersSortInput.ID_A_TO_Z }))
+            .thenReturn(buildCompanyOrdersResponseWith('WHATEVER_VALUES'));
+
+          await userEvent.click(within(orderHeader).getByRole('button'));
+
+          await waitFor(() => {
+            expect(getOrders).toHaveBeenCalledWith(
+              expect.objectContaining({ sortBy: OrdersSortInput.ID_A_TO_Z }),
+            );
+          });
+
+          expect(screen.getByRole('columnheader', { name: 'Order' })).toHaveAttribute(
+            'aria-sort',
+            'ascending',
+          );
+        });
+      });
+
+      it('uses CREATED_AT_NEWEST when first activating the Created on column', async () => {
+        const getOrders = vi
+          .fn()
+          .mockReturnValue(buildCompanyOrdersResponseWith('WHATEVER_VALUES'));
+
+        server.use(
+          graphql.query('GetCompanyOrders', ({ variables }) =>
+            HttpResponse.json(getOrders(variables)),
+          ),
+        );
+
+        renderWithProviders(<CompanyOrders />, { preloadedState: b2bStateWithFlag(flagOn) });
+
+        await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+        when(getOrders)
+          .calledWith(expect.objectContaining({ sortBy: OrdersSortInput.CREATED_AT_NEWEST }))
+          .thenReturn(buildCompanyOrdersResponseWith('WHATEVER_VALUES'));
+
+        await userEvent.click(
+          within(screen.getByRole('columnheader', { name: 'Created on' })).getByRole('button'),
+        );
+
+        await waitFor(() => {
+          expect(getOrders).toHaveBeenCalledWith(
+            expect.objectContaining({ sortBy: OrdersSortInput.CREATED_AT_NEWEST }),
+          );
+        });
+
+        expect(screen.getByRole('columnheader', { name: 'Created on' })).toHaveAttribute(
+          'aria-sort',
+          'descending',
+        );
+      });
+
+      it('uses REFERENCE_Z_TO_A when first activating the PO/Reference column', async () => {
+        const getOrders = vi
+          .fn()
+          .mockReturnValue(buildCompanyOrdersResponseWith('WHATEVER_VALUES'));
+
+        server.use(
+          graphql.query('GetCompanyOrders', ({ variables }) =>
+            HttpResponse.json(getOrders(variables)),
+          ),
+        );
+
+        renderWithProviders(<CompanyOrders />, { preloadedState: b2bStateWithFlag(flagOn) });
+
+        await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+        when(getOrders)
+          .calledWith(expect.objectContaining({ sortBy: OrdersSortInput.REFERENCE_Z_TO_A }))
+          .thenReturn(buildCompanyOrdersResponseWith('WHATEVER_VALUES'));
+
+        await userEvent.click(
+          within(screen.getByRole('columnheader', { name: 'PO / Reference' })).getByRole('button'),
+        );
+
+        await waitFor(() => {
+          expect(getOrders).toHaveBeenCalledWith(
+            expect.objectContaining({ sortBy: OrdersSortInput.REFERENCE_Z_TO_A }),
+          );
+        });
+      });
+
+      it('uses HIGHEST_TOTAL_INC_TAX when first activating the Grand Total column', async () => {
+        const getOrders = vi
+          .fn()
+          .mockReturnValue(buildCompanyOrdersResponseWith('WHATEVER_VALUES'));
+
+        server.use(
+          graphql.query('GetCompanyOrders', ({ variables }) =>
+            HttpResponse.json(getOrders(variables)),
+          ),
+        );
+
+        renderWithProviders(<CompanyOrders />, { preloadedState: b2bStateWithFlag(flagOn) });
+
+        await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+        when(getOrders)
+          .calledWith(expect.objectContaining({ sortBy: OrdersSortInput.HIGHEST_TOTAL_INC_TAX }))
+          .thenReturn(buildCompanyOrdersResponseWith('WHATEVER_VALUES'));
+
+        await userEvent.click(
+          within(screen.getByRole('columnheader', { name: 'Grand total' })).getByRole('button'),
+        );
+
+        await waitFor(() => {
+          expect(getOrders).toHaveBeenCalledWith(
+            expect.objectContaining({ sortBy: OrdersSortInput.HIGHEST_TOTAL_INC_TAX }),
+          );
+        });
+
+        expect(screen.getByRole('columnheader', { name: 'Grand total' })).toHaveAttribute(
+          'aria-sort',
+          'descending',
+        );
+      });
+
+      it('uses PLACED_BY_Z_TO_A when first activating the Placed by column', async () => {
+        const getOrders = vi
+          .fn()
+          .mockReturnValue(buildCompanyOrdersResponseWith('WHATEVER_VALUES'));
+
+        server.use(
+          graphql.query('GetCompanyOrders', ({ variables }) =>
+            HttpResponse.json(getOrders(variables)),
+          ),
+        );
+
+        renderWithProviders(<CompanyOrders />, { preloadedState: b2bStateWithFlag(flagOn) });
+
+        await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+        when(getOrders)
+          .calledWith(expect.objectContaining({ sortBy: OrdersSortInput.PLACED_BY_Z_TO_A }))
+          .thenReturn(buildCompanyOrdersResponseWith('WHATEVER_VALUES'));
+
+        await userEvent.click(
+          within(screen.getByRole('columnheader', { name: 'Placed by' })).getByRole('button'),
+        );
+
+        await waitFor(() => {
+          expect(getOrders).toHaveBeenCalledWith(
+            expect.objectContaining({ sortBy: OrdersSortInput.PLACED_BY_Z_TO_A }),
+          );
+        });
+      });
+
+      it('clears cursor variables when sort changes after paging forward', async () => {
+        const page1Response = buildPagedCompanyOrdersResponse(
+          [{ entityId: 1001 }, { entityId: 1002 }],
+          {
+            hasNextPage: true,
+            hasPreviousPage: false,
+            startCursor: 'cursor-1001',
+            endCursor: 'cursor-1002',
+          },
+          4,
+        );
+
+        const getOrders = vi.fn().mockReturnValue(page1Response);
+
+        when(getOrders)
+          .calledWith(expect.objectContaining({ after: 'cursor-1002' }))
+          .thenReturn(
+            buildPagedCompanyOrdersResponse(
+              [{ entityId: 2001 }, { entityId: 2002 }],
+              {
+                hasNextPage: false,
+                hasPreviousPage: true,
+                startCursor: 'cursor-2001',
+                endCursor: 'cursor-2002',
+              },
+              4,
+            ),
+          );
+
+        server.use(
+          graphql.query('GetCompanyOrders', ({ variables }) =>
+            HttpResponse.json(getOrders(variables)),
+          ),
+        );
+
+        renderWithProviders(<CompanyOrders />, { preloadedState: b2bStateWithFlag(flagOn) });
+
+        await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+        await userEvent.click(screen.getByRole('button', { name: 'Go to next page' }));
+
+        await waitFor(() => {
+          expect(screen.getByText('2001').closest('tr')!).toBeInTheDocument();
+        });
+
+        await userEvent.click(
+          within(screen.getByRole('columnheader', { name: 'Created on' })).getByRole('button'),
+        );
+
+        await waitFor(() => {
+          const { calls } = getOrders.mock;
+          const lastVars = calls[calls.length - 1]?.[0] as {
+            sortBy?: string;
+            after?: string;
+            before?: string;
+          };
+          expect(lastVars?.sortBy).toBe(OrdersSortInput.CREATED_AT_NEWEST);
+          expect(lastVars?.after).toBeUndefined();
+          expect(lastVars?.before).toBeUndefined();
+        });
+      });
+
+      it('includes sortBy with applied search filters', async () => {
+        const getOrders = vi
+          .fn()
+          .mockReturnValue(buildCompanyOrdersResponseWith('WHATEVER_VALUES'));
+
+        server.use(
+          graphql.query('GetCompanyOrders', ({ variables }) =>
+            HttpResponse.json(getOrders(variables)),
+          ),
+        );
+
+        renderWithProviders(<CompanyOrders />, { preloadedState: b2bStateWithFlag(flagOn) });
+
+        await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+        when(getOrders)
+          .calledWith(
+            expect.objectContaining({
+              filters: expect.objectContaining({ search: 'findme' }),
+              sortBy: OrdersSortInput.ID_Z_TO_A,
+            }),
+          )
+          .thenReturn(filteredCompanyOrdersResponse(66996));
+
+        await userEvent.type(screen.getByPlaceholderText('Search'), 'findme');
+
+        await waitFor(() => {
+          expect(getOrders).toHaveBeenCalledWith(
+            expect.objectContaining({
+              filters: expect.objectContaining({ search: 'findme' }),
+              sortBy: OrdersSortInput.ID_Z_TO_A,
+            }),
+          );
+        });
+      });
     });
 
     describe('filter behavior', () => {
@@ -602,34 +917,8 @@ describe('Company Orders — unified SF GQL orders (B2B-4616)', () => {
     });
 
     describe('cursor pagination', () => {
-      const buildPagedResponse = (
-        orders: Array<{ entityId: number }>,
-        pageInfo: {
-          hasNextPage: boolean;
-          hasPreviousPage: boolean;
-          startCursor: string | null;
-          endCursor: string | null;
-        },
-        totalItems: number,
-      ): GetCompanyOrdersResponse => ({
-        data: {
-          customer: {
-            activeCompany: {
-              orders: {
-                edges: orders.map((o) => ({
-                  node: buildSfGqlOrderWith(o),
-                  cursor: `cursor-${o.entityId}`,
-                })),
-                pageInfo,
-                collectionInfo: { totalItems },
-              },
-            },
-          },
-        },
-      });
-
       it('passes after cursor when navigating to the next page', async () => {
-        const page1Response = buildPagedResponse(
+        const page1Response = buildPagedCompanyOrdersResponse(
           [{ entityId: 1001 }, { entityId: 1002 }],
           {
             hasNextPage: true,
@@ -645,7 +934,7 @@ describe('Company Orders — unified SF GQL orders (B2B-4616)', () => {
         when(getOrders)
           .calledWith(expect.objectContaining({ after: 'cursor-1002' }))
           .thenReturn(
-            buildPagedResponse(
+            buildPagedCompanyOrdersResponse(
               [{ entityId: 2001 }, { entityId: 2002 }],
               {
                 hasNextPage: false,
@@ -676,7 +965,7 @@ describe('Company Orders — unified SF GQL orders (B2B-4616)', () => {
       });
 
       it('passes before cursor when navigating to the previous page', async () => {
-        const page1Response = buildPagedResponse(
+        const page1Response = buildPagedCompanyOrdersResponse(
           [{ entityId: 1001 }],
           {
             hasNextPage: true,
@@ -692,7 +981,7 @@ describe('Company Orders — unified SF GQL orders (B2B-4616)', () => {
         when(getOrders)
           .calledWith(expect.objectContaining({ after: 'cursor-1001' }))
           .thenReturn(
-            buildPagedResponse(
+            buildPagedCompanyOrdersResponse(
               [{ entityId: 2001 }],
               {
                 hasNextPage: false,


### PR DESCRIPTION
Jira: [B2B-4619](https://bigcommercecloud.atlassian.net/browse/B2B-4619)

## What/Why?
- Add unified SF GraphQL company orders sorting tests for default Order ID sort, active-column toggle, and first activation of sortable columns.
- Verify company-specific sorting behavior for the Placed by column.
- Cover sorting behavior with search filters and cursor pagination reset when sort changes.

| Test added | What it verifies |
|---|---|
| `requests ID_Z_TO_A initially` | Default unified company orders request sorts by Order ID descending: `ID_Z_TO_A`. |
| `toggles to ID_A_TO_Z when the active Order column is clicked` | Clicking the active Order column toggles to ascending: `ID_A_TO_Z`, and the header shows `aria-sort="ascending"`. |
| `uses CREATED_AT_NEWEST when first activating the Created on column` | First click on Created on starts descending: `CREATED_AT_NEWEST`, with descending sort indicator. |
| `uses REFERENCE_Z_TO_A when first activating the PO/Reference column` | First click on PO/Reference starts descending: `REFERENCE_Z_TO_A`. |
| `uses HIGHEST_TOTAL_INC_TAX when first activating the Grand Total column` | First click on Grand Total starts descending/highest first: `HIGHEST_TOTAL_INC_TAX`, with descending sort indicator. |
| `uses PLACED_BY_Z_TO_A when first activating the Placed by column` | Placed by column maps to `PLACED_BY_Z_TO_A` on first click. |
| `clears cursor variables when sort changes after paging forward` | After moving to the next cursor page, changing sort clears `after`/`before` and returns to first page. |
| `includes sortBy with applied search filters` | Search and sorting compose correctly in the same `GetCompanyOrders` request. |

## Rollout/Rollback
Test only in this PR, and revet if needed

## Testing
```
cd apps/storefront
npx vitest run src/pages/CompanyOrderList/unified-company-orders.test.tsx
```

All test passed.



[B2B-4619]: https://bigcommercecloud.atlassian.net/browse/B2B-4619?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes are limited to test code, adding assertions around GraphQL `sortBy` variables and cursor reset behavior with no production logic changes.
> 
> **Overview**
> Adds a new `sorting` test suite for unified SF GraphQL company orders, asserting the default `sortBy` (`ID_Z_TO_A`), sort toggling on the active Order column, and the initial sort direction/mapping for other sortable columns (Created on, PO/Reference, Grand total, Placed by).
> 
> Extends coverage to ensure sorting composes with search filters and that changing sort after cursor pagination clears `after`/`before` variables, plus a small test helper refactor to reuse a shared paged-response builder.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ddac174217349cf73240761ee3b0df2b6901a11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->