### PR TITLE
fix(orders): B2B-4620 fix test failures from merge of B2B-4619 and B2B-4620

### DIFF
--- a/apps/storefront/src/pages/CompanyOrderList/unified-company-orders.test.tsx
+++ b/apps/storefront/src/pages/CompanyOrderList/unified-company-orders.test.tsx
@@ -586,7 +586,7 @@ describe('Company Orders — unified SF GQL orders (B2B-4616)', () => {
             startCursor: 'cursor-1001',
             endCursor: 'cursor-1002',
           },
-          4,
+          20,
         );
 
         const getOrders = vi.fn().mockReturnValue(page1Response);
@@ -602,7 +602,7 @@ describe('Company Orders — unified SF GQL orders (B2B-4616)', () => {
                 startCursor: 'cursor-2001',
                 endCursor: 'cursor-2002',
               },
-              4,
+              20,
             ),
           );
 
@@ -1069,7 +1069,7 @@ describe('Company Orders — unified SF GQL orders (B2B-4616)', () => {
       });
 
       it('displays total count from collectionInfo.totalItems', async () => {
-        const response = buildPagedResponse(
+        const response = buildPagedCompanyOrdersResponse(
           [{ entityId: 3001 }, { entityId: 3002 }],
           {
             hasNextPage: true,


### PR DESCRIPTION
Jira: [B2B-4620](https://bigcommercecloud.atlassian.net/browse/B2B-4620)

## What/Why?

Fixes 3 test failures on main introduced when [B2B-4620 (#861)](https://github.com/bigcommerce/b2b-buyer-portal/pull/861) and [B2B-4619 (#858)](https://github.com/bigcommerce/b2b-buyer-portal/pull/858) merged concurrently.

**Failed CI run:** [CircleCI job #22063](https://app.circleci.com/pipelines/gh/bigcommerce/b2b-buyer-portal/4350/workflows/1aa8bc7e-1cdc-4675-93da-90a275fcc5f8/jobs/22063/tests)

**Failing tests:**
1. `sorting > clears cursor variables when sort changes after paging forward`
2. `sorting > includes sortBy with applied search filters`
3. `cursor pagination > displays total count from collectionInfo.totalItems`

**Root causes:**

1. **`buildPagedResponse` → `buildPagedCompanyOrdersResponse` (ReferenceError):** B2B-4619 renamed the test helper from `buildPagedResponse` to `buildPagedCompanyOrdersResponse`. B2B-4620 added a new test (`displays total count`) that used the old name. Both PRs passed CI individually, but after merge the reference broke. **Fixes test 3**.

2. **`totalItems: 4` → `totalItems: 20` (MUI page-out-of-range warning):** B2B-4619's sorting test creates paginated responses with `totalItems: 4`. B2B-4620 made the pagination `count` dynamic (previously hardcoded to `-1`). With `totalItems: 4` and default `pageSize: 10`, navigating to page 2 gives MUI `count=4, page=1` — MUI fires a propType `console.error` warning because page 1 exceeds `ceil(4/10)-1 = 0`. CI's `vitest-fail-on-console` treats any `console.error` as a test failure, which failed test 1 and test 2. **Fixes tests 1 and 2**.

## Rollout/Rollback

Test-only change. No runtime impact.

## Testing

```
cd apps/storefront
npx vitest run src/pages/CompanyOrderList/unified-company-orders.test.tsx
```

All 23 tests pass.

[B2B-4620]: https://bigcommercecloud.atlassian.net/browse/B2B-4620?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes updating mock pagination totals and a renamed response builder to eliminate console-error-driven CI failures; no production logic is modified.
> 
> **Overview**
> Fixes failures in `unified-company-orders.test.tsx` by aligning with the renamed `buildPagedCompanyOrdersResponse` helper and updating mocked `collectionInfo.totalItems` values used in cursor/sorting pagination tests.
> 
> This prevents page-out-of-range `console.error` warnings during pagination (via more realistic totals) and restores the total-count assertion to use the correct builder.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf09a52f46fbfad755c446d89cf804d483e9ea51. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->