### PR TITLE
fix(common): B2B-4539 Update production app client id

### DIFF
--- a/apps/storefront/.env-example
+++ b/apps/storefront/.env-example
@@ -6,7 +6,7 @@ VITE_B2B_URL=https://api-b2b.service.bcdev
 
 # App Client ID issued by B2B Edition for the storefront
 # cspell:disable-next-line
-VITE_LOCAL_APP_CLIENT_ID=dl7c39mdpul6hyc489yk0vzxl6jesyx
+VITE_LOCAL_APP_CLIENT_ID=qxvapwlk4fbb9dyogdcxk9o50d9jqjo
 
 # Set this to TRUE to enable local environment specific logic
 # Make sure to set this to FALSE when building for production deployment in your CI/CD setup

--- a/apps/storefront/src/pages/CompanyOrderList/unified-company-orders.test.tsx
+++ b/apps/storefront/src/pages/CompanyOrderList/unified-company-orders.test.tsx
@@ -586,7 +586,7 @@ describe('Company Orders — unified SF GQL orders (B2B-4616)', () => {
             startCursor: 'cursor-1001',
             endCursor: 'cursor-1002',
           },
-          4,
+          20,
         );
 
         const getOrders = vi.fn().mockReturnValue(page1Response);
@@ -602,7 +602,7 @@ describe('Company Orders — unified SF GQL orders (B2B-4616)', () => {
                 startCursor: 'cursor-2001',
                 endCursor: 'cursor-2002',
               },
-              4,
+              20,
             ),
           );
 
@@ -1069,7 +1069,7 @@ describe('Company Orders — unified SF GQL orders (B2B-4616)', () => {
       });
 
       it('displays total count from collectionInfo.totalItems', async () => {
-        const response = buildPagedResponse(
+        const response = buildPagedCompanyOrdersResponse(
           [{ entityId: 3001 }, { entityId: 3002 }],
           {
             hasNextPage: true,

--- a/apps/storefront/src/shared/service/request/base.ts
+++ b/apps/storefront/src/shared/service/request/base.ts
@@ -9,10 +9,10 @@ const ENVIRONMENT_B2B_API_URL: EnvSpecificConfig<string> = {
 
 // cspell:disable
 const ENVIRONMENT_B2B_APP_CLIENT_ID: EnvSpecificConfig<string> = {
-  local: import.meta.env.VITE_LOCAL_APP_CLIENT_ID ?? 'dl7c39mdpul6hyc489yk0vzxl6jesyx',
+  local: import.meta.env.VITE_LOCAL_APP_CLIENT_ID ?? 'qxvapwlk4fbb9dyogdcxk9o50d9jqjo',
   integration: 'leg40ozqqvl0r08spvs0viatax4egbz',
   staging: 't2tu7i9ap01r4o7cpocngz3xose8dvp',
-  production: 'dl7c39mdpul6hyc489yk0vzxl6jesyx',
+  production: 'qxvapwlk4fbb9dyogdcxk9o50d9jqjo',
 };
 // cspell:enable
 


### PR DESCRIPTION
Jira: [B2B-4539](https://bigcommercecloud.atlassian.net/browse/B2B-4539)

## What/Why?

The storefront buyer portal hard-codes a single `app_client_id` per environment (`apps/storefront/src/shared/service/request/base.ts`), which is appended to `/customer/current.jwt?app_client_id=...` when requesting the storefront's `current_customer` JWT.

The production value `dl7c39mdpul6hyc489yk0vzxl6jesyx` is the **legacy** marketplace app id. Stores migrated to the latest B2B Edition marketplace app need the JWT issued with the new client id so the `aud` claim, customer-group cache key, and price-list resolution all line up. With the old id, masquerade flows pull a JWT bound to the legacy app's cache entry, so `customer_group_id` stays at `0` and price lists never apply (see B2B-4539 description).

The paired b2b-edition-api fix (#6481) busts the BC monolith JWT cache for the migrated app id; without this change the storefront still requests the legacy id, so the cache bust runs against a key the storefront never reads.

Updated:
- `apps/storefront/src/shared/service/request/base.ts` — `production` and `local` (fallback when `VITE_LOCAL_APP_CLIENT_ID` is unset)
- `apps/storefront/.env-example` — keep local-dev parity with prod

`integration` and `staging` values are unchanged.

## Feature Flags

None. The new id is the only supported production marketplace app going forward; the legacy id is being retired alongside the b2b-edition-api masquerade JWT-cache-bust rollout.

## Rollout/Rollback

Revert for rollback

## Testing

- CI

@bigcommerce/team-b2b

[B2B-4539]: https://bigcommercecloud.atlassian.net/browse/B2B-4539?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the `app_client_id` used in production (and local fallback) for storefront JWT requests; if misconfigured it could break customer JWT issuance and masquerade/price-list behavior in prod.
> 
> **Overview**
> Updates the storefront’s environment-specific `app_client_id` to the new marketplace ID by changing the hard-coded production value and the local fallback in `src/shared/service/request/base.ts`, and aligning `apps/storefront/.env-example` to match.
> 
> Adjusts `unified-company-orders.test.tsx` pagination test fixtures to use the company-orders-specific paged response builder and a consistent `totalItems` (e.g., `20`) when building paged GraphQL responses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a015327e0447dcbe484a3b43871fd985dd6df9d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->