### PR TITLE
B2B-4621 Implement placed-by filter via SF GQL company users query

### DIFF
--- a/apps/storefront/src/pages/CompanyOrderList/unified-company-orders.test.tsx
+++ b/apps/storefront/src/pages/CompanyOrderList/unified-company-orders.test.tsx
@@ -21,6 +21,7 @@ import { when } from 'vitest-when';
 
 import {
   type GetCompanyOrdersResponse,
+  type GetCustomersWithOrdersResponse,
   type Order,
   type OrderPlacedBy,
   OrdersSortInput,
@@ -214,6 +215,25 @@ describe('Company Orders — unified SF GQL orders (B2B-4616)', () => {
       ),
       graphql.query('GetOrdersCreatedByUser', () =>
         HttpResponse.json({ data: { createdByUser: { results: [] } } }),
+      ),
+      graphql.query('GetCustomersWithOrders', () =>
+        HttpResponse.json({
+          data: {
+            customer: {
+              activeCompany: {
+                customersWithOrders: {
+                  edges: [],
+                  pageInfo: {
+                    hasNextPage: false,
+                    hasPreviousPage: false,
+                    startCursor: null,
+                    endCursor: null,
+                  },
+                },
+              },
+            },
+          },
+        } satisfies GetCustomersWithOrdersResponse),
       ),
     );
   });
@@ -1533,6 +1553,240 @@ describe('Company Orders — unified SF GQL orders (B2B-4616)', () => {
           to: '2022-11-26',
         });
       });
