### PR TITLE
B2B-4622 Add subsidiary hierarchy filter tests for unified Company Orders

### DIFF
--- a/apps/storefront/src/pages/CompanyOrderList/unified-company-orders.test.tsx
+++ b/apps/storefront/src/pages/CompanyOrderList/unified-company-orders.test.tsx
@@ -1146,4 +1146,393 @@ describe('Company Orders — unified SF GQL orders (B2B-4616)', () => {
       });
     });
   });
+
+  describe('subsidiary hierarchy filter', () => {
+    const hierarchyState = (featureFlags: Record<string, boolean>) => ({
+      company: buildCompanyStateWith({
+        customer: { role: CustomerRole.SENIOR_BUYER, userType: UserTypes.MULTIPLE_B2C },
+        companyInfo: {
+          id: '100',
+          companyName: 'Parent Corp',
+          status: CompanyStatus.APPROVED,
+        },
+        companyHierarchyInfo: {
+          isEnabledCompanyHierarchy: true,
+          isHasCurrentPagePermission: true,
+          selectCompanyHierarchyId: '',
+          companyHierarchyList: [
+            {
+              companyId: 100,
+              companyName: 'Parent Corp',
+              parentCompanyId: null,
+              channelFlag: true,
+            },
+            {
+              companyId: 200,
+              companyName: 'Sub Corp Alpha',
+              parentCompanyId: 100,
+              parentCompanyName: 'Parent Corp',
+              channelFlag: true,
+            },
+            {
+              companyId: 300,
+              companyName: 'Sub Corp Beta',
+              parentCompanyId: 100,
+              parentCompanyName: 'Parent Corp',
+              channelFlag: true,
+            },
+          ],
+          companyHierarchyAllList: [],
+          companyHierarchySelectSubsidiariesList: [],
+        },
+        pagesSubsidiariesPermission: { order: true },
+      }),
+      global: buildGlobalStateWith({ featureFlags }),
+      storeInfo: buildStoreInfoStateWith({ timeFormat: { display: 'j F Y' } }),
+    });
+
+    const noHierarchyState = (featureFlags: Record<string, boolean>) => ({
+      company: buildCompanyStateWith({
+        customer: { role: CustomerRole.SENIOR_BUYER, userType: UserTypes.MULTIPLE_B2C },
+        companyInfo: {
+          id: '100',
+          companyName: 'Parent Corp',
+          status: CompanyStatus.APPROVED,
+        },
+        companyHierarchyInfo: {
+          isEnabledCompanyHierarchy: false,
+          isHasCurrentPagePermission: true,
+          selectCompanyHierarchyId: '',
+          companyHierarchyList: [],
+          companyHierarchyAllList: [],
+          companyHierarchySelectSubsidiariesList: [],
+        },
+        pagesSubsidiariesPermission: { order: false },
+      }),
+      global: buildGlobalStateWith({ featureFlags }),
+      storeInfo: buildStoreInfoStateWith({ timeFormat: { display: 'j F Y' } }),
+    });
+
+    const noOrderPermissionState = (featureFlags: Record<string, boolean>) => ({
+      company: buildCompanyStateWith({
+        customer: { role: CustomerRole.SENIOR_BUYER, userType: UserTypes.MULTIPLE_B2C },
+        companyInfo: {
+          id: '100',
+          companyName: 'Parent Corp',
+          status: CompanyStatus.APPROVED,
+        },
+        companyHierarchyInfo: {
+          isEnabledCompanyHierarchy: true,
+          isHasCurrentPagePermission: true,
+          selectCompanyHierarchyId: '',
+          companyHierarchyList: [
+            {
+              companyId: 100,
+              companyName: 'Parent Corp',
+              parentCompanyId: null,
+              channelFlag: true,
+            },
+          ],
+          companyHierarchyAllList: [],
+          companyHierarchySelectSubsidiariesList: [],
+        },
+        pagesSubsidiariesPermission: { order: false },
+      }),
+      global: buildGlobalStateWith({ featureFlags }),
+      storeInfo: buildStoreInfoStateWith({ timeFormat: { display: 'j F Y' } }),
+    });
+
+    it('renders subsidiary selector when hierarchy is enabled and order permission is granted', async () => {
+      server.use(
+        graphql.query('GetCompanyOrders', () =>
+          HttpResponse.json(buildCompanyOrdersResponseWith('WHATEVER_VALUES')),
+        ),
+      );
+
+      renderWithProviders(<CompanyOrders />, { preloadedState: hierarchyState(flagOn) });
+
+      await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+      expect(screen.getByLabelText('Company')).toBeInTheDocument();
+    });
+
+    it('does NOT render subsidiary selector when hierarchy is disabled', async () => {
+      server.use(
+        graphql.query('GetCompanyOrders', () =>
+          HttpResponse.json(buildCompanyOrdersResponseWith('WHATEVER_VALUES')),
+        ),
+      );
+
+      renderWithProviders(<CompanyOrders />, { preloadedState: noHierarchyState(flagOn) });
+
+      await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+      expect(screen.queryByLabelText('Company')).not.toBeInTheDocument();
+    });
+
+    it('does NOT render subsidiary selector when order subsidiary permission is denied', async () => {
+      server.use(
+        graphql.query('GetCompanyOrders', () =>
+          HttpResponse.json(buildCompanyOrdersResponseWith('WHATEVER_VALUES')),
+        ),
+      );
+
+      renderWithProviders(<CompanyOrders />, {
+        preloadedState: noOrderPermissionState(flagOn),
+      });
+
+      await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+      expect(screen.queryByLabelText('Company')).not.toBeInTheDocument();
+    });
+
+    it('sends companyIds in the initial query scoped to the current company', async () => {
+      const getOrders = vi.fn().mockReturnValue(buildCompanyOrdersResponseWith('WHATEVER_VALUES'));
+
+      server.use(
+        graphql.query('GetCompanyOrders', ({ variables }) =>
+          HttpResponse.json(getOrders(variables)),
+        ),
+      );
+
+      renderWithProviders(<CompanyOrders />, { preloadedState: hierarchyState(flagOn) });
+
+      await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+      expect(getOrders).toHaveBeenCalledWith(
+        expect.objectContaining({
+          filters: expect.objectContaining({ companyIds: ['100'] }),
+        }),
+      );
+    });
+
+    it('sends selected subsidiary companyId when a subsidiary is chosen', async () => {
+      const getOrders = vi.fn().mockReturnValue(buildCompanyOrdersResponseWith('WHATEVER_VALUES'));
+
+      server.use(
+        graphql.query('GetCompanyOrders', ({ variables }) =>
+          HttpResponse.json(getOrders(variables)),
+        ),
+      );
+
+      renderWithProviders(<CompanyOrders />, { preloadedState: hierarchyState(flagOn) });
+
+      await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+      const companySelect = screen.getByLabelText('Company');
+      await userEvent.click(companySelect);
+      await userEvent.click(screen.getByRole('option', { name: /Sub Corp Alpha/ }));
+
+      await waitFor(() => {
+        const { calls } = getOrders.mock;
+        const lastVars = calls[calls.length - 1]?.[0] as {
+          filters?: { companyIds?: string[] };
+        };
+        expect(lastVars?.filters?.companyIds).toEqual(expect.arrayContaining(['200']));
+      });
+    });
+
+    it('removes companyIds from filters when "All" is selected', async () => {
+      const getOrders = vi.fn().mockReturnValue(buildCompanyOrdersResponseWith('WHATEVER_VALUES'));
+
+      server.use(
+        graphql.query('GetCompanyOrders', ({ variables }) =>
+          HttpResponse.json(getOrders(variables)),
+        ),
+      );
+
+      renderWithProviders(<CompanyOrders />, { preloadedState: hierarchyState(flagOn) });
+
+      await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+      const companySelect = screen.getByLabelText('Company');
+      await userEvent.click(companySelect);
+      await userEvent.click(screen.getByRole('option', { name: /All/ }));
+
+      await waitFor(() => {
+        const { calls } = getOrders.mock;
+        const lastVars = calls[calls.length - 1]?.[0] as {
+          filters?: { companyIds?: string[] };
+        };
+        expect(lastVars?.filters?.companyIds).toBeUndefined();
+      });
+    });
+
+    it('resets pagination when subsidiary filter changes', async () => {
+      const page1Response = buildPagedCompanyOrdersResponse(
+        [{ entityId: 4001 }, { entityId: 4002 }],
+        {
+          hasNextPage: true,
+          hasPreviousPage: false,
+          startCursor: 'cursor-4001',
+          endCursor: 'cursor-4002',
+        },
+        20,
+      );
+
+      const getOrders = vi.fn().mockReturnValue(page1Response);
+
+      when(getOrders)
+        .calledWith(expect.objectContaining({ after: 'cursor-4002' }))
+        .thenReturn(
+          buildPagedCompanyOrdersResponse(
+            [{ entityId: 5001 }, { entityId: 5002 }],
+            {
+              hasNextPage: false,
+              hasPreviousPage: true,
+              startCursor: 'cursor-5001',
+              endCursor: 'cursor-5002',
+            },
+            20,
+          ),
+        );
+
+      server.use(
+        graphql.query('GetCompanyOrders', ({ variables }) =>
+          HttpResponse.json(getOrders(variables)),
+        ),
+      );
+
+      renderWithProviders(<CompanyOrders />, { preloadedState: hierarchyState(flagOn) });
+
+      await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+      await userEvent.click(screen.getByRole('button', { name: 'Go to next page' }));
+
+      await waitFor(() => {
+        expect(screen.getByText('5001').closest('tr')!).toBeInTheDocument();
+      });
+
+      const companySelect = screen.getByLabelText('Company');
+      await userEvent.click(companySelect);
+      await userEvent.click(screen.getByRole('option', { name: /Sub Corp Alpha/ }));
+
+      await waitFor(() => {
+        const { calls } = getOrders.mock;
+        const lastVars = calls[calls.length - 1]?.[0] as {
+          after?: string;
+          before?: string;
+        };
+        expect(lastVars?.after).toBeUndefined();
+        expect(lastVars?.before).toBeUndefined();
+      });
+    });
+
+    it('composes companyIds with search filter', async () => {
+      const getOrders = vi.fn().mockReturnValue(buildCompanyOrdersResponseWith('WHATEVER_VALUES'));
+
+      server.use(
+        graphql.query('GetCompanyOrders', ({ variables }) =>
+          HttpResponse.json(getOrders(variables)),
+        ),
+      );
+
+      renderWithProviders(<CompanyOrders />, { preloadedState: hierarchyState(flagOn) });
+
+      await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+      const companySelect = screen.getByLabelText('Company');
+      await userEvent.click(companySelect);
+      await userEvent.click(screen.getByRole('option', { name: /Sub Corp Beta/ }));
+
+      await waitFor(() => {
+        const { calls } = getOrders.mock;
+        const lastVars = calls[calls.length - 1]?.[0] as {
+          filters?: { companyIds?: string[] };
+        };
+        expect(lastVars?.filters?.companyIds).toEqual(expect.arrayContaining(['300']));
+      });
+
+      // Close the dropdown before interacting with the search input
+      await userEvent.keyboard('{Escape}');
+
+      await userEvent.type(screen.getByPlaceholderText('Search'), 'widget');
+
+      await waitFor(() => {
+        const { calls } = getOrders.mock;
+        const lastVars = calls[calls.length - 1]?.[0] as {
+          filters?: { companyIds?: string[]; search?: string };
+        };
+        expect(lastVars?.filters?.search).toBe('widget');
+        expect(lastVars?.filters?.companyIds).toEqual(expect.arrayContaining(['300']));
+      });
+    });
+
+    it('composes companyIds with status and date range filters', async () => {
+      vi.setSystemTime(new Date('21 November 2022'));
+
+      const getOrders = vi.fn().mockReturnValue(buildCompanyOrdersResponseWith('WHATEVER_VALUES'));
+
+      server.use(
+        graphql.query('GetOrderStatuses', () =>
+          HttpResponse.json(
+            buildLegacyB2BOrderStatusesResponseWith({
+              data: {
+                orderStatuses: [
+                  buildLegacyOrderStatusWith({
+                    systemLabel: 'Shipped',
+                    customLabel: 'Shipped',
+                  }),
+                ],
+              },
+            }),
+          ),
+        ),
+        graphql.query('GetCompanyOrders', ({ variables }) =>
+          HttpResponse.json(getOrders(variables)),
+        ),
+      );
+
+      renderWithProviders(<CompanyOrders />, { preloadedState: hierarchyState(flagOn) });
+
+      await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+      const companySelect = screen.getByLabelText('Company');
+      await userEvent.click(companySelect);
+      await userEvent.click(screen.getByRole('option', { name: /Sub Corp Alpha/ }));
+
+      await waitFor(() => {
+        const { calls } = getOrders.mock;
+        const lastVars = calls[calls.length - 1]?.[0] as {
+          filters?: { companyIds?: string[] };
+        };
+        expect(lastVars?.filters?.companyIds).toEqual(expect.arrayContaining(['200']));
+      });
+
+      // Close the dropdown before opening the filters dialog
+      await userEvent.keyboard('{Escape}');
+
+      await userEvent.click(screen.getByRole('button', { name: 'edit' }));
+
+      const dialog = await screen.findByRole('dialog', { name: 'Filters' });
+
+      await userEvent.click(within(dialog).getByRole('combobox', { name: 'Order status' }));
+      await userEvent.click(screen.getByRole('option', { name: 'Shipped' }));
+
+      await userEvent.click(within(dialog).getByRole('textbox', { name: 'From' }));
+      await userEvent.click(screen.getByRole('gridcell', { name: '15' }));
+
+      await userEvent.click(within(dialog).getByRole('textbox', { name: 'To' }));
+      await userEvent.click(screen.getByRole('gridcell', { name: '26' }));
+
+      await userEvent.click(screen.getByRole('button', { name: 'Apply' }));
+
+      await waitFor(() => {
+        const { calls } = getOrders.mock;
+        const lastVars = calls[calls.length - 1]?.[0] as {
+          filters?: {
+            companyIds?: string[];
+            status?: string[];
+            dateRange?: { from: string; to: string };
+          };
+        };
+        expect(lastVars?.filters?.companyIds).toEqual(expect.arrayContaining(['200']));
+        expect(lastVars?.filters?.status).toEqual(['Shipped']);
+        expect(lastVars?.filters?.dateRange).toEqual({
+          from: '2022-11-15',
+          to: '2022-11-26',
+        });
+      });
+    });
+  });
 });

