### PR TITLE
feat(quick-order): BACK-619 add backorder display to quick order pad

### DIFF
--- a/apps/storefront/src/components/B3ProductList.tsx
+++ b/apps/storefront/src/components/B3ProductList.tsx
@@ -3,12 +3,15 @@ import styled from '@emotion/styled';
 import { Box, Button, Checkbox, FormControlLabel, TextField, Typography } from '@mui/material';
 import noop from 'lodash-es/noop';
 
+import BackorderMessage from '@/components/BackorderMessage';
 import { PRODUCT_DEFAULT_IMAGE } from '@/constants';
 import { useMobile } from '@/hooks/useMobile';
 import { useB3Lang } from '@/lib/lang';
+import type { CatalogQuickVariantSku } from '@/shared/service/b2b/graphql/product';
 import { useAppSelector } from '@/store';
 import { currencyFormat, ordersCurrencyFormat } from '@/utils/b3CurrencyFormat';
 import { getDisplayPrice, judgmentBuyerProduct } from '@/utils/b3Product/b3Product';
+import { getCatalogProductRowDisplayState } from '@/utils/catalogBackorderDisplay';
 
 import { MoneyFormat, ProductItem } from '../types';
 
@@ -125,6 +128,15 @@ interface ProductProps<T> {
   textAlign?: string;
   type?: string;
   getCurrentProductUrls?: (productId: number | undefined) => void;
+  catalogBackorderUiEnabled?: boolean;
+  catalogInventoryBySku?: Record<string, CatalogQuickVariantSku>;
+  showAvailableToSellHelper?: boolean;
+  formatOnlyAvailable?: (availableToSell: number) => string;
+}
+
+function getProductVariantSku(product: ProductItem): string {
+  // List backorder UI only runs for no-options rows; the sole variant is always variants[0].
+  return product.variants?.[0]?.sku ?? product.sku;
 }
 
 export function B3ProductList<T>(props: ProductProps<T>) {
@@ -144,12 +156,17 @@ export function B3ProductList<T>(props: ProductProps<T>) {
     money,
     type,
     getCurrentProductUrls,
+    catalogBackorderUiEnabled = false,
+    catalogInventoryBySku,
+    showAvailableToSellHelper = false,
+    formatOnlyAvailable = () => '',
   } = props;
 
   const [list, setList] = useState<ProductItem[]>([]);
   const [isMobile] = useMobile();
   const b3Lang = useB3Lang();
   const showInclusiveTaxPrice = useAppSelector(({ global }) => global.showInclusiveTaxPrice);
+  const quantityStackItemsAlignment = textAlign === 'right' ? 'flex-end' : 'flex-start';
 
   const getQuantity = (product: any) => parseInt(product[quantityKey]?.toString() || '', 10) || '';
 
@@ -215,6 +232,10 @@ export function B3ProductList<T>(props: ProductProps<T>) {
   }, [products]);
 
   const itemStyle = isMobile ? mobileItemStyle : defaultItemStyle;
