### PR TITLE
feat(orders): B2B-4629 Implement Order Detail Navigation with Cursor Pagination

### DIFF
--- a/apps/storefront/src/lib/lang/locales/en.json
+++ b/apps/storefront/src/lib/lang/locales/en.json
@@ -336,6 +336,7 @@
   "orderDetail.backToOrders": "Back to orders",
   "orderDetail.pagination.order": "Order",
   "orderDetail.pagination.of": "of",
+  "orderDetail.pagination.orderNavigation": "Order navigation",
   "orderDetail.pagination.previousOrder": "Previous order",
   "orderDetail.pagination.nextOrder": "Next order",
   "orderDetail.pagination.fetchError": "Failed to load orders. Please try again.",

--- a/apps/storefront/src/lib/lang/locales/en.json
+++ b/apps/storefront/src/lib/lang/locales/en.json
@@ -336,6 +336,8 @@
   "orderDetail.backToOrders": "Back to orders",
   "orderDetail.pagination.order": "Order",
   "orderDetail.pagination.of": "of",
+  "orderDetail.pagination.previousOrder": "Previous order",
+  "orderDetail.pagination.nextOrder": "Next order",
   "orderDetail.paymentMethod": "Payment by {paymentMethod}",
   "orderDetail.customerName": "{firstName} {lastName}",
   "orderDetail.customerAddress": "{city}, {state} {zip}, {country}",

--- a/apps/storefront/src/lib/lang/locales/en.json
+++ b/apps/storefront/src/lib/lang/locales/en.json
@@ -338,6 +338,7 @@
   "orderDetail.pagination.of": "of",
   "orderDetail.pagination.previousOrder": "Previous order",
   "orderDetail.pagination.nextOrder": "Next order",
+  "orderDetail.pagination.fetchError": "Failed to load orders. Please try again.",
   "orderDetail.paymentMethod": "Payment by {paymentMethod}",
   "orderDetail.customerName": "{firstName} {lastName}",
   "orderDetail.customerAddress": "{city}, {state} {zip}, {country}",

