### PR TITLE
feat(common): B2B-4859 Add local feature flag overrides

### DIFF
--- a/apps/storefront/.env-example
+++ b/apps/storefront/.env-example
@@ -14,3 +14,9 @@ VITE_IS_LOCAL_ENVIRONMENT=TRUE
 
 # For custom host, set this to the absolute path where will be hosted the generated assets after your run `yarn build`
 VITE_ASSETS_ABSOLUTE_PATH=''
+
+# Optional local development overrides.
+# VITE_USE_MOCK_API=true routes registered B3Request GraphQL operations to src/mocks.
+# VITE_FEATURE_FLAG_OVERRIDES is a JSON object that overrides backend-loaded feature flags in dev only.
+VITE_USE_MOCK_API=false
+VITE_FEATURE_FLAG_OVERRIDES='{}'

--- a/apps/storefront/.env-example
+++ b/apps/storefront/.env-example
@@ -16,7 +16,5 @@ VITE_IS_LOCAL_ENVIRONMENT=TRUE
 VITE_ASSETS_ABSOLUTE_PATH=''
 
 # Optional local development overrides.
-# VITE_USE_MOCK_API=true routes registered B3Request GraphQL operations to src/mocks.
 # VITE_FEATURE_FLAG_OVERRIDES is a JSON object that overrides backend-loaded feature flags in dev only.
-VITE_USE_MOCK_API=false
 VITE_FEATURE_FLAG_OVERRIDES='{}'

--- a/apps/storefront/src/hooks/useFeatureFlag.test.ts
+++ b/apps/storefront/src/hooks/useFeatureFlag.test.ts
@@ -1,12 +1,16 @@
 import { buildGlobalStateWith } from 'tests/storeStateBuilders';
 import { renderHookWithProviders } from 'tests/utils/hook-test-utils';
