### PR TITLE
feat(orders): BACK-634 add quantity validation errors to re-order dialog

### DIFF
--- a/apps/storefront/src/lib/lang/locales/en.json
+++ b/apps/storefront/src/lib/lang/locales/en.json
@@ -345,6 +345,8 @@
   "orderDetail.reorder.partialSuccess": "{count, plural, one {# Product was added to the cart.} other {# Products were added to the cart.}}",
   "orderDetail.reorder.failedToAdd.helperText": "Add failed, try again.",
   "orderDetail.reorder.addToCartError": "There was an issue with adding products to the cart. Please check the errors below.",
+  "orderDetail.reorder.adjustQuantitiesBanner": "Some items were not added to the cart. Please adjust quantities.",
+  "orderDetail.reorder.onlyAvailable": "{count, plural, one {Only # available} other {Only # available}}",
   "orderDetail.reorder.product": "Product",
   "orderDetail.reorder.price": "Price",
   "orderDetail.reorder.qty": "Qty",

--- a/apps/storefront/src/pages/OrderDetail/components/OrderCheckboxProduct.tsx
+++ b/apps/storefront/src/pages/OrderDetail/components/OrderCheckboxProduct.tsx
@@ -19,7 +19,7 @@ import {
   ProductImage,
   ProductOptionText,
 } from '../styled';
