### PR TITLE
fix(common): B2B-3876 normalise uppercase currency token_location

### DIFF
--- a/apps/storefront/src/pages/QuoteDetail/index.test.tsx
+++ b/apps/storefront/src/pages/QuoteDetail/index.test.tsx
@@ -1618,5 +1618,38 @@ describe('when the user is a B2B customer', () => {
       const summary = screen.getByTestId('quote-summary');
       expect(within(summary).getByText('€200.00')).toBeInTheDocument();
     });
+
+    it('places the token on the left when BC config has uppercase token_location LEFT and flag is enabled', async () => {
+      const eurWithUppercaseLeft = JSON.parse(
+        JSON.stringify({ ...eurOnLeftInBcConfig, token_location: 'LEFT' }),
+      );
+
+      renderWithProviders(<QuoteDetail />, {
+        preloadedState: {
+          ...preloadedState,
+          storeConfigs: {
+            currencies: {
+              currencies: [eurWithUppercaseLeft],
+              channelCurrencies: {
+                channel_id: 1,
+                enabled_currencies: ['EUR'],
+                default_currency: 'EUR',
+              },
+              enteredInclusiveTax: false,
+            },
+          },
+          global: buildGlobalStateWith({
+            backorderEnabled: false,
+            featureFlags: { 'B2B-3876.fix_quote_currency_symbol_placement': true },
+          }),
+        },
+      });
+
+      const row = (await screen.findByText('Wool Socks')).closest('tr')!;
+      expect(within(row).getByRole('cell', { name: '€49.00' })).toBeInTheDocument();
+
+      const summary = screen.getByTestId('quote-summary');
+      expect(within(summary).getByText('€200.00')).toBeInTheDocument();
+    });
   });
 });

--- a/apps/storefront/src/pages/QuoteDraft/index.test.tsx
+++ b/apps/storefront/src/pages/QuoteDraft/index.test.tsx
@@ -5158,3 +5158,69 @@ describe('when the user is a B2B customer', () => {
     });
   });
 });
+
+describe('currency token placement', () => {
+  beforeEach(() => {
+    server.use(
+      graphql.query('Countries', () => HttpResponse.json({ data: { countries: [fakeCountry] } })),
+      graphql.query('Addresses', () =>
+        HttpResponse.json({ data: { addresses: { totalCount: 0, edges: [] } } }),
+      ),
+      graphql.query('getQuoteExtraFields', () =>
+        HttpResponse.json({ data: { quoteExtraFieldsConfig: [] } }),
+      ),
+    );
+  });
+
+  it('places the token on the right when the active currency has uppercase token_location RIGHT', async () => {
+    const eurOnRight = JSON.parse(
+      JSON.stringify({
+        id: '2',
+        is_default: false,
+        last_updated: '2024-01-01',
+        country_iso2: 'DE',
+        default_for_country_codes: [],
+        currency_code: 'EUR',
+        currency_exchange_rate: '1.0000000000',
+        name: 'Euro',
+        token: '€',
+        auto_update: false,
+        decimal_token: '.',
+        decimal_places: 2,
+        enabled: true,
+        is_transactional: true,
+        token_location: 'RIGHT',
+        thousands_token: ',',
+      }),
+    );
+
+    const woolSocks = buildDraftQuoteItemWith({
+      node: { productName: 'Wool Socks', basePrice: 49, quantity: 3 },
+    });
+
+    const quoteInfo = buildQuoteInfoStateWith({ draftQuoteList: [woolSocks] });
+
+    renderWithProviders(<QuoteDraft setOpenPage={vi.fn()} />, {
+      preloadedState: {
+        ...preloadedState,
+        quoteInfo,
+        storeConfigs: {
+          currencies: {
+            currencies: [eurOnRight],
+            channelCurrencies: {
+              channel_id: 1,
+              enabled_currencies: ['EUR'],
+              default_currency: 'EUR',
+            },
+            enteredInclusiveTax: false,
+          },
+          activeCurrency: { node: { isActive: true, entityId: 2 } },
+        },
+      },
+    });
+
+    const row = await screen.findByRole('row', { name: /Wool Socks/ });
+    expect(within(row).getByRole('cell', { name: '49.00€' })).toBeInTheDocument();
+    expect(within(row).getByRole('cell', { name: '147.00€' })).toBeInTheDocument();
+  });
+});

