### PR TITLE
fix(quotes): B2B-3876 replace inline currency object with shared formatter in quote draft

### DIFF
--- a/apps/storefront/src/pages/QuoteDraft/index.tsx
+++ b/apps/storefront/src/pages/QuoteDraft/index.tsx
@@ -47,6 +47,7 @@ import { B3LStorage } from '@/utils/b3Storage';
 import { snackbar } from '@/utils/b3Tip';
 import { channelId, storeHash } from '@/utils/basicConfig';
 import { deleteCartData } from '@/utils/cartUtils';
+import { formatBcCurrencyToDisplayCurrency } from '@/utils/currencyUtils';
 import validateObject from '@/utils/quoteUtils';
 import {
   convertStockAndThresholdValidationErrorToWarning,
@@ -159,6 +160,7 @@ function QuoteDraft({ setOpenPage }: PageProps) {
   );
   const quoteInfoOrigin = useAppSelector(({ quoteInfo }) => quoteInfo.draftQuoteInfo);
   const currency = useAppSelector(activeCurrencyInfoSelector);
+  const displayCurrency = useMemo(() => formatBcCurrencyToDisplayCurrency(currency), [currency]);
   const quoteSubmissionResponseInfo = useAppSelector(
     ({ global }) => global.quoteSubmissionResponse,
   );
@@ -562,6 +564,7 @@ function QuoteDraft({ setOpenPage }: PageProps) {
 
     try {
       const info = cloneDeep(quoteInfoOrigin);
+      const { decimalPlaces } = displayCurrency;
       if (isEdit && contactInfoRef?.current) {
         const data = await handleCollectingData(info);
         if (!data) return;
@@ -674,9 +677,9 @@ function QuoteDraft({ setOpenPage }: PageProps) {
         const items = {
           productId: node?.productsSearch?.id,
           sku: node.variantSku,
-          basePrice: Number(node?.basePrice || 0).toFixed(currency.decimal_places),
+          basePrice: Number(node?.basePrice || 0).toFixed(decimalPlaces),
           discount: '0.00',
-          offeredPrice: Number(node?.basePrice || 0).toFixed(currency.decimal_places),
+          offeredPrice: Number(node?.basePrice || 0).toFixed(decimalPlaces),
           quantity: node.quantity,
           variantId: variantsItem?.variant_id,
           imageUrl: node.primaryImage,
@@ -694,10 +697,10 @@ function QuoteDraft({ setOpenPage }: PageProps) {
         message: newNote,
         legalTerms: '',
         totalAmount: enteredInclusiveTax
-          ? allPrice.toFixed(currency.decimal_places)
-          : (allPrice + allTaxPrice).toFixed(currency.decimal_places),
-        grandTotal: allPrice.toFixed(currency.decimal_places),
-        subtotal: allPrice.toFixed(currency.decimal_places),
+          ? allPrice.toFixed(decimalPlaces)
+          : (allPrice + allTaxPrice).toFixed(decimalPlaces),
+        grandTotal: allPrice.toFixed(decimalPlaces),
+        subtotal: allPrice.toFixed(decimalPlaces),
         companyId: isB2BUser ? selectCompanyHierarchyId || companyB2BId || salesRepCompanyId : '',
         storeHash,
         quoteTitle,
@@ -709,16 +712,8 @@ function QuoteDraft({ setOpenPage }: PageProps) {
         contactInfo,
         productList,
         fileList,
-        taxTotal: allTaxPrice.toFixed(currency.decimal_places),
-        currency: {
-          currencyExchangeRate: currency.currency_exchange_rate,
-          token: currency.token,
-          location: currency.token_location,
-          decimalToken: currency.decimal_token,
-          decimalPlaces: currency.decimal_places,
-          thousandsToken: currency.thousands_token,
-          currencyCode: currency.currency_code,
-        },
+        taxTotal: allTaxPrice.toFixed(decimalPlaces),
+        currency: displayCurrency,
         referenceNumber: `${info.referenceNumber}` || '',
         extraFields: info.extraFields || [],
         recipients: info.recipients || [],

--- a/apps/storefront/src/utils/currencyUtils.ts
+++ b/apps/storefront/src/utils/currencyUtils.ts
@@ -32,4 +32,9 @@ const buildCurrenciesMap = (currencies: Currency[]): Record<string, DisplayCurre
     return acc;
   }, {});
 
-export { getActiveCurrencyInfo, handleGetCorrespondingCurrencyToken, buildCurrenciesMap };
+export {
+  getActiveCurrencyInfo,
+  handleGetCorrespondingCurrencyToken,
+  buildCurrenciesMap,
+  formatBcCurrencyToDisplayCurrency,
+};


### PR DESCRIPTION
## Summary
- Introduces `DisplayCurrency` interface as the canonical typed shape for display currency
- Adds `formatBcCurrencyToDisplayCurrency` in `currencyUtils.ts` to map BC snake_case fields consistently
- Simplifies `getActiveCurrencyInfo` to delegate to `activeCurrencyInfoSelector` — single source of logic
- In `QuoteDraft`, replaces the inline 8-field currency object construction with `formatBcCurrencyToDisplayCurrency`, ensuring all quote flows use the same field mapping

## Test plan
- [ ] Quote draft displays correct currency formatting
- [ ] All 60 QuoteDraft tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Dev Testing
<img width="900" height="772" alt="Screenshot 2026-05-18 at 1 01 17 pm" src="https://github.com/user-attachments/assets/d4f53a5e-72a1-4836-babf-5789b04dad2e" />



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches quote draft submission payload formatting (totals, line prices, and `currency` object), which can affect quote creation and downstream currency display/rounding.
> 
> **Overview**
> Quote draft submission now derives a normalized `DisplayCurrency` via `formatBcCurrencyToDisplayCurrency` and reuses its `decimalPlaces` for all `.toFixed(...)` formatting, instead of relying on `currency.decimal_places` and an inline `currency` payload.
> 
> `currencyUtils` now exports `formatBcCurrencyToDisplayCurrency` so quote flows can share a single, consistent mapping from BigCommerce currency fields to the app’s display-currency shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2fec574096e72fdacdb6da4ee2f07d2f0acee41. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->