### PR TITLE
fix(quotes): B2B-3876 fix stale currency symbol placement in quote details

### DIFF
--- a/apps/storefront/src/pages/QuoteDetail/index.test.tsx
+++ b/apps/storefront/src/pages/QuoteDetail/index.test.tsx
@@ -1510,4 +1510,113 @@ describe('when the user is a B2B customer', () => {
       expect(screen.queryByText(/backorder details/i)).not.toBeInTheDocument();
     });
   });
+
+  describe('fix_quote_currency_symbol_placement feature flag', () => {
+    const woolSock = buildQuoteProductWith({
+      productName: 'Wool Socks',
+      quantity: 3,
+      basePrice: '49.00',
+      offeredPrice: '49.00',
+    });
+
+    const eurOnRightInQuote = {
+      token: '€',
+      location: 'right',
+      currencyCode: 'EUR',
+      decimalToken: '.',
+      decimalPlaces: 2,
+      thousandsToken: ',',
+      currencyExchangeRate: '1.0000000000',
+    };
+
+    const eurOnLeftInBcConfig = {
+      id: '2',
+      is_default: false,
+      last_updated: '2024-01-01',
+      country_iso2: 'DE',
+      default_for_country_codes: [],
+      currency_code: 'EUR',
+      currency_exchange_rate: '1.0000000000',
+      name: 'Euro',
+      token: '€',
+      auto_update: false,
+      decimal_token: '.',
+      decimal_places: 2,
+      enabled: true,
+      is_transactional: true,
+      token_location: 'left' as const,
+      thousands_token: ',',
+    };
+
+    const storeConfigsWithUpdatedEurPlacement = {
+      currencies: {
+        currencies: [eurOnLeftInBcConfig],
+        channelCurrencies: { channel_id: 1, enabled_currencies: ['EUR'], default_currency: 'EUR' },
+        enteredInclusiveTax: false,
+      },
+    };
+
+    beforeEach(() => {
+      const quote = buildQuoteWith({
+        data: {
+          quote: {
+            id: '272989',
+            productsList: [woolSock],
+            currency: eurOnRightInQuote,
+            totalAmount: '200.00',
+          },
+        },
+      });
+
+      server.use(
+        graphql.query('GetQuoteInfoB2B', () => HttpResponse.json(quote)),
+        graphql.query('SearchProducts', () =>
+          HttpResponse.json(buildProductSearchResponseWith('WHATEVER_VALUES')),
+        ),
+        graphql.query('getQuoteExtraFields', () =>
+          HttpResponse.json(buildQuoteExtraFieldsWith('WHATEVER_VALUES')),
+        ),
+      );
+
+      vitest.mocked(useParams).mockReturnValue({ id: '272989' });
+    });
+
+    it('uses the saved quote currency placement when the flag is disabled', async () => {
+      renderWithProviders(<QuoteDetail />, {
+        preloadedState: {
+          ...preloadedState,
+          storeConfigs: storeConfigsWithUpdatedEurPlacement,
+          global: buildGlobalStateWith({
+            backorderEnabled: false,
+            featureFlags: { 'B2B-3876.fix_quote_currency_symbol_placement': false },
+          }),
+        },
+      });
+
+      const row = (await screen.findByText('Wool Socks')).closest('tr')!;
+      expect(within(row).getByRole('cell', { name: '49.00€' })).toBeInTheDocument();
+
+      const summary = screen.getByTestId('quote-summary');
+      expect(within(summary).getByText('200.00€')).toBeInTheDocument();
+    });
+
+    it('uses the current BC currency placement when the flag is enabled', async () => {
+      renderWithProviders(<QuoteDetail />, {
+        preloadedState: {
+          ...preloadedState,
+          storeConfigs: storeConfigsWithUpdatedEurPlacement,
+          global: buildGlobalStateWith({
+            backorderEnabled: false,
+            featureFlags: { 'B2B-3876.fix_quote_currency_symbol_placement': true },
+          }),
+        },
+      });
+
+      const row = (await screen.findByText('Wool Socks')).closest('tr')!;
+      expect(within(row).getByRole('cell', { name: '€49.00' })).toBeInTheDocument();
+
+      const summary = screen.getByTestId('quote-summary');
+      expect(within(summary).getByText('€200.00')).toBeInTheDocument();
+    });
+  });
 });

