### PR TITLE
feat(orders): BACK-617 add backorder display to re-order dialog

### DIFF
--- a/apps/storefront/src/hooks/useBackorderStorefrontMessaging.test.ts
+++ b/apps/storefront/src/hooks/useBackorderStorefrontMessaging.test.ts
@@ -1,0 +1,72 @@
+import { buildGlobalStateWith } from 'tests/storeStateBuilders';
+import { renderHookWithProviders } from 'tests/utils/hook-test-utils';
+import { describe, expect, it } from 'vitest';
+
+import {
+  BACKORDER_STOREFRONT_MESSAGING_FEATURE_FLAG,
+  useBackorderStorefrontMessaging,
+} from './useBackorderStorefrontMessaging';
+
+describe('useBackorderStorefrontMessaging', () => {
+  it('combines store backorder, messaging flag, and display settings', () => {
+    const { result } = renderHookWithProviders(() => useBackorderStorefrontMessaging(), {
+      preloadedState: {
+        global: buildGlobalStateWith({
+          backorderEnabled: true,
+          featureFlags: {
+            [BACKORDER_STOREFRONT_MESSAGING_FEATURE_FLAG]: true,
+          },
+          backorderDisplaySettings: {
+            showQuantityOnBackorder: true,
+            showQuantityOnHand: false,
+            showBackorderMessage: false,
+            showDefaultShippingExpectationPrompt: false,
+            defaultShippingExpectationPrompt: '',
+          },
+        }),
+      },
+    });
+
+    expect(result.result.current.isBackorderEnabled).toBe(true);
+    expect(result.result.current.isBackorderMessagingEnabled).toBe(true);
+    expect(result.result.current.isBackorderMessagingContextEnabled).toBe(true);
+    expect(result.result.current.hasAnyBackorderDisplay).toBe(true);
+  });
+
+  it('sets isBackorderMessagingContextEnabled false when the feature flag is off', () => {
+    const { result } = renderHookWithProviders(() => useBackorderStorefrontMessaging(), {
+      preloadedState: {
+        global: buildGlobalStateWith({
+          backorderEnabled: true,
+          featureFlags: {
+            [BACKORDER_STOREFRONT_MESSAGING_FEATURE_FLAG]: false,
+          },
+        }),
+      },
+    });
+
+    expect(result.result.current.isBackorderMessagingContextEnabled).toBe(false);
+  });
+
+  it('sets hasAnyBackorderDisplay false when all display toggles are off', () => {
+    const { result } = renderHookWithProviders(() => useBackorderStorefrontMessaging(), {
+      preloadedState: {
+        global: buildGlobalStateWith({
+          backorderEnabled: true,
+          featureFlags: {
+            [BACKORDER_STOREFRONT_MESSAGING_FEATURE_FLAG]: true,
+          },
+          backorderDisplaySettings: {
+            showQuantityOnBackorder: false,
+            showQuantityOnHand: false,
+            showBackorderMessage: false,
+            showDefaultShippingExpectationPrompt: false,
+            defaultShippingExpectationPrompt: '',
+          },
+        }),
+      },
+    });
+
+    expect(result.result.current.hasAnyBackorderDisplay).toBe(false);
+  });
+});

--- a/apps/storefront/src/hooks/useBackorderStorefrontMessaging.ts
+++ b/apps/storefront/src/hooks/useBackorderStorefrontMessaging.ts
@@ -1,0 +1,27 @@
+import { useFeatureFlag } from '@/hooks/useFeatureFlag';
+import { useIsBackorderEnabled } from '@/hooks/useIsBackorderEnabled';
+import { useAppSelector } from '@/store';
+import type { FeatureFlagKey } from '@/utils/featureFlags';
+
+export const BACKORDER_STOREFRONT_MESSAGING_FEATURE_FLAG =
+  'BACK-134.backorders_phase_1_1_control_messaging_on_storefront' satisfies FeatureFlagKey;
+
+export function useBackorderStorefrontMessaging() {
+  const isBackorderEnabled = useIsBackorderEnabled();
+  const isBackorderMessagingEnabled = useFeatureFlag(BACKORDER_STOREFRONT_MESSAGING_FEATURE_FLAG);
+  const { showQuantityOnBackorder, showQuantityOnHand, showBackorderMessage } = useAppSelector(
+    ({ global }) => global.backorderDisplaySettings,
+  );
+
+  const isBackorderMessagingContextEnabled = isBackorderEnabled && isBackorderMessagingEnabled;
+
+  const hasAnyBackorderDisplay =
+    showQuantityOnBackorder || showQuantityOnHand || showBackorderMessage;
+
+  return {
+    isBackorderEnabled,
+    isBackorderMessagingEnabled,
+    isBackorderMessagingContextEnabled,
+    hasAnyBackorderDisplay,
+  };
+}

--- a/apps/storefront/src/pages/OrderDetail/components/OrderCheckboxProduct.tsx
+++ b/apps/storefront/src/pages/OrderDetail/components/OrderCheckboxProduct.tsx
@@ -1,9 +1,11 @@
 import { ChangeEvent, KeyboardEvent, useEffect, useState } from 'react';
 import { Box, Checkbox, FormControlLabel, TextField, Typography } from '@mui/material';
 
