### PR TITLE
fix(common): B2B-4848 replace anchor with button for Business Account Application nav

### DIFF
--- a/apps/storefront/src/hooks/dom/useRegisteredbctob2b.test.ts
+++ b/apps/storefront/src/hooks/dom/useRegisteredbctob2b.test.ts
@@ -1,0 +1,121 @@
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { buildCompanyStateWith } from 'tests/storeStateBuilders';
+import { renderHookWithProviders } from 'tests/utils/hook-test-utils';
+
+import { CompanyStatus, CustomerRole } from '@/types';
+
+import b2bVerifyBcLoginStatus from '../../utils/b2bVerifyBcLoginStatus';
+
+import useRegisteredbctob2b from './useRegisteredbctob2b';
+
+vi.mock('../../utils/b2bVerifyBcLoginStatus');
+vi.mock('./useDomVariation', () => ({ default: () => [true] }));
+
+const mockedB2bVerifyBcLoginStatus = vi.mocked(b2bVerifyBcLoginStatus);
+
+function setupNavDOM() {
+  document.body.innerHTML = `
+    <ul class="navUser-section navUser-section--alt">
+      <li class="navUser-item navUser-item--account">
+        <a class="navUser-action" href="/login.php">Sign In</a>
+      </li>
+    </ul>
+  `;
+}
+
+const b2cCustomerState = buildCompanyStateWith({
+  customer: {
+    id: 123,
+    role: CustomerRole.B2C,
+  },
+  companyInfo: {
+    status: CompanyStatus.DEFAULT,
+  },
+});
+
+describe('useRegisteredbctob2b', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    mockedB2bVerifyBcLoginStatus.mockResolvedValue(true);
+  });
+
+  it('renders a "Business Account Application" button in the nav', async () => {
+    setupNavDOM();
+
+    renderHookWithProviders(() => useRegisteredbctob2b(vi.fn()), {
+      preloadedState: { company: b2cCustomerState },
+    });
+
+    expect(
+      await screen.findByRole('button', { name: 'Business Account Application' }),
+    ).toBeVisible();
+  });
+
+  it('does not render the button when bc login check returns false', async () => {
+    mockedB2bVerifyBcLoginStatus.mockResolvedValue(false);
+    setupNavDOM();
+
+    renderHookWithProviders(() => useRegisteredbctob2b(vi.fn()), {
+      preloadedState: { company: b2cCustomerState },
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole('button', { name: 'Business Account Application' }),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it('does not render the button when registration is disabled', async () => {
+    setupNavDOM();
+
+    renderHookWithProviders(() => useRegisteredbctob2b(vi.fn()), {
+      preloadedState: { company: b2cCustomerState },
+      initialGlobalContext: { registerEnabled: false },
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole('button', { name: 'Business Account Application' }),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it('does not render the button when company status is not DEFAULT', async () => {
+    setupNavDOM();
+
+    renderHookWithProviders(() => useRegisteredbctob2b(vi.fn()), {
+      preloadedState: {
+        company: buildCompanyStateWith({
+          customer: { id: 123, role: CustomerRole.B2C },
+          companyInfo: { status: CompanyStatus.APPROVED },
+        }),
+      },
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole('button', { name: 'Business Account Application' }),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it('opens the Business Account Application page when the button is clicked', async () => {
+    setupNavDOM();
+    const setOpenPage = vi.fn();
+
+    renderHookWithProviders(() => useRegisteredbctob2b(setOpenPage), {
+      preloadedState: { company: b2cCustomerState },
+    });
+
+    await userEvent.click(
+      await screen.findByRole('button', { name: 'Business Account Application' }),
+    );
+
+    expect(setOpenPage).toHaveBeenCalledWith({
+      isOpen: true,
+      openUrl: '/registeredbctob2b',
+    });
+  });
+});

--- a/apps/storefront/src/hooks/dom/useRegisteredbctob2b.test.ts
+++ b/apps/storefront/src/hooks/dom/useRegisteredbctob2b.test.ts
@@ -40,19 +40,19 @@ describe('useRegisteredbctob2b', () => {
     mockedB2bVerifyBcLoginStatus.mockResolvedValue(true);
   });
 
-  it('renders a "Business Account Application" button in the nav', async () => {
+  it('renders a "Business Account Application" link in the nav', async () => {
     setupNavDOM();
 
     renderHookWithProviders(() => useRegisteredbctob2b(vi.fn()), {
       preloadedState: { company: b2cCustomerState },
     });
 
-    expect(
-      await screen.findByRole('button', { name: 'Business Account Application' }),
-    ).toBeVisible();
+    const link = await screen.findByRole('link', { name: 'Business Account Application' });
+    expect(link).toBeVisible();
+    expect(link).toHaveAttribute('href', '/registeredbctob2b');
   });
 
-  it('does not render the button when bc login check returns false', async () => {
+  it('does not render the link when bc login check returns false', async () => {
     mockedB2bVerifyBcLoginStatus.mockResolvedValue(false);
     setupNavDOM();
 
@@ -62,12 +62,12 @@ describe('useRegisteredbctob2b', () => {
 
     await waitFor(() => {
       expect(
-        screen.queryByRole('button', { name: 'Business Account Application' }),
+        screen.queryByRole('link', { name: 'Business Account Application' }),
       ).not.toBeInTheDocument();
     });
   });
 
-  it('does not render the button when registration is disabled', async () => {
+  it('does not render the link when registration is disabled', async () => {
     setupNavDOM();
 
     renderHookWithProviders(() => useRegisteredbctob2b(vi.fn()), {
@@ -77,12 +77,12 @@ describe('useRegisteredbctob2b', () => {
 
     await waitFor(() => {
       expect(
-        screen.queryByRole('button', { name: 'Business Account Application' }),
+        screen.queryByRole('link', { name: 'Business Account Application' }),
       ).not.toBeInTheDocument();
     });
   });
 
-  it('does not render the button when company status is not DEFAULT', async () => {
+  it('does not render the link when company status is not DEFAULT', async () => {
     setupNavDOM();
 
     renderHookWithProviders(() => useRegisteredbctob2b(vi.fn()), {
@@ -96,12 +96,12 @@ describe('useRegisteredbctob2b', () => {
 
     await waitFor(() => {
       expect(
-        screen.queryByRole('button', { name: 'Business Account Application' }),
+        screen.queryByRole('link', { name: 'Business Account Application' }),
       ).not.toBeInTheDocument();
     });
   });
 
-  it('opens the Business Account Application page when the button is clicked', async () => {
+  it('opens the Business Account Application page when the link is clicked', async () => {
     setupNavDOM();
     const setOpenPage = vi.fn();
 
@@ -110,7 +110,7 @@ describe('useRegisteredbctob2b', () => {
     });
 
     await userEvent.click(
-      await screen.findByRole('button', { name: 'Business Account Application' }),
+      await screen.findByRole('link', { name: 'Business Account Application' }),
     );
 
     expect(setOpenPage).toHaveBeenCalledWith({

--- a/apps/storefront/src/hooks/dom/useRegisteredbctob2b.ts
+++ b/apps/storefront/src/hooks/dom/useRegisteredbctob2b.ts
@@ -53,12 +53,9 @@ const useRegisteredbctob2b = (setOpenPage: Dispatch<SetStateAction<OpenPageState
       const convertB2BNavNode = document.createElement('li');
       convertB2BNavNode.className = 'navUser-item navUser-convert-b2b';
       convertB2BNavNode.innerHTML = `
-        <button
-          class="navUser-action"
-          type="button"
-        >
+        <a class="navUser-action" href="/registeredbctob2b">
           ${b3Lang('global.registerB2B.linkText')}
-        </button>
+        </a>
       `;
       return convertB2BNavNode;
     };
@@ -86,9 +83,10 @@ const useRegisteredbctob2b = (setOpenPage: Dispatch<SetStateAction<OpenPageState
 
       accountNode?.parentNode?.insertBefore(convertB2BNavNode, accountNode);
 
-      const linkNode = convertB2BNavNode.querySelector('button');
+      const linkNode = convertB2BNavNode.querySelector('a');
       if (linkNode) {
-        linkNode.onclick = () => {
+        linkNode.onclick = (e) => {
+          e.preventDefault();
           setOpenPage({
             isOpen: true,
             openUrl: '/registeredbctob2b',

--- a/apps/storefront/src/hooks/dom/useRegisteredbctob2b.ts
+++ b/apps/storefront/src/hooks/dom/useRegisteredbctob2b.ts
@@ -53,9 +53,12 @@ const useRegisteredbctob2b = (setOpenPage: Dispatch<SetStateAction<OpenPageState
       const convertB2BNavNode = document.createElement('li');
       convertB2BNavNode.className = 'navUser-item navUser-convert-b2b';
       convertB2BNavNode.innerHTML = `
-        <a class="navUser-action" href="javascript:;" aria-label="Gift Certificates">
+        <button
+          class="navUser-action"
+          type="button"
+        >
           ${b3Lang('global.registerB2B.linkText')}
-        </a>
+        </button>
       `;
       return convertB2BNavNode;
     };
@@ -83,7 +86,7 @@ const useRegisteredbctob2b = (setOpenPage: Dispatch<SetStateAction<OpenPageState
 
       accountNode?.parentNode?.insertBefore(convertB2BNavNode, accountNode);
 
-      const linkNode = convertB2BNavNode.querySelector('a');
+      const linkNode = convertB2BNavNode.querySelector('button');
       if (linkNode) {
         linkNode.onclick = () => {
           setOpenPage({


### PR DESCRIPTION
Jira: [B2B-4848](https://bigcommercecloud.atlassian.net/browse/B2B-4848)

## What/Why?
### Problem

The "Business Account Application" link injected into the storefront navigation had two accessibility violations:

- The element was an `<a>` tag with `href="javascript:;"` — a placeholder that gives no meaningful destination. Screen readers and keyboard users expect an anchor to navigate somewhere; using it purely as a click trigger is misleading and does not meet WCAG 2.1.1 (Keyboard) or WCAG 4.1.2 (Name, Role, Value).
- The `aria-label` was hardcoded as `"Gift Certificates"` introducing misleading.

### Fix

Replaced `href="javascript:;"` with `href="/registeredbctob2b"` and removed the incorrect `aria-label` in `useRegisteredbctob2b.ts`.

### Why `<a>` is kept instead of changing to `<button>`

The element is kept as an `<a>` tag because it represents navigation to a real destination, here `/registeredbctob2b` is a registered route in the application. In a nav bar where all sibling items are links, using `<a>` is semantically correct and consistent with user expectations.

The click handler calls `e.preventDefault()` so the SPA can handle routing via `setOpenPage`, opening the registration form as an overlay. And the `href` provides a meaningful, accessible destination while JavaScript handles the in-app experience. Without JavaScript, the `href` still points somewhere real rather than nowhere.

`<button>` would be appropriate if this element had no URL destination, for example, opening a modal with no corresponding route. Since `/registeredbctob2b` is a real route, `<a>` is the correct element.

### Why `aria-label` was removed

Per the [MDN ARIA spec](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-label), `aria-label` is intended for elements that have no visible text label, for example an icon-only link or button. A `<a>`'s accessible name is derived automatically from its text content. Since the link already renders the visible text "Business Account Application" (from `global.registerB2B.linkText`), adding `aria-label` would override that visible text, hiding it from assistive technologies and risking a WCAG 2.5.3 (Label in Name) mismatch. Removing it means the accessible name and the visible label are identical, which is the most correct and robust state.

## Rollout/Rollback
Revert this PR if needed

## Testing

**After**

https://github.com/user-attachments/assets/a0edba4b-5f56-431c-9270-69eb5552f9d9


[B2B-4848]: https://bigcommercecloud.atlassian.net/browse/B2B-4848?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