### PR TITLE
fix(quotes): B2B-3879 fix stale currency symbol placement in quotes list

### DIFF
--- a/apps/storefront/src/pages/QuotesList/QuoteItemCard.tsx
+++ b/apps/storefront/src/pages/QuotesList/QuoteItemCard.tsx
@@ -7,6 +7,7 @@ import Typography from '@mui/material/Typography';
 
 import { TableColumnItem } from '@/components/table/B3Table';
 import { useB3Lang } from '@/lib/lang';
+import { DisplayCurrency } from '@/types/currency';
 import { currencyFormat } from '@/utils/b3CurrencyFormat';
 import { displayFormat } from '@/utils/b3DateFormat';
 
@@ -16,6 +17,7 @@ interface ListItem {
   [key: string]: string | Object;
   status: string;
   quoteNumber: string;
+  currency: CurrencyProps | DisplayCurrency;
 }
 
 interface QuoteItemCardProps {

--- a/apps/storefront/src/pages/QuotesList/index.test.tsx
+++ b/apps/storefront/src/pages/QuotesList/index.test.tsx
@@ -2,6 +2,7 @@ import { PersistPartial } from 'redux-persist/es/persistReducer';
 import {
   buildCompanyStateWith,
   builder,
+  buildGlobalStateWith,
   buildStoreInfoStateWith,
   bulk,
   faker,
@@ -1342,5 +1343,96 @@ describe('when the user is a B2C customer', () => {
       expect(await screen.findByText('No data')).toBeInTheDocument();
       expect(screen.queryByRole('table')).not.toBeInTheDocument();
     });
+  });
+});
+
+describe('fix_quote_currency_symbol_placement feature flag', () => {
+  const nonCompany = buildCompanyStateWith({ customer: { b2bId: undefined } });
+  const storeInfoWithDateFormat = buildStoreInfoStateWith({ timeFormat: { display: 'j F Y' } });
+
+  const eurOnRightInQuote = {
+    token: '€',
+    location: 'right',
+    currencyCode: 'EUR',
+    decimalToken: '.',
+    decimalPlaces: 2,
+    thousandsToken: ',',
+    currencyExchangeRate: '1.0000000000',
+  };
+
+  const eurOnLeftInBcConfig = {
+    id: '2',
+    is_default: false,
+    last_updated: '2024-01-01',
+    country_iso2: 'DE',
+    default_for_country_codes: [],
+    currency_code: 'EUR',
+    currency_exchange_rate: '1.0000000000',
+    name: 'Euro',
+    token: '€',
+    auto_update: false,
+    decimal_token: '.',
+    decimal_places: 2,
+    enabled: true,
+    is_transactional: true,
+    token_location: 'left' as const,
+    thousands_token: ',',
+  };
+
+  const quoteWithEurOnRight = buildQuotesListBCWith({
+    data: {
+      customerQuotes: {
+        totalCount: 1,
+        edges: [
+          buildQuoteEdgeWith({
+            node: { totalAmount: '100.00', currency: eurOnRightInQuote },
+          }),
+        ],
+      },
+    },
+  });
+
+  const storeConfigsWithUpdatedEurPlacement = {
+    currencies: {
+      currencies: [eurOnLeftInBcConfig],
+      channelCurrencies: { channel_id: 1, enabled_currencies: ['EUR'], default_currency: 'EUR' },
+      enteredInclusiveTax: false,
+    },
+  };
+
+  beforeEach(() => {
+    server.use(graphql.query('GetQuotesList', () => HttpResponse.json(quoteWithEurOnRight)));
+  });
+
+  it('uses the saved quote currency placement when the flag is disabled', async () => {
+    renderWithProviders(<QuotesList />, {
+      preloadedState: {
+        company: nonCompany,
+        storeInfo: storeInfoWithDateFormat,
+        storeConfigs: storeConfigsWithUpdatedEurPlacement,
+        global: buildGlobalStateWith({
+          featureFlags: { 'B2B-3876.fix_quote_currency_symbol_placement': false },
+        }),
+      },
+    });
+
+    const table = await screen.findByRole('table');
+    expect(within(table).getByRole('cell', { name: '100.00€' })).toBeInTheDocument();
+  });
+
+  it('uses the current BC currency placement when the flag is enabled', async () => {
+    renderWithProviders(<QuotesList />, {
+      preloadedState: {
+        company: nonCompany,
+        storeInfo: storeInfoWithDateFormat,
+        storeConfigs: storeConfigsWithUpdatedEurPlacement,
+        global: buildGlobalStateWith({
+          featureFlags: { 'B2B-3876.fix_quote_currency_symbol_placement': true },
+        }),
+      },
+    });
+
+    const table = await screen.findByRole('table');
+    expect(within(table).getByRole('cell', { name: '€100.00' })).toBeInTheDocument();
   });
 });