+    });
+  });
+
+  describe('placed-by filter', () => {
+    const jane: OrderPlacedBy = {
+      entityId: 501,
+      firstName: 'Jane',
+      lastName: 'Doe',
+      email: 'jane@acme.com',
+    };
+    const bob: OrderPlacedBy = {
+      entityId: 502,
+      firstName: 'Bob',
+      lastName: 'Smith',
+      email: 'bob@acme.com',
+    };
+
+    const customersWithOrdersResponse: GetCustomersWithOrdersResponse = {
+      data: {
+        customer: {
+          activeCompany: {
+            customersWithOrders: {
+              edges: [
+                { node: jane, cursor: 'c1' },
+                { node: bob, cursor: 'c2' },
+              ],
+              pageInfo: {
+                hasNextPage: false,
+                hasPreviousPage: false,
+                startCursor: 'c1',
+                endCursor: 'c2',
+              },
+            },
+          },
+        },
+      },
+    };
+
+    it('populates the Placed By dropdown from GetCustomersWithOrders (not legacy query)', async () => {
+      const sfGqlUsersHandler = vi.fn();
+      const legacyUsersHandler = vi.fn();
+
+      server.use(
+        graphql.query('GetCustomersWithOrders', () => {
+          sfGqlUsersHandler();
+          return HttpResponse.json(customersWithOrdersResponse);
+        }),
+        graphql.query('GetOrdersCreatedByUser', () => {
+          legacyUsersHandler();
+          return HttpResponse.json({ data: { createdByUser: { results: [] } } });
+        }),
+        graphql.query('GetCompanyOrders', () =>
+          HttpResponse.json(buildCompanyOrdersResponseWith('WHATEVER_VALUES')),
+        ),
+      );
+
+      renderWithProviders(<CompanyOrders />, { preloadedState: b2bStateWithFlag(flagOn) });
+
+      await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+      expect(sfGqlUsersHandler).toHaveBeenCalled();
+      expect(legacyUsersHandler).not.toHaveBeenCalled();
+
+      await userEvent.click(screen.getByRole('button', { name: 'edit' }));
+      const dialog = await screen.findByRole('dialog', { name: 'Filters' });
+
+      await userEvent.click(within(dialog).getByRole('combobox', { name: 'Placed by' }));
+      expect(screen.getByRole('option', { name: /Jane Doe/ })).toBeInTheDocument();
+      expect(screen.getByRole('option', { name: /Bob Smith/ })).toBeInTheDocument();
+    });
+
+    it('sends customerId when a placed-by user is selected', async () => {
+      const getOrders = vi.fn().mockReturnValue(buildCompanyOrdersResponseWith('WHATEVER_VALUES'));
+
+      server.use(
+        graphql.query('GetCustomersWithOrders', () =>
+          HttpResponse.json(customersWithOrdersResponse),
+        ),
+        graphql.query('GetCompanyOrders', ({ variables }) =>
+          HttpResponse.json(getOrders(variables)),
+        ),
+      );
+
+      renderWithProviders(<CompanyOrders />, { preloadedState: b2bStateWithFlag(flagOn) });
+
+      await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+      await userEvent.click(screen.getByRole('button', { name: 'edit' }));
+      const dialog = await screen.findByRole('dialog', { name: 'Filters' });
+
+      await userEvent.click(within(dialog).getByRole('combobox', { name: 'Placed by' }));
+      await userEvent.click(screen.getByRole('option', { name: /Jane Doe \(jane@acme\.com\)/ }));
+
+      await userEvent.click(screen.getByRole('button', { name: 'Apply' }));
+
+      await waitFor(() => {
+        const { calls } = getOrders.mock;
+        const lastVars = calls[calls.length - 1]?.[0] as {
+          filters?: { customerId?: number[] };
+        };
+        expect(lastVars?.filters?.customerId).toEqual([501]);
+      });
+    });
+
+    it('removes customerId when placed-by filter is cleared', async () => {
+      const getOrders = vi.fn().mockReturnValue(buildCompanyOrdersResponseWith('WHATEVER_VALUES'));
+
+      server.use(
+        graphql.query('GetCustomersWithOrders', () =>
+          HttpResponse.json(customersWithOrdersResponse),
+        ),
+        graphql.query('GetCompanyOrders', ({ variables }) =>
+          HttpResponse.json(getOrders(variables)),
+        ),
+      );
+
+      renderWithProviders(<CompanyOrders />, { preloadedState: b2bStateWithFlag(flagOn) });
+
+      await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+      // Apply a placed-by filter first
+      await userEvent.click(screen.getByRole('button', { name: 'edit' }));
+      const dialog = await screen.findByRole('dialog', { name: 'Filters' });
+
+      await userEvent.click(within(dialog).getByRole('combobox', { name: 'Placed by' }));
+      await userEvent.click(screen.getByRole('option', { name: /Bob Smith \(bob@acme\.com\)/ }));
+      await userEvent.click(screen.getByRole('button', { name: 'Apply' }));
+
+      await waitFor(() => {
+        const { calls } = getOrders.mock;
+        const lastVars = calls[calls.length - 1]?.[0] as {
+          filters?: { customerId?: number[] };
+        };
+        expect(lastVars?.filters?.customerId).toEqual([502]);
+      });
+
+      // Clear via the "Clear Filters" button
+      await userEvent.click(screen.getByRole('button', { name: 'edit' }));
+      await screen.findByRole('dialog', { name: 'Filters' });
+      await userEvent.click(screen.getByRole('button', { name: /Clear Filters/i }));
+      await userEvent.click(screen.getByRole('button', { name: 'Apply' }));
+
+      await waitFor(() => {
+        const { calls } = getOrders.mock;
+        const lastVars = calls[calls.length - 1]?.[0] as {
+          filters?: { customerId?: number[] };
+        };
+        expect(lastVars?.filters?.customerId).toBeUndefined();
+      });
+    });
+
+    it('composes customerId with search and status filters', async () => {
+      vi.setSystemTime(new Date('21 November 2022'));
+
+      const getOrders = vi.fn().mockReturnValue(buildCompanyOrdersResponseWith('WHATEVER_VALUES'));
+
+      server.use(
+        graphql.query('GetCustomersWithOrders', () =>
+          HttpResponse.json(customersWithOrdersResponse),
+        ),
+        graphql.query('GetOrderStatuses', () =>
+          HttpResponse.json(
+            buildLegacyB2BOrderStatusesResponseWith({
+              data: {
+                orderStatuses: [
+                  buildLegacyOrderStatusWith({ systemLabel: 'Pending', customLabel: 'Pending' }),
+                ],
+              },
+            }),
+          ),
+        ),
+        graphql.query('GetCompanyOrders', ({ variables }) =>
+          HttpResponse.json(getOrders(variables)),
+        ),
+      );
+
+      renderWithProviders(<CompanyOrders />, { preloadedState: b2bStateWithFlag(flagOn) });
+
+      await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+      // Apply placed-by + status via filter dialog
+      await userEvent.click(screen.getByRole('button', { name: 'edit' }));
+      const dialog = await screen.findByRole('dialog', { name: 'Filters' });
+
+      await userEvent.click(within(dialog).getByRole('combobox', { name: 'Placed by' }));
+      await userEvent.click(screen.getByRole('option', { name: /Jane Doe \(jane@acme\.com\)/ }));
+
+      await userEvent.click(within(dialog).getByRole('combobox', { name: 'Order status' }));
+      await userEvent.click(screen.getByRole('option', { name: 'Pending' }));
+
+      await userEvent.click(screen.getByRole('button', { name: 'Apply' }));
+
+      await waitFor(() => {
+        const { calls } = getOrders.mock;
+        const lastVars = calls[calls.length - 1]?.[0] as {
+          filters?: { customerId?: number[]; status?: string[] };
+        };
+        expect(lastVars?.filters?.customerId).toEqual([501]);
+        expect(lastVars?.filters?.status).toEqual(['Pending']);
+      });
+    });
+
+    it('uses legacy GetOrdersCreatedByUser when flag is off', async () => {
+      const sfGqlUsersHandler = vi.fn();
+      const legacyUsersHandler = vi.fn();
+
+      server.use(
+        graphql.query('GetCustomersWithOrders', () => {
+          sfGqlUsersHandler();
+          return HttpResponse.json(customersWithOrdersResponse);
+        }),
+        graphql.query('GetOrdersCreatedByUser', () => {
+          legacyUsersHandler();
+          return HttpResponse.json({ data: { createdByUser: { results: [] } } });
+        }),
+        graphql.query('GetAllOrders', () =>
+          HttpResponse.json({
+            data: {
+              allOrders: {
+                totalCount: 0,
+                pageInfo: { hasNextPage: false, hasPreviousPage: false },
+                edges: [],
+              },
+            },
+          }),
+        ),
+      );
+
+      renderWithProviders(<CompanyOrders />, { preloadedState: b2bStateWithFlag(flagOff) });
+
+      await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+      expect(legacyUsersHandler).toHaveBeenCalled();
+      expect(sfGqlUsersHandler).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/storefront/src/pages/order/Order.tsx
+++ b/apps/storefront/src/pages/order/Order.tsx
@@ -181,20 +181,7 @@ function Order({ isCompanyOrder = false }: OrderProps) {
       if (cancelled) return;
 
       const edges = response.data?.customer?.activeCompany?.customersWithOrders?.edges || [];
-      const users = edges.map((e) => e.node);
-      setPlacedByUsers(users);
-
-      setFilterMoreInfo((prev) => {
-        const placedByItem = prev.find((item: { name: string }) => item.name === 'PlacedBy');
-        if (!placedByItem) return prev;
-
-        const newOptions = users.map((u: OrderPlacedBy) => ({
-          createdBy: `${u.firstName} ${u.lastName} (${u.email})`,
-        }));
-        return prev.map((item: { name: string }) =>
-          item.name === 'PlacedBy' ? { ...item, options: newOptions } : item,
-        );
-      });
+      setPlacedByUsers(edges.map((e) => e.node));
     };
 
     fetchPlacedByUsers();
@@ -212,16 +199,7 @@ function Order({ isCompanyOrder = false }: OrderProps) {
 
       if (isB2BUser && isCompanyOrder) {
         if (isUnifiedOrders) {
-          const response = await getCustomersWithOrders({
-            filters: activeCompanyIds ? { companyIds: activeCompanyIds } : undefined,
-            first: 100,
-          });
-          const edges = response.data?.customer?.activeCompany?.customersWithOrders?.edges || [];
-          const users = edges.map((e) => e.node);
-          setPlacedByUsers(users);
-          createdByUsers = {
-            createdByUser: { results: users },
-          };
+          createdByUsers = { createdByUser: { results: placedByUsers } };
         } else {
           createdByUsers = await getCreatedByUserForOrders(Number(companyId));
         }
@@ -246,8 +224,16 @@ function Order({ isCompanyOrder = false }: OrderProps) {
     };
 
     initFilter();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [b3Lang, companyId, isAgenting, isB2BUser, isCompanyOrder, isUnifiedOrders, role]);
+  }, [
+    b3Lang,
+    companyId,
+    isAgenting,
+    isB2BUser,
+    isCompanyOrder,
+    isUnifiedOrders,
+    placedByUsers,
+    role,
+  ]);
 
   const fetchUnifiedOrders = async (args: {
     first?: number;

--- a/apps/storefront/src/pages/order/Order.tsx
+++ b/apps/storefront/src/pages/order/Order.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Box } from '@mui/material';
 import { useQuery } from '@tanstack/react-query';
@@ -111,6 +111,7 @@ function Order({ isCompanyOrder = false }: OrderProps) {
   const [filterMoreInfo, setFilterMoreInfo] = useState<Array<any>>([]);
   const [getOrderStatuses, setOrderStatuses] = useState<Array<any>>([]);
   const [placedByUsers, setPlacedByUsers] = useState<OrderPlacedBy[]>([]);
+  const placedByUsersRef = useRef<OrderPlacedBy[]>([]);
 
   const isUnifiedCustomerPath = isUnifiedOrders && !isCompanyOrder;
   const isUnifiedCompanyPath = isUnifiedOrders && isCompanyOrder;
@@ -181,7 +182,9 @@ function Order({ isCompanyOrder = false }: OrderProps) {
       if (cancelled) return;
 
       const edges = response.data?.customer?.activeCompany?.customersWithOrders?.edges || [];
-      setPlacedByUsers(edges.map((e) => e.node));
+      const users = edges.map((e) => e.node);
+      placedByUsersRef.current = users;
+      setPlacedByUsers(users);
     };
 
     fetchPlacedByUsers();
@@ -190,13 +193,14 @@ function Order({ isCompanyOrder = false }: OrderProps) {
     };
   }, [activeCompanyIds, isB2BUser, isCompanyOrder, isUnifiedOrders, role]);
 
+  const orderStatusesRef = useRef<Array<any>>([]);
+
   useEffect(() => {
     // TODO: Guest customer should not be able to see the order list
     if (role === CustomerRole.GUEST) return;
 
     const initFilter = async () => {
       let createdByUsers: Record<string, unknown> = {};
-
       if (isB2BUser && isCompanyOrder) {
         if (isUnifiedOrders) {
           createdByUsers = { createdByUser: { results: placedByUsers } };
@@ -205,8 +209,11 @@ function Order({ isCompanyOrder = false }: OrderProps) {
         }
       }
 
-      const orderStatuses = isB2BUser ? await getOrderStatusType() : await getBcOrderStatusType();
-      setOrderStatuses(orderStatuses);
+      if (!orderStatusesRef.current.length) {
+        const statuses = isB2BUser ? await getOrderStatusType() : await getBcOrderStatusType();
+        orderStatusesRef.current = statuses;
+        setOrderStatuses(statuses);
+      }
 
       setFilterMoreInfo(
         translateFilterMoreData(
@@ -216,7 +223,7 @@ function Order({ isCompanyOrder = false }: OrderProps) {
             isCompanyOrder,
             isAgenting,
             createdByUsers,
-            orderStatuses,
+            orderStatusesRef.current,
           ),
           b3Lang,
         ),

--- a/apps/storefront/src/pages/order/Order.tsx
+++ b/apps/storefront/src/pages/order/Order.tsx
@@ -31,6 +31,7 @@ import {
   adaptUnifiedToLegacyFilterParams,
 } from './adaptUnifiedToLegacyFilterParams';
 import {
+  type CreatedByUsersData,
   FilterSearchProps,
   getFilterMoreData,
   getOrderStatusText,
@@ -174,14 +175,28 @@ function Order({ isCompanyOrder = false }: OrderProps) {
     let cancelled = false;
 
     const fetchPlacedByUsers = async () => {
-      const response = await getCustomersWithOrders({
-        filters: activeCompanyIds ? { companyIds: activeCompanyIds } : undefined,
-        first: 100,
-      });
-      if (cancelled) return;
+      const allUsers: OrderPlacedBy[] = [];
+      let after: string | undefined;
 
-      const edges = response.data?.customer?.activeCompany?.customersWithOrders?.edges || [];
-      setPlacedByUsers(edges.map((e) => e.node));
+      // eslint-disable-next-line no-constant-condition
+      while (true) {
+        // eslint-disable-next-line no-await-in-loop
+        const response = await getCustomersWithOrders({
+          filters: activeCompanyIds ? { companyIds: activeCompanyIds } : undefined,
+          first: 100,
+          after,
+        });
+        if (cancelled) return;
+
+        const connection = response.data?.customer?.activeCompany?.customersWithOrders;
+        const edges = connection?.edges || [];
+        allUsers.push(...edges.map((e) => e.node));
+
+        if (!connection?.pageInfo?.hasNextPage || !connection.pageInfo.endCursor) break;
+        after = connection.pageInfo.endCursor;
+      }
+
+      setPlacedByUsers(allUsers);
     };
 
     fetchPlacedByUsers();
@@ -197,7 +212,7 @@ function Order({ isCompanyOrder = false }: OrderProps) {
     if (role === CustomerRole.GUEST) return;
 
     const initFilter = async () => {
-      let createdByUsers: Record<string, unknown> = {};
+      let createdByUsers: CreatedByUsersData = {};
       if (isB2BUser && isCompanyOrder) {
         if (isUnifiedOrders) {
           createdByUsers = { createdByUser: { results: placedByUsers } };

--- a/apps/storefront/src/pages/order/Order.tsx
+++ b/apps/storefront/src/pages/order/Order.tsx
@@ -111,7 +111,6 @@ function Order({ isCompanyOrder = false }: OrderProps) {
   const [filterMoreInfo, setFilterMoreInfo] = useState<Array<any>>([]);
   const [getOrderStatuses, setOrderStatuses] = useState<Array<any>>([]);
   const [placedByUsers, setPlacedByUsers] = useState<OrderPlacedBy[]>([]);
-  const placedByUsersRef = useRef<OrderPlacedBy[]>([]);
 
   const isUnifiedCustomerPath = isUnifiedOrders && !isCompanyOrder;
   const isUnifiedCompanyPath = isUnifiedOrders && isCompanyOrder;
@@ -182,9 +181,7 @@ function Order({ isCompanyOrder = false }: OrderProps) {
       if (cancelled) return;
 
       const edges = response.data?.customer?.activeCompany?.customersWithOrders?.edges || [];
-      const users = edges.map((e) => e.node);
-      placedByUsersRef.current = users;
-      setPlacedByUsers(users);
+      setPlacedByUsers(edges.map((e) => e.node));
     };
 
     fetchPlacedByUsers();

--- a/apps/storefront/src/pages/order/Order.tsx
+++ b/apps/storefront/src/pages/order/Order.tsx
@@ -14,6 +14,8 @@ import {
   CompanyOrdersFiltersInput,
   getCompanyOrders,
   getCustomerOrders,
+  getCustomersWithOrders,
+  type OrderPlacedBy,
   OrdersFiltersInput,
   OrdersSortInput,
 } from '@/shared/service/bc/graphql/orders';
@@ -108,6 +110,7 @@ function Order({ isCompanyOrder = false }: OrderProps) {
   const [allTotal, setAllTotal] = useState(0);
   const [filterMoreInfo, setFilterMoreInfo] = useState<Array<any>>([]);
   const [getOrderStatuses, setOrderStatuses] = useState<Array<any>>([]);
+  const [placedByUsers, setPlacedByUsers] = useState<OrderPlacedBy[]>([]);
 
   const isUnifiedCustomerPath = isUnifiedOrders && !isCompanyOrder;
   const isUnifiedCompanyPath = isUnifiedOrders && isCompanyOrder;
@@ -125,6 +128,7 @@ function Order({ isCompanyOrder = false }: OrderProps) {
   const companyFilterState = useCompanyOrdersState({
     selectedCompanyId,
     orderStatuses: getOrderStatuses,
+    placedByUsers,
   });
 
   const getActiveFilterState = () => {
@@ -160,21 +164,72 @@ function Order({ isCompanyOrder = false }: OrderProps) {
 
   const { filterData, orderBy } = getFilterDataAndOrderBy();
 
+  const activeCompanyIds = companyFilterState.filters.companyIds;
+
+  useEffect(() => {
+    if (role === CustomerRole.GUEST || !isUnifiedOrders || !isB2BUser || !isCompanyOrder) {
+      return undefined;
+    }
+
+    let cancelled = false;
+
+    const fetchPlacedByUsers = async () => {
+      const response = await getCustomersWithOrders({
+        filters: activeCompanyIds ? { companyIds: activeCompanyIds } : undefined,
+        first: 100,
+      });
+      if (cancelled) return;
+
+      const edges = response.data?.customer?.activeCompany?.customersWithOrders?.edges || [];
+      const users = edges.map((e) => e.node);
+      setPlacedByUsers(users);
+
+      setFilterMoreInfo((prev) => {
+        const placedByItem = prev.find((item: { name: string }) => item.name === 'PlacedBy');
+        if (!placedByItem) return prev;
+
+        const newOptions = users.map((u: OrderPlacedBy) => ({
+          createdBy: `${u.firstName} ${u.lastName} (${u.email})`,
+        }));
+        return prev.map((item: { name: string }) =>
+          item.name === 'PlacedBy' ? { ...item, options: newOptions } : item,
+        );
+      });
+    };
+
+    fetchPlacedByUsers();
+    return () => {
+      cancelled = true;
+    };
+  }, [activeCompanyIds, isB2BUser, isCompanyOrder, isUnifiedOrders, role]);
+
   useEffect(() => {
     // TODO: Guest customer should not be able to see the order list
     if (role === CustomerRole.GUEST) return;
 
     const initFilter = async () => {
-      const createdByUsers =
-        isB2BUser && isCompanyOrder ? await getCreatedByUserForOrders(Number(companyId)) : {};
-      //  Caution: This api hasn't yet been ported to unified order api
+      let createdByUsers: Record<string, unknown> = {};
+
+      if (isB2BUser && isCompanyOrder) {
+        if (isUnifiedOrders) {
+          const response = await getCustomersWithOrders({
+            filters: activeCompanyIds ? { companyIds: activeCompanyIds } : undefined,
+            first: 100,
+          });
+          const edges = response.data?.customer?.activeCompany?.customersWithOrders?.edges || [];
+          const users = edges.map((e) => e.node);
+          setPlacedByUsers(users);
+          createdByUsers = {
+            createdByUser: { results: users },
+          };
+        } else {
+          createdByUsers = await getCreatedByUserForOrders(Number(companyId));
+        }
+      }
+
       const orderStatuses = isB2BUser ? await getOrderStatusType() : await getBcOrderStatusType();
       setOrderStatuses(orderStatuses);
 
-      /* 
-        returns what all fields to show in more filter (funnel icon)
-        and styles associated to those fields
-      */
       setFilterMoreInfo(
         translateFilterMoreData(
           getFilterMoreData(
@@ -191,7 +246,8 @@ function Order({ isCompanyOrder = false }: OrderProps) {
     };
 
     initFilter();
-  }, [b3Lang, companyId, isAgenting, isB2BUser, isCompanyOrder, role]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [b3Lang, companyId, isAgenting, isB2BUser, isCompanyOrder, isUnifiedOrders, role]);
 
   const fetchUnifiedOrders = async (args: {
     first?: number;

--- a/apps/storefront/src/pages/order/Order.tsx
+++ b/apps/storefront/src/pages/order/Order.tsx
@@ -14,8 +14,6 @@ import {
   CompanyOrdersFiltersInput,
   getCompanyOrders,
   getCustomerOrders,
-  getCustomersWithOrders,
-  type OrderPlacedBy,
   OrdersFiltersInput,
   OrdersSortInput,
 } from '@/shared/service/bc/graphql/orders';
@@ -111,8 +109,6 @@ function Order({ isCompanyOrder = false }: OrderProps) {
   const [allTotal, setAllTotal] = useState(0);
   const [filterMoreInfo, setFilterMoreInfo] = useState<Array<any>>([]);
   const [getOrderStatuses, setOrderStatuses] = useState<Array<any>>([]);
-  const [placedByUsers, setPlacedByUsers] = useState<OrderPlacedBy[]>([]);
-
   const isUnifiedCustomerPath = isUnifiedOrders && !isCompanyOrder;
   const isUnifiedCompanyPath = isUnifiedOrders && isCompanyOrder;
 
@@ -129,7 +125,7 @@ function Order({ isCompanyOrder = false }: OrderProps) {
   const companyFilterState = useCompanyOrdersState({
     selectedCompanyId,
     orderStatuses: getOrderStatuses,
-    placedByUsers,
+    isEnabled: isUnifiedCompanyPath && role !== CustomerRole.GUEST,
   });
 
   const getActiveFilterState = () => {
@@ -165,46 +161,6 @@ function Order({ isCompanyOrder = false }: OrderProps) {
 
   const { filterData, orderBy } = getFilterDataAndOrderBy();
 
-  const activeCompanyIds = companyFilterState.filters.companyIds;
-
-  useEffect(() => {
-    if (role === CustomerRole.GUEST || !isUnifiedOrders || !isB2BUser || !isCompanyOrder) {
-      return undefined;
-    }
-
-    let cancelled = false;
-
-    const fetchPlacedByUsers = async () => {
-      const allUsers: OrderPlacedBy[] = [];
-      let after: string | undefined;
-
-      // eslint-disable-next-line no-constant-condition
-      while (true) {
-        // eslint-disable-next-line no-await-in-loop
-        const response = await getCustomersWithOrders({
-          filters: activeCompanyIds ? { companyIds: activeCompanyIds } : undefined,
-          first: 100,
-          after,
-        });
-        if (cancelled) return;
-
-        const connection = response.data?.customer?.activeCompany?.customersWithOrders;
-        const edges = connection?.edges || [];
-        allUsers.push(...edges.map((e) => e.node));
-
-        if (!connection?.pageInfo?.hasNextPage || !connection.pageInfo.endCursor) break;
-        after = connection.pageInfo.endCursor;
-      }
-
-      setPlacedByUsers(allUsers);
-    };
-
-    fetchPlacedByUsers();
-    return () => {
-      cancelled = true;
-    };
-  }, [activeCompanyIds, isB2BUser, isCompanyOrder, isUnifiedOrders, role]);
-
   const orderStatusesRef = useRef<Array<any>>([]);
 
   useEffect(() => {
@@ -215,7 +171,7 @@ function Order({ isCompanyOrder = false }: OrderProps) {
       let createdByUsers: CreatedByUsersData = {};
       if (isB2BUser && isCompanyOrder) {
         if (isUnifiedOrders) {
-          createdByUsers = { createdByUser: { results: placedByUsers } };
+          createdByUsers = { createdByUser: { results: companyFilterState.placedByUsers } };
         } else {
           createdByUsers = await getCreatedByUserForOrders(Number(companyId));
         }
@@ -250,7 +206,7 @@ function Order({ isCompanyOrder = false }: OrderProps) {
     isB2BUser,
     isCompanyOrder,
     isUnifiedOrders,
-    placedByUsers,
+    companyFilterState.placedByUsers,
     role,
   ]);
 

--- a/apps/storefront/src/pages/order/config.ts
+++ b/apps/storefront/src/pages/order/config.ts
@@ -1,7 +1,12 @@
+import { OrderPlacedBy } from '@/shared/service/bc/graphql/orders';
 import { CustomerRole } from '@/types';
 import { OrderStatusType } from '@/types/gql/graphql';
 
 import { orderStatusTranslationVariables } from './shared/getOrderStatus';
+
+export interface CreatedByUsersData {
+  createdByUser?: { results: OrderPlacedBy[] };
+}
 
 export interface FilterSearchProps {
   [key: string]: string | number | number[] | null;
@@ -25,6 +30,9 @@ export const sortKeys = {
   createdAt: 'createdAt',
 };
 
+export const formatPlacedByLabel = (user: { firstName: string; lastName: string; email: string }) =>
+  `${user.firstName} ${user.lastName} (${user.email})`;
+
 export function assertSortKey(key: string): asserts key is keyof typeof sortKeys {
   if (!Object.keys(sortKeys).includes(key)) {
     throw new Error(`Invalid sort key: ${key}`);
@@ -44,7 +52,7 @@ export const getFilterMoreData = (
   );
   const newCreatedByUsers =
     createdByUsers?.createdByUser?.results.map((item: any) => ({
-      createdBy: `${item.firstName} ${item.lastName} (${item.email})`,
+      createdBy: formatPlacedByLabel(item),
     })) || [];
   const filterMoreList = [
     {

--- a/apps/storefront/src/pages/order/useCompanyOrdersState.ts
+++ b/apps/storefront/src/pages/order/useCompanyOrdersState.ts
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react';
 import { CompanyOrdersFiltersInput, OrderPlacedBy } from '@/shared/service/bc/graphql/orders';
 import { OrderStatusItem } from '@/types';
 
+import { formatPlacedByLabel } from './config';
 import {
   getCompanyOrdersInitFilter,
   normalizeString,
@@ -73,9 +74,7 @@ export const useCompanyOrdersState = ({
     let resolvedCustomerId: number[] | undefined;
     const rawPlacedBy = normalizeString(value.PlacedBy);
     if (rawPlacedBy) {
-      const match = placedByUsers.find(
-        (u) => `${u.firstName} ${u.lastName} (${u.email})` === rawPlacedBy,
-      );
+      const match = placedByUsers.find((u) => formatPlacedByLabel(u) === rawPlacedBy);
       resolvedCustomerId = match ? [match.entityId] : undefined;
     }
 

--- a/apps/storefront/src/pages/order/useCompanyOrdersState.ts
+++ b/apps/storefront/src/pages/order/useCompanyOrdersState.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 
-import { CompanyOrdersFiltersInput, OrderPlacedBy } from '@/shared/service/bc/graphql/orders';
+import { CompanyOrdersFiltersInput } from '@/shared/service/bc/graphql/orders';
 import { OrderStatusItem } from '@/types';
 
 import { formatPlacedByLabel } from './config';
@@ -10,6 +10,7 @@ import {
   packDateRange,
 } from './unifiedApiFiltersHelper';
 import { CompanySortableColumnKey, useCompanyOrderSorting } from './useCompanyOrderSorting';
+import { usePlacedByUsers } from './usePlacedByUsers';
 import { UseUnifiedOrderSortingResult } from './useUnifiedOrderSorting';
 import {
   useUnifiedOrdersPagination,
@@ -27,13 +28,14 @@ interface AppliedFilters {
 interface UseCompanyOrdersStateArgs {
   selectedCompanyId: number;
   orderStatuses: OrderStatusItem[];
-  placedByUsers: OrderPlacedBy[];
+  isEnabled: boolean;
 }
 
 export interface UseCompanyOrdersStateResult
   extends UseUnifiedOrdersPaginationResult,
     UseUnifiedOrderSortingResult<CompanySortableColumnKey> {
   filters: CompanyOrdersFiltersInput;
+  placedByUsers: ReturnType<typeof usePlacedByUsers>;
   handleSearchChange: (key: string, value: string) => void;
   handleFilterChange: (value: AppliedFilters) => void;
   handleCompanyIdsChange: (companyIds: number[]) => void;
@@ -42,7 +44,7 @@ export interface UseCompanyOrdersStateResult
 export const useCompanyOrdersState = ({
   selectedCompanyId,
   orderStatuses,
-  placedByUsers,
+  isEnabled,
 }: UseCompanyOrdersStateArgs): UseCompanyOrdersStateResult => {
   const [filters, setFilters] = useState<CompanyOrdersFiltersInput>(() =>
     getCompanyOrdersInitFilter(selectedCompanyId),
@@ -50,6 +52,11 @@ export const useCompanyOrdersState = ({
 
   const pagination = useUnifiedOrdersPagination();
   const sorting = useCompanyOrderSorting(pagination.resetPagination);
+
+  const placedByUsers = usePlacedByUsers({
+    enabled: isEnabled,
+    companyIds: filters.companyIds,
+  });
 
   useEffect(() => {
     setFilters(getCompanyOrdersInitFilter(selectedCompanyId));
@@ -101,6 +108,7 @@ export const useCompanyOrdersState = ({
     ...pagination,
     ...sorting,
     filters,
+    placedByUsers,
     handleSearchChange,
     handleFilterChange,
     handleCompanyIdsChange,

--- a/apps/storefront/src/pages/order/useCompanyOrdersState.ts
+++ b/apps/storefront/src/pages/order/useCompanyOrdersState.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 
-import { CompanyOrdersFiltersInput } from '@/shared/service/bc/graphql/orders';
+import { CompanyOrdersFiltersInput, OrderPlacedBy } from '@/shared/service/bc/graphql/orders';
 import { OrderStatusItem } from '@/types';
 
 import {
@@ -26,6 +26,7 @@ interface AppliedFilters {
 interface UseCompanyOrdersStateArgs {
   selectedCompanyId: number;
   orderStatuses: OrderStatusItem[];
+  placedByUsers: OrderPlacedBy[];
 }
 
 export interface UseCompanyOrdersStateResult
@@ -40,6 +41,7 @@ export interface UseCompanyOrdersStateResult
 export const useCompanyOrdersState = ({
   selectedCompanyId,
   orderStatuses,
+  placedByUsers,
 }: UseCompanyOrdersStateArgs): UseCompanyOrdersStateResult => {
   const [filters, setFilters] = useState<CompanyOrdersFiltersInput>(() =>
     getCompanyOrdersInitFilter(selectedCompanyId),
@@ -68,11 +70,21 @@ export const useCompanyOrdersState = ({
       resolvedStatuses = originalStatus?.systemLabel ? [originalStatus.systemLabel] : undefined;
     }
 
+    let resolvedCustomerId: number[] | undefined;
+    const rawPlacedBy = normalizeString(value.PlacedBy);
+    if (rawPlacedBy) {
+      const match = placedByUsers.find(
+        (u) => `${u.firstName} ${u.lastName} (${u.email})` === rawPlacedBy,
+      );
+      resolvedCustomerId = match ? [match.entityId] : undefined;
+    }
+
     pagination.resetPagination();
     setFilters((prev) => ({
       ...prev,
       status: resolvedStatuses,
       dateRange: packDateRange(value.startValue, value.endValue),
+      customerId: resolvedCustomerId,
     }));
   };
 

--- a/apps/storefront/src/pages/order/useCompanyOrdersState.ts
+++ b/apps/storefront/src/pages/order/useCompanyOrdersState.ts
@@ -94,6 +94,7 @@ export const useCompanyOrdersState = ({
     setFilters((prev) => ({
       ...prev,
       companyIds: isAll ? undefined : companyIds.map(String),
+      customerId: undefined,
     }));
   };
 

--- a/apps/storefront/src/pages/order/usePlacedByUsers.test.ts
+++ b/apps/storefront/src/pages/order/usePlacedByUsers.test.ts
@@ -1,0 +1,150 @@
+import { createElement, PropsWithChildren } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import type {
+  GetCustomersWithOrdersResponse,
+  OrderPlacedBy,
+} from '@/shared/service/bc/graphql/orders';
+
+import { usePlacedByUsers } from './usePlacedByUsers';
+
+vi.mock('@/shared/service/bc/graphql/orders', () => ({
+  getCustomersWithOrders: vi.fn(),
+}));
+
+const { getCustomersWithOrders } = await import('@/shared/service/bc/graphql/orders');
+const mockGetCustomersWithOrders = vi.mocked(getCustomersWithOrders);
+
+function makeUser(entityId: number): OrderPlacedBy {
+  return {
+    entityId,
+    firstName: `First${entityId}`,
+    lastName: `Last${entityId}`,
+    email: `user${entityId}@test.com`,
+  };
+}
+
+function makePage(
+  users: OrderPlacedBy[],
+  hasNextPage: boolean,
+  endCursor: string | null = null,
+): GetCustomersWithOrdersResponse {
+  return {
+    data: {
+      customer: {
+        activeCompany: {
+          customersWithOrders: {
+            edges: users.map((u) => ({ node: u, cursor: String(u.entityId) })),
+            pageInfo: {
+              hasNextPage,
+              hasPreviousPage: false,
+              startCursor: users.length ? String(users[0].entityId) : null,
+              endCursor,
+            },
+          },
+        },
+      },
+    },
+  };
+}
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return function Wrapper({ children }: PropsWithChildren) {
+    return createElement(QueryClientProvider, { client: queryClient }, children);
+  };
+}
+
+describe('usePlacedByUsers', () => {
+  it('returns empty array when disabled', () => {
+    const { result } = renderHook(
+      () => usePlacedByUsers({ enabled: false, companyIds: undefined }),
+      { wrapper: createWrapper() },
+    );
+    expect(result.current).toEqual([]);
+    expect(mockGetCustomersWithOrders).not.toHaveBeenCalled();
+  });
+
+  it('fetches a single page of users', async () => {
+    const users = [makeUser(1), makeUser(2)];
+    mockGetCustomersWithOrders.mockResolvedValueOnce(makePage(users, false));
+
+    const { result } = renderHook(
+      () => usePlacedByUsers({ enabled: true, companyIds: undefined }),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => expect(result.current).toHaveLength(2));
+    expect(result.current).toEqual(users);
+    expect(mockGetCustomersWithOrders).toHaveBeenCalledTimes(1);
+    expect(mockGetCustomersWithOrders).toHaveBeenCalledWith({
+      filters: undefined,
+      first: 100,
+      after: undefined,
+    });
+  });
+
+  it('paginates through multiple pages', async () => {
+    const page1Users = [makeUser(1), makeUser(2)];
+    const page2Users = [makeUser(3)];
+    mockGetCustomersWithOrders
+      .mockResolvedValueOnce(makePage(page1Users, true, 'cursor-2'))
+      .mockResolvedValueOnce(makePage(page2Users, false));
+
+    const { result } = renderHook(
+      () => usePlacedByUsers({ enabled: true, companyIds: undefined }),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => expect(result.current).toHaveLength(3));
+    expect(result.current).toEqual([...page1Users, ...page2Users]);
+    expect(mockGetCustomersWithOrders).toHaveBeenCalledTimes(2);
+    expect(mockGetCustomersWithOrders).toHaveBeenLastCalledWith({
+      filters: undefined,
+      first: 100,
+      after: 'cursor-2',
+    });
+  });
+
+  it('passes companyIds filter when provided', async () => {
+    mockGetCustomersWithOrders.mockResolvedValueOnce(makePage([makeUser(1)], false));
+
+    const { result } = renderHook(
+      () => usePlacedByUsers({ enabled: true, companyIds: ['10', '20'] }),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => expect(result.current).toHaveLength(1));
+    expect(mockGetCustomersWithOrders).toHaveBeenCalledWith({
+      filters: { companyIds: ['10', '20'] },
+      first: 100,
+      after: undefined,
+    });
+  });
+
+  it('refetches when companyIds change', async () => {
+    const usersA = [makeUser(1)];
+    const usersB = [makeUser(2), makeUser(3)];
+    mockGetCustomersWithOrders
+      .mockResolvedValueOnce(makePage(usersA, false))
+      .mockResolvedValueOnce(makePage(usersB, false));
+
+    const { result, rerender } = renderHook(
+      ({ companyIds }: { companyIds: string[] | undefined }) =>
+        usePlacedByUsers({ enabled: true, companyIds }),
+      { wrapper: createWrapper(), initialProps: { companyIds: ['10'] } },
+    );
+
+    await waitFor(() => expect(result.current).toHaveLength(1));
+    expect(result.current).toEqual(usersA);
+
+    rerender({ companyIds: ['20'] });
+
+    await waitFor(() => expect(result.current).toHaveLength(2));
+    expect(result.current).toEqual(usersB);
+  });
+});

--- a/apps/storefront/src/pages/order/usePlacedByUsers.ts
+++ b/apps/storefront/src/pages/order/usePlacedByUsers.ts
@@ -1,0 +1,46 @@
+import { useEffect, useMemo } from 'react';
+import { useInfiniteQuery } from '@tanstack/react-query';
+
+import {
+  getCustomersWithOrders,
+  type GetCustomersWithOrdersResponse,
+  type OrderPlacedBy,
+} from '@/shared/service/bc/graphql/orders';
+
+interface UsePlacedByUsersArgs {
+  enabled: boolean;
+  companyIds?: string[];
+}
+
+export function usePlacedByUsers({ enabled, companyIds }: UsePlacedByUsersArgs): OrderPlacedBy[] {
+  const { data, hasNextPage, isFetchingNextPage, fetchNextPage } = useInfiniteQuery({
+    queryKey: ['placedByUsers', companyIds],
+    enabled,
+    queryFn: ({ pageParam }: { pageParam: string | undefined }) =>
+      getCustomersWithOrders({
+        filters: companyIds ? { companyIds } : undefined,
+        first: 100,
+        after: pageParam,
+      }),
+    initialPageParam: undefined as string | undefined,
+    getNextPageParam: (lastPage: GetCustomersWithOrdersResponse) => {
+      const pageInfo = lastPage.data?.customer?.activeCompany?.customersWithOrders?.pageInfo;
+      return pageInfo?.hasNextPage ? (pageInfo.endCursor ?? undefined) : undefined;
+    },
+  });
+
+  useEffect(() => {
+    if (hasNextPage && !isFetchingNextPage) {
+      fetchNextPage();
+    }
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
+
+  return useMemo(
+    () =>
+      data?.pages.flatMap(
+        (page) =>
+          page.data?.customer?.activeCompany?.customersWithOrders?.edges?.map((e) => e.node) ?? [],
+      ) ?? [],
+    [data],
+  );
+}


### PR DESCRIPTION
Jira: [B2B-4621](https://bigcommercecloud.atlassian.net/browse/B2B-4621)

## What/Why?

Replaces the legacy `getCreatedByUserForOrders` (B2B Edition GraphQL `createdByUser` query)
with the unified SF GQL `getCustomersWithOrders` service function to populate the "Placed By"
filter dropdown on Company Orders.

On the unified path (feature flag on):
- Fetches users via `customer.activeCompany.customersWithOrders(...)` instead of the legacy
  `createdByUser(companyId, module: 0)` query
- Resolves the selected dropdown value (formatted string like "Jane Doe (jane@acme.com)")
  back to an `entityId` via a lookup built at fetch time
- Maps the resolved entityId to `CompanyOrdersFiltersInput.customerId: [entityId]`
- When subsidiary filtering is active, passes `companyIds` to
  `CustomerWithOrdersFiltersInput` so the user list is scoped to selected subsidiaries
- Re-fetches the user list when the subsidiary selection changes
- Clearing the filter removes `customerId` from the query

Legacy path (flag off) is unchanged — continues using `getCreatedByUserForOrders`.

**Key files:**
- `useCompanyOrdersState.ts` — accepts `placedByUsers` array, resolves PlacedBy → customerId
  in `handleFilterChange`
- `Order.tsx` — new `useEffect` fetches users via SF GQL with subsidiary scoping, stores
  lookup for entityId resolution. `initFilter` also calls SF GQL on unified path for initial
  dropdown population.

## Rollout/Rollback

All changes are behind the `B2B-4613.buyer_portal_unified_sf_gql_orders` feature flag.
No production code runs unless the flag is enabled. Rollback: disable the feature flag —
the legacy `getCreatedByUserForOrders` path is preserved and untouched.

## Testing

- 5 new functional tests in `unified-company-orders.test.tsx`:
  1. Populates Placed By dropdown from `GetCustomersWithOrders` (not legacy query)
  2. Sends `customerId: [entityId]` when a user is selected
  3. Removes `customerId` when filter is cleared
  4. Composes `customerId` with search and status filters
  5. Uses legacy `GetOrdersCreatedByUser` when flag is off
- Added `GetCustomersWithOrders` MSW handler to `beforeEach` for all existing tests
- All 169 order-related tests pass (8 files, 0 regressions)
- Full suite: 876 passed, lint clean, build passes


**FF ON:**

<img width="1849" height="732" alt="image" src="https://github.com/user-attachments/assets/5e383e57-c7c0-49a1-bb7d-83715d96ffae" />


[B2B-4621]: https://bigcommercecloud.atlassian.net/browse/B2B-4621?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how company order list filters are built and which GraphQL queries run on the unified path, but behavior is gated by the feature flag and legacy flow is preserved when off.
> 
> **Overview**
> On the unified Company Orders path (`B2B-4613.buyer_portal_unified_sf_gql_orders`), the **Placed by** filter now loads options from SF GQL `getCustomersWithOrders` instead of legacy `getCreatedByUserForOrders`. A new `usePlacedByUsers` hook paginates that list (optionally scoped by subsidiary `companyIds`), and `useCompanyOrdersState` maps the selected display label to `filters.customerId` for `GetCompanyOrders`. Subsidiary changes clear `customerId`; the flag-off path is unchanged.
> 
> `Order.tsx` wires the unified dropdown from `companyFilterState.placedByUsers` and caches order statuses in a ref so filter UI does not re-fetch statuses on every user-list update. Shared `formatPlacedByLabel` keeps dropdown labels consistent with filter resolution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 242898a718976474b6035d17b6135192d3973b1a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->