### PR TITLE
Revert "fix(common): B2B-4539 Update production app client id"

### DIFF
--- a/apps/storefront/.env-example
+++ b/apps/storefront/.env-example
@@ -6,7 +6,7 @@ VITE_B2B_URL=https://api-b2b.service.bcdev
 
 # App Client ID issued by B2B Edition for the storefront
 # cspell:disable-next-line
-VITE_LOCAL_APP_CLIENT_ID=qxvapwlk4fbb9dyogdcxk9o50d9jqjo
+VITE_LOCAL_APP_CLIENT_ID=dl7c39mdpul6hyc489yk0vzxl6jesyx
 
 # Set this to TRUE to enable local environment specific logic
 # Make sure to set this to FALSE when building for production deployment in your CI/CD setup

--- a/apps/storefront/src/shared/service/request/base.ts
+++ b/apps/storefront/src/shared/service/request/base.ts
@@ -9,10 +9,10 @@ const ENVIRONMENT_B2B_API_URL: EnvSpecificConfig<string> = {
 
 // cspell:disable
 const ENVIRONMENT_B2B_APP_CLIENT_ID: EnvSpecificConfig<string> = {
-  local: import.meta.env.VITE_LOCAL_APP_CLIENT_ID ?? 'qxvapwlk4fbb9dyogdcxk9o50d9jqjo',
+  local: import.meta.env.VITE_LOCAL_APP_CLIENT_ID ?? 'dl7c39mdpul6hyc489yk0vzxl6jesyx',
   integration: 'leg40ozqqvl0r08spvs0viatax4egbz',
   staging: 't2tu7i9ap01r4o7cpocngz3xose8dvp',
-  production: 'qxvapwlk4fbb9dyogdcxk9o50d9jqjo',
+  production: 'dl7c39mdpul6hyc489yk0vzxl6jesyx',
 };
 // cspell:enable
 


### PR DESCRIPTION
Reverts bigcommerce/b2b-buyer-portal#868

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the default B2B app client ID used for local and production requests; if the ID is wrong for a deployed environment it can break API authentication/authorization.
> 
> **Overview**
> Updates the storefront’s configured B2B app client ID by replacing the previous ID with a new one in both `.env-example` and the `ENVIRONMENT_B2B_APP_CLIENT_ID` defaults in `request/base.ts` (including the production fallback).
> 
> No behavior changes beyond which client ID is used when `VITE_LOCAL_APP_CLIENT_ID` isn’t explicitly set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b64eb2b9ea16ab2473f2c1538433b027caf45858. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->