--- a/apps/storefront/src/pages/QuotesList/index.test.tsx
+++ b/apps/storefront/src/pages/QuotesList/index.test.tsx
@@ -1435,4 +1435,34 @@ describe('fix_quote_currency_symbol_placement feature flag', () => {
     const table = await screen.findByRole('table');
     expect(within(table).getByRole('cell', { name: '€100.00' })).toBeInTheDocument();
   });
+
+  it('places the token on the left when BC config has uppercase token_location LEFT and flag is enabled', async () => {
+    const eurWithUppercaseLeft = JSON.parse(
+      JSON.stringify({ ...eurOnLeftInBcConfig, token_location: 'LEFT' }),
+    );
+
+    renderWithProviders(<QuotesList />, {
+      preloadedState: {
+        company: nonCompany,
+        storeInfo: storeInfoWithDateFormat,
+        storeConfigs: {
+          currencies: {
+            currencies: [eurWithUppercaseLeft],
+            channelCurrencies: {
+              channel_id: 1,
+              enabled_currencies: ['EUR'],
+              default_currency: 'EUR',
+            },
+            enteredInclusiveTax: false,
+          },
+        },
+        global: buildGlobalStateWith({
+          featureFlags: { 'B2B-3876.fix_quote_currency_symbol_placement': true },
+        }),
+      },
+    });
+
+    const table = await screen.findByRole('table');
+    expect(within(table).getByRole('cell', { name: '€100.00' })).toBeInTheDocument();
+  });
 });