--- a/apps/storefront/src/pages/QuotesList/index.tsx
+++ b/apps/storefront/src/pages/QuotesList/index.tsx
@@ -6,6 +6,7 @@ import B3Filter from '@/components/filter/B3Filter';
 import B3Spin from '@/components/spin/B3Spin';
 import { B3PaginationTable, GetRequestList } from '@/components/table/B3PaginationTable';
 import { TableColumnItem } from '@/components/table/B3Table';
+import { useFeatureFlag } from '@/hooks/useFeatureFlag';
 import { useMobile } from '@/hooks/useMobile';
 import { useSort } from '@/hooks/useSort';
 import { useB3Lang } from '@/lib/lang';
@@ -16,9 +17,11 @@ import {
   getShoppingListsCreatedByUser,
 } from '@/shared/service/b2b';
 import { isB2BUserSelector, useAppSelector } from '@/store';
+import { DisplayCurrency } from '@/types/currency';
 import { currencyFormatConvert } from '@/utils/b3CurrencyFormat';
 import { displayFormat } from '@/utils/b3DateFormat';
 import { channelId } from '@/utils/basicConfig';
+import { formatBcCurrencyToDisplayCurrency } from '@/utils/currencyUtils';
 
 import QuoteStatus from '../quote/components/QuoteStatus';
 import { addPrice } from '../quote/shared/config';
