### PR TITLE
POC: B2B-4822 Remove bcGraphqlToken bearer from SF GQL

### DIFF
--- a/apps/storefront/src/shared/service/request/b3Fetch.ts
+++ b/apps/storefront/src/shared/service/request/b3Fetch.ts
@@ -142,11 +142,8 @@ const B3Request = {
    * Request used in stencil store to call bigcommerce graphql storefront api
    */
   graphqlBC: function post<T = any>(data: GQLRequest): Promise<T> {
-    const { bcGraphqlToken } = store.getState().company.tokens;
-    const config = {
-      Authorization: `Bearer  ${bcGraphqlToken}`,
-    };
-    return graphqlRequest(RequestType.BCGraphql, data, config);
+    // POC B2B-4822: removed bcGraphqlToken bearer — testing same-origin requests without it
+    return graphqlRequest(RequestType.BCGraphql, data, {});
   },
   /**
    * Request used in headless context to talk to the bigcommerce graphql storefront api via proxy


### PR DESCRIPTION
Jira: [B2B-4822](https://bigcommercecloud.atlassian.net/browse/B2B-4822)

## What/Why?

POC to validate the core assumption behind login unification
If all pass, the full login unification plan is validated and implementation can proceed.

## Feature Flags

No feature flag — this is a POC branch for integration testing only, not intended to merge to main.

## Rollout/Rollback

POC only. Not for production rollout.

## Testing

Manual testing on integration environment against the scenarios listed above.

[B2B-4822]: https://bigcommercecloud.atlassian.net/browse/B2B-4822?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