--- a/apps/storefront/src/store/slices/storeConfigs.ts
+++ b/apps/storefront/src/store/slices/storeConfigs.ts
@@ -47,7 +47,13 @@ const storeConfigSlice = createSlice({
   reducers: {
     clearState: () => initialState,
     setCurrencies: (state, { payload }: PayloadAction<Currencies>) => {
-      state.currencies = payload;
+      state.currencies = {
+        ...payload,
+        currencies: payload.currencies.map((currency) => ({
+          ...currency,
+          token_location: currency.token_location?.toLowerCase() === 'right' ? 'right' : 'left',
+        })),
+      };
     },
     setActiveCurrency: (state, { payload }: PayloadAction<ActiveCurrency>) => {
       state.activeCurrency = payload;

--- a/apps/storefront/src/utils/b3CurrencyFormat.ts
+++ b/apps/storefront/src/utils/b3CurrencyFormat.ts
@@ -53,7 +53,7 @@ export const ordersCurrencyFormat = (
       decimalPart ? `${moneyFormat.decimal_token}${decimalPart}` : ''
     }`;
     const priceStr =
-      moneyFormat.currency_location === 'left'
+      moneyFormat.currency_location?.toLowerCase() === 'left'
         ? `${showCurrencyToken ? moneyFormat.currency_token : ''}${newPrice}`
         : `${newPrice}${showCurrencyToken ? moneyFormat.currency_token : ''}`;
     return priceStr;
@@ -105,7 +105,7 @@ export const currencyFormatConvert = (
         moneyFormat.thousands_token,
       )}${decimalPart ? `${moneyFormat.decimal_token}${decimalPart}` : ''}`;
       const priceStr =
-        moneyFormat.currency_location === 'left'
+        moneyFormat.currency_location?.toLowerCase() === 'left'
           ? `${showCurrencyToken ? moneyFormat.currency_token : ''}${newPrice}`
           : `${newPrice}${showCurrencyToken ? moneyFormat.currency_token : ''}`;
       return priceStr;
@@ -115,7 +115,7 @@ export const currencyFormatConvert = (
       decimalPart ? `${moneyFormat.decimal_token}${decimalPart}` : ''
     }`;
     const priceStr =
-      moneyFormat.currency_location === 'left'
+      moneyFormat.currency_location?.toLowerCase() === 'left'
         ? `${showCurrencyToken ? moneyFormat.currency_token : ''}${newPrice}`
         : `${newPrice}${showCurrencyToken ? moneyFormat.currency_token : ''}`;
     return priceStr;
@@ -141,7 +141,7 @@ export const currencyFormat = (
       decimalPart ? `${moneyFormat.decimal_token}${decimalPart}` : ''
     }`;
     const priceStr =
-      moneyFormat.currency_location === 'left'
+      moneyFormat.currency_location?.toLowerCase() === 'left'
         ? `${showCurrencyToken ? moneyFormat.currency_token : ''}${newPrice}`
         : `${newPrice}${showCurrencyToken ? moneyFormat.currency_token : ''}`;
     return priceStr;


### PR DESCRIPTION
Jira: [B2B-3876](https://bigcommercecloud.atlassian.net/browse/B2B-3876)

## What/Why?
<!--
  A description about what this pull request implements and its purpose.
  Try to be detailed and describe any technical details to simplify the job
  of the reviewer and the individual on production support.
-->
Currency location in prod coming as LEFT/RIGHT instead of left/right, causing the currency direction issue.

This pull request improves the handling of currency symbol placement in the storefront by making the placement logic case-insensitive and adding comprehensive tests to cover different configurations, especially when the `token_location` is set to uppercase values like `LEFT` or `RIGHT`. This ensures that the currency symbol appears in the correct position regardless of the casing in the configuration, and that the feature flag for fixing currency symbol placement works as intended.

**Currency formatting logic improvements:**

* Updated the `ordersCurrencyFormat`, `currencyFormatConvert`, and `currencyFormat` functions in `b3CurrencyFormat.ts` to make the currency symbol placement logic case-insensitive by using `.toLowerCase()` when checking `currency_location`. [[1]](diffhunk://#diff-a94673c9a25b5464d5be3777a128c1794d45fce493121acebd889791b9e5df19L56-R56) [[2]](diffhunk://#diff-a94673c9a25b5464d5be3777a128c1794d45fce493121acebd889791b9e5df19L108-R108) [[3]](diffhunk://#diff-a94673c9a25b5464d5be3777a128c1794d45fce493121acebd889791b9e5df19L118-R118) [[4]](diffhunk://#diff-a94673c9a25b5464d5be3777a128c1794d45fce493121acebd889791b9e5df19L144-R144)

## Rollout/Rollback
<!--
Detail how this change will be rolled out. Include reference to any
experiments and how the success will be measured as the experiment is
ramped.

Document rollback procedures. Is rolling back the change as simple as
rolling back an experiment or does it require reverting code? Are there
database migrations that may change our decision to roll forward instead of
back?
-->
Revert the PR

## Testing
<!--
Provide as much information as you can about how you tested and how another
Engineer can test your change. Include screenshots, or test run output
where appropriate.
-->

* Added tests in `QuoteDetail/index.test.tsx` and `QuotesList/index.test.tsx` to verify that the currency symbol is placed on the left when the `token_location` is set to uppercase `LEFT` and the relevant feature flag is enabled. [[1]](diffhunk://#diff-f0613f5f4f8e1051966f6ace5a5269833351c30ef13c0e571a11ffc0781ec752R1621-R1653) [[2]](diffhunk://#diff-a1bb8013ae4330146235b4e69700cf4ebf98749386c79c4256ca02942f3bb5b0R1438-R1463)
* Added a new test suite in `QuoteDraft/index.test.tsx` to check that the currency symbol is placed on the right when the active currency has an uppercase `token_location` of `RIGHT`.

[B2B-3876]: https://bigcommercecloud.atlassian.net/browse/B2B-3876?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, localized change to currency formatting and store-config normalization plus added tests; main risk is subtle display regressions for currencies with unexpected `token_location` values.
> 
> **Overview**
> Fixes quote currency symbol placement when BigCommerce returns uppercase `token_location` values by **normalizing `storeConfigs.setCurrencies` to always store `token_location` as lowercase `left`/`right`**.
> 
> Makes `b3CurrencyFormat` placement checks case-insensitive (`currency_location?.toLowerCase()`), and adds tests in `QuoteDetail`, `QuotesList`, and `QuoteDraft` to cover uppercase `LEFT`/`RIGHT` scenarios (including the feature-flagged quote placement behavior).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62b20f708cc3aa54569deacedfbe851b3da65ea8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->