@@ -29,6 +32,7 @@ interface ListItem {
   [key: string]: string | Object;
   status: string;
   quoteNumber: string;
+  currency: CurrencyProps | DisplayCurrency;
 }
 
 interface FilterSearchProps {
@@ -79,6 +83,7 @@ function useData() {
   const isB2BUser = useAppSelector(isB2BUserSelector);
   const draftQuoteListLength = useAppSelector(({ quoteInfo }) => quoteInfo.draftQuoteList.length);
   const salesRepCompanyId = useAppSelector(({ b2bFeatures }) => b2bFeatures.masqueradeCompany.id);
+  const currencies = useAppSelector(({ storeConfigs }) => storeConfigs.currencies.currencies);
   const b3Lang = useB3Lang();
 
   const companyId = companyB2BId || salesRepCompanyId;
@@ -168,8 +173,18 @@ function useData() {
     return getFilters();
   };
 
+  const currenciesMap = useMemo(
+    () =>
+      currencies.reduce<Record<string, DisplayCurrency>>((currenciesByCode, currency) => {
+        currenciesByCode[currency.currency_code] = formatBcCurrencyToDisplayCurrency(currency);
+        return currenciesByCode;
+      }, {}),
+    [currencies],
+  );
+
   return {
     companyId,
+    currenciesMap,
     isB2BUser,
     draftQuoteListLength,
     customer,
@@ -178,8 +193,38 @@ function useData() {
   };
 }
 
-const useColumnList = (): Array<TableColumnItem<ListItem>> => {
+const useColumnList = (
+  currenciesMap: Record<string, DisplayCurrency>,
+  isCurrencySymbolPlacementFixEnabled: boolean,
+): Array<TableColumnItem<ListItem>> => {
   const b3Lang = useB3Lang();
+
+  const getTotalAmount = useMemo(() => {
+    const getTotalAmountWithCurrency = (item: ListItem) => {
+      const { totalAmount, currency } = item;
+      return currencyFormatConvert(Number(totalAmount), {
+        currency,
+        isConversionRate: false,
+        useCurrentCurrency: !!currency,
+      });
+    };
+
+    const getTotalAmountWithLatestCurrencySettings = (item: ListItem) => {
+      const { totalAmount, currency } = item;
+      const { currencyCode } = currency;
+      const currencySnapshot = currenciesMap[currencyCode] || currency;
+      return currencyFormatConvert(Number(totalAmount), {
+        currency: currencySnapshot,
+        isConversionRate: false,
+        useCurrentCurrency: !!currencySnapshot,
+      });
+    };
+
+    return (item: ListItem) =>
+      isCurrencySymbolPlacementFixEnabled
+        ? getTotalAmountWithLatestCurrencySettings(item)
+        : getTotalAmountWithCurrency(item);
+  }, [isCurrencySymbolPlacementFixEnabled, currenciesMap]);
 
   return useMemo(
     () => [
@@ -230,15 +275,7 @@ const useColumnList = (): Array<TableColumnItem<ListItem>> => {
       {
         key: 'totalAmount',
         title: b3Lang('quotes.subtotal'),
-        render: (item: ListItem) => {
-          const { totalAmount, currency } = item;
-          const newCurrency = currency as CurrencyProps;
-          return currencyFormatConvert(Number(totalAmount), {
-            currency: newCurrency,
-            isConversionRate: false,
-            useCurrentCurrency: !!currency,
-          });
-        },
+        render: getTotalAmount,
         style: {
           textAlign: 'right',
         },
@@ -250,13 +287,17 @@ const useColumnList = (): Array<TableColumnItem<ListItem>> => {
         isSortable: true,
       },
     ],
-    [b3Lang],
+    [b3Lang, getTotalAmount],
   );
 };
 
 function QuotesList() {
-  const { getAvailableFilters, draftQuoteListLength, customer, getQuotesList } = useData();
-  const columns = useColumnList();
+  const { getAvailableFilters, draftQuoteListLength, customer, getQuotesList, currenciesMap } =
+    useData();
+  const fixQuoteCurrencySymbolPlacement = useFeatureFlag(
+    'B2B-3876.fix_quote_currency_symbol_placement',
+  );
+  const columns = useColumnList(currenciesMap, fixQuoteCurrencySymbolPlacement);
 
   const initSearch = {
     q: '',

--- a/apps/storefront/src/types/currency.ts
+++ b/apps/storefront/src/types/currency.ts
@@ -29,6 +29,16 @@ export interface Currency {
   thousands_token: string;
 }
 
+export interface DisplayCurrency {
+  token: string;
+  location: 'left' | 'right';
+  currencyCode: string;
+  decimalToken: string;
+  decimalPlaces: number;
+  thousandsToken: string;
+  currencyExchangeRate: string;
+}
+
 interface Node {
   isActive: boolean;
   entityId: number;

--- a/apps/storefront/src/utils/b3CurrencyFormat.ts
+++ b/apps/storefront/src/utils/b3CurrencyFormat.ts
@@ -1,4 +1,5 @@
 import { store } from '@/store';
+import { DisplayCurrency } from '@/types/currency';
 
 import b2bLogger from './b3Logger';
 import { getActiveCurrencyInfo } from './currencyUtils';
@@ -63,7 +64,7 @@ export const ordersCurrencyFormat = (
 };
 
 interface CurrencyOption {
-  currency: CurrencyProps;
+  currency: CurrencyProps | DisplayCurrency;
   showCurrencyToken?: boolean;
   isConversionRate?: boolean;
   useCurrentCurrency?: boolean;

--- a/apps/storefront/src/utils/currencyUtils.ts
+++ b/apps/storefront/src/utils/currencyUtils.ts
@@ -1,18 +1,7 @@
-import { store } from '@/store';
-import { defaultCurrenciesState } from '@/store/slices/storeConfigs';
-import { Currency } from '@/types';
+import { activeCurrencyInfoSelector, store } from '@/store';
+import { Currency, DisplayCurrency } from '@/types';
 
-const defaultCurrency: Currency = defaultCurrenciesState.currencies[0];
-
-const getActiveCurrencyInfo = () => {
-  const { currencies } = store.getState().storeConfigs.currencies;
-  const activeCurrencyObj = store.getState().storeConfigs.activeCurrency?.node;
-  const activeCurrency = currencies.find(
-    (currency) => Number(currency.id) === activeCurrencyObj?.entityId,
-  );
-
-  return activeCurrency || defaultCurrency;
-};
+const getActiveCurrencyInfo = () => activeCurrencyInfoSelector(store.getState());
 
 const handleGetCorrespondingCurrencyToken = (code: string) => {
   const correspondingCurrency = store
@@ -27,4 +16,18 @@ const handleGetCorrespondingCurrencyToken = (code: string) => {
   return token;
 };
 
-export { getActiveCurrencyInfo, handleGetCorrespondingCurrencyToken };
+const formatBcCurrencyToDisplayCurrency = (bcCurrency: Currency): DisplayCurrency => ({
+  token: bcCurrency.token,
+  location: bcCurrency.token_location,
+  currencyCode: bcCurrency.currency_code,
+  decimalToken: bcCurrency.decimal_token,
+  decimalPlaces: bcCurrency.decimal_places,
+  thousandsToken: bcCurrency.thousands_token,
+  currencyExchangeRate: bcCurrency.currency_exchange_rate,
+});
+
+export {
+  getActiveCurrencyInfo,
+  handleGetCorrespondingCurrencyToken,
+  formatBcCurrencyToDisplayCurrency,
+};

--- a/apps/storefront/src/utils/featureFlags.ts
+++ b/apps/storefront/src/utils/featureFlags.ts
@@ -35,6 +35,10 @@ export const featureFlags = [
     key: 'LOCAL-3191.B2B_multi_language',
     name: 'b2bMultiLanguage',
   },
+  {
+    key: 'B2B-3876.fix_quote_currency_symbol_placement',
+    name: 'fixQuoteCurrencySymbolPlacement',
+  },
 ] as const;
 
 export type FeatureFlagKey = (typeof featureFlags)[number]['key'];


### PR DESCRIPTION
## Summary
- Adds `DisplayCurrency` interface to `@/types/currency` as the canonical typed shape for display currency
- Adds `formatBcCurrencyToDisplayCurrency` helper in `currencyUtils.ts` to map BC snake_case fields to display convention
- Simplifies `getActiveCurrencyInfo` to delegate to `activeCurrencyInfoSelector` — single source of logic
- In `QuotesList`, pre-builds a `currenciesMap` (keyed by `currencyCode`) from live BC store config and uses it to resolve the latest currency display settings at render time, gated behind feature flag `B2B-3879.fix_quote_currency_symbol_placement`

## Test plan
- [ ] Flag OFF: quote saved with EUR `location: right` renders `100.00€` even when BC config has EUR on left
- [ ] Flag ON: quote saved with EUR `location: right` renders `€100.00` after BC config moves EUR to left
- [ ] All 32 QuotesList tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared currency formatting utilities and active-currency selection logic, which could affect price display outside quotes if the new typing/selector behavior diverges. Behavior change in `QuotesList` is gated behind a feature flag to limit rollout risk.
> 
> **Overview**
> Fixes stale currency symbol placement in the quotes list by optionally formatting quote subtotals using the *current* BigCommerce currency configuration rather than the currency snapshot saved on the quote.
> 
> Adds a canonical `DisplayCurrency` type plus a `formatBcCurrencyToDisplayCurrency` mapper, updates `currencyFormatConvert` to accept this display shape, and simplifies `getActiveCurrencyInfo` to use `activeCurrencyInfoSelector`. Introduces feature flag `B2B-3876.fix_quote_currency_symbol_placement` and adds tests covering flag-on/flag-off rendering (`100.00€` vs `€100.00`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34518a7eccd1418d397f8ccf57a6ef8d1eedc64e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->