+  const desktopQtyColumnExtraSx: FlexItemProps['sx'] =
+    catalogBackorderUiEnabled && !isMobile ? { minWidth: '160px' } : undefined;
+  const desktopQtyColumnStyle =
+    catalogBackorderUiEnabled && !isMobile ? { width: '22%' } : itemStyle.qty;
 
   const showTypePrice = (newMoney: string | number, product: CustomFieldItems): string | number => {
     if (type === 'quote') {
@@ -250,7 +271,11 @@ export function B3ProductList<T>(props: ProductProps<T>) {
           <FlexItem textAlignLocation={textAlign} {...itemStyle.default}>
             <ProductHead>{b3Lang('global.searchProduct.price')}</ProductHead>
           </FlexItem>
-          <FlexItem textAlignLocation={textAlign} {...itemStyle.qty}>
+          <FlexItem
+            textAlignLocation={textAlign}
+            {...desktopQtyColumnStyle}
+            sx={desktopQtyColumnExtraSx}
+          >
             <ProductHead>{b3Lang('global.searchProduct.qty')}</ProductHead>
           </FlexItem>
           <FlexItem textAlignLocation={textAlign} {...itemStyle.default}>
@@ -311,6 +336,17 @@ export function B3ProductList<T>(props: ProductProps<T>) {
 
         const discountedPrice = Number(productPrice) - Number(discountAccountForSingleProduct);
         const discountedTotalPrice = getProductTotals(quantity, discountedPrice);
+
+        const variantSku = getProductVariantSku(product);
+        const inventoryRow = catalogInventoryBySku?.[variantSku.toUpperCase()];
+        const { qtyHelperText, backorderFields } = getCatalogProductRowDisplayState({
+          qty: Number(quantity) || 0,
+          productHelperText: product.helperText,
+          showAvailableToSellHelper,
+          inventoryRow,
+          backorderUiEnabled: catalogBackorderUiEnabled,
+          formatOnlyAvailable,
+        });
 
         const getDisplayPrice = (priceValue: number) => {
           const newMoney = money
@@ -429,36 +465,67 @@ export function B3ProductList<T>(props: ProductProps<T>) {
             {renderPrice('Price', productPrice, discountedPrice)}
             <FlexItem
               textAlignLocation={textAlign}
-              {...itemStyle.qty}
-              sx={
-                isMobile
+              {...desktopQtyColumnStyle}
+              sx={{
+                ...desktopQtyColumnExtraSx,
+                ...(isMobile
                   ? {
                       fontSize: '14px',
                     }
-                  : {}
-              }
+                  : {}),
+              }}
             >
               {quantityEditable ? (
-                <TextField
-                  type="number"
-                  variant="filled"
-                  hiddenLabel={!isMobile}
-                  label={isMobile ? 'Qty' : ''}
-                  value={quantity}
-                  onChange={handleProductQuantityChange(product.id)}
-                  onKeyDown={handleNumberInputKeyDown}
-                  onBlur={handleNumberInputBlur(product)}
-                  size="small"
+                <Box
                   sx={{
-                    width: isMobile ? '110px' : '72px',
-                    '& .MuiFormHelperText-root': {
-                      marginLeft: '0',
-                      marginRight: '0',
-                    },
+                    display: 'flex',
+                    flexDirection: 'column',
+                    alignItems: quantityStackItemsAlignment,
+                    width: '100%',
+                    maxWidth: '100%',
+                    minWidth: 0,
                   }}
-                  error={!!product.helperText}
-                  helperText={product.helperText}
-                />
+                >
+                  <TextField
+                    type="number"
+                    variant="filled"
+                    hiddenLabel={!isMobile}
+                    label={isMobile ? 'Qty' : ''}
+                    value={quantity}
+                    onChange={handleProductQuantityChange(product.id)}
+                    onKeyDown={handleNumberInputKeyDown}
+                    onBlur={handleNumberInputBlur(product)}
+                    size="small"
+                    sx={{
+                      width: isMobile ? '110px' : '72px',
+                      '& .MuiFormHelperText-root': {
+                        marginLeft: '0',
+                        marginRight: '0',
+                      },
+                    }}
+                    error={Boolean(qtyHelperText)}
+                    helperText={qtyHelperText || undefined}
+                  />
+                  {backorderFields && (
+                    <Box
+                      sx={{
+                        mt: 1,
+                        width: '100%',
+                        maxWidth: '100%',
+                        minWidth: 0,
+                        textAlign,
+                        alignSelf: quantityStackItemsAlignment,
+                      }}
+                    >
+                      <BackorderMessage
+                        totalOnHand={backorderFields.totalOnHand}
+                        quantityBackordered={backorderFields.quantityBackordered}
+                        backorderMessage={backorderFields.backorderMessage}
+                        visible
+                      />
+                    </Box>
+                  )}
+                </Box>
               ) : (
                 <>
                   {isMobile && <span>Qty: </span>}

--- a/apps/storefront/src/pages/QuickOrder/components/ProductListDialog.tsx
+++ b/apps/storefront/src/pages/QuickOrder/components/ProductListDialog.tsx
@@ -1,4 +1,12 @@
-import { ChangeEvent, KeyboardEvent, useCallback, useContext } from 'react';
+import {
+  ChangeEvent,
+  KeyboardEvent,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
 import { Search as SearchIcon } from '@mui/icons-material';
 import { Box, InputAdornment, TextField, Typography } from '@mui/material';
 
@@ -6,9 +14,14 @@ import B3Dialog from '@/components/B3Dialog';
 import { B3ProductList } from '@/components/B3ProductList';
 import CustomButton from '@/components/button/CustomButton';
 import B3Spin from '@/components/spin/B3Spin';
+import { useBackorderStorefrontMessaging } from '@/hooks/useBackorderStorefrontMessaging';
 import { useMobile } from '@/hooks/useMobile';
 import { useB3Lang } from '@/lib/lang';
 import { ShoppingListDetailsContext } from '@/pages/ShoppingListDetails/context/ShoppingListDetailsContext';
+import {
+  type CatalogQuickVariantSku,
+  getVariantInfoBySkus,
+} from '@/shared/service/b2b/graphql/product';
 import { useAppSelector } from '@/store';
 import { ShoppingListProductItem } from '@/types';
 import { snackbar } from '@/utils/b3Tip';
@@ -97,6 +110,67 @@ export default function ProductListDialog(props: ProductListDialogProps) {
   );
 
   const [isMobile] = useMobile();
+  const { isBackorderMessagingContextEnabled, hasAnyBackorderDisplay } =
+    useBackorderStorefrontMessaging();
+  const backorderUiEnabled = isBackorderMessagingContextEnabled && hasAnyBackorderDisplay;
+  const [variantInfoList, setVariantInfoList] = useState<CatalogQuickVariantSku[]>([]);
+
+  const variantSkuDependencyKey = useMemo(() => {
+    return [
+      ...new Set(
+        productList
+          .map((product) => product.variants?.[0]?.sku ?? product.sku)
+          .filter((sku): sku is string => Boolean(sku)),
+      ),
+    ]
+      .sort()
+      .join('|');
+  }, [productList]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      setVariantInfoList([]);
+
+      return () => {};
+    }
+
+    if (!backorderUiEnabled || !variantSkuDependencyKey) {
+      return () => {};
+    }
+
+    let cancelled = false;
+    const skus = variantSkuDependencyKey.split('|');
+
+    const fetchVariantInfo = async () => {
+      try {
+        const { variantSku: nextVariantInfoList = [] } = await getVariantInfoBySkus(skus);
+
+        if (!cancelled) {
+          setVariantInfoList(nextVariantInfoList);
+        }
+      } catch {
+        if (!cancelled) {
+          setVariantInfoList([]);
+        }
+      }
+    };
+
+    fetchVariantInfo();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen, backorderUiEnabled, variantSkuDependencyKey]);
+
+  const inventoryBySku = useMemo(() => {
+    const map: Record<string, CatalogQuickVariantSku> = {};
+    variantInfoList.forEach((row) => {
+      if (row.variantSku) {
+        map[row.variantSku.toUpperCase()] = row;
+      }
+    });
+    return map;
+  }, [variantInfoList]);
 
   const handleCancelClicked = () => {
     onCancel();
@@ -121,6 +195,12 @@ export default function ProductListDialog(props: ProductListDialogProps) {
       return true;
     },
     [b3Lang, isEnableProduct],
+  );
+
+  const formatOnlyAvailable = useCallback(
+    (count: number) =>
+      b3Lang('purchasedProducts.quickAdd.inlineErrors.insufficientStockSku', { count }),
+    [b3Lang],
   );
 
   const handleAddToList = (id: number) => {
@@ -191,6 +271,10 @@ export default function ProductListDialog(props: ProductListDialogProps) {
               type="quickOrder"
               textAlign={isMobile ? 'left' : 'right'}
               canToProduct
+              catalogBackorderUiEnabled={backorderUiEnabled}
+              catalogInventoryBySku={inventoryBySku}
+              showAvailableToSellHelper
+              formatOnlyAvailable={formatOnlyAvailable}
               onProductQuantityChange={onProductQuantityChange}
               renderAction={(product) => (
                 <ProductTableAction

--- a/apps/storefront/src/pages/QuickOrder/index.quickpad.test.tsx
+++ b/apps/storefront/src/pages/QuickOrder/index.quickpad.test.tsx
@@ -3,6 +3,7 @@ import { set } from 'lodash-es';
 import {
   buildCompanyStateWith,
   builder,
+  buildGlobalStateWith,
   buildStoreInfoStateWith,
   bulk,
   faker,
@@ -13,6 +14,7 @@ import {
   startMockServer,
   stringContainingAll,
   userEvent,
+  waitFor,
   within,
 } from 'tests/test-utils';
 import { when } from 'vitest-when';
@@ -206,6 +208,81 @@ const storeInfoWithDateFormat = buildStoreInfoStateWith({ timeFormat: { display:
 
 const preloadedState = { company: approvedB2BCompany, storeInfo: storeInfoWithDateFormat };
 
+interface VariantInfo {
+  isStock: '1' | '0';
+  stock: number;
+  calculatedPrice: string;
+  productId: string;
+  variantId: string;
+  baseSku: string;
+  productName: string;
+  categories: string[];
+  option: unknown[];
+  isVisible: '1' | '0';
+  minQuantity: number;
+  maxQuantity: number;
+  modifiers: unknown[];
+  purchasingDisabled: '1' | '0';
+  variantSku: string;
+  imageUrl: string;
+  inventoryTracking?: string;
+  availableToSell?: number;
+  unlimitedBackorder?: boolean;
+  totalOnHand?: number | null;
+  backorderMessage?: string | null;
+}
+
+interface VariantInfoResponse {
+  data: {
+    variantSku: VariantInfo[];
+  };
+}
+
+const buildVariantInfoWith = builder<VariantInfo>(() => ({
+  isStock: faker.helpers.arrayElement(['0', '1']),
+  stock: faker.number.int(),
+  calculatedPrice: faker.commerce.price(),
+  productId: faker.number.int().toString(),
+  variantId: faker.number.int().toString(),
+  baseSku: faker.string.uuid(),
+  productName: faker.commerce.productName(),
+  categories: Array.from({ length: faker.number.int({ min: 0, max: 3 }) }, () =>
+    faker.number.int().toString(),
+  ),
+  imageUrl: faker.image.url(),
+  option: [],
+  isVisible: faker.helpers.arrayElement(['0', '1']),
+  minQuantity: faker.number.int(),
+  maxQuantity: faker.number.int(),
+  modifiers: [],
+  purchasingDisabled: faker.helpers.arrayElement(['0', '1']),
+  variantSku: faker.string.uuid(),
+}));
+
+const buildVariantInfoResponseWith = builder<VariantInfoResponse>(() => ({
+  data: {
+    variantSku: [],
+  },
+}));
+
+const backorderPreloadedState = {
+  company: approvedB2BCompany,
+  storeInfo: storeInfoWithDateFormat,
+  global: buildGlobalStateWith({
+    backorderEnabled: true,
+    backorderDisplaySettings: {
+      showQuantityOnBackorder: true,
+      showQuantityOnHand: true,
+      showBackorderMessage: true,
+      showDefaultShippingExpectationPrompt: false,
+      defaultShippingExpectationPrompt: '',
+    },
+    featureFlags: {
+      'BACK-134.backorders_phase_1_1_control_messaging_on_storefront': true,
+    },
+  }),
+};
+
 beforeEach(() => {
   set(window, 'b2b.callbacks.dispatchEvent', vi.fn());
 });
@@ -385,6 +462,11 @@ describe('when search returns results', () => {
       initialSelectionEnd: Infinity,
     });
 
+    expect(within(dialog).queryByText('ready to ship', { exact: false })).not.toBeInTheDocument();
+    expect(
+      within(dialog).queryByText('will be backordered', { exact: false }),
+    ).not.toBeInTheDocument();
+
     expect(within(dialog).getByText('Laugh Canister')).toBeInTheDocument();
     expect(within(dialog).getByText('$123.00')).toBeInTheDocument();
     expect(within(dialog).getByText('$246.00')).toBeInTheDocument();
@@ -399,5 +481,94 @@ describe('when search returns results', () => {
     expect(window.b2b.callbacks.dispatchEvent).toHaveBeenCalledWith('on-cart-created', {
       cartId: '12345',
     });
+  });
+});
+
+describe('when backorder messaging is enabled', () => {
+  it('shows backorder prompts and available helper that updates when qty changes', async () => {
+    renderWithProviders(<QuickOrderPad />, { preloadedState: backorderPreloadedState });
+
+    const variantSku = 'LC-123';
+
+    const variant = buildVariantWith({
+      sku: variantSku,
+      purchasing_disabled: false,
+      bc_calculated_price: {
+        tax_exclusive: 123,
+      },
+    });
+
+    const searchProducts = vi.fn<(...arg: unknown[]) => SearchProductsResponse>();
+
+    when(searchProducts)
+      .calledWith(stringContainingAll('search: "Laugh Canister"', 'currencyCode: "USD"'))
+      .thenReturn({
+        data: {
+          productsSearch: [
+            buildSearchProductWith({
+              id: variant.product_id,
+              name: 'Laugh Canister',
+              sku: variantSku,
+              optionsV3: [],
+              isPriceHidden: false,
+              orderQuantityMinimum: 0,
+              orderQuantityMaximum: 0,
+              inventoryLevel: 100,
+              variants: [variant],
+            }),
+          ],
+        },
+      });
+
+    const variantInfo = buildVariantInfoWith({
+      variantSku,
+      inventoryTracking: 'variant',
+      availableToSell: 4,
+      unlimitedBackorder: false,
+      totalOnHand: 2,
+      backorderMessage: 'Lead time: 2-4 weeks',
+    });
+
+    const getVariantInfoBySkus = when(vi.fn())
+      .calledWith(expect.stringContaining(`variantSkus: ["${variantSku}"]`))
+      .thenReturn(buildVariantInfoResponseWith({ data: { variantSku: [variantInfo] } }));
+
+    server.use(
+      graphql.query('SearchProducts', ({ query }) => HttpResponse.json(searchProducts(query))),
+      graphql.query('GetVariantInfoBySkus', ({ query }) =>
+        HttpResponse.json(getVariantInfoBySkus(query)),
+      ),
+    );
+
+    const searchBox = screen.getByPlaceholderText('Search products');
+    await userEvent.type(searchBox, 'Laugh Canister');
+    await userEvent.click(screen.getByRole('button', { name: 'Search product' }));
+
+    const dialog = await screen.findByRole('dialog', { name: 'Quick order pad' });
+    const quantityInput = within(dialog).getByRole('spinbutton');
+
+    await userEvent.type(quantityInput, '10', {
+      initialSelectionStart: 0,
+      initialSelectionEnd: Infinity,
+    });
+
+    await waitFor(() => {
+      expect(within(dialog).getByText('4 available')).toBeVisible();
+    });
+    expect(within(dialog).getByText('2 ready to ship')).toBeVisible();
+    expect(within(dialog).getByText('2 will be backordered')).toBeVisible();
+    expect(within(dialog).getByText('Lead time: 2-4 weeks')).toBeVisible();
+
+    await userEvent.type(quantityInput, '2', {
+      initialSelectionStart: 0,
+      initialSelectionEnd: Infinity,
+    });
+
+    await waitFor(() => {
+      expect(within(dialog).queryByText('2 ready to ship')).not.toBeInTheDocument();
+    });
+    expect(within(dialog).queryByText('2 will be backordered')).not.toBeInTheDocument();
+    expect(within(dialog).queryByText('Lead time: 2-4 weeks')).not.toBeInTheDocument();
+    expect(within(dialog).queryByText('4 available')).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Jira: [BACK-619](https://bigcommercecloud.atlassian.net/browse/BACK-619)

## What/Why?
Adding backorder display lines to the the quick order pad, from the quick order flow.

## Rollout/Rollback
Merge/revert. Backorder display is gated by `Feature_Backorder && BACK-134.backorders_phase_1_1_control_messaging_on_storefront`.

## Testing
Quick order pad shows expected backorder lines and errors with changing quantity.

https://github.com/user-attachments/assets/a0fb7273-db80-4de7-8bcd-396be25845a5

Backorder display does not appear for disabled `Feature_Backorder && BACK-134.backorders_phase_1_1_control_messaging_on_storefront`.

https://github.com/user-attachments/assets/5c7d4063-06c9-4986-b927-cdeea3cf026b

Ping @animesh1987 @benpratt77 

[BACK-619]: https://bigcommercecloud.atlassian.net/browse/BACK-619?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Storefront quick-order quantity UX now depends on variant inventory GraphQL and shared backorder display logic; behavior is feature-flagged but affects what buyers see before add-to-cart.
> 
> **Overview**
> The quick order pad search results dialog now shows **backorder and availability messaging** next to quantity when storefront backorder settings and the BACK-134 messaging flag are on.
> 
> **`B3ProductList`** gains optional catalog props: it loads per-row inventory by variant SKU, derives helper text and backorder lines via `getCatalogProductRowDisplayState`, renders `BackorderMessage` under the qty field, and widens the desktop qty column when that UI is active.
> 
> **`ProductListDialog`** wires this up for quick order: it uses `useBackorderStorefrontMessaging`, fetches `getVariantInfoBySkus` for visible SKUs while the dialog is open, and passes inventory plus localized “only X available” formatting into the list.
> 
> Tests assert backorder copy is absent with default state and appears/updates with quantity when backorder preloaded state and `GetVariantInfoBySkus` are mocked.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22a9a4df782bcfe6fa73155d68420ea7f1c33b12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->