--- a/apps/storefront/src/pages/CompanyOrderList/unified-company-orders.test.tsx
+++ b/apps/storefront/src/pages/CompanyOrderList/unified-company-orders.test.tsx
@@ -1207,7 +1207,7 @@ describe('Company Orders — unified SF GQL orders (B2B-4616)', () => {
           companyHierarchyAllList: [],
           companyHierarchySelectSubsidiariesList: [],
         },
-        pagesSubsidiariesPermission: { order: false },
+        pagesSubsidiariesPermission: { order: true },
       }),
       global: buildGlobalStateWith({ featureFlags }),
       storeInfo: buildStoreInfoStateWith({ timeFormat: { display: 'j F Y' } }),


### PR DESCRIPTION
Jira: [B2B-4622](https://bigcommercecloud.atlassian.net/browse/B2B-4622)

## What/Why?

Adds test coverage for the subsidiary/hierarchy `companyIds` filter on the unified SF GQL Company Orders path. The production plumbing for this filter was already wired in prior Stage 3 tickets (3a/B2B-4616):

- `CompanyOrdersFiltersInput.companyIds` passes through to `GET_COMPANY_ORDERS`
- `useCompanyOrdersState.handleCompanyIdsChange` converts `number[]` → `string[]`
- `B2BAutoCompleteCheckbox` renders when hierarchy is enabled + order permission granted
- Pagination resets on filter change

This PR validates all of the above with 9 new MSW-based component tests covering visibility gating, initial scoping, subsidiary selection, "All" clearing, pagination reset, and filter composition (search, status, date range).

Confirmed `companyIds: [ID!]` against the unified schema gist — our local `string[]` mapping is correct.

## Rollout/Rollback

All changes are behind the `B2B-4613.buyer_portal_unified_sf_gql_orders` feature flag. Test-only change — no production code modified. Rollback is not applicable; disabling the feature flag reverts to the legacy path.

## Testing

- 9 new functional tests in `unified-company-orders.test.tsx`
- All 32 tests in the file pass
- All 173 order-related tests pass (8 test files, 0 regressions)

Test cases:
1. Renders subsidiary selector when hierarchy enabled + order permission granted
2. Does NOT render when hierarchy disabled
3. Does NOT render when order subsidiary permission denied
4. Sends `companyIds` scoped to current company in initial query
5. Sends selected subsidiary `companyId` when chosen
6. Removes `companyIds` from filters when "All" is selected
7. Resets pagination when subsidiary filter changes
8. Composes `companyIds` with search filter
9. Composes `companyIds` with status and date range filters

[B2B-4622]: https://bigcommercecloud.atlassian.net/browse/B2B-4622?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes that add coverage around the unified SF GQL Company Orders `companyIds` filtering and related UI/pagination behavior, with no production logic modified.
> 
> **Overview**
> Adds a new `subsidiary hierarchy filter` test suite to `unified-company-orders.test.tsx` covering the unified SF GQL Company Orders path.
> 
> The new MSW-based component tests validate subsidiary selector visibility gating (hierarchy enabled + permission), initial query scoping to the current company, selecting/clearing subsidiaries (including "All"), pagination reset on filter change, and correct composition of `companyIds` with search, status, and date-range filters.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff6b2c7e5cdde2211c57423cb9d8942cd399ecd6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->