### PR TITLE
refactor(quotes): replace ambient CurrencyProps with explicit DisplayCurrency type

### DIFF
--- a/apps/storefront/src/index.d.ts
+++ b/apps/storefront/src/index.d.ts
@@ -126,16 +126,6 @@ declare global {
     };
   }
 
-  declare interface CurrencyProps {
-    token: string;
-    location: string;
-    currencyCode: string;
-    decimalToken: string;
-    decimalPlaces: number;
-    thousandsToken: string;
-    currencyExchangeRate: string;
-  }
-
   declare interface Window {
     b2b: {
       callbacks: {

--- a/apps/storefront/src/pages/QuotesList/index.tsx
+++ b/apps/storefront/src/pages/QuotesList/index.tsx
@@ -16,6 +16,7 @@ import {
   getShoppingListsCreatedByUser,
 } from '@/shared/service/b2b';
 import { isB2BUserSelector, useAppSelector } from '@/store';
+import { DisplayCurrency } from '@/types/currency';
 import { currencyFormatConvert } from '@/utils/b3CurrencyFormat';
 import { displayFormat } from '@/utils/b3DateFormat';
 import { channelId } from '@/utils/basicConfig';
@@ -232,7 +233,7 @@ const useColumnList = (): Array<TableColumnItem<ListItem>> => {
         title: b3Lang('quotes.subtotal'),
         render: (item: ListItem) => {
           const { totalAmount, currency } = item;
-          const newCurrency = currency as CurrencyProps;
+          const newCurrency = currency as DisplayCurrency;
           return currencyFormatConvert(Number(totalAmount), {
             currency: newCurrency,
             isConversionRate: false,

--- a/apps/storefront/src/pages/quote/components/QuoteDetailTable.tsx
+++ b/apps/storefront/src/pages/quote/components/QuoteDetailTable.tsx
@@ -8,6 +8,7 @@ import { PRODUCT_DEFAULT_IMAGE } from '@/constants';
 import { useFeatureFlag } from '@/hooks/useFeatureFlag';
 import { useB3Lang } from '@/lib/lang';
 import { useAppSelector } from '@/store';
+import { DisplayCurrency } from '@/types/currency';
 import { currencyFormatConvert } from '@/utils/b3CurrencyFormat';
 import { getBCPrice, getDisplayPrice } from '@/utils/b3Product/b3Product';
 
@@ -49,7 +50,7 @@ interface ShoppingDetailTableProps {
   quoteReviewedBySalesRep: boolean;
   getTaxRate: (variants: any) => number;
   displayDiscount: boolean;
-  currency: CurrencyProps;
+  currency: DisplayCurrency;
   status: string | number;
 }
 

--- a/apps/storefront/src/pages/quote/components/QuoteDetailTableCard.tsx
+++ b/apps/storefront/src/pages/quote/components/QuoteDetailTableCard.tsx
@@ -5,6 +5,7 @@ import { PRODUCT_DEFAULT_IMAGE } from '@/constants';
 import { useFeatureFlag } from '@/hooks/useFeatureFlag';
 import { useB3Lang } from '@/lib/lang';
 import { useAppSelector } from '@/store';
+import { DisplayCurrency } from '@/types/currency';
 import { currencyFormatConvert } from '@/utils/b3CurrencyFormat';
 import { getBCPrice } from '@/utils/b3Product/b3Product';
 
@@ -15,7 +16,7 @@ interface QuoteTableCardProps {
   itemIndex?: number;
   showPrice: (price: string, row: CustomFieldItems) => string | number;
   displayDiscount: boolean;
-  currency: CurrencyProps;
+  currency: DisplayCurrency;
   showBackorderDetails?: boolean;
   status?: string | number;
 }

--- a/apps/storefront/src/types/currency.ts
+++ b/apps/storefront/src/types/currency.ts
@@ -29,6 +29,16 @@ export interface Currency {
   thousands_token: string;
 }
 
+export interface DisplayCurrency {
+  token: string;
+  location: 'left' | 'right';
+  currencyCode: string;
+  decimalToken: string;
+  decimalPlaces: number;
+  thousandsToken: string;
+  currencyExchangeRate: string;
+}
+
 interface Node {
   isActive: boolean;
   entityId: number;

--- a/apps/storefront/src/utils/b3CurrencyFormat.ts
+++ b/apps/storefront/src/utils/b3CurrencyFormat.ts
@@ -1,4 +1,5 @@
 import { store } from '@/store';
+import { DisplayCurrency } from '@/types/currency';
 
 import b2bLogger from './b3Logger';
 import { getActiveCurrencyInfo } from './currencyUtils';
@@ -63,7 +64,7 @@ export const ordersCurrencyFormat = (
 };
 
 interface CurrencyOption {
-  currency: CurrencyProps;
+  currency: DisplayCurrency;
   showCurrencyToken?: boolean;
   isConversionRate?: boolean;
   useCurrentCurrency?: boolean;


### PR DESCRIPTION
## Summary

- Adds `DisplayCurrency` interface to `src/types/currency.ts` with a strict `location: 'left' | 'right'` (narrower than the old `string`)
- Removes the ambient `CurrencyProps` global declaration from `src/index.d.ts`
- Replaces all `CurrencyProps` usages with `DisplayCurrency` in `b3CurrencyFormat.ts`, `QuoteDetailTable.tsx`, `QuoteDetailTableCard.tsx`, and `QuotesList/index.tsx`

## Test plan

- [x] `yarn tsc --noEmit` — no type errors
- [x] `yarn lint:eslint` — no violations
- [x] All affected tests pass (78 tests across 7 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a type-only refactor that centralizes the currency shape and narrows `location` to `'left' | 'right'`, with no intended runtime behavior changes beyond catching type mismatches.
> 
> **Overview**
> Removes the ambient global `CurrencyProps` from `index.d.ts` and introduces an explicit exported `DisplayCurrency` type in `types/currency.ts`.
> 
> Updates quote list/detail components and `currencyFormatConvert` to accept/cast to `DisplayCurrency`, tightening currency typing (notably `location`) while keeping formatting/conversion logic the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b3cfd99729a4acdc66f3f91068d5c74d58cbab5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->