-import { getReorderBackorderDisplayFields } from '../utils/reorderBackorderDisplay';
+import { getReorderProductRowDisplayState } from '../utils/reorderBackorderDisplay';
 
 interface ReturnListProps {
   returnId: number;
@@ -118,6 +118,9 @@ export default function OrderCheckboxProduct(props: OrderCheckboxProductProps) {
       const valueNum = e.target.value;
       if (Number(valueNum) >= 0 && Number(valueNum) <= 1000000) {
         element.editQuantity = valueNum;
+        if (type === 'reOrder') {
+          element.helperText = '';
+        }
         if (type === 'return') {
           if (Number(valueNum) > Number(product.quantity)) {
             element.editQuantity = product.quantity;
@@ -198,9 +201,15 @@ export default function OrderCheckboxProduct(props: OrderCheckboxProductProps) {
 
       {products.map((product: EditableProductItem) => {
         const qty = Number(getProductQuantity(product)) || 0;
-        const invRow = reorderInventoryBySku?.[product.sku.toUpperCase()];
-        const backorderFields = getReorderBackorderDisplayFields(qty, invRow);
-        const showReorderBackorder = reorderBackorderUiEnabled && Boolean(backorderFields);
+        const { qtyHelperText, backorderFields } = getReorderProductRowDisplayState({
+          qty,
+          productHelperText: product.helperText,
+          isReorder: type === 'reOrder',
+          inventoryRow:
+            type === 'reOrder' ? reorderInventoryBySku?.[product.sku.toUpperCase()] : undefined,
+          backorderUiEnabled: reorderBackorderUiEnabled,
+          formatOnlyAvailable: (count) => b3Lang('orderDetail.reorder.onlyAvailable', { count }),
+        });
 
         return (
           <Flex
@@ -271,10 +280,10 @@ export default function OrderCheckboxProduct(props: OrderCheckboxProductProps) {
                       marginRight: '0',
                     },
                   }}
-                  error={!!product.helperText}
-                  helperText={product.helperText}
+                  error={Boolean(qtyHelperText)}
+                  helperText={qtyHelperText}
                 />
-                {showReorderBackorder && backorderFields && (
+                {backorderFields && (
                   <Box
                     sx={{
                       mt: 1,

--- a/apps/storefront/src/pages/OrderDetail/components/OrderDialog.tsx
+++ b/apps/storefront/src/pages/OrderDetail/components/OrderDialog.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { FieldValues, useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
-import { Box, Typography } from '@mui/material';
+import { Alert, Box, Typography } from '@mui/material';
 import Cookies from 'js-cookie';
 
 import { B3CustomForm } from '@/components/B3CustomForm';
@@ -15,14 +15,20 @@ import {
   addProductToShoppingList,
   getVariantInfoBySkus,
 } from '@/shared/service/b2b';
-import type { CatalogQuickVariantSku } from '@/shared/service/b2b/graphql/product';
+import {
+  type CatalogQuickVariantSku,
+  QUOTE_VALIDATION_ERROR_CODES,
+} from '@/shared/service/b2b/graphql/product';
 import { isB2BUserSelector, useAppSelector } from '@/store';
 import b2bLogger from '@/utils/b3Logger';
 import { snackbar } from '@/utils/b3Tip';
 import b3TriggerCartNumber from '@/utils/b3TriggerCartNumber';
 import { BigCommerceStorefrontAPIBaseURL } from '@/utils/basicConfig';
 import { createOrUpdateExistingCart } from '@/utils/cartUtils';
-import { validateProductsLegacy as rawValidateProducts } from '@/utils/validateProducts';
+import {
+  VALIDATED_PRODUCT_ERROR_TYPES,
+  validateProductsLegacy as rawValidateProducts,
+} from '@/utils/validateProducts';
 
 import { EditableProductItem, OrderProductItem } from '../../../types';
 import getReturnFormFields from '../shared/config';
@@ -107,6 +113,7 @@ export default function OrderDialog({
   const [isRequestLoading, setIsRequestLoading] = useState(false);
   const [checkedArr, setCheckedArr] = useState<number[]>([]);
   const [returnArr, setReturnArr] = useState<ReturnListProps[]>([]);
+  const [reorderValidationBanner, setReorderValidationBanner] = useState(false);
 
   const [returnFormFields] = useState(getReturnFormFields());
 
@@ -287,6 +294,8 @@ export default function OrderDialog({
       return;
     }
 
+    setReorderValidationBanner(false);
+
     const validationResult = await validateProducts(items);
 
     const helperTextMap = new Map<number, string>();
@@ -296,12 +305,32 @@ export default function OrderDialog({
     });
 
     validationResult.error.forEach(({ product, error }) => {
-      if (error.type === 'network') {
+      if (error.type === VALIDATED_PRODUCT_ERROR_TYPES.NETWORK) {
         helperTextMap.set(product.variantId, b3Lang('orderDetail.reorder.failedToAdd.helperText'));
-      } else {
-        helperTextMap.set(product.variantId, error.message || '');
+      } else if (error.type === VALIDATED_PRODUCT_ERROR_TYPES.VALIDATION) {
+        helperTextMap.set(
+          product.variantId,
+          error.errorCode === QUOTE_VALIDATION_ERROR_CODES.OOS
+            ? b3Lang('orderDetail.reorder.onlyAvailable', { count: error.availableToSell })
+            : error.message || '',
+        );
       }
     });
+
+    const hasValidationErrors = validationResult.error.some(
+      ({ error }) => error.type === VALIDATED_PRODUCT_ERROR_TYPES.VALIDATION,
+    );
+    const hasNetworkErrors = validationResult.error.some(
+      ({ error }) => error.type === VALIDATED_PRODUCT_ERROR_TYPES.NETWORK,
+    );
+
+    if (hasValidationErrors && !hasNetworkErrors) {
+      setReorderValidationBanner(true);
+    }
+
+    if (hasNetworkErrors) {
+      snackbar.error(b3Lang('orderDetail.reorder.addToCartError'));
+    }
 
     const successVariantIds = validationResult.success.map(({ product }) => product.variantId);
 
@@ -323,7 +352,9 @@ export default function OrderDialog({
     );
 
     if (validationResult.success.length === 0) {
-      snackbar.error(b3Lang('orderDetail.reorder.addToCartError'));
+      if (!hasValidationErrors && !hasNetworkErrors) {
+        snackbar.error(b3Lang('orderDetail.reorder.addToCartError'));
+      }
       return;
     }
 
@@ -339,9 +370,9 @@ export default function OrderDialog({
 
     if (successfulVariantIds.length === checkedArr.length) {
       setOpen(false);
+      setReorderValidationBanner(false);
       showSuccessSnackbarWithCartLink(b3Lang('orderDetail.reorder.productsAdded'));
     } else {
-      snackbar.error(b3Lang('orderDetail.reorder.addToCartError'));
       showSuccessSnackbarWithCartLink(
         b3Lang('orderDetail.reorder.partialSuccess', { count: validItems.length }),
       );
@@ -490,6 +521,8 @@ export default function OrderDialog({
 
     let cancelled = false;
 
+    setReorderValidationBanner(false);
+
     const getVariantInfoByList = async () => {
       const visibleProducts = products.filter((item: OrderProductItem) => item?.isVisible);
 
@@ -512,6 +545,9 @@ export default function OrderDialog({
   }, [isB2BUser, open, products]);
 
   const handleProductChange = (products: EditableProductItem[]) => {
+    if (type === 'reOrder') {
+      setReorderValidationBanner(false);
+    }
     setEditableProducts(products);
   };
 
@@ -541,6 +577,11 @@ export default function OrderDialog({
           >
             {currentDialogData?.description || ''}
           </Typography>
+          {reorderValidationBanner && type === 'reOrder' && (
+            <Alert severity="error" sx={{ mb: 2 }}>
+              {b3Lang('orderDetail.reorder.adjustQuantitiesBanner')}
+            </Alert>
+          )}
           <OrderCheckboxProduct
             products={editableProducts}
             onProductChange={handleProductChange}

--- a/apps/storefront/src/pages/OrderDetail/index.test.tsx
+++ b/apps/storefront/src/pages/OrderDetail/index.test.tsx
@@ -1823,7 +1823,7 @@ describe('when a personal customer visits an order', () => {
               errorCode: 'OOS',
               responseType: 'ERROR',
               message: 'A message from the backend',
-              product: { availableToSell: faker.number.int() },
+              product: { availableToSell: 7 },
             },
           },
         });
@@ -1861,15 +1861,198 @@ describe('when a personal customer visits an order', () => {
 
       await waitFor(() => {
         expect(
+          screen.getByText('Some items were not added to the cart. Please adjust quantities.'),
+        ).toBeVisible();
+      });
+
+      expect(within(dialog).getByText('Only 7 available')).toBeVisible();
+
+      expect(window.b2b.callbacks.dispatchEvent).not.toHaveBeenCalled();
+    });
+
+    it('shows a snackbar when all selected products return validation warnings', async () => {
+      const laughCanister = buildProductWith({
+        product_id: 123,
+        variant_id: 456,
+        name: 'Laugh Canister',
+        quantity: 1,
+        product_options: [],
+      });
+
+      const validateProducts = when(vi.fn())
+        .calledWith({
+          productId: 123,
+          variantId: 456,
+          quantity: 1,
+          productOptions: [],
+          target: 'CART',
+        })
+        .thenReturn({
+          data: {
+            validateProduct: {
+              responseType: 'WARNING',
+              message: 'A warning message from the backend',
+            },
+          },
+        });
+
+      server.use(
+        graphql.query('GetCustomerOrderStatuses', () =>
+          HttpResponse.json(buildCustomerOrderStatusesWith('WHATEVER_VALUES')),
+        ),
+        graphql.query('AddressConfig', () =>
+          HttpResponse.json(buildAddressConfigResponseWith('WHATEVER_VALUES')),
+        ),
+        graphql.query('GetCustomerOrder', () =>
+          HttpResponse.json(
+            buildCustomerOrderResponseWith({
+              data: { customerOrder: { products: [laughCanister] } },
+            }),
+          ),
+        ),
+        graphql.query('ValidateProduct', ({ variables }) =>
+          HttpResponse.json(validateProducts(variables)),
+        ),
+      );
+
+      renderWithProviders(<OrderDetails />, { preloadedState });
+
+      await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+      await userEvent.click(screen.getByRole('button', { name: 'Re-Order' }));
+
+      const dialog = await screen.findByRole('dialog', { name: 'Re-Order' });
+
+      await userEvent.click(within(dialog).getAllByRole('checkbox')[0]);
+
+      await userEvent.click(screen.getByRole('button', { name: 'Add to cart' }));
+
+      await waitFor(() => {
+        expect(
           screen.getByText(
             'There was an issue with adding products to the cart. Please check the errors below.',
           ),
         ).toBeVisible();
       });
 
-      expect(within(dialog).getByText('A message from the backend')).toBeVisible();
+      expect(
+        screen.queryByText('Some items were not added to the cart. Please adjust quantities.'),
+      ).not.toBeInTheDocument();
+
+      expect(within(dialog).getByText('A warning message from the backend')).toBeVisible();
 
       expect(window.b2b.callbacks.dispatchEvent).not.toHaveBeenCalled();
+    });
+
+    it('shows banner and only-available line when one product fails validation and another succeeds', async () => {
+      const screamCanister = buildProductWith({
+        name: 'Scream Canister',
+        quantity: 2,
+        product_id: 999,
+        variant_id: 100,
+        product_options: [],
+      });
+      const laughCanister = buildProductWith({
+        product_id: 123,
+        variant_id: 456,
+        name: 'Laugh Canister',
+        quantity: 1,
+        product_options: [],
+      });
+
+      const createCartSimple = vi.fn();
+
+      server.use(
+        graphql.query('GetCustomerOrderStatuses', () =>
+          HttpResponse.json(buildCustomerOrderStatusesWith('WHATEVER_VALUES')),
+        ),
+        graphql.query('AddressConfig', () =>
+          HttpResponse.json(buildAddressConfigResponseWith('WHATEVER_VALUES')),
+        ),
+        graphql.query('GetCustomerOrder', () =>
+          HttpResponse.json(
+            buildCustomerOrderResponseWith({
+              data: { customerOrder: { products: [screamCanister, laughCanister] } },
+            }),
+          ),
+        ),
+        graphql.query('getCart', () => HttpResponse.json({ data: { site: { cart: null } } })),
+        graphql.mutation('createCartSimple', ({ variables }) =>
+          HttpResponse.json(createCartSimple(variables)),
+        ),
+        graphql.query('ValidateProduct', ({ variables }) => {
+          const v = variables as { variantId: number };
+          if (v.variantId === 456) {
+            return HttpResponse.json({
+              data: {
+                validateProduct: {
+                  errorCode: 'OOS',
+                  responseType: 'ERROR',
+                  message: '',
+                  product: { availableToSell: 2 },
+                },
+              },
+            });
+          }
+          return HttpResponse.json({
+            data: {
+              validateProduct: {
+                responseType: 'SUCCESS',
+                message: '',
+              },
+            },
+          });
+        }),
+      );
+
+      when(createCartSimple)
+        .calledWith({
+          createCartInput: {
+            lineItems: [
+              {
+                quantity: 2,
+                productEntityId: 999,
+                variantEntityId: 100,
+                selectedOptions: {
+                  multipleChoices: [],
+                  textFields: [],
+                },
+              },
+            ],
+          },
+        })
+        .thenReturn({ data: { cart: { createCart: { cart: { entityId: 'partial-cart' } } } } });
+
+      renderWithProviders(<OrderDetails />, { preloadedState });
+
+      await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+      await userEvent.click(screen.getByRole('button', { name: 'Re-Order' }));
+
+      const dialog = await screen.findByRole('dialog', { name: 'Re-Order' });
+
+      await userEvent.click(within(dialog).getAllByRole('checkbox')[0]);
+
+      await userEvent.click(screen.getByRole('button', { name: 'Add to cart' }));
+
+      await waitFor(() => {
+        expect(
+          screen.getByText('Some items were not added to the cart. Please adjust quantities.'),
+        ).toBeVisible();
+      });
+
+      const laughGroup = within(dialog).getByRole('group', { name: 'Laugh Canister' });
+      expect(within(laughGroup).getByText('Only 2 available')).toBeVisible();
+
+      await waitFor(() => {
+        expect(
+          screen.getByText('1 Product was added to the cart.', { exact: false }),
+        ).toBeVisible();
+      });
+
+      expect(window.b2b.callbacks.dispatchEvent).toHaveBeenCalledWith('on-cart-created', {
+        cartId: 'partial-cart',
+      });
     });
 
     it('displays an error when a network error occurs', async () => {
@@ -1917,6 +2100,10 @@ describe('when a personal customer visits an order', () => {
           ),
         ).toBeVisible();
       });
+
+      expect(
+        screen.queryByText('Some items were not added to the cart. Please adjust quantities.'),
+      ).not.toBeInTheDocument();
 
       expect(within(dialog).getByText('Add failed, try again.')).toBeVisible();
     });
@@ -2173,7 +2360,7 @@ describe('when a personal customer visits an order', () => {
               responseType: 'ERROR',
               message: 'An error message from the backend',
               errorCode: 'OOS',
-              product: { availableToSell: faker.number.int() },
+              product: { availableToSell: 5 },
             },
           },
         });
@@ -2236,13 +2423,9 @@ describe('when a personal customer visits an order', () => {
         expect(screen.getByText('1 Product was added to the cart.')).toBeVisible();
       });
 
-      await waitFor(() => {
-        expect(
-          screen.getByText(
-            'There was an issue with adding products to the cart. Please check the errors below.',
-          ),
-        ).toBeVisible();
-      });
+      expect(
+        screen.getByText('Some items were not added to the cart. Please adjust quantities.'),
+      ).toBeVisible();
 
       expect(window.b2b.callbacks.dispatchEvent).toHaveBeenCalledWith('on-cart-created', {
         cartId: 'foo-bar',
@@ -2253,7 +2436,7 @@ describe('when a personal customer visits an order', () => {
       const groupWithError = within(dialog).getByRole('group', { name: 'Product with Error' });
 
       expect(within(groupWithError).getByRole('checkbox')).toBeChecked();
-      expect(within(groupWithError).getByText('An error message from the backend')).toBeVisible();
+      expect(within(groupWithError).getByText('Only 5 available')).toBeVisible();
 
       const groupWithWarning = within(dialog).getByRole('group', { name: 'Product with Warning' });
       expect(within(groupWithWarning).getByRole('checkbox')).toBeChecked();

--- a/apps/storefront/src/pages/OrderDetail/utils/reorderBackorderDisplay.test.ts
+++ b/apps/storefront/src/pages/OrderDetail/utils/reorderBackorderDisplay.test.ts
@@ -2,9 +2,90 @@ import { describe, expect, it } from 'vitest';
 
 import type { CatalogQuickVariantSku } from '@/shared/service/b2b/graphql/product';
 
-import { getReorderBackorderDisplayFields } from './reorderBackorderDisplay';
+import {
+  getReorderBackorderDisplayFields,
+  getReorderBackorderDisplayQuantity,
+  getReorderProductRowDisplayState,
+  reorderQuantityExceedsAvailableToSell,
+} from './reorderBackorderDisplay';
 
 describe('reorderBackorderDisplay', () => {
+  it('reorderQuantityExceedsAvailableToSell is false when unlimited backorder', () => {
+    const row = {
+      inventoryTracking: 'variant',
+      unlimitedBackorder: true,
+      availableToSell: 2,
+    } as CatalogQuickVariantSku;
+
+    expect(reorderQuantityExceedsAvailableToSell(100, row)).toBe(false);
+  });
+
+  it('reorderQuantityExceedsAvailableToSell is false when tracking is none', () => {
+    const row = {
+      inventoryTracking: 'none',
+      availableToSell: 0,
+    } as CatalogQuickVariantSku;
+
+    expect(reorderQuantityExceedsAvailableToSell(100, row)).toBe(false);
+  });
+
+  it('reorderQuantityExceedsAvailableToSell when qty exceeds available to sell', () => {
+    const row = {
+      inventoryTracking: 'variant',
+      unlimitedBackorder: false,
+      availableToSell: 5,
+    } as CatalogQuickVariantSku;
+
+    expect(reorderQuantityExceedsAvailableToSell(6, row)).toBe(true);
+    expect(reorderQuantityExceedsAvailableToSell(5, row)).toBe(false);
+  });
+
+  it('reorderQuantityExceedsAvailableToSell is false when row is undefined', () => {
+    expect(reorderQuantityExceedsAvailableToSell(10, undefined)).toBe(false);
+  });
+
+  it('getReorderBackorderDisplayQuantity caps at available to sell when order qty exceeds it', () => {
+    const row = {
+      inventoryTracking: 'variant',
+      unlimitedBackorder: false,
+      availableToSell: 10,
+      totalOnHand: 9,
+    } as CatalogQuickVariantSku;
+
+    expect(getReorderBackorderDisplayQuantity(100, row)).toBe(10);
+  });
+
+  it('getReorderBackorderDisplayQuantity returns order qty when within available to sell', () => {
+    const row = {
+      inventoryTracking: 'variant',
+      unlimitedBackorder: false,
+      availableToSell: 10,
+    } as CatalogQuickVariantSku;
+
+    expect(getReorderBackorderDisplayQuantity(7, row)).toBe(7);
+  });
+
+  it('getReorderBackorderDisplayQuantity returns order qty when row undefined', () => {
+    expect(getReorderBackorderDisplayQuantity(100, undefined)).toBe(100);
+  });
+
+  it('backorder fields from capped qty when raw qty far exceeds available to sell', () => {
+    const row = {
+      inventoryTracking: 'variant',
+      unlimitedBackorder: false,
+      availableToSell: 10,
+      totalOnHand: 9,
+      backorderMessage: '2-4 weeks',
+    } as CatalogQuickVariantSku;
+
+    const capped = getReorderBackorderDisplayQuantity(100, row);
+    expect(getReorderBackorderDisplayFields(capped, row)).toEqual({
+      totalOnHand: 9,
+      quantityBackordered: 1,
+      backorderMessage: '2-4 weeks',
+    });
+  });
+
   it('getReorderBackorderDisplayFields computes quantity backordered vs total on hand', () => {
     const row = {
       inventoryTracking: 'variant',
@@ -71,6 +152,56 @@ describe('reorderBackorderDisplay', () => {
       totalOnHand: -3,
       quantityBackordered: 13,
       backorderMessage: undefined,
+    });
+  });
+
+  describe('getReorderProductRowDisplayState', () => {
+    const inventoryRow = {
+      inventoryTracking: 'variant',
+      unlimitedBackorder: false,
+      availableToSell: 5,
+      totalOnHand: 3,
+      backorderMessage: '2 weeks',
+    } as CatalogQuickVariantSku;
+
+    const formatOnlyAvailable = (count: number) => `Only ${count} available`;
+
+    it('uses validation helper text when present', () => {
+      expect(
+        getReorderProductRowDisplayState({
+          qty: 10,
+          productHelperText: 'Server error',
+          isReorder: true,
+          inventoryRow,
+          backorderUiEnabled: true,
+          formatOnlyAvailable,
+        }).qtyHelperText,
+      ).toBe('Server error');
+    });
+
+    it('falls back to available-to-sell helper when validation helper is cleared', () => {
+      expect(
+        getReorderProductRowDisplayState({
+          qty: 10,
+          productHelperText: '',
+          isReorder: true,
+          inventoryRow,
+          backorderUiEnabled: true,
+          formatOnlyAvailable,
+        }).qtyHelperText,
+      ).toBe('Only 5 available');
+    });
+
+    it('returns null backorder fields when backorder UI is disabled', () => {
+      expect(
+        getReorderProductRowDisplayState({
+          qty: 10,
+          isReorder: true,
+          inventoryRow,
+          backorderUiEnabled: false,
+          formatOnlyAvailable,
+        }).backorderFields,
+      ).toBeNull();
     });
   });
 });

--- a/apps/storefront/src/pages/OrderDetail/utils/reorderBackorderDisplay.ts
+++ b/apps/storefront/src/pages/OrderDetail/utils/reorderBackorderDisplay.ts
@@ -2,6 +2,30 @@ import type { CatalogQuickVariantSku } from '@/shared/service/b2b/graphql/produc
 import type { BackorderDisplayFields } from '@/utils/backorderDisplayFromInventory';
 import { getBackorderDisplayFieldsFromOnHand } from '@/utils/backorderDisplayFromInventory';
 
+export function reorderQuantityExceedsAvailableToSell(
+  quantity: number,
+  row: CatalogQuickVariantSku | undefined,
+): boolean {
+  if (!row) return false;
+  const tracking = row.inventoryTracking || 'none';
+  if (tracking === 'none') return false;
+  if (row.unlimitedBackorder) return false;
+  const availableToSell = row.availableToSell ?? 0;
+
+  return quantity > availableToSell;
+}
+
+export function getReorderBackorderDisplayQuantity(
+  orderQty: number,
+  row: CatalogQuickVariantSku | undefined,
+): number {
+  if (!row) return orderQty;
+  if (orderQty <= 0) return orderQty;
+  if (!reorderQuantityExceedsAvailableToSell(orderQty, row)) return orderQty;
+
+  return Math.min(orderQty, row.availableToSell ?? 0);
+}
+
 export function getReorderBackorderDisplayFields(
   quantity: number,
   row: CatalogQuickVariantSku | undefined,
@@ -18,4 +42,43 @@ export function getReorderBackorderDisplayFields(
     totalOnHand,
     row.backorderMessage ?? undefined,
   );
+}
+
+interface ReorderProductRowDisplayState {
+  qtyHelperText: string;
+  backorderFields: BackorderDisplayFields | null;
+}
+
+export function getReorderProductRowDisplayState({
+  qty,
+  productHelperText,
+  isReorder,
+  inventoryRow,
+  backorderUiEnabled,
+  formatOnlyAvailable,
+}: {
+  qty: number;
+  productHelperText?: string;
+  isReorder: boolean;
+  inventoryRow?: CatalogQuickVariantSku;
+  backorderUiEnabled: boolean;
+  formatOnlyAvailable: (availableToSell: number) => string;
+}): ReorderProductRowDisplayState {
+  const quantityExceedsAvailableToSell =
+    isReorder && Boolean(inventoryRow) && reorderQuantityExceedsAvailableToSell(qty, inventoryRow);
+
+  const availableToSellHelperText = quantityExceedsAvailableToSell
+    ? formatOnlyAvailable(inventoryRow?.availableToSell ?? 0)
+    : '';
+
+  const qtyHelperText = productHelperText?.trim() ? productHelperText : availableToSellHelperText;
+
+  const backorderFields = backorderUiEnabled
+    ? getReorderBackorderDisplayFields(
+        getReorderBackorderDisplayQuantity(qty, inventoryRow),
+        inventoryRow,
+      )
+    : null;
+
+  return { qtyHelperText, backorderFields };
 }

--- a/apps/storefront/src/pages/QuickOrder/components/QuickAdd.tsx
+++ b/apps/storefront/src/pages/QuickOrder/components/QuickAdd.tsx
@@ -14,7 +14,11 @@ import { useAppSelector } from '@/store';
 import { snackbar } from '@/utils/b3Tip';
 import b3TriggerCartNumber from '@/utils/b3TriggerCartNumber';
 import { createOrUpdateExistingCart } from '@/utils/cartUtils';
-import { ValidatedProductError, validateProductsLegacy } from '@/utils/validateProducts';
+import {
+  VALIDATED_PRODUCT_ERROR_TYPES,
+  ValidatedProductError,
+  validateProductsLegacy,
+} from '@/utils/validateProducts';
 
 import { SimpleObject } from '../../../types';
 import { getCartProductInfo } from '../utils';
@@ -371,7 +375,7 @@ export default function QuickAdd() {
   ) => {
     const sku = error.product.node?.sku || '';
 
-    if (error.error.type === 'network') {
+    if (error.error.type === VALIDATED_PRODUCT_ERROR_TYPES.NETWORK) {
       const productName = error.product.node?.productName || '';
       snackbar.error(b3Lang('quotes.productValidationFailed', { productName }));
       if (sku) {

--- a/apps/storefront/src/pages/QuoteDetail/index.tsx
+++ b/apps/storefront/src/pages/QuoteDetail/index.tsx
@@ -31,6 +31,7 @@ import { conversionProductsList } from '@/utils/b3Product/shared/config';
 import { snackbar } from '@/utils/b3Tip';
 import { getSearchVal } from '@/utils/loginInfo';
 import {
+  VALIDATED_PRODUCT_ERROR_TYPES,
   ValidatedProductError,
   validateProductsLegacy as validateProductsApi,
 } from '@/utils/validateProducts';
@@ -377,7 +378,7 @@ function QuoteDetail() {
 
     error.forEach((err) => {
       const errorCode =
-        err.error.type === 'network'
+        err.error.type === VALIDATED_PRODUCT_ERROR_TYPES.NETWORK
           ? QUOTE_VALIDATION_ERROR_CODES.NETWORK_ERROR
           : err.error.errorCode;
       snackbar.error(
@@ -450,7 +451,7 @@ function QuoteDetail() {
     if (quoteValidationErrors.length) {
       quoteValidationErrors.forEach((err) => {
         const errorCode =
-          err.error.type === 'network'
+          err.error.type === VALIDATED_PRODUCT_ERROR_TYPES.NETWORK
             ? QUOTE_VALIDATION_ERROR_CODES.NETWORK_ERROR
             : err.error.errorCode;
         snackbar.error(

--- a/apps/storefront/src/pages/QuoteDraft/index.tsx
+++ b/apps/storefront/src/pages/QuoteDraft/index.tsx
@@ -50,6 +50,7 @@ import { deleteCartData } from '@/utils/cartUtils';
 import validateObject from '@/utils/quoteUtils';
 import {
   convertStockAndThresholdValidationErrorToWarning,
+  VALIDATED_PRODUCT_ERROR_TYPES,
   validateProductsLegacy,
 } from '@/utils/validateProducts';
 
@@ -473,7 +474,7 @@ function QuoteDraft({ setOpenPage }: PageProps) {
 
     error.forEach((err) => {
       const errorCode =
-        err.error.type === 'network'
+        err.error.type === VALIDATED_PRODUCT_ERROR_TYPES.NETWORK
           ? QUOTE_VALIDATION_ERROR_CODES.NETWORK_ERROR
           : err.error.errorCode;
 

--- a/apps/storefront/src/utils/validateProducts.test.ts
+++ b/apps/storefront/src/utils/validateProducts.test.ts
@@ -4,6 +4,7 @@ import { when } from 'vitest-when';
 
 import {
   convertStockAndThresholdValidationErrorToWarning,
+  VALIDATED_PRODUCT_ERROR_TYPES,
   validateProductsLegacy,
 } from './validateProducts';
 
@@ -42,7 +43,7 @@ const buildValidatedProductsFixture = () => {
       {
         status: 'error',
         error: {
-          type: 'validation',
+          type: VALIDATED_PRODUCT_ERROR_TYPES.VALIDATION,
           message: minimumThresholdMessage,
           errorCode: 'OTHER',
           availableToSell: 4,
@@ -52,7 +53,7 @@ const buildValidatedProductsFixture = () => {
       {
         status: 'error',
         error: {
-          type: 'validation',
+          type: VALIDATED_PRODUCT_ERROR_TYPES.VALIDATION,
           message: maximumThresholdMessage,
           errorCode: 'OTHER',
           availableToSell: 10,
@@ -62,7 +63,7 @@ const buildValidatedProductsFixture = () => {
       {
         status: 'error',
         error: {
-          type: 'validation',
+          type: VALIDATED_PRODUCT_ERROR_TYPES.VALIDATION,
           message: 'Not purchasable for this account.',
           errorCode: 'NON_PURCHASABLE',
           availableToSell: 0,
@@ -72,7 +73,7 @@ const buildValidatedProductsFixture = () => {
       {
         status: 'error',
         error: {
-          type: 'validation',
+          type: VALIDATED_PRODUCT_ERROR_TYPES.VALIDATION,
           message: 'Out of stock.',
           errorCode: 'OOS',
           availableToSell: 0,
@@ -81,7 +82,7 @@ const buildValidatedProductsFixture = () => {
       },
       {
         status: 'error',
-        error: { type: 'network', errorCode: 'NETWORK_ERROR' },
+        error: { type: VALIDATED_PRODUCT_ERROR_TYPES.NETWORK, errorCode: 'NETWORK_ERROR' },
         product: products.network,
       },
     ],
@@ -220,12 +221,17 @@ it('groups products by their validation status', async () => {
     error: [
       {
         status: 'error',
-        error: { type: 'validation', message: 'foo bar', errorCode: 'OTHER', availableToSell: 12 },
+        error: {
+          type: VALIDATED_PRODUCT_ERROR_TYPES.VALIDATION,
+          message: 'foo bar',
+          errorCode: 'OTHER',
+          availableToSell: 12,
+        },
         product: products[2],
       },
       {
         status: 'error',
-        error: { type: 'network', errorCode: 'NETWORK_ERROR' },
+        error: { type: VALIDATED_PRODUCT_ERROR_TYPES.NETWORK, errorCode: 'NETWORK_ERROR' },
         product: products[3],
       },
     ],
@@ -277,7 +283,7 @@ describe('convertStockAndThresholdValidationErrorToWarning', () => {
       {
         status: 'error',
         error: {
-          type: 'validation',
+          type: VALIDATED_PRODUCT_ERROR_TYPES.VALIDATION,
           message: 'Not purchasable for this account.',
           errorCode: 'NON_PURCHASABLE',
           availableToSell: 0,
@@ -286,7 +292,7 @@ describe('convertStockAndThresholdValidationErrorToWarning', () => {
       },
       {
         status: 'error',
-        error: { type: 'network', errorCode: 'NETWORK_ERROR' },
+        error: { type: VALIDATED_PRODUCT_ERROR_TYPES.NETWORK, errorCode: 'NETWORK_ERROR' },
         product: products.network,
       },
     ]);

--- a/apps/storefront/src/utils/validateProducts.ts
+++ b/apps/storefront/src/utils/validateProducts.ts
@@ -6,6 +6,11 @@ import {
   type ValidationTarget,
 } from '@/shared/service/b2b/graphql/product';
 
+export const VALIDATED_PRODUCT_ERROR_TYPES = {
+  VALIDATION: 'validation',
+  NETWORK: 'network',
+} as const;
+
 interface Option {
   optionId: number | `attribute[${number}]`;
   optionValue: string;
@@ -32,7 +37,7 @@ interface ValidatedProductWarning<T> {
 interface ValidatedProductServerError<T> {
   status: 'error';
   error: {
-    type: 'validation';
+    type: typeof VALIDATED_PRODUCT_ERROR_TYPES.VALIDATION;
     errorCode: ProductValidationErrorCode;
     message: string;
     availableToSell: number;
@@ -43,7 +48,7 @@ interface ValidatedProductServerError<T> {
 interface ValidatedProductNetworkError<T> {
   status: 'error';
   error: {
-    type: 'network';
+    type: typeof VALIDATED_PRODUCT_ERROR_TYPES.NETWORK;
     errorCode: typeof QUOTE_VALIDATION_ERROR_CODES.NETWORK_ERROR;
   };
   product: T;
@@ -195,7 +200,7 @@ export const validateProductsLegacy = async <T extends ValidateProductsInput>(
       return {
         status: 'error',
         error: {
-          type: 'network',
+          type: VALIDATED_PRODUCT_ERROR_TYPES.NETWORK,
           errorCode: QUOTE_VALIDATION_ERROR_CODES.NETWORK_ERROR,
         },
         product,
@@ -207,7 +212,7 @@ export const validateProductsLegacy = async <T extends ValidateProductsInput>(
         return {
           status: 'error',
           error: {
-            type: 'validation',
+            type: VALIDATED_PRODUCT_ERROR_TYPES.VALIDATION,
             message: res.value.message,
             errorCode: res.value.errorCode,
             availableToSell: res.value.product.availableToSell,
@@ -253,7 +258,7 @@ export const validateProducts = async <T extends ValidateProductsInput>(
         return {
           status: 'error',
           error: {
-            type: 'validation',
+            type: VALIDATED_PRODUCT_ERROR_TYPES.VALIDATION,
             message: res.message,
             errorCode: res.errorCode,
             availableToSell: res.product.availableToSell,
@@ -296,7 +301,7 @@ export function convertStockAndThresholdValidationErrorToWarning<T extends Valid
   validatedProducts: ValidateProductsLegacyResult<T> | ValidateProductsResult<T>,
 ): ValidateProductsLegacyResult<T> | ValidateProductsResult<T> {
   const isThresholdError = (error: ValidatedProductError<T>['error']) =>
-    error.type === 'validation' &&
+    error.type === VALIDATED_PRODUCT_ERROR_TYPES.VALIDATION &&
     error.errorCode === QUOTE_VALIDATION_ERROR_CODES.OTHER &&
     /purchase a (minimum|maximum) of/im.test(error.message);
 


### PR DESCRIPTION
Jira: [BACK-634](https://bigcommercecloud.atlassian.net/browse/BACK-634)

## What/Why?
Extends the re-order dialog with quantity validation against ATS. User see feedback when requested qty exceeds stock, both while editing and after add-to-cart validation fails.
- **Inline qty errors:** When `qty > ATS` (and inventory is tracked, not unlimited backorder), the qty field shows “Only {n} available.”
- **Backorder UI:** Backorder breakdown uses a capped display quantity, so backorder display does not exceed stock.
- **Add-to-cart validation:** OOS validation errors map to “Only {n} available” copy instead of raw API messages. Banner appears when any items fail: “Some items were not added to the cart. Please adjust quantities.”
- **Partial success:** Existing partial-add flow is unchanged; new tests cover mixed success/failure and OOS handling.

## Rollout/Rollback
Merge/revert. Backorder display is gated by `Feature_Backorder && BACK-134.backorders_phase_1_1_control_messaging_on_storefront`.

## Testing
For product with 5 on-hand and 5 backorder limit, backorder display caps for these values. Expected banner and inline errors. Reducing quantity is successful.

https://github.com/user-attachments/assets/e0b8d31b-9a9c-4e32-b606-d8312099e1b5

Partial success, in-stock products are added to cart with expected errors. 

https://github.com/user-attachments/assets/36a770c5-cf33-462b-8d91-cdc3c25a02c3

Ping @benpratt77 @animesh1987 

[BACK-634]: https://bigcommercecloud.atlassian.net/browse/BACK-634?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: changes reorder validation/error handling and cart-add flows, which can affect purchasing UX and edge cases around partial successes and backorder messaging.
> 
> **Overview**
> **Re-order dialog now surfaces ATS quantity validation more clearly.** It adds new i18n strings and updates product rows to show inline qty helper text (preferring backend validation messages, otherwise showing *Only N available* when qty exceeds ATS) and to cap the quantity used for backorder breakdown calculations.
> 
> **Backend validation UX is refined.** `OrderDialog` maps OOS validation errors to the new *Only N available* copy, shows a banner prompting users to adjust quantities when validation errors occur (but not for network errors), and avoids duplicate/snackbar errors in partial-success scenarios.
> 
> **Validation error typing is standardized and coverage expanded.** Introduces `VALIDATED_PRODUCT_ERROR_TYPES` constants (replacing string literals) across reorder/quote/quick order flows, and adds/updates unit tests for the new banner/inline messaging and the new reorder backorder display helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0ab01d86c9ffd00d5e6ac3bbec3511fac57ae00. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->