+import BackorderMessage from '@/components/BackorderMessage';
 import { PRODUCT_DEFAULT_IMAGE } from '@/constants';
 import { useMobile } from '@/hooks/useMobile';
 import { useB3Lang } from '@/lib/lang';
+import type { CatalogQuickVariantSku } from '@/shared/service/b2b/graphql/product';
 import { currencyFormat } from '@/utils/b3CurrencyFormat';
 import { snackbar } from '@/utils/b3Tip';
 
@@ -17,6 +19,7 @@ import {
   ProductImage,
   ProductOptionText,
 } from '../styled';
+import { getReorderBackorderDisplayFields } from '../utils/reorderBackorderDisplay';
 
 interface ReturnListProps {
   returnId: number;
@@ -31,6 +34,8 @@ interface OrderCheckboxProductProps {
   setReturnArr?: (items: ReturnListProps[]) => void;
   textAlign?: string;
   type?: string;
+  reorderInventoryBySku?: Record<string, CatalogQuickVariantSku>;
+  reorderBackorderUiEnabled?: boolean;
 }
 
 export default function OrderCheckboxProduct(props: OrderCheckboxProductProps) {
@@ -43,6 +48,8 @@ export default function OrderCheckboxProduct(props: OrderCheckboxProductProps) {
     setReturnArr = () => {},
     textAlign = 'left',
     type,
+    reorderInventoryBySku,
+    reorderBackorderUiEnabled = false,
   } = props;
 
   const b3Lang = useB3Lang();
@@ -59,6 +66,11 @@ export default function OrderCheckboxProduct(props: OrderCheckboxProductProps) {
   };
 
   const itemStyle = isMobile ? mobileItemStyle : defaultItemStyle;
+  const qtyStackAlignItems = textAlign === 'right' ? 'flex-end' : 'flex-start';
+  const desktopQtyColumnStyle =
+    reorderBackorderUiEnabled && !isMobile
+      ? { width: '22%', minWidth: 'max-content' }
+      : itemStyle.default;
 
   const handleSelectAllChange = () => {
     if (checkedArr.length === products.length) {
@@ -160,7 +172,7 @@ export default function OrderCheckboxProduct(props: OrderCheckboxProductProps) {
           <FlexItem textAlignLocation={textAlign} {...itemStyle.default}>
             <ProductHead>{b3Lang('orderDetail.reorder.price')}</ProductHead>
           </FlexItem>
-          <FlexItem textAlignLocation={textAlign} {...itemStyle.default}>
+          <FlexItem textAlignLocation={textAlign} {...desktopQtyColumnStyle}>
             <ProductHead>{b3Lang('orderDetail.reorder.qty')}</ProductHead>
           </FlexItem>
           <FlexItem textAlignLocation={textAlign} {...itemStyle.default}>
@@ -184,71 +196,112 @@ export default function OrderCheckboxProduct(props: OrderCheckboxProductProps) {
         />
       )}
 
-      {products.map((product: EditableProductItem) => (
-        <Flex
-          isMobile={isMobile}
-          key={product.sku}
-          role="group"
-          aria-labelledby={`group-label-${product.id}`}
-        >
-          <Checkbox
-            checked={isChecked(product.variant_id)}
-            onChange={() =>
-              handleSelectChange(product.variant_id, product.id, Number(product.editQuantity))
-            }
-          />
-          <FlexItem>
-            <ProductImage src={product.imageUrl || PRODUCT_DEFAULT_IMAGE} />
-            <Box
-              sx={{
-                marginLeft: '16px',
-              }}
-            >
-              <Typography variant="body1" color="#212121" id={`group-label-${product.id}`}>
-                {product.name}
-              </Typography>
-              <Typography variant="body1" color="#616161">
-                {product.sku}
-              </Typography>
-              {(product.product_options || []).map((option: OrderProductOption) => (
-                <ProductOptionText key={option.id}>
-                  {`${option.display_name}: ${option.display_value}`}
-                </ProductOptionText>
-              ))}
-            </Box>
-          </FlexItem>
-          <FlexItem textAlignLocation={textAlign} padding="10px 0 0" {...itemStyle.default}>
-            {isMobile && <span>{b3Lang('orderDetail.reorder.price')} </span>}
-            {currencyFormat(product.base_price)}
-          </FlexItem>
-          <FlexItem textAlignLocation={textAlign} {...itemStyle.default}>
-            <TextField
-              type="number"
-              variant="filled"
-              hiddenLabel={!isMobile}
-              label={isMobile ? b3Lang('orderDetail.reorder.qty') : ''}
-              value={getProductQuantity(product)}
-              onChange={handleProductQuantityChange(product)}
-              onKeyDown={handleNumberInputKeyDown}
-              onBlur={handleNumberInputBlur(product)}
-              size="small"
-              sx={{
-                width: isMobile ? '60%' : '80px',
-                '& .MuiFormHelperText-root': {
-                  marginLeft: '0',
-                  marginRight: '0',
-                },
-              }}
-              error={!!product.helperText}
-              helperText={product.helperText}
+      {products.map((product: EditableProductItem) => {
+        const qty = Number(getProductQuantity(product)) || 0;
+        const invRow = reorderInventoryBySku?.[product.sku.toUpperCase()];
+        const backorderFields = getReorderBackorderDisplayFields(qty, invRow);
+        const showReorderBackorder = reorderBackorderUiEnabled && Boolean(backorderFields);
+
+        return (
+          <Flex
+            isMobile={isMobile}
+            key={product.sku}
+            role="group"
+            aria-labelledby={`group-label-${product.id}`}
+          >
+            <Checkbox
+              checked={isChecked(product.variant_id)}
+              onChange={() =>
+                handleSelectChange(product.variant_id, product.id, Number(product.editQuantity))
+              }
             />
-          </FlexItem>
-          <FlexItem textAlignLocation={textAlign} padding="10px 0 0" {...itemStyle.default}>
-            {isMobile && <span>{b3Lang('orderDetail.reorder.total')} </span>}
-            {currencyFormat(getProductTotals(getProductQuantity(product), product.base_price))}
-          </FlexItem>
-        </Flex>
-      ))}
+            <FlexItem>
+              <ProductImage src={product.imageUrl || PRODUCT_DEFAULT_IMAGE} />
+              <Box
+                sx={{
+                  marginLeft: '16px',
+                }}
+              >
+                <Typography variant="body1" color="#212121" id={`group-label-${product.id}`}>
+                  {product.name}
+                </Typography>
+                <Typography variant="body1" color="#616161">
+                  {product.sku}
+                </Typography>
+                {(product.product_options || []).map((option: OrderProductOption) => (
+                  <ProductOptionText key={option.id}>
+                    {`${option.display_name}: ${option.display_value}`}
+                  </ProductOptionText>
+                ))}
+              </Box>
+            </FlexItem>
+            <FlexItem textAlignLocation={textAlign} padding="10px 0 0" {...itemStyle.default}>
+              {isMobile && <span>{b3Lang('orderDetail.reorder.price')} </span>}
+              {currencyFormat(product.base_price)}
+            </FlexItem>
+            <FlexItem
+              textAlignLocation={textAlign}
+              padding={isMobile ? undefined : '10px 0 0'}
+              {...desktopQtyColumnStyle}
+            >
+              <Box
+                sx={{
+                  display: 'flex',
+                  flexDirection: 'column',
+                  alignItems: qtyStackAlignItems,
+                  width: '100%',
+                  maxWidth: '100%',
+                  minWidth: 0,
+                }}
+              >
+                <TextField
+                  type="number"
+                  variant="filled"
+                  hiddenLabel={!isMobile}
+                  label={isMobile ? b3Lang('orderDetail.reorder.qty') : ''}
+                  value={getProductQuantity(product)}
+                  onChange={handleProductQuantityChange(product)}
+                  onKeyDown={handleNumberInputKeyDown}
+                  onBlur={handleNumberInputBlur(product)}
+                  size="small"
+                  sx={{
+                    width: isMobile ? '60%' : '80px',
+                    '& .MuiFormHelperText-root': {
+                      marginLeft: '0',
+                      marginRight: '0',
+                    },
+                  }}
+                  error={!!product.helperText}
+                  helperText={product.helperText}
+                />
+                {showReorderBackorder && backorderFields && (
+                  <Box
+                    sx={{
+                      mt: 1,
+                      width: '100%',
+                      maxWidth: '100%',
+                      minWidth: 0,
+                      textAlign: 'right',
+                      alignSelf: 'flex-end',
+                    }}
+                  >
+                    <BackorderMessage
+                      totalOnHand={backorderFields.totalOnHand}
+                      quantityBackordered={backorderFields.quantityBackordered}
+                      backorderMessage={backorderFields.backorderMessage}
+                      visible
+                    />
+                  </Box>
+                )}
+              </Box>
+            </FlexItem>
+            <FlexItem textAlignLocation={textAlign} padding="10px 0 0" {...itemStyle.default}>
+              {isMobile && <span>{b3Lang('orderDetail.reorder.total')} </span>}
+              {currencyFormat(getProductTotals(getProductQuantity(product), product.base_price))}
+            </FlexItem>
+          </Flex>
+        );
+      })}
     </Box>
   ) : null;
 }

--- a/apps/storefront/src/pages/OrderDetail/components/OrderDialog.tsx
+++ b/apps/storefront/src/pages/OrderDetail/components/OrderDialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { FieldValues, useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
 import { Box, Typography } from '@mui/material';
@@ -7,7 +7,7 @@ import Cookies from 'js-cookie';
 import { B3CustomForm } from '@/components/B3CustomForm';
 import B3Dialog from '@/components/B3Dialog';
 import { CART_URL } from '@/constants';
-import { useIsBackorderEnabled } from '@/hooks/useIsBackorderEnabled';
+import { useBackorderStorefrontMessaging } from '@/hooks/useBackorderStorefrontMessaging';
 import { useMobile } from '@/hooks/useMobile';
 import { useB3Lang } from '@/lib/lang';
 import {
@@ -15,6 +15,7 @@ import {
   addProductToShoppingList,
   getVariantInfoBySkus,
 } from '@/shared/service/b2b';
+import type { CatalogQuickVariantSku } from '@/shared/service/b2b/graphql/product';
 import { isB2BUserSelector, useAppSelector } from '@/store';
 import b2bLogger from '@/utils/b3Logger';
 import { snackbar } from '@/utils/b3Tip';
@@ -96,12 +97,13 @@ export default function OrderDialog({
   orderId,
 }: OrderDialogProps) {
   const navigate = useNavigate();
-  const isBackorderEnabled = useIsBackorderEnabled();
+  const { isBackorderEnabled, isBackorderMessagingContextEnabled, hasAnyBackorderDisplay } =
+    useBackorderStorefrontMessaging();
   const isB2BUser = useAppSelector(isB2BUserSelector);
   const [isOpenCreateShopping, setOpenCreateShopping] = useState(false);
   const [openShoppingList, setOpenShoppingList] = useState(false);
   const [editableProducts, setEditableProducts] = useState<EditableProductItem[]>([]);
-  const [variantInfoList, setVariantInfoList] = useState<CustomFieldItems[]>([]);
+  const [variantInfoList, setVariantInfoList] = useState<CatalogQuickVariantSku[]>([]);
   const [isRequestLoading, setIsRequestLoading] = useState(false);
   const [checkedArr, setCheckedArr] = useState<number[]>([]);
   const [returnArr, setReturnArr] = useState<ReturnListProps[]>([]);
@@ -461,8 +463,22 @@ export default function OrderDialog({
     setOpenShoppingList(true);
   };
 
+  const reorderInventoryBySku = useMemo(() => {
+    const map: Record<string, CatalogQuickVariantSku> = {};
+    variantInfoList.forEach((row) => {
+      if (row.variantSku) {
+        map[row.variantSku.toUpperCase()] = row;
+      }
+    });
+    return map;
+  }, [variantInfoList]);
+
   useEffect(() => {
-    if (!open) return;
+    if (!open) {
+      setVariantInfoList([]);
+      return () => {};
+    }
+
     setEditableProducts(
       products.map((item: OrderProductItem) => ({
         ...item,
@@ -470,6 +486,9 @@ export default function OrderDialog({
       })),
     );
     setCheckedArr([]);
+    setVariantInfoList([]);
+
+    let cancelled = false;
 
     const getVariantInfoByList = async () => {
       const visibleProducts = products.filter((item: OrderProductItem) => item?.isVisible);
@@ -478,12 +497,18 @@ export default function OrderDialog({
 
       if (visibleSkus.length === 0) return;
 
-      const { variantSku: variantInfoList = [] } = await getVariantInfoBySkus(visibleSkus);
+      const { variantSku: nextVariantInfoList = [] } = await getVariantInfoBySkus(visibleSkus);
 
-      setVariantInfoList(variantInfoList);
+      if (!cancelled) {
+        setVariantInfoList(nextVariantInfoList);
+      }
     };
 
     getVariantInfoByList();
+
+    return () => {
+      cancelled = true;
+    };
   }, [isB2BUser, open, products]);
 
   const handleProductChange = (products: EditableProductItem[]) => {
@@ -524,6 +549,10 @@ export default function OrderDialog({
             setReturnArr={setReturnArr}
             textAlign={isMobile ? 'left' : 'right'}
             type={type}
+            reorderInventoryBySku={reorderInventoryBySku}
+            reorderBackorderUiEnabled={
+              isBackorderMessagingContextEnabled && hasAnyBackorderDisplay && type === 'reOrder'
+            }
           />
 
           {type === 'return' && (

--- a/apps/storefront/src/pages/OrderDetail/styled.ts
+++ b/apps/storefront/src/pages/OrderDetail/styled.ts
@@ -9,7 +9,7 @@ interface FlexItemProps {
   width?: string;
   padding?: string;
   flexBasis?: string;
-  minHeight?: string;
+  minWidth?: string;
   textAlignLocation?: string;
 }
 
@@ -48,7 +48,7 @@ const Flex = styled('div')<FlexProps>(({ isHeader, isMobile }) => {
 });
 
 const FlexItem = styled('div')(
-  ({ width, padding = '0', flexBasis, textAlignLocation }: FlexItemProps) => ({
+  ({ width, padding = '0', flexBasis, textAlignLocation, minWidth }: FlexItemProps) => ({
     display: 'flex',
     flexGrow: width ? 0 : 1,
     flexShrink: width ? 0 : 1,
@@ -56,6 +56,7 @@ const FlexItem = styled('div')(
     justifyContent: textAlignLocation === 'right' ? 'flex-end' : 'flex-start',
     flexBasis,
     width,
+    minWidth,
     padding,
   }),
 );

--- a/apps/storefront/src/pages/OrderDetail/utils/reorderBackorderDisplay.test.ts
+++ b/apps/storefront/src/pages/OrderDetail/utils/reorderBackorderDisplay.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+
+import type { CatalogQuickVariantSku } from '@/shared/service/b2b/graphql/product';
+
+import { getReorderBackorderDisplayFields } from './reorderBackorderDisplay';
+
+describe('reorderBackorderDisplay', () => {
+  it('getReorderBackorderDisplayFields computes quantity backordered vs total on hand', () => {
+    const row = {
+      inventoryTracking: 'variant',
+      totalOnHand: 9,
+      backorderMessage: 'Ships in 2 weeks',
+    } as CatalogQuickVariantSku;
+
+    const fields = getReorderBackorderDisplayFields(10, row);
+
+    expect(fields).toEqual({
+      totalOnHand: 9,
+      quantityBackordered: 1,
+      backorderMessage: 'Ships in 2 weeks',
+    });
+  });
+
+  it('getReorderBackorderDisplayFields returns null when no backordered quantity', () => {
+    const row = {
+      inventoryTracking: 'variant',
+      totalOnHand: 10,
+    } as CatalogQuickVariantSku;
+
+    expect(getReorderBackorderDisplayFields(10, row)).toBeNull();
+  });
+
+  it('getReorderBackorderDisplayFields returns null when inventory tracking is none', () => {
+    const row = {
+      inventoryTracking: 'none',
+      totalOnHand: 0,
+    } as CatalogQuickVariantSku;
+
+    expect(getReorderBackorderDisplayFields(10, row)).toBeNull();
+  });
+
+  it('getReorderBackorderDisplayFields returns null when row is undefined', () => {
+    expect(getReorderBackorderDisplayFields(10, undefined)).toBeNull();
+  });
+
+  it('getReorderBackorderDisplayFields returns null when totalOnHand is null', () => {
+    const row = {
+      inventoryTracking: 'variant',
+      totalOnHand: null,
+    } as CatalogQuickVariantSku;
+
+    expect(getReorderBackorderDisplayFields(10, row)).toBeNull();
+  });
+
+  it('getReorderBackorderDisplayFields returns null when quantity is 0', () => {
+    const row = {
+      inventoryTracking: 'variant',
+      totalOnHand: 5,
+    } as CatalogQuickVariantSku;
+
+    expect(getReorderBackorderDisplayFields(0, row)).toBeNull();
+  });
+
+  it('getReorderBackorderDisplayFields treats negative totalOnHand as fully backordered', () => {
+    const row = {
+      inventoryTracking: 'variant',
+      totalOnHand: -3,
+    } as CatalogQuickVariantSku;
+
+    expect(getReorderBackorderDisplayFields(10, row)).toEqual({
+      totalOnHand: -3,
+      quantityBackordered: 13,
+      backorderMessage: undefined,
+    });
+  });
+});

--- a/apps/storefront/src/pages/OrderDetail/utils/reorderBackorderDisplay.ts
+++ b/apps/storefront/src/pages/OrderDetail/utils/reorderBackorderDisplay.ts
@@ -1,0 +1,21 @@
+import type { CatalogQuickVariantSku } from '@/shared/service/b2b/graphql/product';
+import type { BackorderDisplayFields } from '@/utils/backorderDisplayFromInventory';
+import { getBackorderDisplayFieldsFromOnHand } from '@/utils/backorderDisplayFromInventory';
+
+export function getReorderBackorderDisplayFields(
+  quantity: number,
+  row: CatalogQuickVariantSku | undefined,
+): BackorderDisplayFields | null {
+  if (!row) return null;
+  const tracking = row.inventoryTracking || 'none';
+  if (tracking !== 'product' && tracking !== 'variant') return null;
+
+  const { totalOnHand } = row;
+  if (totalOnHand === null || totalOnHand === undefined) return null;
+
+  return getBackorderDisplayFieldsFromOnHand(
+    quantity,
+    totalOnHand,
+    row.backorderMessage ?? undefined,
+  );
+}

--- a/apps/storefront/src/pages/quote/components/QuoteDetailTable.tsx
+++ b/apps/storefront/src/pages/quote/components/QuoteDetailTable.tsx
@@ -5,7 +5,7 @@ import BackorderMessage from '@/components/BackorderMessage';
 import { B3PaginationTable, GetRequestList } from '@/components/table/B3PaginationTable';
 import { TableColumnItem } from '@/components/table/B3Table';
 import { PRODUCT_DEFAULT_IMAGE } from '@/constants';
-import { useFeatureFlag } from '@/hooks/useFeatureFlag';
+import { useBackorderStorefrontMessaging } from '@/hooks/useBackorderStorefrontMessaging';
 import { useB3Lang } from '@/lib/lang';
 import { useAppSelector } from '@/store';
 import { currencyFormatConvert } from '@/utils/b3CurrencyFormat';
@@ -120,15 +120,8 @@ function QuoteDetailTable(props: ShoppingDetailTableProps, ref: Ref<unknown>) {
   const isEnableProduct = useAppSelector(
     ({ global }) => global.blockPendingQuoteNonPurchasableOOS.isEnableProduct,
   );
-  const isBackorderEnabled = useAppSelector(({ global }) => global.backorderEnabled);
-  const isBackorderMessagingEnabled = useFeatureFlag(
-    'BACK-134.backorders_phase_1_1_control_messaging_on_storefront',
-  );
-  const { showQuantityOnBackorder, showQuantityOnHand, showBackorderMessage } = useAppSelector(
-    ({ global }) => global.backorderDisplaySettings,
-  );
-  const hasAnyBackorderDisplay =
-    showQuantityOnBackorder || showQuantityOnHand || showBackorderMessage;
+  const { isBackorderMessagingContextEnabled, hasAnyBackorderDisplay } =
+    useBackorderStorefrontMessaging();
   const enteredInclusiveTax = useAppSelector(
     ({ storeConfigs }) => storeConfigs.currencies.enteredInclusiveTax,
   );
@@ -315,7 +308,7 @@ function QuoteDetailTable(props: ShoppingDetailTableProps, ref: Ref<unknown>) {
       render: (row) => (
         <Box>
           <Typography sx={{ padding: '12px 0' }}>{row.quantity}</Typography>
-          {isBackorderEnabled && isBackorderMessagingEnabled && !isOrdered && (
+          {isBackorderMessagingContextEnabled && hasAnyBackorderDisplay && !isOrdered && (
             <BackorderMessage
               totalOnHand={row.totalOnHand}
               quantityBackordered={row.quantityBackordered}
@@ -418,10 +411,9 @@ function QuoteDetailTable(props: ShoppingDetailTableProps, ref: Ref<unknown>) {
         >
           {b3Lang('quoteDetail.table.totalProducts', { total: total || 0 })}
         </Typography>
-        {isBackorderEnabled &&
-          isBackorderMessagingEnabled &&
-          !isOrdered &&
+        {isBackorderMessagingContextEnabled &&
           hasAnyBackorderDisplay &&
+          !isOrdered &&
           hasBackorderedItems && (
             <FormControlLabel
               control={

--- a/apps/storefront/src/pages/quote/components/QuoteDetailTableCard.tsx
+++ b/apps/storefront/src/pages/quote/components/QuoteDetailTableCard.tsx
@@ -2,7 +2,7 @@ import { Box, CardContent, styled, Typography } from '@mui/material';
 
 import BackorderMessage from '@/components/BackorderMessage';
 import { PRODUCT_DEFAULT_IMAGE } from '@/constants';
-import { useFeatureFlag } from '@/hooks/useFeatureFlag';
+import { useBackorderStorefrontMessaging } from '@/hooks/useBackorderStorefrontMessaging';
 import { useB3Lang } from '@/lib/lang';
 import { useAppSelector } from '@/store';
 import { currencyFormatConvert } from '@/utils/b3CurrencyFormat';
@@ -43,10 +43,8 @@ function QuoteDetailTableCard(props: QuoteTableCardProps) {
   const enteredInclusiveTax = useAppSelector(
     ({ storeConfigs }) => storeConfigs.currencies.enteredInclusiveTax,
   );
-  const isBackorderEnabled = useAppSelector(({ global }) => global.backorderEnabled);
-  const isBackorderMessagingEnabled = useFeatureFlag(
-    'BACK-134.backorders_phase_1_1_control_messaging_on_storefront',
-  );
+  const { isBackorderMessagingContextEnabled, hasAnyBackorderDisplay } =
+    useBackorderStorefrontMessaging();
 
   const {
     basePrice,
@@ -149,7 +147,7 @@ function QuoteDetailTableCard(props: QuoteTableCardProps) {
           <Typography variant="body1" color="#616161">
             {notes}
           </Typography>
-          {isBackorderEnabled && isBackorderMessagingEnabled && !isOrdered && (
+          {isBackorderMessagingContextEnabled && hasAnyBackorderDisplay && !isOrdered && (
             <BackorderMessage
               totalOnHand={totalOnHand}
               quantityBackordered={quantityBackordered}

--- a/apps/storefront/src/pages/quote/components/QuoteTable.tsx
+++ b/apps/storefront/src/pages/quote/components/QuoteTable.tsx
@@ -7,15 +7,9 @@ import BackorderMessage from '@/components/BackorderMessage';
 import { TableColumnItem } from '@/components/table/B3Table';
 import PaginationTable from '@/components/table/PaginationTable';
 import { PRODUCT_DEFAULT_IMAGE } from '@/constants';
-import { useFeatureFlag } from '@/hooks/useFeatureFlag';
-import { useIsBackorderEnabled } from '@/hooks/useIsBackorderEnabled';
+import { useBackorderStorefrontMessaging } from '@/hooks/useBackorderStorefrontMessaging';
 import { LangFormatFunction, useB3Lang } from '@/lib/lang';
-import {
-  deleteProductFromDraftQuoteList,
-  setDraftProduct,
-  useAppDispatch,
-  useAppSelector,
-} from '@/store';
+import { deleteProductFromDraftQuoteList, setDraftProduct, useAppDispatch } from '@/store';
 import { Product } from '@/types';
 import { QuoteItem } from '@/types/quotes';
 import { currencyFormat } from '@/utils/b3CurrencyFormat';
@@ -170,20 +164,17 @@ interface QuoteTableProps {
 function QuoteTable({ total, items, updateSummary }: QuoteTableProps) {
   const b3Lang = useB3Lang();
   const dispatch = useAppDispatch();
-  const isBackorderEnabled = useIsBackorderEnabled();
-  const isBackorderMessagingEnabled = useFeatureFlag(
-    'BACK-134.backorders_phase_1_1_control_messaging_on_storefront',
-  );
-  const { showQuantityOnBackorder, showQuantityOnHand, showBackorderMessage } = useAppSelector(
-    ({ global }) => global.backorderDisplaySettings,
-  );
-  const hasAnyBackorderDisplay =
-    showQuantityOnBackorder || showQuantityOnHand || showBackorderMessage;
+  const {
+    isBackorderEnabled,
+    isBackorderMessagingEnabled,
+    isBackorderMessagingContextEnabled,
+    hasAnyBackorderDisplay,
+  } = useBackorderStorefrontMessaging();
 
   const [showBackorderDetails, setShowBackorderDetails] = useState(false);
 
   const draftQuoteBackorderContextEnabled =
-    isBackorderEnabled && isBackorderMessagingEnabled && hasAnyBackorderDisplay;
+    isBackorderMessagingContextEnabled && hasAnyBackorderDisplay;
 
   const showBackorderMessageBase = draftQuoteBackorderContextEnabled && showBackorderDetails;
 

--- a/apps/storefront/src/pages/quote/utils/getDraftBackorderDisplayFields.ts
+++ b/apps/storefront/src/pages/quote/utils/getDraftBackorderDisplayFields.ts
@@ -1,5 +1,6 @@
 import type { Variant } from '@/types/products';
 import { QuoteItem } from '@/types/quotes';
+import { getBackorderDisplayFieldsFromOnHand } from '@/utils/backorderDisplayFromInventory';
 
 type QuoteItemBackendAvailability = {
   exceedsAvailableToSell: boolean;
@@ -32,12 +33,6 @@ export function getQuoteItemBackendAvailability(
 
 export function draftRowQuantityExceedsAvailableToSell(row: QuoteItem['node']): boolean {
   return getQuoteItemBackendAvailability(row)?.exceedsAvailableToSell ?? false;
-}
-
-interface DraftBackorderDisplayFields {
-  totalOnHand: number;
-  backorderMessage?: string;
-  quantityBackordered: number;
 }
 
 type DraftBackorderTracking = 'product' | 'variant';
@@ -79,16 +74,7 @@ function getDraftBackorderBackorderMessage(
   return variant.backorder_message ?? undefined;
 }
 
-function getDraftBackorderQuantityBackordered(
-  orderedQuantity: number,
-  totalOnHand: number,
-): number {
-  return Math.max(0, orderedQuantity - totalOnHand);
-}
-
-export function getDraftBackorderDisplayFields(
-  row: QuoteItem['node'],
-): DraftBackorderDisplayFields | null {
+export function getDraftBackorderDisplayFields(row: QuoteItem['node']) {
   const tracking = getDraftBackorderTracking(row);
   if (!tracking) return null;
 
@@ -97,15 +83,7 @@ export function getDraftBackorderDisplayFields(
 
   const backorderMessage = getDraftBackorderBackorderMessage(row, tracking);
   const qty = Number(row.quantity ?? 0);
-  const quantityBackordered = getDraftBackorderQuantityBackordered(qty, totalOnHand);
-
-  if (quantityBackordered <= 0) return null;
-
-  return {
-    totalOnHand,
-    backorderMessage,
-    quantityBackordered,
-  };
+  return getBackorderDisplayFieldsFromOnHand(qty, totalOnHand, backorderMessage);
 }
 
 export function draftQuoteListHasBackorderedItemsForDisplay(draftQuoteList: QuoteItem[]): boolean {

--- a/apps/storefront/src/shared/service/b2b/graphql/product.ts
+++ b/apps/storefront/src/shared/service/b2b/graphql/product.ts
@@ -11,6 +11,15 @@ interface ProductPurchasable {
   sku: string;
 }
 
+export type CatalogQuickVariantSku = CustomFieldItems & {
+  variantSku?: string;
+  inventoryTracking?: string;
+  availableToSell?: number;
+  unlimitedBackorder?: boolean;
+  totalOnHand?: number | null;
+  backorderMessage?: string | null;
+};
+
 const getVariantInfoBySkusQuery = (skuList: string[]) => `
 query GetVariantInfoBySkus {
   variantSku (
@@ -34,6 +43,11 @@ query GetVariantInfoBySkus {
     purchasingDisabled,
     variantSku,
     imageUrl,
+    inventoryTracking,
+    availableToSell,
+    unlimitedBackorder,
+    totalOnHand,
+    backorderMessage,
   }
 }`;
 
@@ -68,7 +82,7 @@ const getSearchProductsQuery = (data: CustomFieldItems, useVariablesImplementati
     $storeHash: String,
     $channelId: Int,
     $customerGroupId: Int,
-    ${data?.categoryFilter ? `$categoryFilter: Boolean,` : ''}    
+    ${data?.categoryFilter ? `$categoryFilter: Boolean,` : ''}
   ) {
     productsSearch (
       search: $search,

--- a/apps/storefront/src/utils/backorderDisplayFromInventory.test.ts
+++ b/apps/storefront/src/utils/backorderDisplayFromInventory.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+
+import { getBackorderDisplayFieldsFromOnHand } from './backorderDisplayFromInventory';
+
+describe('getBackorderDisplayFieldsFromOnHand', () => {
+  it('returns null when ordered quantity is within on hand', () => {
+    expect(getBackorderDisplayFieldsFromOnHand(3, 10)).toBeNull();
+  });
+
+  it('returns quantity backordered and optional message when qty exceeds on hand', () => {
+    expect(getBackorderDisplayFieldsFromOnHand(10, 3, 'Soon')).toEqual({
+      totalOnHand: 3,
+      quantityBackordered: 7,
+      backorderMessage: 'Soon',
+    });
+  });
+
+  it('treats negative total on hand as fully backordered', () => {
+    expect(getBackorderDisplayFieldsFromOnHand(10, -1)).toEqual({
+      totalOnHand: -1,
+      quantityBackordered: 11,
+      backorderMessage: undefined,
+    });
+  });
+});

--- a/apps/storefront/src/utils/backorderDisplayFromInventory.ts
+++ b/apps/storefront/src/utils/backorderDisplayFromInventory.ts
@@ -1,0 +1,20 @@
+export interface BackorderDisplayFields {
+  totalOnHand: number;
+  quantityBackordered: number;
+  backorderMessage?: string;
+}
+
+export function getBackorderDisplayFieldsFromOnHand(
+  orderedQuantity: number,
+  totalOnHand: number,
+  backorderMessage?: string,
+): BackorderDisplayFields | null {
+  const quantityBackordered = Math.max(0, orderedQuantity - totalOnHand);
+  if (quantityBackordered <= 0) return null;
+
+  return {
+    totalOnHand,
+    quantityBackordered,
+    backorderMessage,
+  };
+}


### PR DESCRIPTION
Jira: [BACK-617](https://bigcommercecloud.atlassian.net/browse/BACK-617)

## What/Why?
When backorder features are enabled, the order re-order dialog loads variant inventory from `getVariantInfoBySkus` (including `totalOnHand` and `backorderMessage`) and shows the same backorder lines as quotes do (i.e. ATS, backorder amount, backorder message).

## Rollout/Rollback
Merge/revert. Backorder display is gated by `Feature_Backorder && BACK-134.backorders_phase_1_1_control_messaging_on_storefront`.

## Testing
Backorder display appears as expected for a variety of cases, updates with quantity.

https://github.com/user-attachments/assets/2b41ef65-8eb9-4402-ac02-3a88c6428783

Order with no backordered quantity does not display backorder lines.

<img width="918" height="370" alt="Screenshot 2026-05-13 at 10 50 30 am" src="https://github.com/user-attachments/assets/0b188bd0-8306-4d68-b10f-899df6323d60" />

Lines do not appear when `Feature_Backorder && BACK-134.backorders_phase_1_1_control_messaging_on_storefront` disabled.

<img width="915" height="557" alt="Screenshot 2026-05-13 at 10 58 45 am" src="https://github.com/user-attachments/assets/c6d72885-7eae-4b28-8515-1c0d5d169909" />

Regression - backorder display still appears as expected for both `quoteDraft` and `quoteDisplay`.

<img width="758" height="385" alt="Screenshot 2026-05-14 at 11 03 52 am" src="https://github.com/user-attachments/assets/4fa0cd29-ab43-4f3e-88c9-8efda3c326a3" />

<img width="758" height="385" alt="Screenshot 2026-05-14 at 11 04 17 am" src="https://github.com/user-attachments/assets/f0cb7356-985b-4b1d-9ff7-fe49995cda29" />

Ping @animesh1987 @benpratt77

[BACK-617]: https://bigcommercecloud.atlassian.net/browse/BACK-617?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds inventory/backorder fields to the `getVariantInfoBySkus` GraphQL query and uses them to conditionally render backorder messaging in the re-order flow; incorrect query/typing or gating logic could impact ordering UI and data shown to customers.
> 
> **Overview**
> Adds a new `useBackorderStorefrontMessaging` hook (with tests) to centralize storefront backorder messaging gating via `Feature_Backorder`, the `BACK-134...` flag, and backorder display settings.
> 
> Extends the order re-order dialog to fetch per-SKU inventory (`totalOnHand`, `backorderMessage`, etc.) via `getVariantInfoBySkus`, compute backorder display fields, and render `BackorderMessage` beneath the quantity input when enabled.
> 
> Refactors quote backorder gating to use the new hook, and unifies backorder field computation by introducing `getBackorderDisplayFieldsFromOnHand` and reusing it for draft quotes and re-order display (with added unit tests).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 342e0577ffc5c0a8be6d4ac2d454b5c00b74a7f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->