--- a/apps/storefront/src/pages/OrderDetail/components/CursorDetailPagination.test.tsx
+++ b/apps/storefront/src/pages/OrderDetail/components/CursorDetailPagination.test.tsx
@@ -1,0 +1,315 @@
+import {
+  graphql,
+  HttpResponse,
+  renderWithProviders,
+  screen,
+  startMockServer,
+  waitFor,
+} from 'tests/test-utils';
+
+import { CursorDetailPagination } from '@/pages/OrderDetail/components/CursorDetailPagination';
+import type { CursorLocationState } from '@/pages/OrderDetail/components/CursorDetailPagination';
+import { OrdersSortInput } from '@/shared/service/bc/graphql/orders';
+
+const { server } = startMockServer();
+
+// ---------------------------------------------------------------------------
+// MSW response builders
+// ---------------------------------------------------------------------------
+
+function makeCustomerPage(
+  orders: Array<{ orderId: number; cursor: string }>,
+  hasNext = false,
+  hasPrev = false,
+) {
+  return {
+    data: {
+      customer: {
+        orders: {
+          edges: orders.map(({ orderId, cursor }) => ({ node: { entityId: orderId }, cursor })),
+          pageInfo: {
+            hasNextPage: hasNext,
+            hasPreviousPage: hasPrev,
+            startCursor: null,
+            endCursor: null,
+          },
+        },
+      },
+    },
+  };
+}
+
+function makeCompanyPage(
+  orders: Array<{ orderId: number; cursor: string }>,
+  hasNext = false,
+  hasPrev = false,
+) {
+  return {
+    data: {
+      customer: {
+        activeCompany: {
+          orders: {
+            edges: orders.map(({ orderId, cursor }) => ({ node: { entityId: orderId }, cursor })),
+            pageInfo: {
+              hasNextPage: hasNext,
+              hasPreviousPage: hasPrev,
+              startCursor: null,
+              endCursor: null,
+            },
+            collectionInfo: null,
+          },
+        },
+      },
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Base state: 3 orders on the page, current is the middle one (index 1)
+// ---------------------------------------------------------------------------
+
+const BASE_ORDERS = [
+  { orderId: '100', cursor: 'cursor-100' },
+  { orderId: '101', cursor: 'cursor-101' },
+  { orderId: '102', cursor: 'cursor-102' },
+];
+
+const BASE_STATE: CursorLocationState = {
+  isCompanyOrder: false,
+  currentIndex: 1,
+  orders: BASE_ORDERS,
+  pageInfo: { hasNextPage: true, hasPreviousPage: true },
+  filters: {},
+  sortBy: OrdersSortInput.CREATED_AT_NEWEST,
+};
+
+function renderComponent(state: CursorLocationState | null, onChange = vi.fn()) {
+  return renderWithProviders(<CursorDetailPagination onChange={onChange} color="#000000" />, {
+    initialEntries: state ? [{ pathname: '/orderDetail/101', state }] : ['/orderDetail/101'],
+  });
+}
+
+const getPrevButton = () => screen.getByRole('button', { name: /previous order/i });
+const getNextButton = () => screen.getByRole('button', { name: /next order/i });
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('CursorDetailPagination', () => {
+  describe('when there is no cursor state (e.g. direct URL navigation)', () => {
+    it('renders nothing', () => {
+      const { result } = renderComponent(null);
+      expect(result.container).toBeEmptyDOMElement();
+    });
+  });
+
+  describe('when cursor state is present', () => {
+    it('renders a navigation landmark with two buttons', () => {
+      renderComponent(BASE_STATE);
+      expect(screen.getByRole('navigation')).toBeInTheDocument();
+      expect(getPrevButton()).toBeInTheDocument();
+      expect(getNextButton()).toBeInTheDocument();
+    });
+
+    describe('initial button enabled/disabled states', () => {
+      it('enables both buttons when in the middle of the page', () => {
+        renderComponent(BASE_STATE);
+        expect(getPrevButton()).not.toBeDisabled();
+        expect(getNextButton()).not.toBeDisabled();
+      });
+
+      it('disables prev when on the first item and hasPreviousPage is false', () => {
+        renderComponent({
+          ...BASE_STATE,
+          currentIndex: 0,
+          pageInfo: { hasNextPage: true, hasPreviousPage: false },
+        });
+        expect(getPrevButton()).toBeDisabled();
+        expect(getNextButton()).not.toBeDisabled();
+      });
+
+      it('disables next when on the last item and hasNextPage is false', () => {
+        renderComponent({
+          ...BASE_STATE,
+          currentIndex: 2,
+          pageInfo: { hasNextPage: false, hasPreviousPage: true },
+        });
+        expect(getPrevButton()).not.toBeDisabled();
+        expect(getNextButton()).toBeDisabled();
+      });
+
+      it('enables prev when on the first item but hasPreviousPage is true (page boundary)', () => {
+        renderComponent({
+          ...BASE_STATE,
+          currentIndex: 0,
+          pageInfo: { hasNextPage: false, hasPreviousPage: true },
+        });
+        expect(getPrevButton()).not.toBeDisabled();
+      });
+
+      it('enables next when on the last item but hasNextPage is true (page boundary)', () => {
+        renderComponent({
+          ...BASE_STATE,
+          currentIndex: 2,
+          pageInfo: { hasNextPage: true, hasPreviousPage: false },
+        });
+        expect(getNextButton()).not.toBeDisabled();
+      });
+    });
+
+    describe('in-page navigation (zero API calls)', () => {
+      it('calls onChange with the previous orderId', async () => {
+        const onChange = vi.fn();
+        const { user } = renderComponent(BASE_STATE, onChange);
+        await user.click(getPrevButton());
+        expect(onChange).toHaveBeenCalledExactlyOnceWith('100');
+      });
+
+      it('calls onChange with the next orderId', async () => {
+        const onChange = vi.fn();
+        const { user } = renderComponent(BASE_STATE, onChange);
+        await user.click(getNextButton());
+        expect(onChange).toHaveBeenCalledExactlyOnceWith('102');
+      });
+
+      it('disables prev after navigating back to the first item with no previous page', async () => {
+        const { user } = renderComponent({
+          ...BASE_STATE,
+          currentIndex: 1,
+          orders: BASE_ORDERS.slice(0, 2),
+          pageInfo: { hasNextPage: false, hasPreviousPage: false },
+        });
+        await user.click(getPrevButton());
+        expect(getPrevButton()).toBeDisabled();
+      });
+
+      it('disables next after navigating forward to the last item with no next page', async () => {
+        const { user } = renderComponent({
+          ...BASE_STATE,
+          currentIndex: 1,
+          orders: BASE_ORDERS.slice(1, 3),
+          pageInfo: { hasNextPage: false, hasPreviousPage: false },
+        });
+        await user.click(getNextButton());
+        expect(getNextButton()).toBeDisabled();
+      });
+    });
+
+    describe('page boundary navigation', () => {
+      it('lands on the last item of the fetched previous page', async () => {
+        server.use(
+          graphql.query('GetCustomerOrders', () =>
+            HttpResponse.json(
+              makeCustomerPage([
+                { orderId: 98, cursor: 'cursor-98' },
+                { orderId: 99, cursor: 'cursor-99' },
+              ]),
+            ),
+          ),
+        );
+        const onChange = vi.fn();
+        const { user } = renderComponent({
+          ...BASE_STATE,
+          currentIndex: 0,
+          pageInfo: { hasNextPage: false, hasPreviousPage: true },
+        }, onChange);
+        await user.click(getPrevButton());
+        await waitFor(() => expect(onChange).toHaveBeenCalledExactlyOnceWith('99'));
+      });
+
+      it('lands on the first item of the fetched next page', async () => {
+        server.use(
+          graphql.query('GetCustomerOrders', () =>
+            HttpResponse.json(
+              makeCustomerPage([
+                { orderId: 103, cursor: 'cursor-103' },
+                { orderId: 104, cursor: 'cursor-104' },
+              ]),
+            ),
+          ),
+        );
+        const onChange = vi.fn();
+        const { user } = renderComponent({
+          ...BASE_STATE,
+          currentIndex: 2,
+          pageInfo: { hasNextPage: true, hasPreviousPage: false },
+        }, onChange);
+        await user.click(getNextButton());
+        await waitFor(() => expect(onChange).toHaveBeenCalledExactlyOnceWith('103'));
+      });
+
+      it('passes last:pageSize before:firstCursor when fetching the previous page', async () => {
+        let capturedVariables: Record<string, unknown> = {};
+        server.use(
+          graphql.query('GetCustomerOrders', ({ variables }) => {
+            capturedVariables = variables;
+            return HttpResponse.json(makeCustomerPage([{ orderId: 99, cursor: 'cursor-99' }]));
+          }),
+        );
+        const { user } = renderComponent({
+          ...BASE_STATE,
+          currentIndex: 0,
+          pageInfo: { hasNextPage: false, hasPreviousPage: true },
+        });
+        await user.click(getPrevButton());
+        await waitFor(() =>
+          expect(capturedVariables).toMatchObject({
+            last: BASE_ORDERS.length,
+            before: 'cursor-100',
+          }),
+        );
+      });
+
+      it('passes first:pageSize after:lastCursor when fetching the next page', async () => {
+        let capturedVariables: Record<string, unknown> = {};
+        server.use(
+          graphql.query('GetCustomerOrders', ({ variables }) => {
+            capturedVariables = variables;
+            return HttpResponse.json(makeCustomerPage([{ orderId: 103, cursor: 'cursor-103' }]));
+          }),
+        );
+        const { user } = renderComponent({
+          ...BASE_STATE,
+          currentIndex: 2,
+          pageInfo: { hasNextPage: true, hasPreviousPage: false },
+        });
+        await user.click(getNextButton());
+        await waitFor(() =>
+          expect(capturedVariables).toMatchObject({
+            first: BASE_ORDERS.length,
+            after: 'cursor-102',
+          }),
+        );
+      });
+    });
+
+    describe('company order path', () => {
+      it('uses GetCompanyOrders (not GetCustomerOrders) when isCompanyOrder is true', async () => {
+        let customerCalls = 0;
+        let companyCalls = 0;
+        server.use(
+          graphql.query('GetCompanyOrders', () => {
+            companyCalls++;
+            return HttpResponse.json(makeCompanyPage([{ orderId: 103, cursor: 'cursor-103' }]));
+          }),
+          graphql.query('GetCustomerOrders', () => {
+            customerCalls++;
+            return HttpResponse.json(makeCustomerPage([{ orderId: 103, cursor: 'cursor-103' }]));
+          }),
+        );
+        const { user } = renderComponent({
+          ...BASE_STATE,
+          isCompanyOrder: true,
+          currentIndex: 2,
+          pageInfo: { hasNextPage: true, hasPreviousPage: false },
+        });
+        await user.click(getNextButton());
+        await waitFor(() => {
+          expect(companyCalls).toBe(1);
+          expect(customerCalls).toBe(0);
+        });
+      });
+    });
+  });
+});

--- a/apps/storefront/src/pages/OrderDetail/components/CursorDetailPagination.test.tsx
+++ b/apps/storefront/src/pages/OrderDetail/components/CursorDetailPagination.test.tsx
@@ -104,7 +104,7 @@ describe('CursorDetailPagination', () => {
   describe('when cursor state is present', () => {
     it('renders a navigation landmark with two buttons', () => {
       renderComponent(BASE_STATE);
-      expect(screen.getByRole('navigation')).toBeInTheDocument();
+      expect(screen.getByRole('navigation', { name: /order navigation/i })).toBeInTheDocument();
       expect(getPrevButton()).toBeInTheDocument();
       expect(getNextButton()).toBeInTheDocument();
     });

--- a/apps/storefront/src/pages/OrderDetail/components/CursorDetailPagination.test.tsx
+++ b/apps/storefront/src/pages/OrderDetail/components/CursorDetailPagination.test.tsx
@@ -91,6 +91,11 @@ describe('CursorDetailPagination', () => {
       const { result } = renderComponent(null);
       expect(result.container).toBeEmptyDOMElement();
     });
+
+    it('renders nothing when orders is an empty array', () => {
+      const { result } = renderComponent({ ...BASE_STATE, orders: [], currentIndex: 0 });
+      expect(result.container).toBeEmptyDOMElement();
+    });
   });
 
   describe('when cursor state is present', () => {
@@ -248,6 +253,46 @@ describe('CursorDetailPagination', () => {
             first: BASE_ORDERS.length,
             after: 'cursor-102',
           });
+        });
+      });
+
+      it('disables prev when the boundary fetch returns no orders', async () => {
+        server.use(
+          graphql.query('GetCustomerOrders', () => HttpResponse.json(makeCustomerPage([]))),
+        );
+        const onChange = vi.fn();
+        const { user } = renderComponent(
+          {
+            ...BASE_STATE,
+            currentIndex: 0,
+            pageInfo: { hasNextPage: false, hasPreviousPage: true },
+          },
+          onChange,
+        );
+        await user.click(getPrevButton());
+        await waitFor(() => {
+          expect(onChange).not.toHaveBeenCalled();
+          expect(getPrevButton()).toBeDisabled();
+        });
+      });
+
+      it('disables next when the boundary fetch returns no orders', async () => {
+        server.use(
+          graphql.query('GetCustomerOrders', () => HttpResponse.json(makeCustomerPage([]))),
+        );
+        const onChange = vi.fn();
+        const { user } = renderComponent(
+          {
+            ...BASE_STATE,
+            currentIndex: 2,
+            pageInfo: { hasNextPage: true, hasPreviousPage: false },
+          },
+          onChange,
+        );
+        await user.click(getNextButton());
+        await waitFor(() => {
+          expect(onChange).not.toHaveBeenCalled();
+          expect(getNextButton()).toBeDisabled();
         });
       });
     });

--- a/apps/storefront/src/pages/OrderDetail/components/CursorDetailPagination.test.tsx
+++ b/apps/storefront/src/pages/OrderDetail/components/CursorDetailPagination.test.tsx
@@ -67,6 +67,8 @@ const BASE_ORDERS = [
   { orderId: '102', cursor: 'cursor-102' },
 ];
 
+const LIST_PAGE_SIZE = 10;
+
 const BASE_STATE: CursorLocationState = {
   isCompanyOrder: false,
   currentIndex: 1,
@@ -74,6 +76,7 @@ const BASE_STATE: CursorLocationState = {
   pageInfo: { hasNextPage: true, hasPreviousPage: true },
   filters: {},
   sortBy: OrdersSortInput.CREATED_AT_NEWEST,
+  pageSize: LIST_PAGE_SIZE,
 };
 
 function renderComponent(state: CursorLocationState | null, onChange = vi.fn()) {
@@ -218,7 +221,7 @@ describe('CursorDetailPagination', () => {
         await waitFor(() => {
           expect(onChange).toHaveBeenCalledExactlyOnceWith('99');
           expect(capturedVariables).toMatchObject({
-            last: BASE_ORDERS.length,
+            last: LIST_PAGE_SIZE,
             before: 'cursor-100',
           });
         });
@@ -250,7 +253,7 @@ describe('CursorDetailPagination', () => {
         await waitFor(() => {
           expect(onChange).toHaveBeenCalledExactlyOnceWith('103');
           expect(capturedVariables).toMatchObject({
-            first: BASE_ORDERS.length,
+            first: LIST_PAGE_SIZE,
             after: 'cursor-102',
           });
         });

--- a/apps/storefront/src/pages/OrderDetail/components/CursorDetailPagination.test.tsx
+++ b/apps/storefront/src/pages/OrderDetail/components/CursorDetailPagination.test.tsx
@@ -60,15 +60,15 @@ function makeCompanyPage(
   };
 }
 
-// Base state: 3 orders on the page, current is the middle one (index 1)
+const LIST_PAGE_SIZE = 10;
+
 const BASE_ORDERS = [
   { orderId: '100', cursor: 'cursor-100' },
   { orderId: '101', cursor: 'cursor-101' },
   { orderId: '102', cursor: 'cursor-102' },
 ];
 
-const LIST_PAGE_SIZE = 10;
-
+// Base state: 3 orders on the page, current is the middle one (index 1)
 const BASE_STATE: CursorLocationState = {
   isCompanyOrder: false,
   currentIndex: 1,
@@ -296,6 +296,68 @@ describe('CursorDetailPagination', () => {
         await waitFor(() => {
           expect(onChange).not.toHaveBeenCalled();
           expect(getNextButton()).toBeDisabled();
+        });
+      });
+
+      it('keeps prev enabled when a boundary fetch fails so the user can retry', async () => {
+        let callCount = 0;
+        server.use(
+          graphql.query('GetCustomerOrders', () => {
+            callCount += 1;
+            if (callCount === 1) {
+              return HttpResponse.error();
+            }
+            return HttpResponse.json(makeCustomerPage([{ orderId: 99, cursor: 'cursor-99' }]));
+          }),
+        );
+        const onChange = vi.fn();
+        const { user } = renderComponent(
+          {
+            ...BASE_STATE,
+            currentIndex: 0,
+            pageInfo: { hasNextPage: false, hasPreviousPage: true },
+          },
+          onChange,
+        );
+        await user.click(getPrevButton());
+        await waitFor(() => {
+          expect(onChange).not.toHaveBeenCalled();
+          expect(getPrevButton()).not.toBeDisabled();
+        });
+        await user.click(getPrevButton());
+        await waitFor(() => {
+          expect(onChange).toHaveBeenCalledExactlyOnceWith('99');
+        });
+      });
+
+      it('keeps next enabled when a boundary fetch fails so the user can retry', async () => {
+        let callCount = 0;
+        server.use(
+          graphql.query('GetCustomerOrders', () => {
+            callCount += 1;
+            if (callCount === 1) {
+              return HttpResponse.error();
+            }
+            return HttpResponse.json(makeCustomerPage([{ orderId: 103, cursor: 'cursor-103' }]));
+          }),
+        );
+        const onChange = vi.fn();
+        const { user } = renderComponent(
+          {
+            ...BASE_STATE,
+            currentIndex: 2,
+            pageInfo: { hasNextPage: true, hasPreviousPage: false },
+          },
+          onChange,
+        );
+        await user.click(getNextButton());
+        await waitFor(() => {
+          expect(onChange).not.toHaveBeenCalled();
+          expect(getNextButton()).not.toBeDisabled();
+        });
+        await user.click(getNextButton());
+        await waitFor(() => {
+          expect(onChange).toHaveBeenCalledExactlyOnceWith('103');
         });
       });
     });

--- a/apps/storefront/src/pages/OrderDetail/components/CursorDetailPagination.test.tsx
+++ b/apps/storefront/src/pages/OrderDetail/components/CursorDetailPagination.test.tsx
@@ -7,15 +7,11 @@ import {
   waitFor,
 } from 'tests/test-utils';
 
-import { CursorDetailPagination } from '@/pages/OrderDetail/components/CursorDetailPagination';
 import type { CursorLocationState } from '@/pages/OrderDetail/components/CursorDetailPagination';
+import { CursorDetailPagination } from '@/pages/OrderDetail/components/CursorDetailPagination';
 import { OrdersSortInput } from '@/shared/service/bc/graphql/orders';
 
 const { server } = startMockServer();
-
-// ---------------------------------------------------------------------------
-// MSW response builders
-// ---------------------------------------------------------------------------
 
 function makeCustomerPage(
   orders: Array<{ orderId: number; cursor: string }>,
@@ -64,10 +60,7 @@ function makeCompanyPage(
   };
 }
 
-// ---------------------------------------------------------------------------
 // Base state: 3 orders on the page, current is the middle one (index 1)
-// ---------------------------------------------------------------------------
-
 const BASE_ORDERS = [
   { orderId: '100', cursor: 'cursor-100' },
   { orderId: '101', cursor: 'cursor-101' },
@@ -91,10 +84,6 @@ function renderComponent(state: CursorLocationState | null, onChange = vi.fn()) 
 
 const getPrevButton = () => screen.getByRole('button', { name: /previous order/i });
 const getNextButton = () => screen.getByRole('button', { name: /next order/i });
-
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
 
 describe('CursorDetailPagination', () => {
   describe('when there is no cursor state (e.g. direct URL navigation)', () => {
@@ -187,100 +176,79 @@ describe('CursorDetailPagination', () => {
       it('disables next after navigating forward to the last item with no next page', async () => {
         const { user } = renderComponent({
           ...BASE_STATE,
-          currentIndex: 1,
+          currentIndex: 0,
           orders: BASE_ORDERS.slice(1, 3),
           pageInfo: { hasNextPage: false, hasPreviousPage: false },
         });
+        expect(getNextButton()).not.toBeDisabled();
         await user.click(getNextButton());
         expect(getNextButton()).toBeDisabled();
       });
     });
 
     describe('page boundary navigation', () => {
-      it('lands on the last item of the fetched previous page', async () => {
+      it('fetches the previous page with correct variables and lands on its last item', async () => {
+        let capturedVariables: Record<string, unknown> = {};
         server.use(
-          graphql.query('GetCustomerOrders', () =>
-            HttpResponse.json(
+          graphql.query('GetCustomerOrders', ({ variables }) => {
+            capturedVariables = variables;
+            return HttpResponse.json(
               makeCustomerPage([
                 { orderId: 98, cursor: 'cursor-98' },
                 { orderId: 99, cursor: 'cursor-99' },
               ]),
-            ),
-          ),
+            );
+          }),
         );
         const onChange = vi.fn();
-        const { user } = renderComponent({
-          ...BASE_STATE,
-          currentIndex: 0,
-          pageInfo: { hasNextPage: false, hasPreviousPage: true },
-        }, onChange);
+        const { user } = renderComponent(
+          {
+            ...BASE_STATE,
+            currentIndex: 0,
+            pageInfo: { hasNextPage: false, hasPreviousPage: true },
+          },
+          onChange,
+        );
         await user.click(getPrevButton());
-        await waitFor(() => expect(onChange).toHaveBeenCalledExactlyOnceWith('99'));
+        await waitFor(() => {
+          expect(onChange).toHaveBeenCalledExactlyOnceWith('99');
+          expect(capturedVariables).toMatchObject({
+            last: BASE_ORDERS.length,
+            before: 'cursor-100',
+          });
+        });
       });
 
-      it('lands on the first item of the fetched next page', async () => {
+      it('fetches the next page with correct variables and lands on its first item', async () => {
+        let capturedVariables: Record<string, unknown> = {};
         server.use(
-          graphql.query('GetCustomerOrders', () =>
-            HttpResponse.json(
+          graphql.query('GetCustomerOrders', ({ variables }) => {
+            capturedVariables = variables;
+            return HttpResponse.json(
               makeCustomerPage([
                 { orderId: 103, cursor: 'cursor-103' },
                 { orderId: 104, cursor: 'cursor-104' },
               ]),
-            ),
-          ),
+            );
+          }),
         );
         const onChange = vi.fn();
-        const { user } = renderComponent({
-          ...BASE_STATE,
-          currentIndex: 2,
-          pageInfo: { hasNextPage: true, hasPreviousPage: false },
-        }, onChange);
+        const { user } = renderComponent(
+          {
+            ...BASE_STATE,
+            currentIndex: 2,
+            pageInfo: { hasNextPage: true, hasPreviousPage: false },
+          },
+          onChange,
+        );
         await user.click(getNextButton());
-        await waitFor(() => expect(onChange).toHaveBeenCalledExactlyOnceWith('103'));
-      });
-
-      it('passes last:pageSize before:firstCursor when fetching the previous page', async () => {
-        let capturedVariables: Record<string, unknown> = {};
-        server.use(
-          graphql.query('GetCustomerOrders', ({ variables }) => {
-            capturedVariables = variables;
-            return HttpResponse.json(makeCustomerPage([{ orderId: 99, cursor: 'cursor-99' }]));
-          }),
-        );
-        const { user } = renderComponent({
-          ...BASE_STATE,
-          currentIndex: 0,
-          pageInfo: { hasNextPage: false, hasPreviousPage: true },
-        });
-        await user.click(getPrevButton());
-        await waitFor(() =>
-          expect(capturedVariables).toMatchObject({
-            last: BASE_ORDERS.length,
-            before: 'cursor-100',
-          }),
-        );
-      });
-
-      it('passes first:pageSize after:lastCursor when fetching the next page', async () => {
-        let capturedVariables: Record<string, unknown> = {};
-        server.use(
-          graphql.query('GetCustomerOrders', ({ variables }) => {
-            capturedVariables = variables;
-            return HttpResponse.json(makeCustomerPage([{ orderId: 103, cursor: 'cursor-103' }]));
-          }),
-        );
-        const { user } = renderComponent({
-          ...BASE_STATE,
-          currentIndex: 2,
-          pageInfo: { hasNextPage: true, hasPreviousPage: false },
-        });
-        await user.click(getNextButton());
-        await waitFor(() =>
+        await waitFor(() => {
+          expect(onChange).toHaveBeenCalledExactlyOnceWith('103');
           expect(capturedVariables).toMatchObject({
             first: BASE_ORDERS.length,
             after: 'cursor-102',
-          }),
-        );
+          });
+        });
       });
     });
 
@@ -290,11 +258,11 @@ describe('CursorDetailPagination', () => {
         let companyCalls = 0;
         server.use(
           graphql.query('GetCompanyOrders', () => {
-            companyCalls++;
+            companyCalls += 1;
             return HttpResponse.json(makeCompanyPage([{ orderId: 103, cursor: 'cursor-103' }]));
           }),
           graphql.query('GetCustomerOrders', () => {
-            customerCalls++;
+            customerCalls += 1;
             return HttpResponse.json(makeCustomerPage([{ orderId: 103, cursor: 'cursor-103' }]));
           }),
         );

--- a/apps/storefront/src/pages/OrderDetail/components/CursorDetailPagination.tsx
+++ b/apps/storefront/src/pages/OrderDetail/components/CursorDetailPagination.tsx
@@ -210,7 +210,11 @@ export function CursorDetailPagination({ onChange, color }: CursorDetailPaginati
   if (!init?.orders?.length) return null;
 
   return (
-    <Box role="navigation" sx={{ display: 'flex', color }}>
+    <Box
+      role="navigation"
+      aria-label={b3Lang('orderDetail.pagination.orderNavigation')}
+      sx={{ display: 'flex', color }}
+    >
       <IconButton
         aria-label={b3Lang('orderDetail.pagination.previousOrder')}
         onClick={handlePrev}

--- a/apps/storefront/src/pages/OrderDetail/components/CursorDetailPagination.tsx
+++ b/apps/storefront/src/pages/OrderDetail/components/CursorDetailPagination.tsx
@@ -16,7 +16,7 @@ import {
   OrdersSortInput,
 } from '@/shared/service/bc/graphql/orders';
 
-export interface OrderPageItem {
+interface OrderPageItem {
   orderId: string;
   cursor: string;
 }
@@ -150,6 +150,19 @@ export function CursorDetailPagination({ onChange, color }: CursorDetailPaginati
     [init, navigate],
   );
 
+  /** No adjacent page found, then stop offering that direction and persist in history. */
+  const exhaustBoundary = useCallback(
+    (direction: 'prev' | 'next') => {
+      const newPageInfo =
+        direction === 'prev'
+          ? { ...pageInfo, hasPreviousPage: false }
+          : { ...pageInfo, hasNextPage: false };
+      setPageInfo(newPageInfo);
+      syncHistory(orders, currentIndex, newPageInfo);
+    },
+    [pageInfo, orders, currentIndex, syncHistory],
+  );
+
   const handlePrev = useCallback(async () => {
     if (!hasPrev || loading || !init) return;
     setLoading(true);
@@ -177,12 +190,28 @@ export function CursorDetailPagination({ onChange, color }: CursorDetailPaginati
           setPageInfo(page.pageInfo);
           onChange(page.orders[newIndex].orderId);
           syncHistory(page.orders, newIndex, page.pageInfo);
+        } else {
+          exhaustBoundary('prev');
         }
+      }
+    } catch {
+      if (currentIndex === 0) {
+        exhaustBoundary('prev');
       }
     } finally {
       setLoading(false);
     }
-  }, [hasPrev, loading, init, currentIndex, orders, pageInfo, onChange, syncHistory]);
+  }, [
+    hasPrev,
+    loading,
+    init,
+    currentIndex,
+    orders,
+    pageInfo,
+    onChange,
+    syncHistory,
+    exhaustBoundary,
+  ]);
 
   const handleNext = useCallback(async () => {
     if (!hasNext || loading || !init) return;
@@ -210,16 +239,32 @@ export function CursorDetailPagination({ onChange, color }: CursorDetailPaginati
           setPageInfo(page.pageInfo);
           onChange(page.orders[0].orderId);
           syncHistory(page.orders, 0, page.pageInfo);
+        } else {
+          exhaustBoundary('next');
         }
+      }
+    } catch {
+      if (currentIndex === orders.length - 1) {
+        exhaustBoundary('next');
       }
     } finally {
       setLoading(false);
     }
-  }, [hasNext, loading, init, currentIndex, orders, pageInfo, onChange, syncHistory]);
+  }, [
+    hasNext,
+    loading,
+    init,
+    currentIndex,
+    orders,
+    pageInfo,
+    onChange,
+    syncHistory,
+    exhaustBoundary,
+  ]);
 
   // Graceful degradation: hide when there is no cached page context
-  // (e.g. the user landed directly on the detail URL without coming from the list).
-  if (!init?.orders) return null;
+  // (e.g. direct URL access, missing cursors, or an empty list page).
+  if (!init?.orders?.length) return null;
 
   return (
     <Box role="navigation" sx={{ display: 'flex', color }}>

--- a/apps/storefront/src/pages/OrderDetail/components/CursorDetailPagination.tsx
+++ b/apps/storefront/src/pages/OrderDetail/components/CursorDetailPagination.tsx
@@ -15,6 +15,7 @@ import {
   OrdersFiltersInput,
   OrdersSortInput,
 } from '@/shared/service/bc/graphql/orders';
+import { snackbar } from '@/utils/b3Tip';
 
 import {
   type CursorItem,
@@ -62,7 +63,7 @@ async function fetchAdjacentPage(
   isCompanyOrder: boolean,
   filters: OrdersFiltersInput | CompanyOrdersFiltersInput,
   sortBy: OrdersSortInput,
-): Promise<{ items: OrderCursorItem[]; pageInfo: CursorLocationState['pageInfo'] } | null> {
+): Promise<{ items: OrderCursorItem[]; pageInfo: CursorLocationState['pageInfo'] }> {
   const paginationArgs =
     mode === 'before' ? { last: pageSize, before: cursor } : { first: pageSize, after: cursor };
 
@@ -73,21 +74,26 @@ async function fetchAdjacentPage(
       cursor: e.cursor,
     }));
 
+  const toPage = (orders: {
+    edges: { cursor: string; node: { entityId: number } }[];
+    pageInfo: CursorLocationState['pageInfo'];
+  }) => ({
+    items: toItems(orders.edges),
+    pageInfo: {
+      hasNextPage: orders.pageInfo.hasNextPage,
+      hasPreviousPage: orders.pageInfo.hasPreviousPage,
+    },
+  });
+
   if (isCompanyOrder) {
     const result = await getCompanyOrders({
       ...paginationArgs,
       filters: filters as CompanyOrdersFiltersInput,
       sortBy,
     });
-    const connection = result.data?.customer?.activeCompany?.orders;
-    if (!connection) return null;
-    return {
-      items: toItems(connection.edges),
-      pageInfo: {
-        hasNextPage: connection.pageInfo.hasNextPage,
-        hasPreviousPage: connection.pageInfo.hasPreviousPage,
-      },
-    };
+    const orders = result.data?.customer?.activeCompany?.orders;
+    if (!orders) throw new Error('Unexpected API response: orders missing');
+    return toPage(orders);
   }
 
   const result = await getCustomerOrders({
@@ -95,15 +101,9 @@ async function fetchAdjacentPage(
     filters: filters as OrdersFiltersInput,
     sortBy,
   });
-  const connection = result.data?.customer?.orders;
-  if (!connection) return null;
-  return {
-    items: toItems(connection.edges),
-    pageInfo: {
-      hasNextPage: connection.pageInfo.hasNextPage,
-      hasPreviousPage: connection.pageInfo.hasPreviousPage,
-    },
-  };
+  const orders = result.data?.customer?.orders;
+  if (!orders) throw new Error('Unexpected API response: orders missing');
+  return toPage(orders);
 }
 
 interface CursorDetailPaginationProps {
@@ -134,18 +134,23 @@ export function CursorDetailPagination({ onChange, color }: CursorDetailPaginati
   }));
 
   const fetchPage = useCallback(
-    (mode: 'before' | 'after', cursor: string) => {
-      if (!init) return Promise.resolve(null);
-      return fetchAdjacentPage(
-        mode,
-        cursor,
-        init.pageSize,
-        init.isCompanyOrder,
-        init.filters,
-        init.sortBy,
-      );
+    async (mode: 'before' | 'after', cursor: string) => {
+      if (!init) return null;
+      try {
+        return await fetchAdjacentPage(
+          mode,
+          cursor,
+          init.pageSize,
+          init.isCompanyOrder,
+          init.filters,
+          init.sortBy,
+        );
+      } catch (error) {
+        snackbar.error(b3Lang('orderDetail.pagination.fetchError'));
+        throw error; // re-throw so the hook leaves pageInfo unchanged and the user can retry
+      }
     },
-    [init],
+    [init, b3Lang],
   );
 
   const buildHistoryState = useCallback(

--- a/apps/storefront/src/pages/OrderDetail/components/CursorDetailPagination.tsx
+++ b/apps/storefront/src/pages/OrderDetail/components/CursorDetailPagination.tsx
@@ -16,22 +16,11 @@ import {
   OrdersSortInput,
 } from '@/shared/service/bc/graphql/orders';
 
-// ===========================================================================
-// Types
-// ===========================================================================
-
 export interface OrderPageItem {
   orderId: string;
   cursor: string;
 }
 
-/**
- * Navigation state written by `Order.tsx#goToDetail` and consumed here.
- * The presence of `orders` distinguishes this shape from the legacy
- * offset-based state checked in `DetailPagination`.
- *
- * Export so callers (Order.tsx) can type their navigate() state arg.
- */
 export interface CursorLocationState {
   isCompanyOrder: boolean;
   /** Index of the current order within `orders`. */
@@ -48,10 +37,6 @@ export interface CursorLocationState {
   sortBy: OrdersSortInput;
 }
 
-// ===========================================================================
-// Module-level helper
-// ===========================================================================
-
 /**
  * Fetches a full adjacent page in the given direction relative to `cursor`.
  * `mode: 'before'` → the previous page; `mode: 'after'` → the next page.
@@ -66,9 +51,7 @@ async function fetchAdjacentPage(
   sortBy: OrdersSortInput,
 ): Promise<{ orders: OrderPageItem[]; pageInfo: CursorLocationState['pageInfo'] } | null> {
   const paginationArgs =
-    mode === 'before'
-      ? { last: pageSize, before: cursor }
-      : { first: pageSize, after: cursor };
+    mode === 'before' ? { last: pageSize, before: cursor } : { first: pageSize, after: cursor };
 
   if (isCompanyOrder) {
     const result = await getCompanyOrders({
@@ -119,7 +102,7 @@ interface CursorDetailPaginationProps {
 }
 
 /**
- * Prev/Next order navigation for the unified SF GQL path (B2B-4629).
+ * Prev/Next order navigation for the unified SF GQL path.
  *
  * Caches the full list page passed from the list view. Within-page navigation
  * is instant (zero API calls). Page-boundary navigation fetches one new page
@@ -134,7 +117,6 @@ export function CursorDetailPagination({ onChange, color }: CursorDetailPaginati
   const navigate = useNavigate();
   const init = location.state as CursorLocationState | null;
 
-  // All hooks must run unconditionally before the null guard at the bottom.
   const [orders, setOrders] = useState<OrderPageItem[]>(init?.orders ?? []);
   const [currentIndex, setCurrentIndex] = useState(init?.currentIndex ?? 0);
   const [pageInfo, setPageInfo] = useState(
@@ -147,7 +129,11 @@ export function CursorDetailPagination({ onChange, color }: CursorDetailPaginati
 
   /** Writes the current navigation state into the history entry. */
   const syncHistory = useCallback(
-    (newOrders: OrderPageItem[], newIndex: number, newPageInfo: CursorLocationState['pageInfo']) => {
+    (
+      newOrders: OrderPageItem[],
+      newIndex: number,
+      newPageInfo: CursorLocationState['pageInfo'],
+    ) => {
       if (!init) return;
       navigate(`/orderDetail/${newOrders[newIndex].orderId}`, {
         replace: true,

--- a/apps/storefront/src/pages/OrderDetail/components/CursorDetailPagination.tsx
+++ b/apps/storefront/src/pages/OrderDetail/components/CursorDetailPagination.tsx
@@ -193,9 +193,7 @@ export function CursorDetailPagination({ onChange, color }: CursorDetailPaginati
         }
       }
     } catch {
-      if (currentIndex === 0) {
-        exhaustBoundary('prev');
-      }
+      // Boundary fetch failed (e.g. network) - leave pageInfo unchanged so the user can retry.
     } finally {
       setLoading(false);
     }
@@ -242,9 +240,7 @@ export function CursorDetailPagination({ onChange, color }: CursorDetailPaginati
         }
       }
     } catch {
-      if (currentIndex === orders.length - 1) {
-        exhaustBoundary('next');
-      }
+      // Boundary fetch failed (e.g. network) — leave pageInfo unchanged so the user can retry.
     } finally {
       setLoading(false);
     }

--- a/apps/storefront/src/pages/OrderDetail/components/CursorDetailPagination.tsx
+++ b/apps/storefront/src/pages/OrderDetail/components/CursorDetailPagination.tsx
@@ -154,16 +154,17 @@ export function CursorDetailPagination({ onChange, color }: CursorDetailPaginati
   );
 
   const buildHistoryState = useCallback(
-    (index: number, items: CursorItem[], pageInfo: CursorPageInfo): CursorLocationState => {
+    (index: number, items: CursorItem[], pageInfo: CursorPageInfo): CursorLocationState | null => {
+      if (!init) return null;
       const orderItems = items as OrderCursorItem[];
       return {
-        isCompanyOrder: init!.isCompanyOrder,
+        isCompanyOrder: init.isCompanyOrder,
         currentIndex: index,
         orders: orderItems.map(({ orderId, cursor }) => ({ orderId, cursor })),
         pageInfo,
-        filters: init!.filters,
-        sortBy: init!.sortBy,
-        pageSize: init!.pageSize,
+        filters: init.filters,
+        sortBy: init.sortBy,
+        pageSize: init.pageSize,
       };
     },
     [init],
@@ -171,26 +172,28 @@ export function CursorDetailPagination({ onChange, color }: CursorDetailPaginati
 
   const onNavigate = useCallback(
     (item: CursorItem, index: number, items: CursorItem[], pageInfo: CursorPageInfo) => {
-      if (!init) return;
+      const nextState = buildHistoryState(index, items, pageInfo);
+      if (!nextState) return;
       onChange(item.id);
       navigate(`/orderDetail/${item.id}`, {
         replace: true,
-        state: buildHistoryState(index, items, pageInfo),
+        state: nextState,
       });
     },
-    [init, navigate, onChange, buildHistoryState],
+    [navigate, onChange, buildHistoryState],
   );
 
   const onSyncHistory = useCallback(
     (index: number, items: CursorItem[], pageInfo: CursorPageInfo) => {
-      if (!init) return;
+      const nextState = buildHistoryState(index, items, pageInfo);
+      if (!nextState) return;
       // Boundary exhausted — current item unchanged, only pageInfo needs persisting.
       navigate(location.pathname, {
         replace: true,
-        state: buildHistoryState(index, items, pageInfo),
+        state: nextState,
       });
     },
-    [init, navigate, location.pathname, buildHistoryState],
+    [navigate, location.pathname, buildHistoryState],
   );
 
   const { hasPrev, hasNext, loading, handlePrev, handleNext } = useCursorDetailPagination({

--- a/apps/storefront/src/pages/OrderDetail/components/CursorDetailPagination.tsx
+++ b/apps/storefront/src/pages/OrderDetail/components/CursorDetailPagination.tsx
@@ -1,0 +1,256 @@
+import { useCallback, useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import {
+  NavigateBefore as NavigateBeforeIcon,
+  NavigateNext as NavigateNextIcon,
+} from '@mui/icons-material';
+import { Box } from '@mui/material';
+import IconButton from '@mui/material/IconButton';
+
+import { useB3Lang } from '@/lib/lang';
+import {
+  CompanyOrdersFiltersInput,
+  getCompanyOrders,
+  getCustomerOrders,
+  OrdersFiltersInput,
+  OrdersSortInput,
+} from '@/shared/service/bc/graphql/orders';
+
+// ===========================================================================
+// Types
+// ===========================================================================
+
+export interface OrderPageItem {
+  orderId: string;
+  cursor: string;
+}
+
+/**
+ * Navigation state written by `Order.tsx#goToDetail` and consumed here.
+ * The presence of `orders` distinguishes this shape from the legacy
+ * offset-based state checked in `DetailPagination`.
+ *
+ * Export so callers (Order.tsx) can type their navigate() state arg.
+ */
+export interface CursorLocationState {
+  isCompanyOrder: boolean;
+  /** Index of the current order within `orders`. */
+  currentIndex: number;
+  /** The full page of orders from the list view. */
+  orders: OrderPageItem[];
+  /** Page-level boundary flags from the list view's most recent pageInfo. */
+  pageInfo: {
+    hasNextPage: boolean;
+    hasPreviousPage: boolean;
+  };
+  /** Filter/sort state forwarded from the list view so we query the same result set. */
+  filters: OrdersFiltersInput | CompanyOrdersFiltersInput;
+  sortBy: OrdersSortInput;
+}
+
+// ===========================================================================
+// Module-level helper
+// ===========================================================================
+
+/**
+ * Fetches a full adjacent page in the given direction relative to `cursor`.
+ * `mode: 'before'` → the previous page; `mode: 'after'` → the next page.
+ * Returns the new orders array and updated pageInfo.
+ */
+async function fetchAdjacentPage(
+  mode: 'before' | 'after',
+  cursor: string,
+  pageSize: number,
+  isCompanyOrder: boolean,
+  filters: OrdersFiltersInput | CompanyOrdersFiltersInput,
+  sortBy: OrdersSortInput,
+): Promise<{ orders: OrderPageItem[]; pageInfo: CursorLocationState['pageInfo'] } | null> {
+  const paginationArgs =
+    mode === 'before'
+      ? { last: pageSize, before: cursor }
+      : { first: pageSize, after: cursor };
+
+  if (isCompanyOrder) {
+    const result = await getCompanyOrders({
+      ...paginationArgs,
+      filters: filters as CompanyOrdersFiltersInput,
+      sortBy,
+    });
+    const connection = result.data?.customer?.activeCompany?.orders;
+    if (!connection) return null;
+    return {
+      orders: connection.edges.map((e) => ({
+        orderId: String(e.node.entityId),
+        cursor: e.cursor,
+      })),
+      pageInfo: {
+        hasNextPage: connection.pageInfo.hasNextPage,
+        hasPreviousPage: connection.pageInfo.hasPreviousPage,
+      },
+    };
+  }
+
+  const result = await getCustomerOrders({
+    ...paginationArgs,
+    filters: filters as OrdersFiltersInput,
+    sortBy,
+  });
+  const connection = result.data?.customer?.orders;
+  if (!connection) return null;
+  return {
+    orders: connection.edges.map((e) => ({
+      orderId: String(e.node.entityId),
+      cursor: e.cursor,
+    })),
+    pageInfo: {
+      hasNextPage: connection.pageInfo.hasNextPage,
+      hasPreviousPage: connection.pageInfo.hasPreviousPage,
+    },
+  };
+}
+
+// ===========================================================================
+// Component
+// ===========================================================================
+
+interface CursorDetailPaginationProps {
+  onChange: (id: number | string) => void;
+  color: string;
+}
+
+/**
+ * Prev/Next order navigation for the unified SF GQL path (B2B-4629).
+ *
+ * Caches the full list page passed from the list view. Within-page navigation
+ * is instant (zero API calls). Page-boundary navigation fetches one new page
+ * and lands on the last (prev) or first (next) order of that page.
+ *
+ * Renders nothing when `orders` is absent (e.g. direct URL access with no
+ * list context), satisfying the acceptance criterion for graceful degradation.
+ */
+export function CursorDetailPagination({ onChange, color }: CursorDetailPaginationProps) {
+  const b3Lang = useB3Lang();
+  const location = useLocation();
+  const navigate = useNavigate();
+  const init = location.state as CursorLocationState | null;
+
+  // All hooks must run unconditionally before the null guard at the bottom.
+  const [orders, setOrders] = useState<OrderPageItem[]>(init?.orders ?? []);
+  const [currentIndex, setCurrentIndex] = useState(init?.currentIndex ?? 0);
+  const [pageInfo, setPageInfo] = useState(
+    init?.pageInfo ?? { hasNextPage: false, hasPreviousPage: false },
+  );
+  const [loading, setLoading] = useState(false);
+
+  const hasPrev = currentIndex > 0 || pageInfo.hasPreviousPage;
+  const hasNext = currentIndex < orders.length - 1 || pageInfo.hasNextPage;
+
+  /** Writes the current navigation state into the history entry. */
+  const syncHistory = useCallback(
+    (newOrders: OrderPageItem[], newIndex: number, newPageInfo: CursorLocationState['pageInfo']) => {
+      if (!init) return;
+      navigate(`/orderDetail/${newOrders[newIndex].orderId}`, {
+        replace: true,
+        state: {
+          isCompanyOrder: init.isCompanyOrder,
+          currentIndex: newIndex,
+          orders: newOrders,
+          pageInfo: newPageInfo,
+          filters: init.filters,
+          sortBy: init.sortBy,
+        } satisfies CursorLocationState,
+      });
+    },
+    [init, navigate],
+  );
+
+  const handlePrev = useCallback(async () => {
+    if (!hasPrev || loading || !init) return;
+    setLoading(true);
+    try {
+      if (currentIndex > 0) {
+        // In-page: instant, zero API calls.
+        const newIndex = currentIndex - 1;
+        setCurrentIndex(newIndex);
+        onChange(orders[newIndex].orderId);
+        syncHistory(orders, newIndex, pageInfo);
+      } else {
+        // Page boundary: fetch the previous page and land on its last item.
+        const page = await fetchAdjacentPage(
+          'before',
+          orders[0].cursor,
+          orders.length,
+          init.isCompanyOrder,
+          init.filters,
+          init.sortBy,
+        );
+        if (page && page.orders.length > 0) {
+          const newIndex = page.orders.length - 1;
+          setOrders(page.orders);
+          setCurrentIndex(newIndex);
+          setPageInfo(page.pageInfo);
+          onChange(page.orders[newIndex].orderId);
+          syncHistory(page.orders, newIndex, page.pageInfo);
+        }
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, [hasPrev, loading, init, currentIndex, orders, pageInfo, onChange, syncHistory]);
+
+  const handleNext = useCallback(async () => {
+    if (!hasNext || loading || !init) return;
+    setLoading(true);
+    try {
+      if (currentIndex < orders.length - 1) {
+        // In-page: instant, zero API calls.
+        const newIndex = currentIndex + 1;
+        setCurrentIndex(newIndex);
+        onChange(orders[newIndex].orderId);
+        syncHistory(orders, newIndex, pageInfo);
+      } else {
+        // Page boundary: fetch the next page and land on its first item.
+        const page = await fetchAdjacentPage(
+          'after',
+          orders[orders.length - 1].cursor,
+          orders.length,
+          init.isCompanyOrder,
+          init.filters,
+          init.sortBy,
+        );
+        if (page && page.orders.length > 0) {
+          setOrders(page.orders);
+          setCurrentIndex(0);
+          setPageInfo(page.pageInfo);
+          onChange(page.orders[0].orderId);
+          syncHistory(page.orders, 0, page.pageInfo);
+        }
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, [hasNext, loading, init, currentIndex, orders, pageInfo, onChange, syncHistory]);
+
+  // Graceful degradation: hide when there is no cached page context
+  // (e.g. the user landed directly on the detail URL without coming from the list).
+  if (!init?.orders) return null;
+
+  return (
+    <Box role="navigation" sx={{ display: 'flex', color }}>
+      <IconButton
+        aria-label={b3Lang('orderDetail.pagination.previousOrder')}
+        onClick={handlePrev}
+        disabled={!hasPrev || loading}
+      >
+        <NavigateBeforeIcon sx={{ color }} />
+      </IconButton>
+      <IconButton
+        aria-label={b3Lang('orderDetail.pagination.nextOrder')}
+        onClick={handleNext}
+        disabled={!hasNext || loading}
+      >
+        <NavigateNextIcon sx={{ color }} />
+      </IconButton>
+    </Box>
+  );
+}

--- a/apps/storefront/src/pages/OrderDetail/components/CursorDetailPagination.tsx
+++ b/apps/storefront/src/pages/OrderDetail/components/CursorDetailPagination.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useCallback } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import {
   NavigateBefore as NavigateBeforeIcon,
@@ -16,9 +16,21 @@ import {
   OrdersSortInput,
 } from '@/shared/service/bc/graphql/orders';
 
+import {
+  type CursorItem,
+  type CursorPageInfo,
+  useCursorDetailPagination,
+} from '../useCursorDetailPagination';
+
+/** Shape stored in router history state (no `id` field required from callers). */
 interface OrderPageItem {
   orderId: string;
   cursor: string;
+}
+
+/** Internal shape used with the generic hook (adds the required `id` field). */
+interface OrderCursorItem extends CursorItem {
+  orderId: string;
 }
 
 export interface CursorLocationState {
@@ -42,7 +54,6 @@ export interface CursorLocationState {
 /**
  * Fetches a full adjacent page in the given direction relative to `cursor`.
  * `mode: 'before'` → the previous page; `mode: 'after'` → the next page.
- * Returns the new orders array and updated pageInfo.
  */
 async function fetchAdjacentPage(
   mode: 'before' | 'after',
@@ -51,9 +62,16 @@ async function fetchAdjacentPage(
   isCompanyOrder: boolean,
   filters: OrdersFiltersInput | CompanyOrdersFiltersInput,
   sortBy: OrdersSortInput,
-): Promise<{ orders: OrderPageItem[]; pageInfo: CursorLocationState['pageInfo'] } | null> {
+): Promise<{ items: OrderCursorItem[]; pageInfo: CursorLocationState['pageInfo'] } | null> {
   const paginationArgs =
     mode === 'before' ? { last: pageSize, before: cursor } : { first: pageSize, after: cursor };
+
+  const toItems = (edges: { cursor: string; node: { entityId: number } }[]): OrderCursorItem[] =>
+    edges.map((e) => ({
+      id: String(e.node.entityId),
+      orderId: String(e.node.entityId),
+      cursor: e.cursor,
+    }));
 
   if (isCompanyOrder) {
     const result = await getCompanyOrders({
@@ -64,10 +82,7 @@ async function fetchAdjacentPage(
     const connection = result.data?.customer?.activeCompany?.orders;
     if (!connection) return null;
     return {
-      orders: connection.edges.map((e) => ({
-        orderId: String(e.node.entityId),
-        cursor: e.cursor,
-      })),
+      items: toItems(connection.edges),
       pageInfo: {
         hasNextPage: connection.pageInfo.hasNextPage,
         hasPreviousPage: connection.pageInfo.hasPreviousPage,
@@ -83,16 +98,14 @@ async function fetchAdjacentPage(
   const connection = result.data?.customer?.orders;
   if (!connection) return null;
   return {
-    orders: connection.edges.map((e) => ({
-      orderId: String(e.node.entityId),
-      cursor: e.cursor,
-    })),
+    items: toItems(connection.edges),
     pageInfo: {
       hasNextPage: connection.pageInfo.hasNextPage,
       hasPreviousPage: connection.pageInfo.hasPreviousPage,
     },
   };
 }
+
 interface CursorDetailPaginationProps {
   onChange: (id: number | string) => void;
   color: string;
@@ -114,147 +127,75 @@ export function CursorDetailPagination({ onChange, color }: CursorDetailPaginati
   const navigate = useNavigate();
   const init = location.state as CursorLocationState | null;
 
-  const [orders, setOrders] = useState<OrderPageItem[]>(init?.orders ?? []);
-  const [currentIndex, setCurrentIndex] = useState(init?.currentIndex ?? 0);
-  const [pageInfo, setPageInfo] = useState(
-    init?.pageInfo ?? { hasNextPage: false, hasPreviousPage: false },
+  // Convert OrderPageItem[] → OrderCursorItem[] for the generic hook.
+  const initialItems: OrderCursorItem[] = (init?.orders ?? []).map((o) => ({
+    ...o,
+    id: o.orderId,
+  }));
+
+  const fetchPage = useCallback(
+    (mode: 'before' | 'after', cursor: string) => {
+      if (!init) return Promise.resolve(null);
+      return fetchAdjacentPage(
+        mode,
+        cursor,
+        init.pageSize,
+        init.isCompanyOrder,
+        init.filters,
+        init.sortBy,
+      );
+    },
+    [init],
   );
-  const [loading, setLoading] = useState(false);
 
-  const hasPrev = currentIndex > 0 || pageInfo.hasPreviousPage;
-  const hasNext = currentIndex < orders.length - 1 || pageInfo.hasNextPage;
+  const buildHistoryState = useCallback(
+    (index: number, items: CursorItem[], pageInfo: CursorPageInfo): CursorLocationState => {
+      const orderItems = items as OrderCursorItem[];
+      return {
+        isCompanyOrder: init!.isCompanyOrder,
+        currentIndex: index,
+        orders: orderItems.map(({ orderId, cursor }) => ({ orderId, cursor })),
+        pageInfo,
+        filters: init!.filters,
+        sortBy: init!.sortBy,
+        pageSize: init!.pageSize,
+      };
+    },
+    [init],
+  );
 
-  /** Writes the current navigation state into the history entry. */
-  const syncHistory = useCallback(
-    (
-      newOrders: OrderPageItem[],
-      newIndex: number,
-      newPageInfo: CursorLocationState['pageInfo'],
-    ) => {
+  const onNavigate = useCallback(
+    (item: CursorItem, index: number, items: CursorItem[], pageInfo: CursorPageInfo) => {
       if (!init) return;
-      navigate(`/orderDetail/${newOrders[newIndex].orderId}`, {
+      onChange(item.id);
+      navigate(`/orderDetail/${item.id}`, {
         replace: true,
-        state: {
-          isCompanyOrder: init.isCompanyOrder,
-          currentIndex: newIndex,
-          orders: newOrders,
-          pageInfo: newPageInfo,
-          filters: init.filters,
-          sortBy: init.sortBy,
-          pageSize: init.pageSize,
-        } satisfies CursorLocationState,
+        state: buildHistoryState(index, items, pageInfo),
       });
     },
-    [init, navigate],
+    [init, navigate, onChange, buildHistoryState],
   );
 
-  /** No adjacent page found, then stop offering that direction and persist in history. */
-  const exhaustBoundary = useCallback(
-    (direction: 'prev' | 'next') => {
-      const newPageInfo =
-        direction === 'prev'
-          ? { ...pageInfo, hasPreviousPage: false }
-          : { ...pageInfo, hasNextPage: false };
-      setPageInfo(newPageInfo);
-      syncHistory(orders, currentIndex, newPageInfo);
+  const onSyncHistory = useCallback(
+    (index: number, items: CursorItem[], pageInfo: CursorPageInfo) => {
+      if (!init) return;
+      // Boundary exhausted — current item unchanged, only pageInfo needs persisting.
+      navigate(location.pathname, {
+        replace: true,
+        state: buildHistoryState(index, items, pageInfo),
+      });
     },
-    [pageInfo, orders, currentIndex, syncHistory],
+    [init, navigate, location.pathname, buildHistoryState],
   );
 
-  const handlePrev = useCallback(async () => {
-    if (!hasPrev || loading || !init) return;
-    setLoading(true);
-    try {
-      if (currentIndex > 0) {
-        // In-page: instant, zero API calls.
-        const newIndex = currentIndex - 1;
-        setCurrentIndex(newIndex);
-        onChange(orders[newIndex].orderId);
-        syncHistory(orders, newIndex, pageInfo);
-      } else {
-        // Page boundary: fetch the previous page and land on its last item.
-        const page = await fetchAdjacentPage(
-          'before',
-          orders[0].cursor,
-          init.pageSize,
-          init.isCompanyOrder,
-          init.filters,
-          init.sortBy,
-        );
-        if (page && page.orders.length > 0) {
-          const newIndex = page.orders.length - 1;
-          setOrders(page.orders);
-          setCurrentIndex(newIndex);
-          setPageInfo(page.pageInfo);
-          onChange(page.orders[newIndex].orderId);
-          syncHistory(page.orders, newIndex, page.pageInfo);
-        } else {
-          exhaustBoundary('prev');
-        }
-      }
-    } catch {
-      // Boundary fetch failed (e.g. network) - leave pageInfo unchanged so the user can retry.
-    } finally {
-      setLoading(false);
-    }
-  }, [
-    hasPrev,
-    loading,
-    init,
-    currentIndex,
-    orders,
-    pageInfo,
-    onChange,
-    syncHistory,
-    exhaustBoundary,
-  ]);
-
-  const handleNext = useCallback(async () => {
-    if (!hasNext || loading || !init) return;
-    setLoading(true);
-    try {
-      if (currentIndex < orders.length - 1) {
-        // In-page: instant, zero API calls.
-        const newIndex = currentIndex + 1;
-        setCurrentIndex(newIndex);
-        onChange(orders[newIndex].orderId);
-        syncHistory(orders, newIndex, pageInfo);
-      } else {
-        // Page boundary: fetch the next page and land on its first item.
-        const page = await fetchAdjacentPage(
-          'after',
-          orders[orders.length - 1].cursor,
-          init.pageSize,
-          init.isCompanyOrder,
-          init.filters,
-          init.sortBy,
-        );
-        if (page && page.orders.length > 0) {
-          setOrders(page.orders);
-          setCurrentIndex(0);
-          setPageInfo(page.pageInfo);
-          onChange(page.orders[0].orderId);
-          syncHistory(page.orders, 0, page.pageInfo);
-        } else {
-          exhaustBoundary('next');
-        }
-      }
-    } catch {
-      // Boundary fetch failed (e.g. network) — leave pageInfo unchanged so the user can retry.
-    } finally {
-      setLoading(false);
-    }
-  }, [
-    hasNext,
-    loading,
-    init,
-    currentIndex,
-    orders,
-    pageInfo,
-    onChange,
-    syncHistory,
-    exhaustBoundary,
-  ]);
+  const { hasPrev, hasNext, loading, handlePrev, handleNext } = useCursorDetailPagination({
+    initialItems,
+    initialIndex: init?.currentIndex ?? 0,
+    initialPageInfo: init?.pageInfo ?? { hasNextPage: false, hasPreviousPage: false },
+    fetchPage,
+    onNavigate,
+    onSyncHistory,
+  });
 
   // Graceful degradation: hide when there is no cached page context
   // (e.g. direct URL access, missing cursors, or an empty list page).

--- a/apps/storefront/src/pages/OrderDetail/components/CursorDetailPagination.tsx
+++ b/apps/storefront/src/pages/OrderDetail/components/CursorDetailPagination.tsx
@@ -35,6 +35,8 @@ export interface CursorLocationState {
   /** Filter/sort state forwarded from the list view so we query the same result set. */
   filters: OrdersFiltersInput | CompanyOrdersFiltersInput;
   sortBy: OrdersSortInput;
+  /** List view page size from `useUnifiedOrdersPagination` */
+  pageSize: number;
 }
 
 /**
@@ -91,11 +93,6 @@ async function fetchAdjacentPage(
     },
   };
 }
-
-// ===========================================================================
-// Component
-// ===========================================================================
-
 interface CursorDetailPaginationProps {
   onChange: (id: number | string) => void;
   color: string;
@@ -144,6 +141,7 @@ export function CursorDetailPagination({ onChange, color }: CursorDetailPaginati
           pageInfo: newPageInfo,
           filters: init.filters,
           sortBy: init.sortBy,
+          pageSize: init.pageSize,
         } satisfies CursorLocationState,
       });
     },
@@ -178,7 +176,7 @@ export function CursorDetailPagination({ onChange, color }: CursorDetailPaginati
         const page = await fetchAdjacentPage(
           'before',
           orders[0].cursor,
-          orders.length,
+          init.pageSize,
           init.isCompanyOrder,
           init.filters,
           init.sortBy,
@@ -228,7 +226,7 @@ export function CursorDetailPagination({ onChange, color }: CursorDetailPaginati
         const page = await fetchAdjacentPage(
           'after',
           orders[orders.length - 1].cursor,
-          orders.length,
+          init.pageSize,
           init.isCompanyOrder,
           init.filters,
           init.sortBy,

--- a/apps/storefront/src/pages/OrderDetail/components/DetailPagination.tsx
+++ b/apps/storefront/src/pages/OrderDetail/components/DetailPagination.tsx
@@ -78,10 +78,7 @@ export function DetailPagination({ onChange, color }: DetailPageProps) {
     searchParams = state?.searchParams || { offset: 0 };
   }
 
-  const isUnifiedPath = totalCount === -1;
-
   const fetchList = async () => {
-    if (isUnifiedPath) return;
     setLoading(true);
 
     const index = () => {
@@ -145,13 +142,6 @@ export function DetailPagination({ onChange, color }: DetailPageProps) {
 
   if (JSON.stringify(searchParams) === '{}') return null;
 
-  // The unified SF GQL path sets totalCount to -1 because collectionInfo is
-  // not available on OrdersConnection. Detail-level prev/next navigation
-  // requires fetching adjacent orders which the cursor-based API doesn't
-  // support in the same way. B2B-4629 (4f) will implement cursor-based
-  // detail navigation. Until then, hide this component in the unified path.
-  if (isUnifiedPath) return null;
-
   const handleBeforePage = () => {
     setListIndex(listIndex - 1);
     onChange(rightLeftSide.leftId);
@@ -163,18 +153,16 @@ export function DetailPagination({ onChange, color }: DetailPageProps) {
   };
   const index = listIndex + 1;
 
-  const showOrderPositionLabel = !isMobile && !isUnifiedPath;
-
   return (
     <Box
       role="navigation"
-      aria-labelledby={showOrderPositionLabel ? id : undefined}
+      aria-labelledby={!isMobile ? id : undefined}
       sx={{
         display: 'flex',
         color,
       }}
     >
-      {showOrderPositionLabel && (
+      {!isMobile && (
         <Box
           id={id}
           sx={{

--- a/apps/storefront/src/pages/OrderDetail/index.tsx
+++ b/apps/storefront/src/pages/OrderDetail/index.tsx
@@ -370,7 +370,11 @@ function OrderDetail() {
           >
             {location?.state &&
               (isUnifiedOrders ? (
-                <CursorDetailPagination key={location.key} onChange={handlePageChange} color={customColor} />
+                <CursorDetailPagination
+                  key={location.key}
+                  onChange={handlePageChange}
+                  color={customColor}
+                />
               ) : (
                 <DetailPagination onChange={handlePageChange} color={customColor} />
               ))}

--- a/apps/storefront/src/pages/OrderDetail/index.tsx
+++ b/apps/storefront/src/pages/OrderDetail/index.tsx
@@ -1,4 +1,4 @@
-import { useContext, useEffect, useState } from 'react';
+import { useCallback, useContext, useEffect, useState } from 'react';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import { ArrowBackIosNew, InfoOutlined } from '@mui/icons-material';
 import { Box, Grid, Stack, Typography } from '@mui/material';
@@ -26,6 +26,7 @@ import b2bLogger from '@/utils/b3Logger';
 import OrderStatus from '../order/components/OrderStatus';
 import { orderStatusTranslationVariables } from '../order/shared/getOrderStatus';
 
+import { CursorDetailPagination } from './components/CursorDetailPagination';
 import { DetailPagination } from './components/DetailPagination';
 import { OrderAction } from './components/OrderAction';
 import { OrderBilling } from './components/OrderBilling';
@@ -240,9 +241,9 @@ function OrderDetail() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isB2BUser, orderId]);
 
-  const handlePageChange = (orderId: string | number) => {
-    setOrderId(orderId.toString());
-  };
+  const handlePageChange = useCallback((nextOrderId: string | number) => {
+    setOrderId(nextOrderId.toString());
+  }, []);
 
   useEffect(() => {
     const getAddressLabelPermission = async () => {
@@ -367,12 +368,12 @@ function OrderDetail() {
               justifyContent: 'flex-end',
             }}
           >
-            {location?.state && (
-              <DetailPagination
-                onChange={(orderId) => handlePageChange(orderId)}
-                color={customColor}
-              />
-            )}
+            {location?.state &&
+              (isUnifiedOrders ? (
+                <CursorDetailPagination onChange={handlePageChange} color={customColor} />
+              ) : (
+                <DetailPagination onChange={handlePageChange} color={customColor} />
+              ))}
           </Grid>
         </Grid>
         {orderId && !isCurrentCompany ? (

--- a/apps/storefront/src/pages/OrderDetail/index.tsx
+++ b/apps/storefront/src/pages/OrderDetail/index.tsx
@@ -370,6 +370,8 @@ function OrderDetail() {
           >
             {location?.state &&
               (isUnifiedOrders ? (
+                // key={location.key} remounts when history changes
+                // so useCursorDetailPagination re-seeds from location.state on mount.
                 <CursorDetailPagination
                   key={location.key}
                   onChange={handlePageChange}

--- a/apps/storefront/src/pages/OrderDetail/index.tsx
+++ b/apps/storefront/src/pages/OrderDetail/index.tsx
@@ -370,7 +370,7 @@ function OrderDetail() {
           >
             {location?.state &&
               (isUnifiedOrders ? (
-                <CursorDetailPagination onChange={handlePageChange} color={customColor} />
+                <CursorDetailPagination key={location.key} onChange={handlePageChange} color={customColor} />
               ) : (
                 <DetailPagination onChange={handlePageChange} color={customColor} />
               ))}

--- a/apps/storefront/src/pages/OrderDetail/useCursorDetailPagination.test.ts
+++ b/apps/storefront/src/pages/OrderDetail/useCursorDetailPagination.test.ts
@@ -282,6 +282,29 @@ describe('useCursorDetailPagination', () => {
 
       expect(view.result.current.hasNext).toBe(false);
     });
+
+    it('exhausts next using pageInfo from a prior boundary fetch, not mount-time pageInfo', async () => {
+      const fetchedPageInfo: CursorPageInfo = { hasNextPage: true, hasPreviousPage: false };
+      const onSyncHistory = vi.fn();
+      const fetchPage = vi
+        .fn()
+        .mockResolvedValueOnce({ items: PAGE_B, pageInfo: fetchedPageInfo })
+        .mockResolvedValueOnce(null);
+      const { view } = renderPagination({
+        initialIndex: 0,
+        initialPageInfo: { hasNextPage: false, hasPreviousPage: true },
+        fetchPage,
+        onSyncHistory,
+      });
+
+      await act(() => view.result.current.handlePrev());
+      await act(() => view.result.current.handleNext());
+
+      expect(onSyncHistory).toHaveBeenLastCalledWith(2, PAGE_B, {
+        hasNextPage: false,
+        hasPreviousPage: false,
+      });
+    });
   });
 
   describe('page-boundary navigation — fetch throws (network error)', () => {
@@ -366,15 +389,15 @@ describe('useCursorDetailPagination', () => {
         fetchPage,
       });
 
-      // Kick off but don't await yet
-      act(() => {
-        view.result.current.handlePrev();
+      let inFlight!: Promise<void>;
+      await act(async () => {
+        inFlight = view.result.current.handlePrev();
       });
       expect(view.result.current.loading).toBe(true);
 
-      // Resolve the fetch and wait for state to settle
-      await act(() => {
+      await act(async () => {
         resolveFetch(null);
+        await inFlight;
       });
       expect(view.result.current.loading).toBe(false);
     });
@@ -393,19 +416,21 @@ describe('useCursorDetailPagination', () => {
         fetchPage,
       });
 
-      act(() => {
-        view.result.current.handlePrev();
+      let inFlight!: Promise<void>;
+      await act(async () => {
+        inFlight = view.result.current.handlePrev();
       });
       expect(view.result.current.loading).toBe(true);
 
-      await act(() => {
-        view.result.current.handlePrev();
+      await act(async () => {
+        await view.result.current.handlePrev();
       });
 
       expect(fetchPage).toHaveBeenCalledTimes(1);
 
-      await act(() => {
+      await act(async () => {
         resolveFetch({ items: PAGE_B, pageInfo: { hasNextPage: true, hasPreviousPage: false } });
+        await inFlight;
       });
     });
 
@@ -424,19 +449,21 @@ describe('useCursorDetailPagination', () => {
         fetchPage,
       });
 
-      act(() => {
-        view.result.current.handleNext();
+      let inFlight!: Promise<void>;
+      await act(async () => {
+        inFlight = view.result.current.handleNext();
       });
       expect(view.result.current.loading).toBe(true);
 
-      await act(() => {
-        view.result.current.handleNext();
+      await act(async () => {
+        await view.result.current.handleNext();
       });
 
       expect(fetchPage).toHaveBeenCalledTimes(1);
 
-      await act(() => {
+      await act(async () => {
         resolveFetch({ items: PAGE_C, pageInfo: { hasNextPage: false, hasPreviousPage: true } });
+        await inFlight;
       });
     });
   });

--- a/apps/storefront/src/pages/OrderDetail/useCursorDetailPagination.test.ts
+++ b/apps/storefront/src/pages/OrderDetail/useCursorDetailPagination.test.ts
@@ -1,0 +1,478 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  type CursorDetailPaginationOptions,
+  CursorItem,
+  CursorPageInfo,
+  useCursorDetailPagination,
+} from './useCursorDetailPagination';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function item(id: string): CursorItem {
+  return { id, cursor: `cursor-${id}` };
+}
+
+const PAGE_A = [item('1'), item('2'), item('3')];
+const PAGE_B = [item('4'), item('5'), item('6')];
+const PAGE_C = [item('7'), item('8'), item('9')];
+
+/** Returns resolved options with sensible defaults so each test only specifies what it cares about. */
+function makeOptions(
+  overrides: Partial<CursorDetailPaginationOptions<CursorItem>> = {},
+): CursorDetailPaginationOptions<CursorItem> {
+  return {
+    initialItems: PAGE_A,
+    initialIndex: 1, // middle item
+    initialPageInfo: { hasNextPage: true, hasPreviousPage: true },
+    fetchPage: vi.fn().mockResolvedValue(null),
+    onNavigate: vi.fn(),
+    onSyncHistory: vi.fn(),
+    ...overrides,
+  };
+}
+
+function renderPagination(overrides: Partial<CursorDetailPaginationOptions<CursorItem>> = {}) {
+  const options = makeOptions(overrides);
+  const view = renderHook(() => useCursorDetailPagination(options));
+  return { view, options };
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('useCursorDetailPagination', () => {
+  describe('initial hasPrev / hasNext', () => {
+    it('enables both when in the middle of the page', () => {
+      const { view } = renderPagination({ initialIndex: 1 });
+      expect(view.result.current.hasPrev).toBe(true);
+      expect(view.result.current.hasNext).toBe(true);
+    });
+
+    it('disables prev when at index 0 with hasPreviousPage: false', () => {
+      const { view } = renderPagination({
+        initialIndex: 0,
+        initialPageInfo: { hasNextPage: true, hasPreviousPage: false },
+      });
+      expect(view.result.current.hasPrev).toBe(false);
+    });
+
+    it('disables next when at the last index with hasNextPage: false', () => {
+      const { view } = renderPagination({
+        initialItems: PAGE_A,
+        initialIndex: 2,
+        initialPageInfo: { hasNextPage: false, hasPreviousPage: true },
+      });
+      expect(view.result.current.hasNext).toBe(false);
+    });
+
+    it('enables prev when at index 0 but hasPreviousPage: true', () => {
+      const { view } = renderPagination({
+        initialIndex: 0,
+        initialPageInfo: { hasNextPage: false, hasPreviousPage: true },
+      });
+      expect(view.result.current.hasPrev).toBe(true);
+    });
+
+    it('enables next when at the last index but hasNextPage: true', () => {
+      const { view } = renderPagination({
+        initialItems: PAGE_A,
+        initialIndex: 2,
+        initialPageInfo: { hasNextPage: true, hasPreviousPage: false },
+      });
+      expect(view.result.current.hasNext).toBe(true);
+    });
+  });
+
+  describe('in-page navigation (no API calls)', () => {
+    it('handlePrev moves to the previous item and calls onNavigate', async () => {
+      const onNavigate = vi.fn();
+      const fetchPage = vi.fn();
+      const { view } = renderPagination({ initialIndex: 2, onNavigate, fetchPage });
+
+      await act(() => view.result.current.handlePrev());
+
+      expect(fetchPage).not.toHaveBeenCalled();
+      expect(onNavigate).toHaveBeenCalledExactlyOnceWith(
+        PAGE_A[1],
+        1,
+        PAGE_A,
+        expect.objectContaining({ hasNextPage: true, hasPreviousPage: true }),
+      );
+    });
+
+    it('handleNext moves to the next item and calls onNavigate', async () => {
+      const onNavigate = vi.fn();
+      const fetchPage = vi.fn();
+      const { view } = renderPagination({ initialIndex: 0, onNavigate, fetchPage });
+
+      await act(() => view.result.current.handleNext());
+
+      expect(fetchPage).not.toHaveBeenCalled();
+      expect(onNavigate).toHaveBeenCalledExactlyOnceWith(
+        PAGE_A[1],
+        1,
+        PAGE_A,
+        expect.objectContaining({ hasNextPage: true, hasPreviousPage: true }),
+      );
+    });
+
+    it('disables prev after stepping back to index 0 with no previous page', async () => {
+      const { view } = renderPagination({
+        initialIndex: 1,
+        initialItems: PAGE_A.slice(0, 2),
+        initialPageInfo: { hasNextPage: false, hasPreviousPage: false },
+      });
+      await act(() => view.result.current.handlePrev());
+      expect(view.result.current.hasPrev).toBe(false);
+    });
+
+    it('disables next after stepping forward to the last index with no next page', async () => {
+      const { view } = renderPagination({
+        initialIndex: 0,
+        initialItems: PAGE_A.slice(0, 2),
+        initialPageInfo: { hasNextPage: false, hasPreviousPage: false },
+      });
+      await act(() => view.result.current.handleNext());
+      expect(view.result.current.hasNext).toBe(false);
+    });
+  });
+
+  describe('page-boundary navigation — successful fetch', () => {
+    it('handlePrev at index 0 calls fetchPage("before", firstCursor)', async () => {
+      const fetchPage = vi.fn().mockResolvedValue({
+        items: PAGE_B,
+        pageInfo: { hasNextPage: true, hasPreviousPage: false },
+      });
+      const { view } = renderPagination({
+        initialIndex: 0,
+        initialPageInfo: { hasNextPage: false, hasPreviousPage: true },
+        fetchPage,
+      });
+
+      await act(() => view.result.current.handlePrev());
+
+      expect(fetchPage).toHaveBeenCalledExactlyOnceWith('before', PAGE_A[0].cursor);
+    });
+
+    it('handlePrev lands on the last item of the fetched page', async () => {
+      const newPageInfo: CursorPageInfo = { hasNextPage: true, hasPreviousPage: false };
+      const fetchPage = vi.fn().mockResolvedValue({ items: PAGE_B, pageInfo: newPageInfo });
+      const onNavigate = vi.fn();
+      const { view } = renderPagination({
+        initialIndex: 0,
+        initialPageInfo: { hasNextPage: false, hasPreviousPage: true },
+        fetchPage,
+        onNavigate,
+      });
+
+      await act(() => view.result.current.handlePrev());
+
+      expect(onNavigate).toHaveBeenCalledExactlyOnceWith(PAGE_B[2], 2, PAGE_B, newPageInfo);
+    });
+
+    it('handleNext at the last index calls fetchPage("after", lastCursor)', async () => {
+      const fetchPage = vi.fn().mockResolvedValue({
+        items: PAGE_C,
+        pageInfo: { hasNextPage: false, hasPreviousPage: true },
+      });
+      const { view } = renderPagination({
+        initialItems: PAGE_A,
+        initialIndex: 2,
+        initialPageInfo: { hasNextPage: true, hasPreviousPage: false },
+        fetchPage,
+      });
+
+      await act(() => view.result.current.handleNext());
+
+      expect(fetchPage).toHaveBeenCalledExactlyOnceWith('after', PAGE_A[2].cursor);
+    });
+
+    it('handleNext lands on the first item of the fetched page', async () => {
+      const newPageInfo: CursorPageInfo = { hasNextPage: false, hasPreviousPage: true };
+      const fetchPage = vi.fn().mockResolvedValue({ items: PAGE_C, pageInfo: newPageInfo });
+      const onNavigate = vi.fn();
+      const { view } = renderPagination({
+        initialItems: PAGE_A,
+        initialIndex: 2,
+        initialPageInfo: { hasNextPage: true, hasPreviousPage: false },
+        fetchPage,
+        onNavigate,
+      });
+
+      await act(() => view.result.current.handleNext());
+
+      expect(onNavigate).toHaveBeenCalledExactlyOnceWith(PAGE_C[0], 0, PAGE_C, newPageInfo);
+    });
+  });
+
+  describe('page-boundary navigation — fetch returns no items (exhausted)', () => {
+    it('disables prev when fetchPage returns null, calls onSyncHistory not onNavigate', async () => {
+      const onNavigate = vi.fn();
+      const onSyncHistory = vi.fn();
+      const { view } = renderPagination({
+        initialIndex: 0,
+        initialPageInfo: { hasNextPage: false, hasPreviousPage: true },
+        fetchPage: vi.fn().mockResolvedValue(null),
+        onNavigate,
+        onSyncHistory,
+      });
+
+      await act(() => view.result.current.handlePrev());
+
+      expect(view.result.current.hasPrev).toBe(false);
+      expect(onNavigate).not.toHaveBeenCalled();
+      expect(onSyncHistory).toHaveBeenCalledExactlyOnceWith(
+        0,
+        PAGE_A,
+        expect.objectContaining({ hasPreviousPage: false }),
+      );
+    });
+
+    it('disables next when fetchPage returns null, calls onSyncHistory not onNavigate', async () => {
+      const onNavigate = vi.fn();
+      const onSyncHistory = vi.fn();
+      const { view } = renderPagination({
+        initialItems: PAGE_A,
+        initialIndex: 2,
+        initialPageInfo: { hasNextPage: true, hasPreviousPage: false },
+        fetchPage: vi.fn().mockResolvedValue(null),
+        onNavigate,
+        onSyncHistory,
+      });
+
+      await act(() => view.result.current.handleNext());
+
+      expect(view.result.current.hasNext).toBe(false);
+      expect(onNavigate).not.toHaveBeenCalled();
+      expect(onSyncHistory).toHaveBeenCalledExactlyOnceWith(
+        2,
+        PAGE_A,
+        expect.objectContaining({ hasNextPage: false }),
+      );
+    });
+
+    it('disables prev when fetchPage returns an empty items array', async () => {
+      const { view } = renderPagination({
+        initialIndex: 0,
+        initialPageInfo: { hasNextPage: false, hasPreviousPage: true },
+        fetchPage: vi.fn().mockResolvedValue({
+          items: [],
+          pageInfo: { hasNextPage: false, hasPreviousPage: false },
+        }),
+      });
+
+      await act(() => view.result.current.handlePrev());
+
+      expect(view.result.current.hasPrev).toBe(false);
+    });
+
+    it('disables next when fetchPage returns an empty items array', async () => {
+      const { view } = renderPagination({
+        initialItems: PAGE_A,
+        initialIndex: 2,
+        initialPageInfo: { hasNextPage: true, hasPreviousPage: false },
+        fetchPage: vi.fn().mockResolvedValue({
+          items: [],
+          pageInfo: { hasNextPage: false, hasPreviousPage: false },
+        }),
+      });
+
+      await act(() => view.result.current.handleNext());
+
+      expect(view.result.current.hasNext).toBe(false);
+    });
+  });
+
+  describe('page-boundary navigation — fetch throws (network error)', () => {
+    it('keeps prev enabled so the user can retry', async () => {
+      const onNavigate = vi.fn();
+      const { view } = renderPagination({
+        initialIndex: 0,
+        initialPageInfo: { hasNextPage: false, hasPreviousPage: true },
+        fetchPage: vi.fn().mockRejectedValue(new Error('network error')),
+        onNavigate,
+      });
+
+      await act(() => view.result.current.handlePrev());
+
+      expect(view.result.current.hasPrev).toBe(true);
+      expect(onNavigate).not.toHaveBeenCalled();
+    });
+
+    it('keeps next enabled so the user can retry', async () => {
+      const onNavigate = vi.fn();
+      const { view } = renderPagination({
+        initialItems: PAGE_A,
+        initialIndex: 2,
+        initialPageInfo: { hasNextPage: true, hasPreviousPage: false },
+        fetchPage: vi.fn().mockRejectedValue(new Error('network error')),
+        onNavigate,
+      });
+
+      await act(() => view.result.current.handleNext());
+
+      expect(view.result.current.hasNext).toBe(true);
+      expect(onNavigate).not.toHaveBeenCalled();
+    });
+
+    it('succeeds on the second call after a first failure', async () => {
+      const onNavigate = vi.fn();
+      let calls = 0;
+      const fetchPage = vi.fn().mockImplementation(() => {
+        calls += 1;
+        if (calls === 1) return Promise.reject(new Error('transient'));
+        return Promise.resolve({
+          items: PAGE_B,
+          pageInfo: { hasNextPage: false, hasPreviousPage: true },
+        });
+      });
+      const { view } = renderPagination({
+        initialItems: PAGE_A,
+        initialIndex: 2,
+        initialPageInfo: { hasNextPage: true, hasPreviousPage: false },
+        fetchPage,
+        onNavigate,
+      });
+
+      // First click — fails silently
+      await act(() => view.result.current.handleNext());
+      expect(onNavigate).not.toHaveBeenCalled();
+      expect(view.result.current.hasNext).toBe(true);
+
+      // Second click — succeeds
+      await act(() => view.result.current.handleNext());
+      expect(onNavigate).toHaveBeenCalledExactlyOnceWith(
+        PAGE_B[0],
+        0,
+        PAGE_B,
+        expect.objectContaining({ hasPreviousPage: true }),
+      );
+    });
+  });
+
+  describe('loading guard', () => {
+    it('sets loading true during a fetch and false after', async () => {
+      let resolveFetch!: (value: null) => void;
+      const fetchPage = vi.fn(
+        () =>
+          new Promise<null>((resolve) => {
+            resolveFetch = resolve;
+          }),
+      );
+      const { view } = renderPagination({
+        initialIndex: 0,
+        initialPageInfo: { hasNextPage: false, hasPreviousPage: true },
+        fetchPage,
+      });
+
+      // Kick off but don't await yet
+      act(() => {
+        view.result.current.handlePrev();
+      });
+      expect(view.result.current.loading).toBe(true);
+
+      // Resolve the fetch and wait for state to settle
+      await act(() => {
+        resolveFetch(null);
+      });
+      expect(view.result.current.loading).toBe(false);
+    });
+
+    it('ignores a second handlePrev call while a fetch is in flight', async () => {
+      let resolveFetch!: (value: { items: typeof PAGE_B; pageInfo: CursorPageInfo }) => void;
+      const fetchPage = vi.fn(
+        () =>
+          new Promise<{ items: typeof PAGE_B; pageInfo: CursorPageInfo }>((resolve) => {
+            resolveFetch = resolve;
+          }),
+      );
+      const { view } = renderPagination({
+        initialIndex: 0,
+        initialPageInfo: { hasNextPage: false, hasPreviousPage: true },
+        fetchPage,
+      });
+
+      act(() => {
+        view.result.current.handlePrev();
+      });
+      expect(view.result.current.loading).toBe(true);
+
+      await act(() => {
+        view.result.current.handlePrev();
+      });
+
+      expect(fetchPage).toHaveBeenCalledTimes(1);
+
+      await act(() => {
+        resolveFetch({ items: PAGE_B, pageInfo: { hasNextPage: true, hasPreviousPage: false } });
+      });
+    });
+
+    it('ignores a second handleNext call while a fetch is in flight', async () => {
+      let resolveFetch!: (value: { items: typeof PAGE_C; pageInfo: CursorPageInfo }) => void;
+      const fetchPage = vi.fn(
+        () =>
+          new Promise<{ items: typeof PAGE_C; pageInfo: CursorPageInfo }>((resolve) => {
+            resolveFetch = resolve;
+          }),
+      );
+      const { view } = renderPagination({
+        initialItems: PAGE_A,
+        initialIndex: 2,
+        initialPageInfo: { hasNextPage: true, hasPreviousPage: false },
+        fetchPage,
+      });
+
+      act(() => {
+        view.result.current.handleNext();
+      });
+      expect(view.result.current.loading).toBe(true);
+
+      await act(() => {
+        view.result.current.handleNext();
+      });
+
+      expect(fetchPage).toHaveBeenCalledTimes(1);
+
+      await act(() => {
+        resolveFetch({ items: PAGE_C, pageInfo: { hasNextPage: false, hasPreviousPage: true } });
+      });
+    });
+  });
+
+  describe('no-ops on disabled directions', () => {
+    it('handlePrev does nothing when hasPrev is false', async () => {
+      const onNavigate = vi.fn();
+      const fetchPage = vi.fn();
+      const { view } = renderPagination({
+        initialIndex: 0,
+        initialPageInfo: { hasNextPage: true, hasPreviousPage: false },
+        onNavigate,
+        fetchPage,
+      });
+
+      await act(() => view.result.current.handlePrev());
+
+      expect(fetchPage).not.toHaveBeenCalled();
+      expect(onNavigate).not.toHaveBeenCalled();
+    });
+
+    it('handleNext does nothing when hasNext is false', async () => {
+      const onNavigate = vi.fn();
+      const fetchPage = vi.fn();
+      const { view } = renderPagination({
+        initialItems: PAGE_A,
+        initialIndex: 2,
+        initialPageInfo: { hasNextPage: false, hasPreviousPage: true },
+        onNavigate,
+        fetchPage,
+      });
+
+      await act(() => view.result.current.handleNext());
+
+      expect(fetchPage).not.toHaveBeenCalled();
+      expect(onNavigate).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/storefront/src/pages/OrderDetail/useCursorDetailPagination.ts
+++ b/apps/storefront/src/pages/OrderDetail/useCursorDetailPagination.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 
 /** Minimum shape every paginated item must satisfy. */
 export interface CursorItem {
@@ -41,7 +41,7 @@ export interface CursorDetailPaginationOptions<TItem extends CursorItem> {
   onSyncHistory: (index: number, items: TItem[], pageInfo: CursorPageInfo) => void;
 }
 
-export interface CursorDetailPaginationResult {
+interface CursorDetailPaginationResult {
   hasPrev: boolean;
   hasNext: boolean;
   loading: boolean;
@@ -69,27 +69,28 @@ export function useCursorDetailPagination<TItem extends CursorItem>({
   const [pageInfo, setPageInfo] = useState<CursorPageInfo>(initialPageInfo);
   const [loading, setLoading] = useState(false);
 
+  const loadingRef = useRef(false);
+  const pageInfoRef = useRef(pageInfo);
+  pageInfoRef.current = pageInfo;
+
   const hasPrev = currentIndex > 0 || pageInfo.hasPreviousPage;
   const hasNext = currentIndex < items.length - 1 || pageInfo.hasNextPage;
 
-  /**
-   * Clamps one boundary flag to false when the adjacent page is exhausted.
-   * Does NOT call onNavigate — the current item hasn't changed.
-   */
   const exhaustBoundary = useCallback(
     (direction: 'prev' | 'next') => {
-      const newPageInfo =
+      const updatedPageInfo =
         direction === 'prev'
-          ? { ...pageInfo, hasPreviousPage: false }
-          : { ...pageInfo, hasNextPage: false };
-      setPageInfo(newPageInfo);
-      onSyncHistory(currentIndex, items, newPageInfo);
+          ? { ...pageInfoRef.current, hasPreviousPage: false }
+          : { ...pageInfoRef.current, hasNextPage: false };
+      setPageInfo(updatedPageInfo);
+      onSyncHistory(currentIndex, items, updatedPageInfo);
     },
-    [pageInfo, items, currentIndex, onSyncHistory],
+    [currentIndex, items, onSyncHistory],
   );
 
   const handlePrev = useCallback(async () => {
-    if (!hasPrev || loading) return;
+    if (!hasPrev || loadingRef.current) return;
+    loadingRef.current = true;
     setLoading(true);
     try {
       if (currentIndex > 0) {
@@ -113,12 +114,14 @@ export function useCursorDetailPagination<TItem extends CursorItem>({
     } catch {
       // Boundary fetch failed (e.g. network) — leave pageInfo unchanged so the user can retry.
     } finally {
+      loadingRef.current = false;
       setLoading(false);
     }
-  }, [hasPrev, loading, currentIndex, items, pageInfo, fetchPage, onNavigate, exhaustBoundary]);
+  }, [hasPrev, currentIndex, items, pageInfo, fetchPage, onNavigate, exhaustBoundary]);
 
   const handleNext = useCallback(async () => {
-    if (!hasNext || loading) return;
+    if (!hasNext || loadingRef.current) return;
+    loadingRef.current = true;
     setLoading(true);
     try {
       if (currentIndex < items.length - 1) {
@@ -141,9 +144,10 @@ export function useCursorDetailPagination<TItem extends CursorItem>({
     } catch {
       // Boundary fetch failed (e.g. network) — leave pageInfo unchanged so the user can retry.
     } finally {
+      loadingRef.current = false;
       setLoading(false);
     }
-  }, [hasNext, loading, currentIndex, items, pageInfo, fetchPage, onNavigate, exhaustBoundary]);
+  }, [hasNext, currentIndex, items, pageInfo, fetchPage, onNavigate, exhaustBoundary]);
 
   return { hasPrev, hasNext, loading, handlePrev, handleNext };
 }

--- a/apps/storefront/src/pages/OrderDetail/useCursorDetailPagination.ts
+++ b/apps/storefront/src/pages/OrderDetail/useCursorDetailPagination.ts
@@ -1,0 +1,149 @@
+import { useCallback, useState } from 'react';
+
+/** Minimum shape every paginated item must satisfy. */
+export interface CursorItem {
+  id: string;
+  cursor: string;
+}
+
+export interface CursorPageInfo {
+  hasNextPage: boolean;
+  hasPreviousPage: boolean;
+}
+
+export interface CursorDetailPaginationOptions<TItem extends CursorItem> {
+  /** Initial items from the list view (one full page). */
+  initialItems: TItem[];
+  /** Index of the item currently being viewed. */
+  initialIndex: number;
+  /** Page-boundary flags from the list view's most recent pageInfo. */
+  initialPageInfo: CursorPageInfo;
+  /**
+   * Called when a page boundary is crossed.
+   * Should fetch the adjacent page and return its items + pageInfo,
+   * or null if the fetch fails / returns nothing.
+   */
+  fetchPage: (
+    mode: 'before' | 'after',
+    cursor: string,
+  ) => Promise<{ items: TItem[]; pageInfo: CursorPageInfo } | null>;
+  /**
+   * Called when navigation moves to a different item.
+   * Use this to trigger data loading and update the router URL.
+   */
+  onNavigate: (item: TItem, index: number, items: TItem[], pageInfo: CursorPageInfo) => void;
+  /**
+   * Called when only pageInfo changes but the current item stays the same
+   * (i.e. a boundary fetch returned nothing and the direction is now exhausted).
+   * Use this to persist the updated pageInfo into history state without
+   * triggering a data reload.
+   */
+  onSyncHistory: (index: number, items: TItem[], pageInfo: CursorPageInfo) => void;
+}
+
+export interface CursorDetailPaginationResult {
+  hasPrev: boolean;
+  hasNext: boolean;
+  loading: boolean;
+  handlePrev: () => Promise<void>;
+  handleNext: () => Promise<void>;
+}
+
+/**
+ * Generic cursor-based prev/next navigation for detail pages.
+ *
+ * Handles in-page navigation (zero API calls) and page-boundary fetches.
+ * Domain-specific concerns (which API to call, how to update the router)
+ * are delegated to `fetchPage`, `onNavigate`, and `onSyncHistory`.
+ */
+export function useCursorDetailPagination<TItem extends CursorItem>({
+  initialItems,
+  initialIndex,
+  initialPageInfo,
+  fetchPage,
+  onNavigate,
+  onSyncHistory,
+}: CursorDetailPaginationOptions<TItem>): CursorDetailPaginationResult {
+  const [items, setItems] = useState<TItem[]>(initialItems);
+  const [currentIndex, setCurrentIndex] = useState(initialIndex);
+  const [pageInfo, setPageInfo] = useState<CursorPageInfo>(initialPageInfo);
+  const [loading, setLoading] = useState(false);
+
+  const hasPrev = currentIndex > 0 || pageInfo.hasPreviousPage;
+  const hasNext = currentIndex < items.length - 1 || pageInfo.hasNextPage;
+
+  /**
+   * Clamps one boundary flag to false when the adjacent page is exhausted.
+   * Does NOT call onNavigate — the current item hasn't changed.
+   */
+  const exhaustBoundary = useCallback(
+    (direction: 'prev' | 'next') => {
+      const newPageInfo =
+        direction === 'prev'
+          ? { ...pageInfo, hasPreviousPage: false }
+          : { ...pageInfo, hasNextPage: false };
+      setPageInfo(newPageInfo);
+      onSyncHistory(currentIndex, items, newPageInfo);
+    },
+    [pageInfo, items, currentIndex, onSyncHistory],
+  );
+
+  const handlePrev = useCallback(async () => {
+    if (!hasPrev || loading) return;
+    setLoading(true);
+    try {
+      if (currentIndex > 0) {
+        // In-page: instant, zero API calls.
+        const newIndex = currentIndex - 1;
+        setCurrentIndex(newIndex);
+        onNavigate(items[newIndex], newIndex, items, pageInfo);
+      } else {
+        // Page boundary: fetch the previous page and land on its last item.
+        const page = await fetchPage('before', items[0].cursor);
+        if (page && page.items.length > 0) {
+          const newIndex = page.items.length - 1;
+          setItems(page.items);
+          setCurrentIndex(newIndex);
+          setPageInfo(page.pageInfo);
+          onNavigate(page.items[newIndex], newIndex, page.items, page.pageInfo);
+        } else {
+          exhaustBoundary('prev');
+        }
+      }
+    } catch {
+      // Boundary fetch failed (e.g. network) — leave pageInfo unchanged so the user can retry.
+    } finally {
+      setLoading(false);
+    }
+  }, [hasPrev, loading, currentIndex, items, pageInfo, fetchPage, onNavigate, exhaustBoundary]);
+
+  const handleNext = useCallback(async () => {
+    if (!hasNext || loading) return;
+    setLoading(true);
+    try {
+      if (currentIndex < items.length - 1) {
+        // In-page: instant, zero API calls.
+        const newIndex = currentIndex + 1;
+        setCurrentIndex(newIndex);
+        onNavigate(items[newIndex], newIndex, items, pageInfo);
+      } else {
+        // Page boundary: fetch the next page and land on its first item.
+        const page = await fetchPage('after', items[items.length - 1].cursor);
+        if (page && page.items.length > 0) {
+          setItems(page.items);
+          setCurrentIndex(0);
+          setPageInfo(page.pageInfo);
+          onNavigate(page.items[0], 0, page.items, page.pageInfo);
+        } else {
+          exhaustBoundary('next');
+        }
+      }
+    } catch {
+      // Boundary fetch failed (e.g. network) — leave pageInfo unchanged so the user can retry.
+    } finally {
+      setLoading(false);
+    }
+  }, [hasNext, loading, currentIndex, items, pageInfo, fetchPage, onNavigate, exhaustBoundary]);
+
+  return { hasPrev, hasNext, loading, handlePrev, handleNext };
+}

--- a/apps/storefront/src/pages/order/Order.tsx
+++ b/apps/storefront/src/pages/order/Order.tsx
@@ -22,6 +22,8 @@ import { CustomerRole } from '@/types';
 import { currencyFormat, ordersCurrencyFormat } from '@/utils/b3CurrencyFormat';
 import { displayFormat } from '@/utils/b3DateFormat';
 
+import { type CursorLocationState } from '../OrderDetail/components/CursorDetailPagination';
+
 import OrderStatus from './components/OrderStatus';
 import { B3Table, PossibleNodeWrapper, TableColumnItem } from './table/B3Table';
 import {
@@ -207,7 +209,9 @@ function Order({ isCompanyOrder = false }: OrderProps) {
   }> => {
     const result = await getCustomerOrders(args);
     const orders = result.data?.customer?.orders;
-    const edges = (orders?.edges || []).map((edge) => mapSfGqlOrderToListItem(edge.node));
+    const edges = (orders?.edges || []).map((edge) =>
+      mapSfGqlOrderToListItem(edge.node, edge.cursor),
+    );
     const pageInfo = orders?.pageInfo ?? null;
 
     return { edges, totalCount: -1, pageInfo };
@@ -227,7 +231,9 @@ function Order({ isCompanyOrder = false }: OrderProps) {
   }> => {
     const result = await getCompanyOrders(args);
     const orders = result.data?.customer?.activeCompany?.orders;
-    const edges = (orders?.edges || []).map((edge) => mapSfGqlOrderToListItem(edge.node));
+    const edges = (orders?.edges || []).map((edge) =>
+      mapSfGqlOrderToListItem(edge.node, edge.cursor),
+    );
     const pageInfo = orders?.pageInfo ?? null;
     const totalCount = orders?.collectionInfo?.totalItems ?? -1;
 
@@ -264,7 +270,7 @@ function Order({ isCompanyOrder = false }: OrderProps) {
           ...filterData,
           orderBy,
         },
-        totalCount: isUnifiedOrders ? -1 : allTotal,
+        totalCount: allTotal,
         isCompanyOrder,
         beginDateAt: filterData?.beginDateAt,
         endDateAt: filterData?.endDateAt,
@@ -272,20 +278,23 @@ function Order({ isCompanyOrder = false }: OrderProps) {
     });
   };
 
-  // TODO B2B-4629: Double check if need more params for unified path
-  const goToDetail = (item: ListItem, index: number) => {
+  const goToDetail = (item: ListItem, index: number, items: ListItem[]) => {
+    const activeFilterState = isUnifiedCompanyPath ? companyFilterState : customerFilterState;
+
     navigate(`/orderDetail/${item.orderId}`, {
       state: {
-        currentIndex: index,
-        totalCount: -1,
         isCompanyOrder,
-        unifiedCustomerFilters: customerFilterState.filters,
-        unifiedCustomerSortBy: customerFilterState.sortBy,
-      },
+        currentIndex: index,
+        orders: items.map(({ orderId, cursor }) => ({ orderId, cursor: cursor ?? '' })),
+        pageInfo: {
+          hasNextPage: activeFilterState.pageInfo?.hasNextPage ?? false,
+          hasPreviousPage: activeFilterState.pageInfo?.hasPreviousPage ?? false,
+        },
+        filters: activeFilterState.filters,
+        sortBy: activeFilterState.sortBy,
+      } satisfies CursorLocationState,
     });
   };
-
-  const navigateToOrderDetail = isUnifiedCustomerPath ? goToDetail : legacyGoToDetail;
 
   const isSuperAdminNotAgenting = Number(role) === CustomerRole.SUPER_ADMIN && !isAgenting;
 
@@ -416,6 +425,10 @@ function Order({ isCompanyOrder = false }: OrderProps) {
       })),
     [data?.edges, getOrderStatuses],
   );
+
+  const navigateToOrderDetail = isUnifiedOrders
+    ? (item: ListItem, index: number) => goToDetail(item, index, listItems)
+    : legacyGoToDetail;
 
   return (
     <B3Spin isSpinning={isFetching}>

--- a/apps/storefront/src/pages/order/Order.tsx
+++ b/apps/storefront/src/pages/order/Order.tsx
@@ -278,14 +278,16 @@ function Order({ isCompanyOrder = false }: OrderProps) {
     });
   };
 
-  const goToDetail = (item: ListItem, index: number, items: ListItem[]) => {
+  const goToDetail = (item: ListItem, items: ListItem[]) => {
     const activeFilterState = isUnifiedCompanyPath ? companyFilterState : customerFilterState;
+    const orders = items.flatMap(({ orderId, cursor }) => (cursor ? [{ orderId, cursor }] : []));
+    const currentIndex = orders.findIndex((o) => o.orderId === item.orderId);
 
     navigate(`/orderDetail/${item.orderId}`, {
       state: {
         isCompanyOrder,
-        currentIndex: index,
-        orders: items.map(({ orderId, cursor }) => ({ orderId, cursor: cursor ?? '' })),
+        currentIndex: currentIndex >= 0 ? currentIndex : 0,
+        orders: currentIndex >= 0 ? orders : [],
         pageInfo: {
           hasNextPage: activeFilterState.pageInfo?.hasNextPage ?? false,
           hasPreviousPage: activeFilterState.pageInfo?.hasPreviousPage ?? false,
@@ -427,7 +429,7 @@ function Order({ isCompanyOrder = false }: OrderProps) {
   );
 
   const navigateToOrderDetail = isUnifiedOrders
-    ? (item: ListItem, index: number) => goToDetail(item, index, listItems)
+    ? (item: ListItem) => goToDetail(item, listItems)
     : legacyGoToDetail;
 
   return (

--- a/apps/storefront/src/pages/order/Order.tsx
+++ b/apps/storefront/src/pages/order/Order.tsx
@@ -294,6 +294,7 @@ function Order({ isCompanyOrder = false }: OrderProps) {
         },
         filters: activeFilterState.filters,
         sortBy: activeFilterState.sortBy,
+        pageSize: activeFilterState.pageSize,
       } satisfies CursorLocationState,
     });
   };

--- a/apps/storefront/src/pages/order/mapSfGqlOrderToListItem.ts
+++ b/apps/storefront/src/pages/order/mapSfGqlOrderToListItem.ts
@@ -13,9 +13,11 @@ export interface ListItem {
   createdAt: string;
   companyName: string;
   companyInfo?: CompanyInfoTypes;
+  /** Cursor from the SF GQL edge — populated for unified order paths only. */
+  cursor?: string;
 }
 
-export const mapSfGqlOrderToListItem = (order: SfGqlOrder): ListItem => ({
+export const mapSfGqlOrderToListItem = (order: SfGqlOrder, cursor?: string): ListItem => ({
   orderId: String(order.entityId),
   poNumber: order.reference || '',
   totalIncTax: String(order.totalIncTax.value),
@@ -39,4 +41,5 @@ export const mapSfGqlOrderToListItem = (order: SfGqlOrder): ListItem => ({
       }
     : undefined,
   money: '',
+  cursor,
 });


### PR DESCRIPTION
Jira: [B2B-4629](https://bigcommercecloud.atlassian.net/browse/B2B-4629)

## What/Why?
Implements prev/next order navigation on the Order Detail page for the unified Storefront GraphQL path. Previously, the `DetailPagination` component was hidden on the unified path because it relied on offset-based list positions which don't map to cursor-based pagination. This PR introduces a dedicated `CursorDetailPagination` component that carries cursor context from the list view and enables seamless order-to-order navigation without reloading the list.

## What changed

**New:**  A self-contained prev/next navigation component `CursorDetailPagination` component for the unified SF GQL path  which use a custom hook `useCursorDetailPagination`. 

**useCursorDetailPagination**: The generic layer (pure cursor state machine) takes care of `currentIndex`, `items`, `pageInfo`, `hasPrev/hasNext`, the in-page vs boundary branching logic, `exhaustBoundary`, and `syncHistory` logic. None of that is order-specific.

**CursorDetailPagination**: The order-specific layer is `fetchAdjacentPage` (which directly calls `getCompanyOrders`/`getCustomerOrders` and knows about `isCompanyOrder`, `OrdersFiltersInput`, `sortBy`) and the hardcoded `/orderDetail/${id}` route

Key behaviours of the new CursorDetailPagination(together with the new hook):
- **In-page navigation is instant (zero API calls).** The full orders page is passed from the list view via React Router location state and cached in component state. Navigating within that page just increments/decrements the index.
- **Page-boundary navigation fetches one adjacent page.** When the user reaches the first or last order of the cached page, the component fetches the previous or next page using `before`/`after` cursor arguments, lands on the last or first order of that page respectively, and updates the cached state.
- **Graceful degradation.** Renders nothing when no cursor context is present (e.g. direct URL access), satisfying the requirement that navigation controls only appear when meaningful.
- **History sync.** Each navigation step calls `navigate(..., { replace: true })` to keep the browser history entry in sync with the current cursor state, so back/forward browser navigation is consistent.
- Supports both customer (`GetCustomerOrders`) and company (`GetCompanyOrders`) order paths via the `isCompanyOrder` flag.

**Updated: `Order.tsx`**

- `goToDetail` now receives the full current page of list items and builds the `CursorLocationState` (orders + cursors, current index, pageInfo, active filters, sortBy) before navigating. This replaces the previous approach of passing a bare index and `totalCount: -1`.
- `mapSfGqlOrderToListItem` calls now forward the edge cursor so it's available on each list item.
- `navigateToOrderDetail` now branches on `isUnifiedOrders` (covering both company and customer unified paths) instead of `isUnifiedCustomerPath`, fixing an omission where company orders didn't get the cursor state.

**Updated: `DetailPagination.tsx`**

- Removed the `isUnifiedPath` guard (`totalCount === -1` check) and its early return, since unified navigation is now fully handled by `CursorDetailPagination`. `DetailPagination` is now legacy-only and no longer needs to know about the unified path.
- Cleaned up `aria-labelledby` and the order-position label which were conditioned on `!isUnifiedPath`.

**Updated: `OrderDetail/index.tsx`**

- Conditionally renders `CursorDetailPagination` (unified path) or `DetailPagination` (legacy path) based on `isUnifiedOrders`.
- Wrapped `handlePageChange` in `useCallback` to stabilise the reference passed as `onChange`.

**Updated: `mapSfGqlOrderToListItem.ts`**

- Added an optional `cursor?: string` field to `ListItem` and the mapper function so the SF GQL edge cursor travels with each list item through to the navigation state.

**Updated: `en.json`**

- Added `orderDetail.pagination.previousOrder` and `orderDetail.pagination.nextOrder` i18n keys used as `aria-label` on the navigation buttons.

## Test coverage

`CursorDetailPagination.test.tsx` (328 lines, new) covers:

- Renders nothing with no cursor state or empty orders list
- Button enabled/disabled states at page start, middle, and end
- In-page prev/next navigation (correct `onChange` calls, button state transitions)
- Page-boundary prev: fetches with correct `last`/`before` variables, lands on last order of returned page
- Page-boundary next: fetches with correct `first`/`after` variables, lands on first order of returned page
- Boundary fetch returning empty results disables the button without calling `onChange`
- Company order path uses `GetCompanyOrders`, not `GetCustomerOrders`

## Why this approach

Three cursor-based approaches were evaluated:

**Option 1: Pass the current item's cursor and adjacent cursors from the list view to the detail view (not chosen).** This would pass only three cursors to the detail view: the previous, current, and next order. The problem is that after the first navigation step those adjacent cursors are consumed — to move again you'd need to fetch the new order's neighbours, meaning every single click triggers an API call. It also breaks down entirely at page boundaries where the adjacent cursor simply doesn't exist in the set passed over.  A branch [B2B-4629](https://github.com/bigcommerce/b2b-buyer-portal/tree/B2B-4629) created based on this Option demonstrated how much effort need to maintain and update three cursors.

**Option 2: Fetch neighbours using `first: 1, after: currentCursor` and `last: 1, before: currentCursor` (not chosen).** This lets the detail page be fully self-sufficient without any state from the list view, but it pays an API round-trip on every navigation step. Stepping through five orders in a row means five sequential fetches, each returning a single item. That makes the feature feel slower than the offset-based legacy pagination it replaces, and it puts unnecessary load on the SF GQL API for the most common interaction pattern.

**Option 3: Cache the full page of order IDs from the list view and navigate within the cached set (chosen).** When the user clicks an order, the full current page of orders with their cursors and the active filter/sort state are passed to the detail view via React Router location state. Within-page navigation (the common case) is then instant with zero API calls — just an index increment/decrement over the cached set. Only crossing a true page boundary triggers a fetch, and that fetch retrieves the full adjacent page so subsequent steps within that page are also instant. The `CursorLocationState` interface is typed explicitly so the shape is clear and can be migrated to a shared store in future without changing the component's internal logic.

The tradeoff is that cursor context is lost on direct URL access or hard refresh. The component handles this by rendering nothing in that case rather than showing broken or misleading navigation controls.

## Rollout/Rollback
This feature is covered under FF, and we can revert this PR if needed

## Testing
All the unit tests added passed

When flag on, with mock data

https://github.com/user-attachments/assets/ff208db3-d9b4-4290-9d7b-8890dab26be4

[B2B-4629]: https://bigcommercecloud.atlassian.net/browse/B2B-4629?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core order list-to-detail navigation and boundary GraphQL fetches, but behavior is gated by the unified orders feature flag with graceful fallback when list context is missing.
> 
> **Overview**
> Adds **prev/next order navigation** on Order Detail for the unified Storefront GraphQL orders path (feature-flagged), replacing the previous behavior where pagination was hidden on that path.
> 
> The list view now passes a **`CursorLocationState`** in router history: the current page of order IDs and cursors, index, `pageInfo`, filters, sort, and page size. **`mapSfGqlOrderToListItem`** carries each edge’s cursor. **`CursorDetailPagination`** plus **`useCursorDetailPagination`** navigate within the cached page without API calls; at list page boundaries they fetch the adjacent page via **`getCustomerOrders`** / **`getCompanyOrders`** and update history with **`replace: true`**. Direct URL access or missing context hides controls. Legacy **`DetailPagination`** remains for non-unified orders; unified-specific guards were removed from it.
> 
> New copy in **`en.json`** covers navigation labels and fetch errors. Broad unit tests cover the hook and component.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4274174ef84a397f12d55c103be0fc0e4017dc79. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->