-import { it } from 'vitest';
+import { afterEach, it, vi } from 'vitest';
 
 import type { FeatureFlagKey } from '@/utils/featureFlags';
 
 import { useFeatureFlag } from './useFeatureFlag';
 
 const TEST_FEATURE_FLAG_KEY = 'B2B-1234.test_feature_flag' as FeatureFlagKey;
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
 
 it('returns true when the requested flag is enabled', () => {
   const preloadedState = {
@@ -48,5 +52,67 @@ it('returns false when the flag is explicitly false', () => {
   const { result } = renderHookWithProviders(() => useFeatureFlag(TEST_FEATURE_FLAG_KEY), {
     preloadedState,
   });
+  expect(result.result.current).toBe(false);
+});
+
+it('uses a local dev override when the requested flag is set to true', () => {
+  vi.stubEnv('DEV', true);
+  vi.stubEnv('MODE', 'development');
+  vi.stubEnv('VITEST', 'false');
+  vi.stubEnv('VITE_FEATURE_FLAG_OVERRIDES', JSON.stringify({ [TEST_FEATURE_FLAG_KEY]: true }));
+
+  const preloadedState = {
+    global: buildGlobalStateWith({
+      featureFlags: {
+        [TEST_FEATURE_FLAG_KEY]: false,
+      },
+    }),
+  };
+
+  const { result } = renderHookWithProviders(() => useFeatureFlag(TEST_FEATURE_FLAG_KEY), {
+    preloadedState,
+  });
+
+  expect(result.result.current).toBe(true);
+});
+
+it('uses a local dev override when the requested flag is set to false', () => {
+  vi.stubEnv('DEV', true);
+  vi.stubEnv('MODE', 'development');
+  vi.stubEnv('VITEST', 'false');
+  vi.stubEnv('VITE_FEATURE_FLAG_OVERRIDES', JSON.stringify({ [TEST_FEATURE_FLAG_KEY]: false }));
+
+  const preloadedState = {
+    global: buildGlobalStateWith({
+      featureFlags: {
+        [TEST_FEATURE_FLAG_KEY]: true,
+      },
+    }),
+  };
+
+  const { result } = renderHookWithProviders(() => useFeatureFlag(TEST_FEATURE_FLAG_KEY), {
+    preloadedState,
+  });
+
+  expect(result.result.current).toBe(false);
+});
+
+it('ignores local overrides during test runs', () => {
+  vi.stubEnv('DEV', true);
+  vi.stubEnv('VITEST', 'true');
+  vi.stubEnv('VITE_FEATURE_FLAG_OVERRIDES', JSON.stringify({ [TEST_FEATURE_FLAG_KEY]: true }));
+
+  const preloadedState = {
+    global: buildGlobalStateWith({
+      featureFlags: {
+        [TEST_FEATURE_FLAG_KEY]: false,
+      },
+    }),
+  };
+
+  const { result } = renderHookWithProviders(() => useFeatureFlag(TEST_FEATURE_FLAG_KEY), {
+    preloadedState,
+  });
+
   expect(result.result.current).toBe(false);
 });

--- a/apps/storefront/src/hooks/useFeatureFlag.ts
+++ b/apps/storefront/src/hooks/useFeatureFlag.ts
@@ -1,8 +1,36 @@
 import { useAppSelector } from '@/store';
 import type { FeatureFlagKey } from '@/utils/featureFlags';
 
+function isFeatureFlagOverrideMap(value: unknown): value is Partial<Record<FeatureFlagKey, boolean>> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function getLocalFeatureFlagOverride(flagKey: FeatureFlagKey): boolean | undefined {
+  if (
+    !import.meta.env.DEV ||
+    import.meta.env.VITEST === 'true' ||
+    !import.meta.env.VITE_FEATURE_FLAG_OVERRIDES
+  ) {
+    return undefined;
+  }
+
+  try {
+    const parsedOverrides: unknown = JSON.parse(import.meta.env.VITE_FEATURE_FLAG_OVERRIDES);
+
+    if (!isFeatureFlagOverrideMap(parsedOverrides)) {
+      return undefined;
+    }
+
+    const override = parsedOverrides[flagKey];
+
+    return typeof override === 'boolean' ? override : undefined;
+  } catch (_error: unknown) {
+    return undefined;
+  }
+}
+
 /**
  * Returns whether a single storefront feature flag is enabled (true / false).
  */
 export const useFeatureFlag = (flagKey: FeatureFlagKey): boolean =>
-  useAppSelector(({ global }) => global.featureFlags[flagKey] ?? false);
+  useAppSelector(({ global }) => getLocalFeatureFlagOverride(flagKey) ?? global.featureFlags[flagKey] ?? false);

--- a/apps/storefront/src/hooks/useFeatureFlag.ts
+++ b/apps/storefront/src/hooks/useFeatureFlag.ts
@@ -1,7 +1,9 @@
 import { useAppSelector } from '@/store';
 import type { FeatureFlagKey } from '@/utils/featureFlags';
 
-function isFeatureFlagOverrideMap(value: unknown): value is Partial<Record<FeatureFlagKey, boolean>> {
+function isFeatureFlagOverrideMap(
+  value: unknown,
+): value is Partial<Record<FeatureFlagKey, boolean>> {
   return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
 }
 
@@ -33,4 +35,6 @@ function getLocalFeatureFlagOverride(flagKey: FeatureFlagKey): boolean | undefin
  * Returns whether a single storefront feature flag is enabled (true / false).
  */
 export const useFeatureFlag = (flagKey: FeatureFlagKey): boolean =>
-  useAppSelector(({ global }) => getLocalFeatureFlagOverride(flagKey) ?? global.featureFlags[flagKey] ?? false);
+  useAppSelector(
+    ({ global }) => getLocalFeatureFlagOverride(flagKey) ?? global.featureFlags[flagKey] ?? false,
+  );


### PR DESCRIPTION
Jira: [B2B-4859](https://bigcommercecloud.atlassian.net/browse/B2B-4859)

## What/Why?

Adds a dev-only local feature flag override path for buyer portal development. Developers can set `VITE_FEATURE_FLAG_OVERRIDES` in their local env to force specific feature flags on or off without changing backend/LaunchDarkly config.

Overrides are ignored outside dev mode and during Vitest runs.

## Rollout/Rollback

Dev-only. Remove `VITE_FEATURE_FLAG_OVERRIDES` from local env to use normal feature flag state.

## Testing

Run from `apps/storefront/`:

```bash
yarn test src/hooks/useFeatureFlag.test.ts --run
yarn tsc --noEmit
yarn lint:eslint src/hooks/useFeatureFlag.ts src/hooks/useFeatureFlag.test.ts
```

[B2B-4859]: https://bigcommercecloud.atlassian.net/browse/B2B-4859?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: behavior change is gated to `import.meta.env.DEV` and explicitly disabled during Vitest runs, so production flag evaluation is unchanged.
> 
> **Overview**
> Adds support for **dev-only feature flag overrides** in `useFeatureFlag` by reading `VITE_FEATURE_FLAG_OVERRIDES` (JSON) and preferring its boolean values over backend-loaded flags.
> 
> Updates `.env-example` to document the new env var and expands `useFeatureFlag.test.ts` to cover override-on/override-off behavior and ensure overrides are ignored during Vitest.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d93d9dfdacf0d41cbebaa351882340f33e3713d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->