### PR TITLE
fix(quotes): B2B-3876 fix stale currency symbol placement in quotes list

### DIFF
--- a/apps/storefront/src/pages/QuotesList/QuoteItemCard.tsx
+++ b/apps/storefront/src/pages/QuotesList/QuoteItemCard.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import styled from '@emotion/styled';
 import { useTheme } from '@mui/material';
 import Box from '@mui/material/Box';
@@ -7,20 +8,24 @@ import Typography from '@mui/material/Typography';
 
 import { TableColumnItem } from '@/components/table/B3Table';
 import { useB3Lang } from '@/lib/lang';
-import { currencyFormat } from '@/utils/b3CurrencyFormat';
+import { DisplayCurrency } from '@/types/currency';
+import { currencyFormatConvert } from '@/utils/b3CurrencyFormat';
 import { displayFormat } from '@/utils/b3DateFormat';
 
 import QuoteStatus from '../quote/components/QuoteStatus';
 
 interface ListItem {
-  [key: string]: string | Object;
+  [key: string]: string | Object | undefined;
   status: string;
   quoteNumber: string;
+  currency?: CurrencyProps | DisplayCurrency;
 }
 
 interface QuoteItemCardProps {
   goToDetail: (val: ListItem, status: number) => void;
   item: ListItem;
+  currenciesMap: Record<string, DisplayCurrency>;
+  isCurrencySymbolPlacementFixEnabled: boolean;
 }
 
 const Flex = styled('div')({
@@ -31,11 +36,24 @@ const Flex = styled('div')({
 });
 
 export function QuoteItemCard(props: QuoteItemCardProps) {
-  const { item, goToDetail } = props;
+  const { item, goToDetail, currenciesMap, isCurrencySymbolPlacementFixEnabled } = props;
   const theme = useTheme();
   const b3Lang = useB3Lang();
 
   const primaryColor = theme.palette.primary.main;
+
+  const getTotalAmount = useMemo(() => {
+    const { totalAmount, currency } = item;
+    const currencyCode = currency?.currencyCode;
+    const effectiveCurrency =
+      (isCurrencySymbolPlacementFixEnabled && currencyCode && currenciesMap[currencyCode]) ||
+      currency;
+    return currencyFormatConvert(Number(totalAmount), {
+      currency: effectiveCurrency,
+      isConversionRate: false,
+      useCurrentCurrency: !!effectiveCurrency,
+    });
+  }, [item, isCurrencySymbolPlacementFixEnabled, currenciesMap]);
 
   const columnAllItems: TableColumnItem<ListItem>[] = [
     {
@@ -71,11 +89,7 @@ export function QuoteItemCard(props: QuoteItemCardProps) {
     {
       key: 'totalAmount',
       title: b3Lang('quotes.quoteItemCard.subtotal'),
-      render: () => {
-        const { totalAmount } = item;
-
-        return currencyFormat(Number(totalAmount));
-      },
+      render: () => getTotalAmount,
     },
   ];
 

--- a/apps/storefront/src/pages/QuotesList/index.test.tsx
+++ b/apps/storefront/src/pages/QuotesList/index.test.tsx
@@ -2,6 +2,7 @@ import { PersistPartial } from 'redux-persist/es/persistReducer';
 import {
   buildCompanyStateWith,
   builder,
+  buildGlobalStateWith,
   buildStoreInfoStateWith,
   bulk,
   faker,
@@ -1342,5 +1343,96 @@ describe('when the user is a B2C customer', () => {
       expect(await screen.findByText('No data')).toBeInTheDocument();
       expect(screen.queryByRole('table')).not.toBeInTheDocument();
     });
+  });
+});
+
+describe('fix_quote_currency_symbol_placement feature flag', () => {
+  const nonCompany = buildCompanyStateWith({ customer: { b2bId: undefined } });
+  const storeInfoWithDateFormat = buildStoreInfoStateWith({ timeFormat: { display: 'j F Y' } });
+
+  const eurOnRightInQuote = {
+    token: '€',
+    location: 'right',
+    currencyCode: 'EUR',
+    decimalToken: '.',
+    decimalPlaces: 2,
+    thousandsToken: ',',
+    currencyExchangeRate: '1.0000000000',
+  };
+
+  const eurOnLeftInBcConfig = {
+    id: '2',
+    is_default: false,
+    last_updated: '2024-01-01',
+    country_iso2: 'DE',
+    default_for_country_codes: [],
+    currency_code: 'EUR',
+    currency_exchange_rate: '1.0000000000',
+    name: 'Euro',
+    token: '€',
+    auto_update: false,
+    decimal_token: '.',
+    decimal_places: 2,
+    enabled: true,
+    is_transactional: true,
+    token_location: 'left' as const,
+    thousands_token: ',',
+  };
+
+  const quoteWithEurOnRight = buildQuotesListBCWith({
+    data: {
+      customerQuotes: {
+        totalCount: 1,
+        edges: [
+          buildQuoteEdgeWith({
+            node: { totalAmount: '100.00', currency: eurOnRightInQuote },
+          }),
+        ],
+      },
+    },
+  });
+
+  const storeConfigsWithUpdatedEurPlacement = {
+    currencies: {
+      currencies: [eurOnLeftInBcConfig],
+      channelCurrencies: { channel_id: 1, enabled_currencies: ['EUR'], default_currency: 'EUR' },
+      enteredInclusiveTax: false,
+    },
+  };
+
+  beforeEach(() => {
+    server.use(graphql.query('GetQuotesList', () => HttpResponse.json(quoteWithEurOnRight)));
+  });
+
+  it('uses the saved quote currency placement when the flag is disabled', async () => {
+    renderWithProviders(<QuotesList />, {
+      preloadedState: {
+        company: nonCompany,
+        storeInfo: storeInfoWithDateFormat,
+        storeConfigs: storeConfigsWithUpdatedEurPlacement,
+        global: buildGlobalStateWith({
+          featureFlags: { 'B2B-3876.fix_quote_currency_symbol_placement': false },
+        }),
+      },
+    });
+
+    const table = await screen.findByRole('table');
+    expect(within(table).getByRole('cell', { name: '100.00€' })).toBeInTheDocument();
+  });
+
+  it('uses the current BC currency placement when the flag is enabled', async () => {
+    renderWithProviders(<QuotesList />, {
+      preloadedState: {
+        company: nonCompany,
+        storeInfo: storeInfoWithDateFormat,
+        storeConfigs: storeConfigsWithUpdatedEurPlacement,
+        global: buildGlobalStateWith({
+          featureFlags: { 'B2B-3876.fix_quote_currency_symbol_placement': true },
+        }),
+      },
+    });
+
+    const table = await screen.findByRole('table');
+    expect(within(table).getByRole('cell', { name: '€100.00' })).toBeInTheDocument();
   });
 });

--- a/apps/storefront/src/pages/QuotesList/index.tsx
+++ b/apps/storefront/src/pages/QuotesList/index.tsx
@@ -6,6 +6,7 @@ import B3Filter from '@/components/filter/B3Filter';
 import B3Spin from '@/components/spin/B3Spin';
 import { B3PaginationTable, GetRequestList } from '@/components/table/B3PaginationTable';
 import { TableColumnItem } from '@/components/table/B3Table';
+import { useFeatureFlag } from '@/hooks/useFeatureFlag';
 import { useMobile } from '@/hooks/useMobile';
 import { useSort } from '@/hooks/useSort';
 import { useB3Lang } from '@/lib/lang';
@@ -16,9 +17,11 @@ import {
   getShoppingListsCreatedByUser,
 } from '@/shared/service/b2b';
 import { isB2BUserSelector, useAppSelector } from '@/store';
+import { DisplayCurrency } from '@/types/currency';
 import { currencyFormatConvert } from '@/utils/b3CurrencyFormat';
 import { displayFormat } from '@/utils/b3DateFormat';
 import { channelId } from '@/utils/basicConfig';
+import { buildCurrenciesMap } from '@/utils/currencyUtils';
 
 import QuoteStatus from '../quote/components/QuoteStatus';
 import { addPrice } from '../quote/shared/config';
@@ -26,9 +29,10 @@ import { addPrice } from '../quote/shared/config';
 import { QuoteItemCard } from './QuoteItemCard';
 
 interface ListItem {
-  [key: string]: string | Object;
+  [key: string]: string | Object | undefined;
   status: string;
   quoteNumber: string;
+  currency?: CurrencyProps | DisplayCurrency;
 }
 
 interface FilterSearchProps {
@@ -79,6 +83,7 @@ function useData() {
   const isB2BUser = useAppSelector(isB2BUserSelector);
   const draftQuoteListLength = useAppSelector(({ quoteInfo }) => quoteInfo.draftQuoteList.length);
   const salesRepCompanyId = useAppSelector(({ b2bFeatures }) => b2bFeatures.masqueradeCompany.id);
+  const currencies = useAppSelector(({ storeConfigs }) => storeConfigs.currencies.currencies);
   const b3Lang = useB3Lang();
 
   const companyId = companyB2BId || salesRepCompanyId;
@@ -168,8 +173,11 @@ function useData() {
     return getFilters();
   };
 
+  const currenciesMap = useMemo(() => buildCurrenciesMap(currencies), [currencies]);
+
   return {
     companyId,
+    currenciesMap,
     isB2BUser,
     draftQuoteListLength,
     customer,
@@ -178,8 +186,27 @@ function useData() {
   };
 }
 
-const useColumnList = (): Array<TableColumnItem<ListItem>> => {
+const useColumnList = (
+  currenciesMap: Record<string, DisplayCurrency>,
+  isCurrencySymbolPlacementFixEnabled: boolean,
+): Array<TableColumnItem<ListItem>> => {
   const b3Lang = useB3Lang();
+
+  const getTotalAmount = useMemo(
+    () => (item: ListItem) => {
+      const { totalAmount, currency } = item;
+      const currencyCode = currency?.currencyCode;
+      const effectiveCurrency =
+        (isCurrencySymbolPlacementFixEnabled && currencyCode && currenciesMap[currencyCode]) ||
+        currency;
+      return currencyFormatConvert(Number(totalAmount), {
+        currency: effectiveCurrency,
+        isConversionRate: false,
+        useCurrentCurrency: !!effectiveCurrency,
+      });
+    },
+    [isCurrencySymbolPlacementFixEnabled, currenciesMap],
+  );
 
   return useMemo(
     () => [
@@ -230,15 +257,7 @@ const useColumnList = (): Array<TableColumnItem<ListItem>> => {
       {
         key: 'totalAmount',
         title: b3Lang('quotes.subtotal'),
-        render: (item: ListItem) => {
-          const { totalAmount, currency } = item;
-          const newCurrency = currency as CurrencyProps;
-          return currencyFormatConvert(Number(totalAmount), {
-            currency: newCurrency,
-            isConversionRate: false,
-            useCurrentCurrency: !!currency,
-          });
-        },
+        render: getTotalAmount,
         style: {
           textAlign: 'right',
         },
@@ -250,13 +269,17 @@ const useColumnList = (): Array<TableColumnItem<ListItem>> => {
         isSortable: true,
       },
     ],
-    [b3Lang],
+    [b3Lang, getTotalAmount],
   );
 };
 
 function QuotesList() {
-  const { getAvailableFilters, draftQuoteListLength, customer, getQuotesList } = useData();
-  const columns = useColumnList();
+  const { getAvailableFilters, draftQuoteListLength, customer, getQuotesList, currenciesMap } =
+    useData();
+  const fixQuoteCurrencySymbolPlacement = useFeatureFlag(
+    'B2B-3876.fix_quote_currency_symbol_placement',
+  );
+  const columns = useColumnList(currenciesMap, fixQuoteCurrencySymbolPlacement);
 
   const initSearch = {
     q: '',
@@ -427,7 +450,14 @@ function QuotesList() {
           labelRowsPerPage={
             isMobile ? b3Lang('quotes.cardsPerPage') : b3Lang('quotes.quotesPerPage')
           }
-          renderItem={(row) => <QuoteItemCard item={row} goToDetail={goToDetail} />}
+          renderItem={(row) => (
+            <QuoteItemCard
+              item={row}
+              goToDetail={goToDetail}
+              currenciesMap={currenciesMap}
+              isCurrencySymbolPlacementFixEnabled={fixQuoteCurrencySymbolPlacement}
+            />
+          )}
           onClickRow={(row) => {
             goToDetail(row, Number(row.status));
           }}

--- a/apps/storefront/src/types/currency.ts
+++ b/apps/storefront/src/types/currency.ts
@@ -29,6 +29,16 @@ export interface Currency {
   thousands_token: string;
 }
 
+export interface DisplayCurrency {
+  token: string;
+  location: 'left' | 'right';
+  currencyCode: string;
+  decimalToken: string;
+  decimalPlaces: number;
+  thousandsToken: string;
+  currencyExchangeRate: string;
+}
+
 interface Node {
   isActive: boolean;
   entityId: number;

--- a/apps/storefront/src/utils/b3CurrencyFormat.ts
+++ b/apps/storefront/src/utils/b3CurrencyFormat.ts
@@ -1,4 +1,5 @@
 import { store } from '@/store';
+import { DisplayCurrency } from '@/types/currency';
 
 import b2bLogger from './b3Logger';
 import { getActiveCurrencyInfo } from './currencyUtils';
@@ -63,7 +64,7 @@ export const ordersCurrencyFormat = (
 };
 
 interface CurrencyOption {
-  currency: CurrencyProps;
+  currency?: CurrencyProps | DisplayCurrency;
   showCurrencyToken?: boolean;
   isConversionRate?: boolean;
   useCurrentCurrency?: boolean;

--- a/apps/storefront/src/utils/currencyUtils.ts
+++ b/apps/storefront/src/utils/currencyUtils.ts
@@ -1,18 +1,7 @@
-import { store } from '@/store';
-import { defaultCurrenciesState } from '@/store/slices/storeConfigs';
-import { Currency } from '@/types';
+import { activeCurrencyInfoSelector, store } from '@/store';
+import { Currency, DisplayCurrency } from '@/types';
 
-const defaultCurrency: Currency = defaultCurrenciesState.currencies[0];
-
-const getActiveCurrencyInfo = () => {
-  const { currencies } = store.getState().storeConfigs.currencies;
-  const activeCurrencyObj = store.getState().storeConfigs.activeCurrency?.node;
-  const activeCurrency = currencies.find(
-    (currency) => Number(currency.id) === activeCurrencyObj?.entityId,
-  );
-
-  return activeCurrency || defaultCurrency;
-};
+const getActiveCurrencyInfo = () => activeCurrencyInfoSelector(store.getState());
 
 const handleGetCorrespondingCurrencyToken = (code: string) => {
   const correspondingCurrency = store
@@ -27,4 +16,20 @@ const handleGetCorrespondingCurrencyToken = (code: string) => {
   return token;
 };
 
-export { getActiveCurrencyInfo, handleGetCorrespondingCurrencyToken };
+const formatBcCurrencyToDisplayCurrency = (bcCurrency: Currency): DisplayCurrency => ({
+  token: bcCurrency.token,
+  location: bcCurrency.token_location,
+  currencyCode: bcCurrency.currency_code,
+  decimalToken: bcCurrency.decimal_token,
+  decimalPlaces: bcCurrency.decimal_places,
+  thousandsToken: bcCurrency.thousands_token,
+  currencyExchangeRate: bcCurrency.currency_exchange_rate,
+});
+
+const buildCurrenciesMap = (currencies: Currency[]): Record<string, DisplayCurrency> =>
+  currencies.reduce<Record<string, DisplayCurrency>>((acc, currency) => {
+    acc[currency.currency_code] = formatBcCurrencyToDisplayCurrency(currency);
+    return acc;
+  }, {});
+
+export { getActiveCurrencyInfo, handleGetCorrespondingCurrencyToken, buildCurrenciesMap };

--- a/apps/storefront/src/utils/featureFlags.ts
+++ b/apps/storefront/src/utils/featureFlags.ts
@@ -35,6 +35,10 @@ export const featureFlags = [
     key: 'LOCAL-3191.B2B_multi_language',
     name: 'b2bMultiLanguage',
   },
+  {
+    key: 'B2B-3876.fix_quote_currency_symbol_placement',
+    name: 'fixQuoteCurrencySymbolPlacement',
+  },
 ] as const;
 
 export type FeatureFlagKey = (typeof featureFlags)[number]['key'];


### PR DESCRIPTION
## Summary
- Adds `DisplayCurrency` interface to `@/types/currency` as the canonical typed shape for display currency
- Adds `formatBcCurrencyToDisplayCurrency` helper in `currencyUtils.ts` to map BC snake_case fields to display convention
- Simplifies `getActiveCurrencyInfo` to delegate to `activeCurrencyInfoSelector` — single source of logic
- In `QuotesList`, pre-builds a `currenciesMap` (keyed by `currencyCode`) from live BC store config and uses it to resolve the latest currency display settings at render time, gated behind feature flag `B2B-3876.fix_quote_currency_symbol_placement`

## Test plan
- [ ] Flag OFF: quote saved with EUR `location: right` renders `100.00€` even when BC config has EUR on left
- [ ] Flag ON: quote saved with EUR `location: right` renders `€100.00` after BC config moves EUR to left
- [ ] All 32 QuotesList tests pass

## Dev Testing
**FF OFF**
<img width="960" height="697" alt="Screenshot 2026-05-18 at 12 35 33 pm" src="https://github.com/user-attachments/assets/d576f173-1916-498d-b771-79acadae4405" />

**FF ON**
<img width="964" height="698" alt="Screenshot 2026-05-18 at 12 36 58 pm" src="https://github.com/user-attachments/assets/2ed4f7bd-e457-4c50-aac4-0624788ff57b" />

**Mobile View**
<img width="212" height="836" alt="Screenshot 2026-05-18 at 12 45 13 pm" src="https://github.com/user-attachments/assets/3f502446-9998-4610-a13e-2bba2175a656" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI formatting change, gated behind a feature flag, plus a small refactor to reuse an existing currency selector; main risk is mismatched currency display if mapping/typing assumptions are wrong.
> 
> **Overview**
> **Adds a feature-flagged fix for quote subtotal currency symbol placement** so the quotes list can render amounts using the *current* BigCommerce currency token location rather than the placement saved on the quote.
> 
> Introduces a canonical `DisplayCurrency` type and a `buildCurrenciesMap` helper to map BC currency config into the display shape, updates `currencyFormatConvert` to accept this optional currency, and wires the new map/flag through both table and mobile card rendering. Adds tests verifying EUR renders `100.00€` with the flag off and `€100.00` with the flag on.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a641b5e10278c5f05e21fb8e9b90715fd9794b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->