--- a/apps/storefront/src/pages/QuoteDetail/index.tsx
+++ b/apps/storefront/src/pages/QuoteDetail/index.tsx
@@ -5,6 +5,7 @@ import copy from 'copy-to-clipboard';
 import { get } from 'lodash-es';
 
 import B3Spin from '@/components/spin/B3Spin';
+import { useFeatureFlag } from '@/hooks/useFeatureFlag';
 import { useIsBackorderEnabled } from '@/hooks/useIsBackorderEnabled';
 import { useMobile } from '@/hooks/useMobile';
 import { useScrollBar } from '@/hooks/useScrollBar';
@@ -29,6 +30,7 @@ import { b2bPermissionsMap } from '@/utils/b3CheckPermissions/config';
 import { getVariantInfoOOSAndPurchase } from '@/utils/b3Product/b3Product';
 import { conversionProductsList } from '@/utils/b3Product/shared/config';
 import { snackbar } from '@/utils/b3Tip';
+import { buildCurrenciesMap } from '@/utils/currencyUtils';
 import { getSearchVal } from '@/utils/loginInfo';
 import {
   ValidatedProductError,
@@ -121,6 +123,8 @@ function useData() {
   const isAgenting = useAppSelector(({ b2bFeatures }) => b2bFeatures.masqueradeCompany.isAgenting);
 
   const { currency_code: currencyCode } = useAppSelector(activeCurrencyInfoSelector);
+  const currencies = useAppSelector(({ storeConfigs }) => storeConfigs.currencies.currencies);
+  const currenciesMap = useMemo(() => buildCurrenciesMap(currencies), [currencies]);
   const enteredInclusiveTax = useAppSelector(
     ({ storeConfigs }) => storeConfigs.currencies.enteredInclusiveTax,
   );
@@ -192,6 +196,7 @@ function useData() {
     isB2BUser,
     selectCompanyHierarchyId,
     isAgenting,
+    currenciesMap,
     enteredInclusiveTax,
     isEnableProduct,
     purchasabilityPermission,
@@ -269,6 +274,7 @@ function QuoteDetail() {
     isB2BUser,
     selectCompanyHierarchyId,
     isAgenting,
+    currenciesMap,
     enteredInclusiveTax,
     isEnableProduct,
     purchasabilityPermission,
@@ -279,6 +285,10 @@ function QuoteDetail() {
   const [isMobile] = useMobile();
 
   const b3Lang = useB3Lang();
+
+  const isCurrencySymbolPlacementFixEnabled = useFeatureFlag(
+    'B2B-3876.fix_quote_currency_symbol_placement',
+  );
 
   const [quoteDetail, setQuoteDetail] = useState<any>({});
   const [productList, setProductList] = useState<ProductInfoProps[]>([]);
@@ -812,6 +822,14 @@ function QuoteDetail() {
     };
   }, [quoteDetail]);
 
+  const displayCurrency = useMemo(() => {
+    if (isCurrencySymbolPlacementFixEnabled && quoteDetail.currency?.currencyCode) {
+      const currencySnapshot = currenciesMap[quoteDetail.currency.currencyCode];
+      if (currencySnapshot) return currencySnapshot;
+    }
+    return quoteDetail.currency;
+  }, [isCurrencySymbolPlacementFixEnabled, quoteDetail.currency, currenciesMap]);
+
   useScrollBar(false);
 
   const { quotePurchasabilityPermission, quoteConvertToOrderPermission } =
@@ -894,7 +912,7 @@ function QuoteDetail() {
               <QuoteDetailTable
                 total={productList.length}
                 productList={productList}
-                currency={quoteDetail.currency}
+                currency={displayCurrency}
                 quoteReviewedBySalesRep={quoteReviewedBySalesRep}
                 getQuoteTableDetails={getQuoteTableDetails}
                 getTaxRate={getTaxRate}
@@ -928,6 +946,7 @@ function QuoteDetail() {
                 quoteDetailTax={quoteDetailTax}
                 status={quoteDetail.status}
                 quoteDetail={quoteDetail}
+                currency={displayCurrency}
                 hasBackorderedItems={hasBackorderedItems}
               />
             </Box>

--- a/apps/storefront/src/pages/quote/components/QuoteDetailSummary.tsx
+++ b/apps/storefront/src/pages/quote/components/QuoteDetailSummary.tsx
@@ -4,6 +4,7 @@ import ShippingExpectationPrompt from '@/components/ShippingExpectationPrompt';
 import { useFeatureFlag } from '@/hooks/useFeatureFlag';
 import { useB3Lang } from '@/lib/lang';
 import { useAppSelector } from '@/store';
+import { DisplayCurrency } from '@/types/currency';
 import { currencyFormatConvert } from '@/utils/b3CurrencyFormat';
 
 interface Summary {
@@ -19,6 +20,7 @@ interface QuoteDetailSummaryProps {
   quoteDetailTax: number;
   status: string;
   quoteDetail: CustomFieldItems;
+  currency?: DisplayCurrency | CurrencyProps;
   shouldHidePrice: boolean;
   hasBackorderedItems: boolean;
 }
@@ -28,6 +30,7 @@ export default function QuoteDetailSummary({
   quoteDetailTax = 0,
   status,
   quoteDetail,
+  currency,
   shouldHidePrice,
   hasBackorderedItems,
 }: QuoteDetailSummaryProps) {
@@ -40,6 +43,9 @@ export default function QuoteDetailSummary({
   const isBackorderMessagingEnabled = useFeatureFlag(
     'BACK-134.backorders_phase_1_1_control_messaging_on_storefront',
   );
+  const isCurrencySymbolPlacementFixEnabled = useFeatureFlag(
+    'B2B-3876.fix_quote_currency_symbol_placement',
+  );
   const { showDefaultShippingExpectationPrompt, defaultShippingExpectationPrompt } = useAppSelector(
     ({ global }) => global.backorderDisplaySettings,
   );
@@ -51,11 +57,15 @@ export default function QuoteDetailSummary({
     return showInclusiveTaxPrice ? price + quoteDetailTax : price;
   };
 
+  const effectiveCurrency = isCurrencySymbolPlacementFixEnabled
+    ? (currency ?? quoteDetail.currency)
+    : quoteDetail.currency;
+
   const priceFormat = (price: number) =>
     currencyFormatConvert(price, {
-      currency: quoteDetail.currency,
+      currency: effectiveCurrency,
       isConversionRate: false,
-      useCurrentCurrency: !!quoteDetail.currency,
+      useCurrentCurrency: !!effectiveCurrency,
     });
 
   const getShippingAndTax = () => {

--- a/apps/storefront/src/pages/quote/components/QuoteDetailTableCard.tsx
+++ b/apps/storefront/src/pages/quote/components/QuoteDetailTableCard.tsx
@@ -3,8 +3,10 @@ import { Box, CardContent, styled, Typography } from '@mui/material';
 import BackorderMessage from '@/components/BackorderMessage';
 import { PRODUCT_DEFAULT_IMAGE } from '@/constants';
 import { useBackorderStorefrontMessaging } from '@/hooks/useBackorderStorefrontMessaging';
+import { useFeatureFlag } from '@/hooks/useFeatureFlag';
 import { useB3Lang } from '@/lib/lang';
 import { useAppSelector } from '@/store';
+import { DisplayCurrency } from '@/types/currency';
 import { currencyFormatConvert } from '@/utils/b3CurrencyFormat';
 import { getBCPrice } from '@/utils/b3Product/b3Product';
 
@@ -15,7 +17,7 @@ interface QuoteTableCardProps {
   itemIndex?: number;
   showPrice: (price: string, row: CustomFieldItems) => string | number;
   displayDiscount: boolean;
-  currency: CurrencyProps;
+  currency: CurrencyProps | DisplayCurrency;
   showBackorderDetails?: boolean;
   status?: string | number;
 }
@@ -40,6 +42,9 @@ function QuoteDetailTableCard(props: QuoteTableCardProps) {
   } = props;
   const isOrdered = Number(status) === 4;
   const b3Lang = useB3Lang();
+  const isCurrencySymbolPlacementFixEnabled = useFeatureFlag(
+    'B2B-3876.fix_quote_currency_symbol_placement',
+  );
   const enteredInclusiveTax = useAppSelector(
     ({ storeConfigs }) => storeConfigs.currencies.enteredInclusiveTax,
   );
@@ -171,6 +176,7 @@ function QuoteDetailTableCard(props: QuoteTableCardProps) {
                 {`${showPrice(
                   currencyFormatConvert(price, {
                     currency,
+                    useCurrentCurrency: isCurrencySymbolPlacementFixEnabled,
                   }),
                   quoteTableItem,
                 )}`}
@@ -185,6 +191,7 @@ function QuoteDetailTableCard(props: QuoteTableCardProps) {
               {`${showPrice(
                 currencyFormatConvert(offeredPrice, {
                   currency,
+                  useCurrentCurrency: isCurrencySymbolPlacementFixEnabled,
                 }),
                 quoteTableItem,
               )}`}
@@ -215,6 +222,7 @@ function QuoteDetailTableCard(props: QuoteTableCardProps) {
                 {`${showPrice(
                   currencyFormatConvert(total, {
                     currency,
+                    useCurrentCurrency: isCurrencySymbolPlacementFixEnabled,
                   }),
                   quoteTableItem,
                 )}`}
@@ -229,6 +237,7 @@ function QuoteDetailTableCard(props: QuoteTableCardProps) {
               {`${showPrice(
                 currencyFormatConvert(totalWithDiscount, {
                   currency,
+                  useCurrentCurrency: isCurrencySymbolPlacementFixEnabled,
                 }),
                 quoteTableItem,
               )}`}


### PR DESCRIPTION
## Summary
- Adds `DisplayCurrency` interface to `@/types/currency` as the canonical typed shape for display currency
- Adds `formatBcCurrencyToDisplayCurrency` helper in `currencyUtils.ts` to map BC snake_case fields to display convention
- Simplifies `getActiveCurrencyInfo` to delegate to `activeCurrencyInfoSelector` — single source of logic
- In `QuoteDetail`, computes `displayCurrency` from the live BC currencies map using only the saved `currencyCode` as the key, gated behind feature flag `B2B-3876.fix_quote_currency_symbol_placement`
- Passes `displayCurrency` explicitly to both `QuoteDetailTable` and `QuoteDetailSummary` to avoid spreading a new object on every render

## Test plan
- [ ] Flag OFF: quote saved with EUR `location: right` renders `49.00€` even when BC config has EUR on left
- [ ] Flag ON: quote saved with EUR `location: right` renders `€49.00` after BC config moves EUR to left
- [ ] All 22 QuoteDetail tests pass

## Dev testing
**BC Currency Settings**
<img width="451" height="566" alt="Screenshot 2026-05-18 at 1 05 26 pm" src="https://github.com/user-attachments/assets/4429d430-d527-45a6-8dbe-4583eca0d029" />

**FF ON**
<img width="907" height="739" alt="Screenshot 2026-05-18 at 1 03 23 pm" src="https://github.com/user-attachments/assets/82ea2620-4096-4494-9497-4da86f8b7279" />


**FF OFF**
<img width="909" height="741" alt="Screenshot 2026-05-18 at 1 03 53 pm" src="https://github.com/user-attachments/assets/94a2dbb4-cabf-4b3c-9cf2-64360f71a06d" />

**Quote Print**
<img width="524" height="737" alt="Screenshot 2026-05-18 at 1 07 08 pm" src="https://github.com/user-attachments/assets/7f161bfd-72e1-4970-950b-266c95718041" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes price/currency rendering in the Quote Detail UI (table + summary) and could affect formatting across currencies, though the behavior is gated behind a feature flag and covered by new tests.
> 
> **Overview**
> **Fixes stale currency symbol placement in `QuoteDetail` behind feature flag `B2B-3876.fix_quote_currency_symbol_placement`.** When enabled, Quote Detail now derives the display currency from the current BigCommerce currency config (via a currencies map keyed by `currencyCode`) instead of relying on the quote’s saved currency snapshot.
> 
> Updates `QuoteDetailSummary` and `QuoteDetailTableCard` to accept/use `DisplayCurrency` and to format prices using the effective currency, plus adds Quote Detail tests verifying EUR symbol placement with the flag on vs off.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28d59a8dbaefd53f7f231176e78bfc11319c06e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->