### PR TITLE
[B2B-4826] Migrate Order Detail shipments, billing, payment to SF GQL

### DIFF
--- a/apps/storefront/src/pages/CompanyOrderList/unified-company-orders.test.tsx
+++ b/apps/storefront/src/pages/CompanyOrderList/unified-company-orders.test.tsx
@@ -88,6 +88,7 @@ const buildSfGqlOrderWith = builder<Order>(() => ({
   quote: null,
   invoice: null,
   extraFields: [],
+  canReturn: true,
 }));
 
 const buildCompanyOrdersResponseWith = builder<GetCompanyOrdersResponse>(() => {

--- a/apps/storefront/src/pages/MyOrders/unified-orders.test.tsx
+++ b/apps/storefront/src/pages/MyOrders/unified-orders.test.tsx
@@ -89,6 +89,7 @@ const buildSfGqlOrderWith = builder<Order>(() => ({
   quote: null,
   invoice: null,
   extraFields: [],
+  canReturn: true,
 }));
 
 const buildSfGqlB2COrderWith = builder<Order>(() => ({

--- a/apps/storefront/src/pages/OrderDetail/index.unified.test.tsx
+++ b/apps/storefront/src/pages/OrderDetail/index.unified.test.tsx
@@ -120,6 +120,7 @@ const buildUnifiedOrderWith = builder<Order>(() => ({
   quote: null,
   invoice: null,
   extraFields: [],
+  canReturn: true,
 }));
 
 const buildOrderDetailResponseWith = builder<GetOrderDetailResponse>(() => ({
@@ -576,6 +577,476 @@ describe('Order detail path with unified SF GQL flag ON', () => {
     expect(screen.getByRole('heading', { name: 'Comments' })).toBeVisible();
     expect(screen.getByText('Customer note: leave at reception')).toBeVisible();
     expect(screen.getByText('Comments: Please call before delivery')).toBeVisible();
+  });
+
+  describe('B2B-4826: shipments', () => {
+    function buildShippedOrder(overrides: Partial<Order> = {}) {
+      return buildUnifiedOrderWith({
+        entityId: 6696,
+        status: { value: 'SHIPPED', label: 'Shipped' },
+        consignments: {
+          shipping: {
+            edges: [
+              {
+                cursor: 'sc1',
+                node: {
+                  entityId: 1001,
+                  shippingAddress: {
+                    firstName: 'Jane',
+                    lastName: 'Doe',
+                    company: 'Acme Corp',
+                    address1: '123 Main St',
+                    address2: null,
+                    city: 'Austin',
+                    stateOrProvince: 'TX',
+                    postalCode: '73301',
+                    country: 'United States',
+                    countryCode: 'US',
+                    phone: null,
+                    email: null,
+                  },
+                  shippingCost: { currencyCode: 'USD', value: 15 },
+                  lineItems: {
+                    edges: [
+                      {
+                        node: {
+                          entityId: 2001,
+                          productEntityId: 3001,
+                          variantEntityId: 4001,
+                          sku: 'WIDGET-A',
+                          brand: 'WidgetCo',
+                          name: 'Premium Widget',
+                          quantity: 3,
+                          productOptions: [],
+                          subTotalListPrice: { currencyCode: 'USD', value: 75 },
+                          image: { url: 'https://example.com/widget.jpg' },
+                          baseCatalogProduct: { path: '/widget/' },
+                        },
+                      },
+                    ],
+                  },
+                  shipments: {
+                    edges: [
+                      {
+                        node: {
+                          entityId: 5001,
+                          shippedAt: { utc: '2026-05-15T10:00:00Z' },
+                          shippingMethodName: 'Standard Shipping',
+                          shippingProviderName: 'FedEx',
+                          tracking: {
+                            number: '1Z999AA10123456784',
+                            url: 'https://fedex.com/track/1Z999AA10123456784',
+                          },
+                        },
+                      },
+                    ],
+                  },
+                },
+              },
+            ],
+          },
+          downloads: null,
+        },
+        payments: [{ description: 'Credit Card' }],
+        ...overrides,
+      });
+    }
+
+    function setupServerWithOrder(order: Order) {
+      server.use(
+        graphql.query('GetOrderDetail', () =>
+          HttpResponse.json(buildOrderDetailResponseWith({ data: { site: { order } } })),
+        ),
+        graphql.query('GetCustomerOrderStatuses', () =>
+          HttpResponse.json(
+            buildCustomerOrderStatusesWith({
+              data: {
+                bcOrderStatuses: [
+                  buildOrderStatusWith({ systemLabel: 'Shipped', customLabel: 'Shipped' }),
+                ],
+              },
+            }),
+          ),
+        ),
+        graphql.query('AddressConfig', () =>
+          HttpResponse.json(buildAddressConfigResponseWith('WHATEVER_VALUES')),
+        ),
+      );
+    }
+
+    async function renderAndWait() {
+      renderWithProviders(<OrderDetails />, {
+        preloadedState,
+        initialEntries: [{ state: { isCompanyOrder: false } }],
+      });
+      await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+    }
+
+    it('renders a shipped products section with tracking', async () => {
+      setupServerWithOrder(buildShippedOrder());
+      await renderAndWait();
+
+      expect(await screen.findByText(/Shipment/)).toBeVisible();
+      expect(screen.getByText(/FedEx/)).toBeVisible();
+      expect(screen.getByText('1Z999AA10123456784')).toBeVisible();
+      expect(screen.getByText('Premium Widget')).toBeVisible();
+    });
+
+    it('renders the shipping address', async () => {
+      setupServerWithOrder(buildShippedOrder());
+      await renderAndWait();
+
+      expect(await screen.findByText(/Jane Doe/)).toBeVisible();
+      expect(screen.getByText(/123 Main St/)).toBeVisible();
+    });
+
+    it('renders a not-shipped products section when no shipments exist', async () => {
+      const unshippedOrder = buildShippedOrder({
+        status: { value: 'PENDING', label: 'Pending' },
+        consignments: {
+          shipping: {
+            edges: [
+              {
+                cursor: 'sc1',
+                node: {
+                  entityId: 1001,
+                  shippingAddress: {
+                    firstName: 'Jane',
+                    lastName: 'Doe',
+                    company: 'Acme Corp',
+                    address1: '123 Main St',
+                    address2: null,
+                    city: 'Austin',
+                    stateOrProvince: 'TX',
+                    postalCode: '73301',
+                    country: 'United States',
+                    countryCode: 'US',
+                    phone: null,
+                    email: null,
+                  },
+                  shippingCost: { currencyCode: 'USD', value: 15 },
+                  lineItems: {
+                    edges: [
+                      {
+                        node: {
+                          entityId: 2001,
+                          productEntityId: 3001,
+                          variantEntityId: 4001,
+                          sku: 'WIDGET-A',
+                          brand: 'WidgetCo',
+                          name: 'Unshipped Widget',
+                          quantity: 2,
+                          productOptions: [],
+                          subTotalListPrice: { currencyCode: 'USD', value: 50 },
+                          image: null,
+                          baseCatalogProduct: null,
+                        },
+                      },
+                    ],
+                  },
+                  shipments: { edges: [] },
+                },
+              },
+            ],
+          },
+          downloads: null,
+        },
+      });
+
+      server.use(
+        graphql.query('GetOrderDetail', () =>
+          HttpResponse.json(
+            buildOrderDetailResponseWith({ data: { site: { order: unshippedOrder } } }),
+          ),
+        ),
+        graphql.query('GetCustomerOrderStatuses', () =>
+          HttpResponse.json(
+            buildCustomerOrderStatusesWith({
+              data: {
+                bcOrderStatuses: [
+                  buildOrderStatusWith({ systemLabel: 'Pending', customLabel: 'Pending' }),
+                ],
+              },
+            }),
+          ),
+        ),
+        graphql.query('AddressConfig', () =>
+          HttpResponse.json(buildAddressConfigResponseWith('WHATEVER_VALUES')),
+        ),
+      );
+
+      await renderAndWait();
+
+      expect(await screen.findByText('Not shipped yet')).toBeVisible();
+      expect(screen.getByText('Unshipped Widget')).toBeVisible();
+    });
+
+    it('renders multiple shipping addresses', async () => {
+      const multiAddressOrder = buildShippedOrder({
+        consignments: {
+          shipping: {
+            edges: [
+              {
+                cursor: 'sc1',
+                node: {
+                  entityId: 1001,
+                  shippingAddress: {
+                    firstName: 'Jane',
+                    lastName: 'Doe',
+                    company: 'Acme Corp',
+                    address1: '123 Main St',
+                    address2: null,
+                    city: 'Austin',
+                    stateOrProvince: 'TX',
+                    postalCode: '73301',
+                    country: 'United States',
+                    countryCode: 'US',
+                    phone: null,
+                    email: null,
+                  },
+                  shippingCost: { currencyCode: 'USD', value: 10 },
+                  lineItems: {
+                    edges: [
+                      {
+                        node: {
+                          entityId: 2001,
+                          productEntityId: 3001,
+                          variantEntityId: 4001,
+                          sku: 'W-A',
+                          brand: null,
+                          name: 'Widget A',
+                          quantity: 1,
+                          productOptions: [],
+                          subTotalListPrice: { currencyCode: 'USD', value: 25 },
+                          image: null,
+                          baseCatalogProduct: null,
+                        },
+                      },
+                    ],
+                  },
+                  shipments: { edges: [] },
+                },
+              },
+              {
+                cursor: 'sc2',
+                node: {
+                  entityId: 1002,
+                  shippingAddress: {
+                    firstName: 'Bob',
+                    lastName: 'Smith',
+                    company: 'Acme Corp',
+                    address1: '456 Oak Ave',
+                    address2: 'Suite 200',
+                    city: 'Dallas',
+                    stateOrProvince: 'TX',
+                    postalCode: '75201',
+                    country: 'United States',
+                    countryCode: 'US',
+                    phone: null,
+                    email: null,
+                  },
+                  shippingCost: { currencyCode: 'USD', value: 12 },
+                  lineItems: {
+                    edges: [
+                      {
+                        node: {
+                          entityId: 2002,
+                          productEntityId: 3002,
+                          variantEntityId: 4002,
+                          sku: 'W-B',
+                          brand: null,
+                          name: 'Widget B',
+                          quantity: 2,
+                          productOptions: [],
+                          subTotalListPrice: { currencyCode: 'USD', value: 50 },
+                          image: null,
+                          baseCatalogProduct: null,
+                        },
+                      },
+                    ],
+                  },
+                  shipments: { edges: [] },
+                },
+              },
+            ],
+          },
+          downloads: null,
+        },
+      });
+
+      setupServerWithOrder(multiAddressOrder);
+      await renderAndWait();
+
+      expect(await screen.findByText(/Jane Doe/)).toBeVisible();
+      expect(screen.getByText(/Bob Smith/)).toBeVisible();
+      expect(screen.getByText(/123 Main St/)).toBeVisible();
+      expect(screen.getByText(/456 Oak Ave/)).toBeVisible();
+    });
+  });
+
+  describe('B2B-4826: payment details', () => {
+    it('renders payment details for a paid-in-full order', async () => {
+      const paidOrder = buildUnifiedOrderWith({
+        entityId: 6696,
+        reference: null,
+        orderedAt: { utc: '2026-05-01T12:00:00Z' },
+        consignments: {
+          shipping: {
+            edges: [
+              {
+                cursor: 'sc1',
+                node: {
+                  entityId: 1001,
+                  shippingAddress: {
+                    firstName: 'Jane',
+                    lastName: 'Doe',
+                    company: '',
+                    address1: '123 Main St',
+                    address2: null,
+                    city: 'Austin',
+                    stateOrProvince: 'TX',
+                    postalCode: '73301',
+                    country: 'United States',
+                    countryCode: 'US',
+                    phone: null,
+                    email: null,
+                  },
+                  shippingCost: { currencyCode: 'USD', value: 0 },
+                  lineItems: {
+                    edges: [
+                      {
+                        node: {
+                          entityId: 2001,
+                          productEntityId: 3001,
+                          variantEntityId: null,
+                          sku: 'SKU1',
+                          brand: null,
+                          name: 'Test Product',
+                          quantity: 1,
+                          productOptions: [],
+                          subTotalListPrice: { currencyCode: 'USD', value: 100 },
+                          image: null,
+                          baseCatalogProduct: null,
+                        },
+                      },
+                    ],
+                  },
+                  shipments: { edges: [] },
+                },
+              },
+            ],
+          },
+          downloads: null,
+        },
+        payments: [{ description: 'Visa ending in 1234' }],
+      });
+
+      server.use(
+        graphql.query('GetOrderDetail', () =>
+          HttpResponse.json(
+            buildOrderDetailResponseWith({ data: { site: { order: paidOrder } } }),
+          ),
+        ),
+        graphql.query('GetCustomerOrderStatuses', () =>
+          HttpResponse.json(buildCustomerOrderStatusesWith('WHATEVER_VALUES')),
+        ),
+        graphql.query('AddressConfig', () =>
+          HttpResponse.json(buildAddressConfigResponseWith('WHATEVER_VALUES')),
+        ),
+      );
+
+      renderWithProviders(<OrderDetails />, {
+        preloadedState,
+        initialEntries: [{ state: { isCompanyOrder: false } }],
+      });
+
+      await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+      expect(screen.getByRole('heading', { name: 'Payment' })).toBeVisible();
+      expect(screen.getByText(/Paid in full/)).toBeVisible();
+      expect(screen.getByText(/Visa ending in 1234/)).toBeVisible();
+    });
+
+    it('renders payment details for a Purchase Order', async () => {
+      const poOrder = buildUnifiedOrderWith({
+        entityId: 6696,
+        reference: 'PO-2026-001',
+        orderedAt: { utc: '2026-05-01T12:00:00Z' },
+        consignments: {
+          shipping: {
+            edges: [
+              {
+                cursor: 'sc1',
+                node: {
+                  entityId: 1001,
+                  shippingAddress: {
+                    firstName: 'Jane',
+                    lastName: 'Doe',
+                    company: '',
+                    address1: '123 Main St',
+                    address2: null,
+                    city: 'Austin',
+                    stateOrProvince: 'TX',
+                    postalCode: '73301',
+                    country: 'United States',
+                    countryCode: 'US',
+                    phone: null,
+                    email: null,
+                  },
+                  shippingCost: { currencyCode: 'USD', value: 0 },
+                  lineItems: {
+                    edges: [
+                      {
+                        node: {
+                          entityId: 2001,
+                          productEntityId: 3001,
+                          variantEntityId: null,
+                          sku: 'SKU1',
+                          brand: null,
+                          name: 'Test Product',
+                          quantity: 1,
+                          productOptions: [],
+                          subTotalListPrice: { currencyCode: 'USD', value: 100 },
+                          image: null,
+                          baseCatalogProduct: null,
+                        },
+                      },
+                    ],
+                  },
+                  shipments: { edges: [] },
+                },
+              },
+            ],
+          },
+          downloads: null,
+        },
+        payments: [{ description: 'Purchase Order' }],
+      });
+
+      server.use(
+        graphql.query('GetOrderDetail', () =>
+          HttpResponse.json(
+            buildOrderDetailResponseWith({ data: { site: { order: poOrder } } }),
+          ),
+        ),
+        graphql.query('GetCustomerOrderStatuses', () =>
+          HttpResponse.json(buildCustomerOrderStatusesWith('WHATEVER_VALUES')),
+        ),
+        graphql.query('AddressConfig', () =>
+          HttpResponse.json(buildAddressConfigResponseWith('WHATEVER_VALUES')),
+        ),
+      );
+
+      renderWithProviders(<OrderDetails />, {
+        preloadedState,
+        initialEntries: [{ state: { isCompanyOrder: false } }],
+      });
+
+      await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+      expect(screen.getByRole('heading', { name: 'Payment' })).toBeVisible();
+      expect(screen.getByText(/PO Submitted/)).toBeVisible();
+    });
   });
 
   describe('when there are order history events', () => {

--- a/apps/storefront/src/pages/OrderDetail/index.unified.test.tsx
+++ b/apps/storefront/src/pages/OrderDetail/index.unified.test.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 import { useParams } from 'react-router-dom';
+import { set } from 'lodash-es';
 import {
   buildCompanyStateWith,
   builder,
@@ -12,11 +13,13 @@ import {
   renderWithProviders,
   screen,
   startMockServer,
+  stringContainingAll,
   userEvent,
   waitFor,
   waitForElementToBeRemoved,
   within,
 } from 'tests/test-utils';
+import { when } from 'vitest-when';
 
 import { AddressConfig } from '@/shared/service/b2b/graphql/address';
 import { CustomerOrderStatues, CustomerOrderStatus } from '@/shared/service/b2b/graphql/orders';
@@ -26,6 +29,7 @@ import { useAppDispatch } from '@/store';
 import { setCurrencies } from '@/store/slices/storeConfigs';
 import { Currency, CustomerRole } from '@/types';
 
+import { DigitalDownloadElementsResponse } from './components/getDigitalDownloadElements';
 import OrderDetails from '.';
 
 vi.mock('react-router-dom');
@@ -131,6 +135,66 @@ const buildOrderDetailResponseWith = builder<GetOrderDetailResponse>(() => ({
   },
 }));
 
+const buildDigitalProductNodeWith = builder<DigitalDownloadElementsResponse>(() => ({
+  data: {
+    site: {
+      order: {
+        consignments: {
+          downloads: [
+            {
+              lineItems: {
+                edges: [
+                  {
+                    node: {
+                      downloadFileUrls: [faker.internet.url(), faker.internet.url()],
+                      downloadPageUrl: faker.internet.url(),
+                      name: faker.commerce.productName(),
+                      productEntityId: faker.number.int(),
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+    },
+  },
+}));
+
+const buildCustomerShoppingListNodeWith = builder(() => ({
+  node: {
+    id: faker.number.int().toString(),
+    name: faker.lorem.word(),
+    description: faker.lorem.sentence(),
+    updatedAt: Math.floor(faker.date.recent().getTime() / 1000),
+    products: {
+      totalCount: faker.number.int({ min: 0, max: 10 }),
+    },
+  },
+}));
+
+const buildCustomerShoppingListResponseWith = builder(() => {
+  const totalCount = faker.number.int({ min: 1, max: 10 });
+
+  return {
+    data: {
+      customerShoppingLists: {
+        totalCount,
+        pageInfo: {
+          hasNextPage: faker.datatype.boolean(),
+          hasPreviousPage: faker.datatype.boolean(),
+        },
+        edges: bulk(buildCustomerShoppingListNodeWith, 'WHATEVER_VALUES').times(totalCount),
+      },
+    },
+  };
+});
+
+beforeEach(() => {
+  set(window, 'b2b.callbacks.dispatchEvent', vi.fn());
+});
+
 function OrderDetailsWithCurrencyHydration({ currencies }: { currencies?: Currency[] }) {
   const dispatch = useAppDispatch();
 
@@ -160,6 +224,7 @@ const preloadedState = {
     customer: { role: CustomerRole.B2C },
   }),
   global: buildGlobalStateWith({
+    backorderEnabled: false,
     featureFlags: {
       'B2B-4613.buyer_portal_unified_sf_gql_orders': true,
     },
@@ -943,9 +1008,7 @@ describe('Order detail path with unified SF GQL flag ON', () => {
 
       server.use(
         graphql.query('GetOrderDetail', () =>
-          HttpResponse.json(
-            buildOrderDetailResponseWith({ data: { site: { order: paidOrder } } }),
-          ),
+          HttpResponse.json(buildOrderDetailResponseWith({ data: { site: { order: paidOrder } } })),
         ),
         graphql.query('GetCustomerOrderStatuses', () =>
           HttpResponse.json(buildCustomerOrderStatusesWith('WHATEVER_VALUES')),
@@ -1025,9 +1088,7 @@ describe('Order detail path with unified SF GQL flag ON', () => {
 
       server.use(
         graphql.query('GetOrderDetail', () =>
-          HttpResponse.json(
-            buildOrderDetailResponseWith({ data: { site: { order: poOrder } } }),
-          ),
+          HttpResponse.json(buildOrderDetailResponseWith({ data: { site: { order: poOrder } } })),
         ),
         graphql.query('GetCustomerOrderStatuses', () =>
           HttpResponse.json(buildCustomerOrderStatusesWith('WHATEVER_VALUES')),
@@ -1121,6 +1182,1994 @@ describe('Order detail path with unified SF GQL flag ON', () => {
       const shippedRow = within(within(table).getByRole('row', { name: /Shipped/ }));
       expect(shippedRow.getByRole('cell', { name: 'Shipped' })).toBeVisible();
       expect(shippedRow.getByRole('cell', { name: 'May 4 2025 @ 7:22 AM' })).toBeVisible();
+    });
+  });
+
+  describe('B2B-4826: digital products', () => {
+    function buildOrderWithDigitalProducts(
+      digitalItems: Array<{
+        entityId: number;
+        productEntityId: number;
+        name: string;
+        quantity: number;
+        productOptions: Array<{ name: string; value: string }>;
+        subTotalListPrice: { currencyCode: string; value: number };
+      }>,
+      physicalConsignment?: Order['consignments'],
+    ) {
+      const downloads = {
+        edges: [
+          {
+            cursor: 'dc1',
+            node: {
+              entityId: 9001,
+              lineItems: {
+                edges: digitalItems.map((item) => ({ node: item })),
+              },
+            },
+          },
+        ],
+      };
+
+      const shipping = physicalConsignment?.shipping ?? { edges: [] };
+
+      return buildUnifiedOrderWith({
+        entityId: 6696,
+        consignments: {
+          shipping,
+          downloads,
+        },
+      });
+    }
+
+    const euro = buildCurrencyWith({
+      country_iso2: 'DE',
+      default_for_country_codes: ['EUR'],
+      currency_code: 'EUR',
+      currency_exchange_rate: '0.85',
+      name: 'Euro',
+      token: '€',
+      decimal_token: ',',
+      thousands_token: '.',
+    });
+
+    const euroPreloadedState = {
+      ...preloadedState,
+      storeConfigs: {
+        currencies: {
+          currencies: [euro],
+          channelCurrencies: {
+            channel_id: 1,
+            enabled_currencies: ['EUR'],
+            default_currency: 'EUR',
+          },
+          enteredInclusiveTax: false,
+        },
+      },
+    };
+
+    it('renders a digital products section', async () => {
+      const digitalOrder = buildOrderWithDigitalProducts([
+        {
+          entityId: 5001,
+          productEntityId: 3001,
+          name: 'Scare Floor Operations Manual (eBook)',
+          quantity: 112,
+          productOptions: [{ name: 'Format', value: 'ePub' }],
+          subTotalListPrice: { currencyCode: 'EUR', value: 2502.08 },
+        },
+      ]);
+
+      server.use(
+        graphql.query('GetOrderDetail', () =>
+          HttpResponse.json(
+            buildOrderDetailResponseWith({ data: { site: { order: digitalOrder } } }),
+          ),
+        ),
+        graphql.query('GetCustomerOrderStatuses', () =>
+          HttpResponse.json(buildCustomerOrderStatusesWith('WHATEVER_VALUES')),
+        ),
+        graphql.query('AddressConfig', () =>
+          HttpResponse.json(buildAddressConfigResponseWith('WHATEVER_VALUES')),
+        ),
+      );
+
+      renderWithProviders(<OrderDetails />, {
+        preloadedState: euroPreloadedState,
+        initialEntries: [{ state: { isCompanyOrder: false } }],
+      });
+
+      await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+      expect(await screen.findByText('Digital products')).toBeVisible();
+      expect(screen.getByText('Scare Floor Operations Manual (eBook)')).toBeVisible();
+      expect(screen.getByText('112')).toBeVisible();
+      expect(screen.getByText('Format: ePub')).toBeVisible();
+    });
+
+    it('displays the view files link for digital products in an order', async () => {
+      const digitalOrder = buildOrderWithDigitalProducts([
+        {
+          entityId: 5001,
+          productEntityId: 1234,
+          name: 'Digital Product',
+          quantity: 1,
+          productOptions: [],
+          subTotalListPrice: { currencyCode: 'USD', value: 10 },
+        },
+      ]);
+
+      const digitalDownloadElements = buildDigitalProductNodeWith({
+        data: {
+          site: {
+            order: {
+              consignments: {
+                downloads: [
+                  {
+                    lineItems: {
+                      edges: [
+                        {
+                          node: {
+                            name: '',
+                            downloadPageUrl: '',
+                            downloadFileUrls: ['cat.com', 'meow.com'],
+                            productEntityId: 1234,
+                          },
+                        },
+                      ],
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        },
+      });
+
+      server.use(
+        graphql.query('GetOrderDetail', () =>
+          HttpResponse.json(
+            buildOrderDetailResponseWith({ data: { site: { order: digitalOrder } } }),
+          ),
+        ),
+        graphql.query('GetCustomerOrderStatuses', () =>
+          HttpResponse.json(buildCustomerOrderStatusesWith('WHATEVER_VALUES')),
+        ),
+        graphql.query('AddressConfig', () =>
+          HttpResponse.json(buildAddressConfigResponseWith('WHATEVER_VALUES')),
+        ),
+        graphql.query('GetDigitalDownloadLinks', () => HttpResponse.json(digitalDownloadElements)),
+      );
+
+      renderWithProviders(<OrderDetails />, {
+        preloadedState,
+        initialEntries: [{ state: { isCompanyOrder: false } }],
+      });
+
+      await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+      expect(await screen.findByText('Digital products')).toBeVisible();
+      expect(await screen.findByText('View files')).toBeVisible();
+      await userEvent.click(await screen.findByText('View files'));
+
+      expect(screen.getByText('Files to download')).toBeVisible();
+
+      await waitFor(() => {
+        expect(screen.getAllByRole('button', { name: 'Download' })).toHaveLength(2);
+      });
+    });
+
+    it('does not render the view files link for physical products and digital products with no file in an order', async () => {
+      const physicalConsignment: Order['consignments'] = {
+        shipping: {
+          edges: [
+            {
+              cursor: 'sc1',
+              node: {
+                entityId: 1001,
+                shippingAddress: {
+                  firstName: 'Jane',
+                  lastName: 'Doe',
+                  company: '',
+                  address1: '123 Main St',
+                  address2: null,
+                  city: 'Austin',
+                  stateOrProvince: 'TX',
+                  postalCode: '73301',
+                  country: 'United States',
+                  countryCode: 'US',
+                  phone: null,
+                  email: null,
+                },
+                shippingCost: { currencyCode: 'USD', value: 0 },
+                lineItems: {
+                  edges: [
+                    {
+                      node: {
+                        entityId: 2001,
+                        productEntityId: 3001,
+                        variantEntityId: 4001,
+                        sku: 'PHONE-1',
+                        brand: null,
+                        name: 'Phone',
+                        quantity: 2,
+                        productOptions: [],
+                        subTotalListPrice: { currencyCode: 'USD', value: 200 },
+                        image: null,
+                        baseCatalogProduct: null,
+                      },
+                    },
+                  ],
+                },
+                shipments: { edges: [] },
+              },
+            },
+          ],
+        },
+        downloads: {
+          edges: [
+            {
+              cursor: 'dc1',
+              node: {
+                entityId: 9001,
+                lineItems: {
+                  edges: [
+                    {
+                      node: {
+                        entityId: 5001,
+                        productEntityId: 3002,
+                        name: 'How to meow',
+                        quantity: 1,
+                        productOptions: [],
+                        subTotalListPrice: { currencyCode: 'USD', value: 10 },
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+          ],
+        },
+      };
+
+      const orderWithBoth = buildUnifiedOrderWith({
+        entityId: 6696,
+        consignments: physicalConsignment,
+      });
+
+      server.use(
+        graphql.query('GetOrderDetail', () =>
+          HttpResponse.json(
+            buildOrderDetailResponseWith({ data: { site: { order: orderWithBoth } } }),
+          ),
+        ),
+        graphql.query('GetCustomerOrderStatuses', () =>
+          HttpResponse.json(buildCustomerOrderStatusesWith('WHATEVER_VALUES')),
+        ),
+        graphql.query('AddressConfig', () =>
+          HttpResponse.json(buildAddressConfigResponseWith('WHATEVER_VALUES')),
+        ),
+      );
+
+      renderWithProviders(<OrderDetails />, {
+        preloadedState,
+        initialEntries: [{ state: { isCompanyOrder: false } }],
+      });
+
+      await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+      expect(await screen.findByText('Phone')).toBeVisible();
+      expect(await screen.findByText('How to meow')).toBeVisible();
+      expect(screen.queryByText('View files')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('B2B-4826: reorder — frontend validation', () => {
+    function buildUnifiedOrderWithProducts(
+      products: Array<{
+        entityId: number;
+        productEntityId: number;
+        variantEntityId: number | null;
+        name: string;
+        quantity: number;
+        productOptions: Array<{ name: string; value: string }>;
+      }>,
+    ) {
+      return buildUnifiedOrderWith({
+        entityId: 6696,
+        consignments: {
+          shipping: {
+            edges: [
+              {
+                cursor: 'sc1',
+                node: {
+                  entityId: 1001,
+                  shippingAddress: {
+                    firstName: 'Jane',
+                    lastName: 'Doe',
+                    company: '',
+                    address1: '123 Main St',
+                    address2: null,
+                    city: 'Austin',
+                    stateOrProvince: 'TX',
+                    postalCode: '73301',
+                    country: 'United States',
+                    countryCode: 'US',
+                    phone: null,
+                    email: null,
+                  },
+                  shippingCost: { currencyCode: 'USD', value: 0 },
+                  lineItems: {
+                    edges: products.map((p) => ({
+                      node: {
+                        entityId: p.entityId,
+                        productEntityId: p.productEntityId,
+                        variantEntityId: p.variantEntityId,
+                        sku: `SKU-${p.productEntityId}`,
+                        brand: null,
+                        name: p.name,
+                        quantity: p.quantity,
+                        productOptions: p.productOptions,
+                        subTotalListPrice: { currencyCode: 'USD', value: p.quantity * 10 },
+                        image: null,
+                        baseCatalogProduct: null,
+                      },
+                    })),
+                  },
+                  shipments: { edges: [] },
+                },
+              },
+            ],
+          },
+          downloads: null,
+        },
+      });
+    }
+
+    it('can re-order a single product', async () => {
+      const screamProduct = {
+        entityId: 2001,
+        productEntityId: 3001,
+        variantEntityId: 4001,
+        name: 'Scream Canister',
+        quantity: 2,
+        productOptions: [] as Array<{ name: string; value: string }>,
+      };
+      const laughProduct = {
+        entityId: 2002,
+        productEntityId: 3002,
+        variantEntityId: 4002,
+        name: 'Laugh Canister',
+        quantity: 1,
+        productOptions: [{ name: 'Color', value: 'bar' }],
+      };
+
+      const order = buildUnifiedOrderWithProducts([screamProduct, laughProduct]);
+      const createCartSimple = vi.fn();
+
+      server.use(
+        graphql.query('GetOrderDetail', () =>
+          HttpResponse.json(buildOrderDetailResponseWith({ data: { site: { order } } })),
+        ),
+        graphql.query('GetCustomerOrderStatuses', () =>
+          HttpResponse.json(buildCustomerOrderStatusesWith('WHATEVER_VALUES')),
+        ),
+        graphql.query('AddressConfig', () =>
+          HttpResponse.json(buildAddressConfigResponseWith('WHATEVER_VALUES')),
+        ),
+        graphql.query('getCart', () => HttpResponse.json({ data: { site: { cart: null } } })),
+        graphql.mutation('createCartSimple', ({ variables }) =>
+          HttpResponse.json(createCartSimple(variables)),
+        ),
+      );
+
+      createCartSimple.mockReturnValue({
+        data: { cart: { createCart: { cart: { entityId: 'foo-bar' } } } },
+      });
+
+      renderWithProviders(<OrderDetails />, {
+        preloadedState,
+        initialEntries: [{ state: { isCompanyOrder: false } }],
+      });
+
+      await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+      await userEvent.click(screen.getByRole('button', { name: 'Re-Order' }));
+
+      const dialog = await screen.findByRole('dialog', { name: 'Re-Order' });
+
+      expect(within(dialog).getByText('Select products and quantity for reorder')).toBeVisible();
+
+      const productGroup = within(dialog).getByRole('group', { name: 'Laugh Canister' });
+
+      await userEvent.click(within(productGroup).getByRole('checkbox'));
+
+      await userEvent.click(screen.getByRole('button', { name: 'Add to cart' }));
+
+      await waitFor(() => {
+        expect(screen.getByText('Products are added to cart')).toBeVisible();
+      });
+
+      expect(createCartSimple).toHaveBeenCalledWith(
+        expect.objectContaining({
+          createCartInput: expect.objectContaining({
+            lineItems: expect.arrayContaining([
+              expect.objectContaining({
+                quantity: 1,
+                productEntityId: 3002,
+                variantEntityId: 4002,
+              }),
+            ]),
+          }),
+        }),
+      );
+
+      expect(window.b2b.callbacks.dispatchEvent).toHaveBeenCalledWith('on-cart-created', {
+        cartId: 'foo-bar',
+      });
+    });
+
+    it('can adjust the quantity of a product', async () => {
+      const screamProduct = {
+        entityId: 2001,
+        productEntityId: 3001,
+        variantEntityId: 4001,
+        name: 'Scream Canister',
+        quantity: 1,
+        productOptions: [] as Array<{ name: string; value: string }>,
+      };
+
+      const order = buildUnifiedOrderWithProducts([screamProduct]);
+      const createCartSimple = vi.fn();
+
+      server.use(
+        graphql.query('GetOrderDetail', () =>
+          HttpResponse.json(buildOrderDetailResponseWith({ data: { site: { order } } })),
+        ),
+        graphql.query('GetCustomerOrderStatuses', () =>
+          HttpResponse.json(buildCustomerOrderStatusesWith('WHATEVER_VALUES')),
+        ),
+        graphql.query('AddressConfig', () =>
+          HttpResponse.json(buildAddressConfigResponseWith('WHATEVER_VALUES')),
+        ),
+        graphql.query('getCart', () => HttpResponse.json({ data: { site: { cart: null } } })),
+        graphql.mutation('createCartSimple', ({ variables }) =>
+          HttpResponse.json(createCartSimple(variables)),
+        ),
+      );
+
+      createCartSimple.mockReturnValue({
+        data: { cart: { createCart: { cart: { entityId: 'foo-bar' } } } },
+      });
+
+      renderWithProviders(<OrderDetails />, {
+        preloadedState,
+        initialEntries: [{ state: { isCompanyOrder: false } }],
+      });
+
+      await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+      await userEvent.click(screen.getByRole('button', { name: 'Re-Order' }));
+
+      const dialog = await screen.findByRole('dialog', { name: 'Re-Order' });
+
+      expect(within(dialog).getByText('Select products and quantity for reorder')).toBeVisible();
+
+      const productGroup = within(dialog).getByRole('group', { name: 'Scream Canister' });
+
+      await userEvent.click(within(productGroup).getByRole('checkbox'));
+
+      await userEvent.type(within(productGroup).getByRole('spinbutton'), '2', {
+        initialSelectionStart: 0,
+        initialSelectionEnd: 1,
+      });
+
+      await userEvent.click(screen.getByRole('button', { name: 'Add to cart' }));
+
+      await waitFor(() => {
+        expect(screen.getByText('Products are added to cart')).toBeVisible();
+      });
+
+      expect(createCartSimple).toHaveBeenCalledWith(
+        expect.objectContaining({
+          createCartInput: expect.objectContaining({
+            lineItems: expect.arrayContaining([
+              expect.objectContaining({
+                quantity: 2,
+                productEntityId: 3001,
+                variantEntityId: 4001,
+              }),
+            ]),
+          }),
+        }),
+      );
+
+      expect(window.b2b.callbacks.dispatchEvent).toHaveBeenCalledWith('on-cart-created', {
+        cartId: 'foo-bar',
+      });
+    });
+
+    it('can re-order all products in one go', async () => {
+      const screamProduct = {
+        entityId: 2001,
+        productEntityId: 3001,
+        variantEntityId: 4001,
+        name: 'Scream Canister',
+        quantity: 2,
+        productOptions: [] as Array<{ name: string; value: string }>,
+      };
+      const laughProduct = {
+        entityId: 2002,
+        productEntityId: 3002,
+        variantEntityId: 4002,
+        name: 'Laugh Canister',
+        quantity: 1,
+        productOptions: [] as Array<{ name: string; value: string }>,
+      };
+
+      const order = buildUnifiedOrderWithProducts([screamProduct, laughProduct]);
+      const createCartSimple = vi.fn();
+
+      server.use(
+        graphql.query('GetOrderDetail', () =>
+          HttpResponse.json(buildOrderDetailResponseWith({ data: { site: { order } } })),
+        ),
+        graphql.query('GetCustomerOrderStatuses', () =>
+          HttpResponse.json(buildCustomerOrderStatusesWith('WHATEVER_VALUES')),
+        ),
+        graphql.query('AddressConfig', () =>
+          HttpResponse.json(buildAddressConfigResponseWith('WHATEVER_VALUES')),
+        ),
+        graphql.query('getCart', () => HttpResponse.json({ data: { site: { cart: null } } })),
+        graphql.mutation('createCartSimple', ({ variables }) =>
+          HttpResponse.json(createCartSimple(variables)),
+        ),
+      );
+
+      createCartSimple.mockReturnValue({
+        data: { cart: { createCart: { cart: { entityId: 'foo-bar' } } } },
+      });
+
+      renderWithProviders(<OrderDetails />, {
+        preloadedState,
+        initialEntries: [{ state: { isCompanyOrder: false } }],
+      });
+
+      await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+      await userEvent.click(screen.getByRole('button', { name: 'Re-Order' }));
+
+      const checkboxes = await screen.findAllByRole('checkbox');
+
+      await userEvent.click(checkboxes[0]); // Select all checkbox
+
+      await userEvent.click(screen.getByRole('button', { name: 'Add to cart' }));
+
+      await waitFor(() => {
+        expect(screen.getByText('Products are added to cart')).toBeVisible();
+      });
+
+      expect(createCartSimple).toHaveBeenCalledWith(
+        expect.objectContaining({
+          createCartInput: expect.objectContaining({
+            lineItems: expect.arrayContaining([
+              expect.objectContaining({
+                quantity: 2,
+                productEntityId: 3001,
+                variantEntityId: 4001,
+              }),
+              expect.objectContaining({
+                quantity: 1,
+                productEntityId: 3002,
+                variantEntityId: 4002,
+              }),
+            ]),
+          }),
+        }),
+      );
+
+      expect(window.b2b.callbacks.dispatchEvent).toHaveBeenCalledWith('on-cart-created', {
+        cartId: 'foo-bar',
+      });
+    });
+
+    it('shows a warning if no product is selected', async () => {
+      const screamProduct = {
+        entityId: 2001,
+        productEntityId: 3001,
+        variantEntityId: 4001,
+        name: 'Scream Canister',
+        quantity: 2,
+        productOptions: [] as Array<{ name: string; value: string }>,
+      };
+      const laughProduct = {
+        entityId: 2002,
+        productEntityId: 3002,
+        variantEntityId: 4002,
+        name: 'Laugh Canister',
+        quantity: 1,
+        productOptions: [] as Array<{ name: string; value: string }>,
+      };
+
+      const order = buildUnifiedOrderWithProducts([screamProduct, laughProduct]);
+
+      server.use(
+        graphql.query('GetOrderDetail', () =>
+          HttpResponse.json(buildOrderDetailResponseWith({ data: { site: { order } } })),
+        ),
+        graphql.query('GetCustomerOrderStatuses', () =>
+          HttpResponse.json(buildCustomerOrderStatusesWith('WHATEVER_VALUES')),
+        ),
+        graphql.query('AddressConfig', () =>
+          HttpResponse.json(buildAddressConfigResponseWith('WHATEVER_VALUES')),
+        ),
+      );
+
+      renderWithProviders(<OrderDetails />, {
+        preloadedState,
+        initialEntries: [{ state: { isCompanyOrder: false } }],
+      });
+
+      await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+      await userEvent.click(screen.getByRole('button', { name: 'Re-Order' }));
+
+      await userEvent.click(screen.getByRole('button', { name: 'Add to cart' }));
+
+      await waitFor(() => {
+        expect(screen.getByText('Please select at least one item')).toBeVisible();
+      });
+    });
+  });
+
+  describe('B2B-4826: reorder — backend validation', () => {
+    const backorderPreloadedState = {
+      company: buildCompanyStateWith({
+        customer: { role: CustomerRole.B2C },
+      }),
+      global: buildGlobalStateWith({
+        backorderEnabled: true,
+        featureFlags: {
+          'B2B-4613.buyer_portal_unified_sf_gql_orders': true,
+        },
+      }),
+      storeInfo: buildStoreInfoStateWith({ timeFormat: { display: 'j F Y' } }),
+    };
+
+    function buildUnifiedOrderWithProducts(
+      products: Array<{
+        entityId: number;
+        productEntityId: number;
+        variantEntityId: number | null;
+        name: string;
+        quantity: number;
+        productOptions: Array<{ name: string; value: string }>;
+      }>,
+    ) {
+      return buildUnifiedOrderWith({
+        entityId: 6696,
+        consignments: {
+          shipping: {
+            edges: [
+              {
+                cursor: 'sc1',
+                node: {
+                  entityId: 1001,
+                  shippingAddress: {
+                    firstName: 'Jane',
+                    lastName: 'Doe',
+                    company: '',
+                    address1: '123 Main St',
+                    address2: null,
+                    city: 'Austin',
+                    stateOrProvince: 'TX',
+                    postalCode: '73301',
+                    country: 'United States',
+                    countryCode: 'US',
+                    phone: null,
+                    email: null,
+                  },
+                  shippingCost: { currencyCode: 'USD', value: 0 },
+                  lineItems: {
+                    edges: products.map((p) => ({
+                      node: {
+                        entityId: p.entityId,
+                        productEntityId: p.productEntityId,
+                        variantEntityId: p.variantEntityId,
+                        sku: `SKU-${p.productEntityId}`,
+                        brand: null,
+                        name: p.name,
+                        quantity: p.quantity,
+                        productOptions: p.productOptions,
+                        subTotalListPrice: { currencyCode: 'USD', value: p.quantity * 10 },
+                        image: null,
+                        baseCatalogProduct: null,
+                      },
+                    })),
+                  },
+                  shipments: { edges: [] },
+                },
+              },
+            ],
+          },
+          downloads: null,
+        },
+      });
+    }
+
+    it('can re-order a single product', async () => {
+      const screamProduct = {
+        entityId: 2001,
+        productEntityId: 3001,
+        variantEntityId: 4001,
+        name: 'Scream Canister',
+        quantity: 2,
+        productOptions: [] as Array<{ name: string; value: string }>,
+      };
+      const laughProduct = {
+        entityId: 2002,
+        productEntityId: 123,
+        variantEntityId: 456,
+        name: 'Laugh Canister',
+        quantity: 1,
+        productOptions: [{ name: 'Color', value: 'bar' }],
+      };
+
+      const order = buildUnifiedOrderWithProducts([screamProduct, laughProduct]);
+      const createCartSimple = vi.fn();
+
+      const validateProducts = when(vi.fn())
+        .calledWith({
+          productId: 123,
+          variantId: 456,
+          quantity: 1,
+          productOptions: [{ optionId: 0, optionValue: 'bar' }],
+          target: 'CART',
+        })
+        .thenReturn({
+          data: {
+            validateProduct: {
+              responseType: 'SUCCESS',
+              message: '',
+            },
+          },
+        });
+
+      server.use(
+        graphql.query('GetOrderDetail', () =>
+          HttpResponse.json(buildOrderDetailResponseWith({ data: { site: { order } } })),
+        ),
+        graphql.query('GetCustomerOrderStatuses', () =>
+          HttpResponse.json(buildCustomerOrderStatusesWith('WHATEVER_VALUES')),
+        ),
+        graphql.query('AddressConfig', () =>
+          HttpResponse.json(buildAddressConfigResponseWith('WHATEVER_VALUES')),
+        ),
+        graphql.query('getCart', () => HttpResponse.json({ data: { site: { cart: null } } })),
+        graphql.mutation('createCartSimple', ({ variables }) =>
+          HttpResponse.json(createCartSimple(variables)),
+        ),
+        graphql.query('ValidateProduct', ({ variables }) =>
+          HttpResponse.json(validateProducts(variables)),
+        ),
+      );
+
+      when(createCartSimple)
+        .calledWith({
+          createCartInput: {
+            lineItems: [
+              {
+                quantity: 1,
+                productEntityId: 123,
+                variantEntityId: 456,
+                selectedOptions: {
+                  multipleChoices: [],
+                  textFields: [{ optionEntityId: 0, text: 'bar' }],
+                },
+              },
+            ],
+          },
+        })
+        .thenReturn({ data: { cart: { createCart: { cart: { entityId: 'foo-bar' } } } } });
+
+      renderWithProviders(<OrderDetails />, {
+        preloadedState: backorderPreloadedState,
+        initialEntries: [{ state: { isCompanyOrder: false } }],
+      });
+
+      await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+      await userEvent.click(screen.getByRole('button', { name: 'Re-Order' }));
+
+      const dialog = await screen.findByRole('dialog', { name: 'Re-Order' });
+
+      expect(within(dialog).getByText('Select products and quantity for reorder')).toBeVisible();
+
+      const productGroup = within(dialog).getByRole('group', { name: 'Laugh Canister' });
+
+      await userEvent.click(within(productGroup).getByRole('checkbox'));
+
+      await userEvent.click(screen.getByRole('button', { name: 'Add to cart' }));
+
+      await waitFor(() => {
+        expect(screen.getByText('Products are added to cart')).toBeVisible();
+      });
+
+      expect(window.b2b.callbacks.dispatchEvent).toHaveBeenCalledWith('on-cart-created', {
+        cartId: 'foo-bar',
+      });
+    });
+
+    it('displays an error message when all products fail validation', async () => {
+      const laughProduct = {
+        entityId: 2001,
+        productEntityId: 123,
+        variantEntityId: 456,
+        name: 'Laugh Canister',
+        quantity: 1,
+        productOptions: [] as Array<{ name: string; value: string }>,
+      };
+
+      const order = buildUnifiedOrderWithProducts([laughProduct]);
+
+      server.use(
+        graphql.query('GetOrderDetail', () =>
+          HttpResponse.json(buildOrderDetailResponseWith({ data: { site: { order } } })),
+        ),
+        graphql.query('GetCustomerOrderStatuses', () =>
+          HttpResponse.json(buildCustomerOrderStatusesWith('WHATEVER_VALUES')),
+        ),
+        graphql.query('AddressConfig', () =>
+          HttpResponse.json(buildAddressConfigResponseWith('WHATEVER_VALUES')),
+        ),
+        graphql.query('ValidateProduct', () =>
+          HttpResponse.json({
+            data: {
+              validateProduct: {
+                errorCode: 'OOS',
+                responseType: 'ERROR',
+                message: 'A message from the backend',
+                product: { availableToSell: 5 },
+              },
+            },
+          }),
+        ),
+      );
+
+      renderWithProviders(<OrderDetails />, {
+        preloadedState: backorderPreloadedState,
+        initialEntries: [{ state: { isCompanyOrder: false } }],
+      });
+
+      await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+      await userEvent.click(screen.getByRole('button', { name: 'Re-Order' }));
+
+      const dialog = await screen.findByRole('dialog', { name: 'Re-Order' });
+
+      await userEvent.click(within(dialog).getAllByRole('checkbox')[0]); // Select all checkbox
+
+      await userEvent.click(screen.getByRole('button', { name: 'Add to cart' }));
+
+      await waitFor(() => {
+        expect(
+          screen.getByText('Some items were not added to the cart. Please adjust quantities.'),
+        ).toBeVisible();
+      });
+
+      expect(within(dialog).getByText('Only 5 available')).toBeVisible();
+
+      expect(window.b2b.callbacks.dispatchEvent).not.toHaveBeenCalled();
+    });
+
+    it('displays an error when a network error occurs', async () => {
+      const laughProduct = {
+        entityId: 2001,
+        productEntityId: 123,
+        variantEntityId: 456,
+        name: 'Laugh Canister',
+        quantity: 1,
+        productOptions: [] as Array<{ name: string; value: string }>,
+      };
+
+      const order = buildUnifiedOrderWithProducts([laughProduct]);
+
+      server.use(
+        graphql.query('GetOrderDetail', () =>
+          HttpResponse.json(buildOrderDetailResponseWith({ data: { site: { order } } })),
+        ),
+        graphql.query('GetCustomerOrderStatuses', () =>
+          HttpResponse.json(buildCustomerOrderStatusesWith('WHATEVER_VALUES')),
+        ),
+        graphql.query('AddressConfig', () =>
+          HttpResponse.json(buildAddressConfigResponseWith('WHATEVER_VALUES')),
+        ),
+        graphql.query('ValidateProduct', () => HttpResponse.error()),
+      );
+
+      renderWithProviders(<OrderDetails />, {
+        preloadedState: backorderPreloadedState,
+        initialEntries: [{ state: { isCompanyOrder: false } }],
+      });
+
+      await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+      await userEvent.click(screen.getByRole('button', { name: 'Re-Order' }));
+
+      const dialog = await screen.findByRole('dialog', { name: 'Re-Order' });
+
+      await userEvent.click(within(dialog).getAllByRole('checkbox')[0]); // Select all checkbox
+
+      await userEvent.click(screen.getByRole('button', { name: 'Add to cart' }));
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(
+            'There was an issue with adding products to the cart. Please check the errors below.',
+          ),
+        ).toBeVisible();
+      });
+
+      expect(within(dialog).getByText('Add failed, try again.')).toBeVisible();
+    });
+
+    it('can adjust the quantity of a product', async () => {
+      const screamProduct = {
+        entityId: 2001,
+        productEntityId: 123,
+        variantEntityId: 456,
+        name: 'Scream Canister',
+        quantity: 1,
+        productOptions: [] as Array<{ name: string; value: string }>,
+      };
+
+      const order = buildUnifiedOrderWithProducts([screamProduct]);
+      const createCartSimple = vi.fn();
+
+      const validateProducts = when(vi.fn())
+        .calledWith({
+          productId: 123,
+          variantId: 456,
+          quantity: 2,
+          productOptions: [],
+          target: 'CART',
+        })
+        .thenReturn({
+          data: {
+            validateProduct: {
+              responseType: 'SUCCESS',
+              message: '',
+            },
+          },
+        });
+
+      server.use(
+        graphql.query('GetOrderDetail', () =>
+          HttpResponse.json(buildOrderDetailResponseWith({ data: { site: { order } } })),
+        ),
+        graphql.query('GetCustomerOrderStatuses', () =>
+          HttpResponse.json(buildCustomerOrderStatusesWith('WHATEVER_VALUES')),
+        ),
+        graphql.query('AddressConfig', () =>
+          HttpResponse.json(buildAddressConfigResponseWith('WHATEVER_VALUES')),
+        ),
+        graphql.query('getCart', () => HttpResponse.json({ data: { site: { cart: null } } })),
+        graphql.mutation('createCartSimple', ({ variables }) =>
+          HttpResponse.json(createCartSimple(variables)),
+        ),
+        graphql.query('ValidateProduct', ({ variables }) =>
+          HttpResponse.json(validateProducts(variables)),
+        ),
+      );
+
+      when(createCartSimple)
+        .calledWith({
+          createCartInput: {
+            lineItems: [
+              {
+                quantity: 2,
+                productEntityId: 123,
+                variantEntityId: 456,
+                selectedOptions: { multipleChoices: [], textFields: [] },
+              },
+            ],
+          },
+        })
+        .thenReturn({ data: { cart: { createCart: { cart: { entityId: 'foo-bar' } } } } });
+
+      renderWithProviders(<OrderDetails />, {
+        preloadedState: backorderPreloadedState,
+        initialEntries: [{ state: { isCompanyOrder: false } }],
+      });
+
+      await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+      await userEvent.click(screen.getByRole('button', { name: 'Re-Order' }));
+
+      const dialog = await screen.findByRole('dialog', { name: 'Re-Order' });
+
+      expect(within(dialog).getByText('Select products and quantity for reorder')).toBeVisible();
+
+      const productGroup = within(dialog).getByRole('group', { name: 'Scream Canister' });
+
+      await userEvent.click(within(productGroup).getByRole('checkbox'));
+
+      await userEvent.type(within(productGroup).getByRole('spinbutton'), '2', {
+        initialSelectionStart: 0,
+        initialSelectionEnd: 1,
+      });
+
+      await userEvent.click(screen.getByRole('button', { name: 'Add to cart' }));
+
+      await waitFor(() => {
+        expect(screen.getByText('Products are added to cart')).toBeVisible();
+      });
+
+      expect(window.b2b.callbacks.dispatchEvent).toHaveBeenCalledWith('on-cart-created', {
+        cartId: 'foo-bar',
+      });
+    });
+
+    it('can re-order all products in one go', async () => {
+      const screamProduct = {
+        entityId: 2001,
+        productEntityId: 3001,
+        variantEntityId: 4001,
+        name: 'Scream Canister',
+        quantity: 2,
+        productOptions: [] as Array<{ name: string; value: string }>,
+      };
+      const laughProduct = {
+        entityId: 2002,
+        productEntityId: 3002,
+        variantEntityId: 4002,
+        name: 'Laugh Canister',
+        quantity: 1,
+        productOptions: [] as Array<{ name: string; value: string }>,
+      };
+
+      const order = buildUnifiedOrderWithProducts([screamProduct, laughProduct]);
+      const createCartSimple = vi.fn();
+
+      const validateProducts = when(vi.fn())
+        .calledWith({
+          productId: 3002,
+          variantId: 4002,
+          quantity: 1,
+          productOptions: [],
+          target: 'CART',
+        })
+        .thenReturn({ data: { validateProduct: { responseType: 'SUCCESS', message: '' } } });
+
+      when(validateProducts)
+        .calledWith({
+          productId: 3001,
+          variantId: 4001,
+          quantity: 2,
+          productOptions: [],
+          target: 'CART',
+        })
+        .thenReturn({ data: { validateProduct: { responseType: 'SUCCESS', message: '' } } });
+
+      server.use(
+        graphql.query('GetOrderDetail', () =>
+          HttpResponse.json(buildOrderDetailResponseWith({ data: { site: { order } } })),
+        ),
+        graphql.query('GetCustomerOrderStatuses', () =>
+          HttpResponse.json(buildCustomerOrderStatusesWith('WHATEVER_VALUES')),
+        ),
+        graphql.query('AddressConfig', () =>
+          HttpResponse.json(buildAddressConfigResponseWith('WHATEVER_VALUES')),
+        ),
+        graphql.query('getCart', () => HttpResponse.json({ data: { site: { cart: null } } })),
+        graphql.mutation('createCartSimple', ({ variables }) =>
+          HttpResponse.json(createCartSimple(variables)),
+        ),
+        graphql.query('ValidateProduct', ({ variables }) =>
+          HttpResponse.json(validateProducts(variables)),
+        ),
+      );
+
+      when(createCartSimple)
+        .calledWith({
+          createCartInput: {
+            lineItems: [
+              {
+                quantity: 2,
+                productEntityId: 3001,
+                variantEntityId: 4001,
+                selectedOptions: { multipleChoices: [], textFields: [] },
+              },
+              {
+                quantity: 1,
+                productEntityId: 3002,
+                variantEntityId: 4002,
+                selectedOptions: { multipleChoices: [], textFields: [] },
+              },
+            ],
+          },
+        })
+        .thenReturn({ data: { cart: { createCart: { cart: { entityId: 'foo-bar' } } } } });
+
+      renderWithProviders(<OrderDetails />, {
+        preloadedState: backorderPreloadedState,
+        initialEntries: [{ state: { isCompanyOrder: false } }],
+      });
+
+      await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+      await userEvent.click(screen.getByRole('button', { name: 'Re-Order' }));
+
+      await userEvent.click(screen.getAllByRole('checkbox')[0]); // Select all checkbox
+
+      await userEvent.click(screen.getByRole('button', { name: 'Add to cart' }));
+
+      await waitFor(() => {
+        expect(screen.getByText('Products are added to cart')).toBeVisible();
+      });
+
+      expect(window.b2b.callbacks.dispatchEvent).toHaveBeenCalledWith('on-cart-created', {
+        cartId: 'foo-bar',
+      });
+    });
+
+    it('handles partial cart updates', async () => {
+      const productWithErrorDef = {
+        entityId: 2001,
+        productEntityId: 3001,
+        variantEntityId: 4001,
+        name: 'Product with Error',
+        quantity: 2,
+        productOptions: [] as Array<{ name: string; value: string }>,
+      };
+      const productWithWarningDef = {
+        entityId: 2002,
+        productEntityId: 3002,
+        variantEntityId: 4002,
+        name: 'Product with Warning',
+        quantity: 2,
+        productOptions: [] as Array<{ name: string; value: string }>,
+      };
+      const laughProductDef = {
+        entityId: 2003,
+        productEntityId: 3003,
+        variantEntityId: 4003,
+        name: 'Laugh Canister',
+        quantity: 1,
+        productOptions: [] as Array<{ name: string; value: string }>,
+      };
+
+      const order = buildUnifiedOrderWithProducts([
+        productWithErrorDef,
+        productWithWarningDef,
+        laughProductDef,
+      ]);
+
+      const createCartSimple = vi.fn().mockReturnValue({
+        data: { cart: { createCart: { cart: { entityId: 'foo-bar' } } } },
+      });
+
+      const validateProductHandler = vi
+        .fn()
+        .mockImplementation((variables: { productId: number }) => {
+          if (variables.productId === 3001) {
+            return {
+              data: {
+                validateProduct: {
+                  responseType: 'ERROR',
+                  message: 'An error message from the backend',
+                  errorCode: 'VALIDATION_ERROR',
+                  product: { availableToSell: 0 },
+                },
+              },
+            };
+          }
+          if (variables.productId === 3002) {
+            return {
+              data: {
+                validateProduct: {
+                  responseType: 'WARNING',
+                  message: 'A warning message from the backend',
+                },
+              },
+            };
+          }
+          return { data: { validateProduct: { responseType: 'SUCCESS', message: '' } } };
+        });
+
+      server.use(
+        graphql.query('GetOrderDetail', () =>
+          HttpResponse.json(buildOrderDetailResponseWith({ data: { site: { order } } })),
+        ),
+        graphql.query('GetCustomerOrderStatuses', () =>
+          HttpResponse.json(buildCustomerOrderStatusesWith('WHATEVER_VALUES')),
+        ),
+        graphql.query('AddressConfig', () =>
+          HttpResponse.json(buildAddressConfigResponseWith('WHATEVER_VALUES')),
+        ),
+        graphql.query('getCart', () => HttpResponse.json({ data: { site: { cart: null } } })),
+        graphql.mutation('createCartSimple', ({ variables }) =>
+          HttpResponse.json(createCartSimple(variables)),
+        ),
+        graphql.query('ValidateProduct', ({ variables }) =>
+          HttpResponse.json(validateProductHandler(variables)),
+        ),
+      );
+
+      renderWithProviders(<OrderDetails />, {
+        preloadedState: backorderPreloadedState,
+        initialEntries: [{ state: { isCompanyOrder: false } }],
+      });
+
+      await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+      await userEvent.click(screen.getByRole('button', { name: 'Re-Order' }));
+
+      const dialog = await screen.findByRole('dialog', { name: 'Re-Order' });
+
+      const checkboxes = await within(dialog).findAllByRole('checkbox');
+
+      await userEvent.click(checkboxes[0]); // Select all checkbox
+
+      await userEvent.click(screen.getByRole('button', { name: 'Add to cart' }));
+
+      await waitFor(() => {
+        expect(screen.getByText('1 Product was added to the cart.')).toBeVisible();
+      });
+
+      await waitFor(() => {
+        expect(
+          screen.getByText('Some items were not added to the cart. Please adjust quantities.'),
+        ).toBeVisible();
+      });
+
+      expect(window.b2b.callbacks.dispatchEvent).toHaveBeenCalledWith('on-cart-created', {
+        cartId: 'foo-bar',
+      });
+
+      expect(dialog).toBeVisible();
+
+      const groupWithError = within(dialog).getByRole('group', { name: 'Product with Error' });
+
+      expect(within(groupWithError).getByRole('checkbox')).toBeChecked();
+      expect(within(groupWithError).getByText('An error message from the backend')).toBeVisible();
+
+      const groupWithWarning = within(dialog).getByRole('group', {
+        name: 'Product with Warning',
+      });
+      expect(within(groupWithWarning).getByRole('checkbox')).toBeChecked();
+      expect(
+        within(groupWithWarning).getByText('A warning message from the backend'),
+      ).toBeVisible();
+
+      const groupWithLaughCanister = within(dialog).getByRole('group', {
+        name: 'Laugh Canister',
+      });
+      expect(within(groupWithLaughCanister).getByRole('checkbox')).not.toBeChecked();
+    });
+
+    it('shows a warning if no product is selected', async () => {
+      const screamProduct = {
+        entityId: 2001,
+        productEntityId: 3001,
+        variantEntityId: 4001,
+        name: 'Scream Canister',
+        quantity: 2,
+        productOptions: [] as Array<{ name: string; value: string }>,
+      };
+      const laughProduct = {
+        entityId: 2002,
+        productEntityId: 3002,
+        variantEntityId: 4002,
+        name: 'Laugh Canister',
+        quantity: 1,
+        productOptions: [] as Array<{ name: string; value: string }>,
+      };
+
+      const order = buildUnifiedOrderWithProducts([screamProduct, laughProduct]);
+
+      server.use(
+        graphql.query('GetOrderDetail', () =>
+          HttpResponse.json(buildOrderDetailResponseWith({ data: { site: { order } } })),
+        ),
+        graphql.query('GetCustomerOrderStatuses', () =>
+          HttpResponse.json(buildCustomerOrderStatusesWith('WHATEVER_VALUES')),
+        ),
+        graphql.query('AddressConfig', () =>
+          HttpResponse.json(buildAddressConfigResponseWith('WHATEVER_VALUES')),
+        ),
+      );
+
+      renderWithProviders(<OrderDetails />, {
+        preloadedState: backorderPreloadedState,
+        initialEntries: [{ state: { isCompanyOrder: false } }],
+      });
+
+      await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+      await userEvent.click(screen.getByRole('button', { name: 'Re-Order' }));
+
+      await userEvent.click(screen.getByRole('button', { name: 'Add to cart' }));
+
+      await waitFor(() => {
+        expect(screen.getByText('Please select at least one item')).toBeVisible();
+      });
+    });
+  });
+
+  describe('B2B-4826: add to shopping list', () => {
+    function buildUnifiedOrderWithProducts(
+      products: Array<{
+        entityId: number;
+        productEntityId: number;
+        variantEntityId: number | null;
+        name: string;
+        quantity: number;
+        productOptions: Array<{ name: string; value: string }>;
+      }>,
+    ) {
+      return buildUnifiedOrderWith({
+        entityId: 6696,
+        consignments: {
+          shipping: {
+            edges: [
+              {
+                cursor: 'sc1',
+                node: {
+                  entityId: 1001,
+                  shippingAddress: {
+                    firstName: 'Jane',
+                    lastName: 'Doe',
+                    company: '',
+                    address1: '123 Main St',
+                    address2: null,
+                    city: 'Austin',
+                    stateOrProvince: 'TX',
+                    postalCode: '73301',
+                    country: 'United States',
+                    countryCode: 'US',
+                    phone: null,
+                    email: null,
+                  },
+                  shippingCost: { currencyCode: 'USD', value: 0 },
+                  lineItems: {
+                    edges: products.map((p) => ({
+                      node: {
+                        entityId: p.entityId,
+                        productEntityId: p.productEntityId,
+                        variantEntityId: p.variantEntityId,
+                        sku: `SKU-${p.productEntityId}`,
+                        brand: null,
+                        name: p.name,
+                        quantity: p.quantity,
+                        productOptions: p.productOptions,
+                        subTotalListPrice: { currencyCode: 'USD', value: p.quantity * 10 },
+                        image: null,
+                        baseCatalogProduct: null,
+                      },
+                    })),
+                  },
+                  shipments: { edges: [] },
+                },
+              },
+            ],
+          },
+          downloads: null,
+        },
+      });
+    }
+
+    it('can add a single product to an existing shopping list', async () => {
+      const screamProduct = {
+        entityId: 2001,
+        productEntityId: 3001,
+        variantEntityId: 4001,
+        name: 'Scream Canister',
+        quantity: 2,
+        productOptions: [] as Array<{ name: string; value: string }>,
+      };
+      const laughProduct = {
+        entityId: 2002,
+        productEntityId: 123,
+        variantEntityId: 456,
+        name: 'Laugh Canister',
+        quantity: 2,
+        productOptions: [{ name: 'Color', value: 'bar' }],
+      };
+
+      const order = buildUnifiedOrderWithProducts([screamProduct, laughProduct]);
+
+      const addItemsToCustomerShoppingList = vi.fn();
+
+      const shoppingList = buildCustomerShoppingListNodeWith({
+        node: { id: '992', name: 'Foo Bar Shopping List' },
+      });
+
+      server.use(
+        graphql.query('CustomerShoppingLists', () =>
+          HttpResponse.json(
+            buildCustomerShoppingListResponseWith({
+              data: { customerShoppingLists: { totalCount: 1, edges: [shoppingList] } },
+            }),
+          ),
+        ),
+        graphql.query('SearchProducts', () => HttpResponse.json({ data: { productsSearch: [] } })),
+        graphql.mutation('AddItemsToCustomerShoppingList', ({ variables }) =>
+          HttpResponse.json(addItemsToCustomerShoppingList({ variables })),
+        ),
+      );
+
+      when(addItemsToCustomerShoppingList)
+        .calledWith(
+          expect.objectContaining({
+            variables: expect.objectContaining({
+              shoppingListId: 992,
+              items: expect.arrayContaining([
+                expect.objectContaining({
+                  productId: 123,
+                  variantId: 456,
+                  quantity: 2,
+                  optionList: expect.arrayContaining([
+                    expect.objectContaining({
+                      optionId: 'attribute[0]',
+                      optionValue: 'bar',
+                    }),
+                  ]),
+                }),
+              ]),
+            }),
+          }),
+        )
+        .thenReturn({
+          data: {
+            customerShoppingListsItemsCreate: {
+              shoppingListsItems: [],
+            },
+          },
+        });
+
+      server.use(
+        graphql.query('GetOrderDetail', () =>
+          HttpResponse.json(buildOrderDetailResponseWith({ data: { site: { order } } })),
+        ),
+        graphql.query('GetCustomerOrderStatuses', () =>
+          HttpResponse.json(buildCustomerOrderStatusesWith('WHATEVER_VALUES')),
+        ),
+        graphql.query('AddressConfig', () =>
+          HttpResponse.json(buildAddressConfigResponseWith('WHATEVER_VALUES')),
+        ),
+      );
+
+      renderWithProviders(<OrderDetails />, {
+        preloadedState,
+        initialEntries: [{ state: { isCompanyOrder: false } }],
+        initialGlobalContext: { shoppingListEnabled: true },
+      });
+
+      await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+      await userEvent.click(screen.getByRole('button', { name: 'ADD TO SHOPPING LIST' }));
+
+      const dialog = await screen.findByRole('dialog', { name: 'Add to shopping list' });
+
+      expect(
+        within(dialog).getByText('Select products and quantity to add to shopping list'),
+      ).toBeVisible();
+
+      const productGroup = within(dialog).getByRole('group', { name: 'Laugh Canister' });
+
+      await userEvent.click(within(productGroup).getByRole('checkbox'));
+
+      await userEvent.click(await screen.findByRole('button', { name: 'Add to shopping list' }));
+
+      await userEvent.click(await screen.findByText('Foo Bar Shopping List'));
+
+      await userEvent.click(screen.getByText('OK'));
+
+      await waitFor(() => {
+        expect(screen.getByText('Products were added to your shopping list')).toBeVisible();
+      });
+    });
+
+    it('can add a product to a new shopping list', async () => {
+      const screamProduct = {
+        entityId: 2001,
+        productEntityId: 3001,
+        variantEntityId: 4001,
+        name: 'Scream Canister',
+        quantity: 2,
+        productOptions: [] as Array<{ name: string; value: string }>,
+      };
+      const laughProduct = {
+        entityId: 2002,
+        productEntityId: 123,
+        variantEntityId: 456,
+        name: 'Laugh Canister',
+        quantity: 2,
+        productOptions: [{ name: 'Color', value: 'bar' }],
+      };
+
+      const order = buildUnifiedOrderWithProducts([screamProduct, laughProduct]);
+
+      const addItemsToCustomerShoppingList = vi.fn();
+      const getCustomerShoppingLists = vi.fn().mockReturnValue(
+        buildCustomerShoppingListResponseWith({
+          data: { customerShoppingLists: { totalCount: 0, edges: [] } },
+        }),
+      );
+
+      when(addItemsToCustomerShoppingList)
+        .calledWith(
+          expect.objectContaining({
+            variables: expect.objectContaining({
+              shoppingListId: 992,
+              items: expect.arrayContaining([
+                expect.objectContaining({
+                  productId: 123,
+                  variantId: 456,
+                  quantity: 2,
+                  optionList: expect.arrayContaining([
+                    expect.objectContaining({
+                      optionId: 'attribute[0]',
+                      optionValue: 'bar',
+                    }),
+                  ]),
+                }),
+              ]),
+            }),
+          }),
+        )
+        .thenReturn({
+          data: {
+            customerShoppingListsItemsCreate: {
+              shoppingListsItems: [],
+            },
+          },
+        });
+
+      const createCustomerShoppingList = vi.fn();
+
+      server.use(
+        graphql.query('GetOrderDetail', () =>
+          HttpResponse.json(buildOrderDetailResponseWith({ data: { site: { order } } })),
+        ),
+        graphql.query('GetCustomerOrderStatuses', () =>
+          HttpResponse.json(buildCustomerOrderStatusesWith('WHATEVER_VALUES')),
+        ),
+        graphql.query('AddressConfig', () =>
+          HttpResponse.json(buildAddressConfigResponseWith('WHATEVER_VALUES')),
+        ),
+        graphql.query('CustomerShoppingLists', ({ query }) =>
+          HttpResponse.json(getCustomerShoppingLists(query)),
+        ),
+        graphql.query('SearchProducts', () => HttpResponse.json({ data: { productsSearch: [] } })),
+        graphql.mutation('AddItemsToCustomerShoppingList', ({ variables }) =>
+          HttpResponse.json(addItemsToCustomerShoppingList({ variables })),
+        ),
+        graphql.mutation('CreateCustomerShoppingList', ({ variables }) =>
+          HttpResponse.json(createCustomerShoppingList(variables)),
+        ),
+      );
+
+      renderWithProviders(<OrderDetails />, {
+        preloadedState,
+        initialEntries: [{ state: { isCompanyOrder: false } }],
+        initialGlobalContext: { shoppingListEnabled: true },
+      });
+
+      await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+      await userEvent.click(screen.getByRole('button', { name: 'ADD TO SHOPPING LIST' }));
+
+      const dialog = await screen.findByRole('dialog', { name: 'Add to shopping list' });
+
+      const productGroup = within(dialog).getByRole('group', { name: 'Laugh Canister' });
+
+      await userEvent.click(within(productGroup).getByRole('checkbox'));
+
+      await userEvent.click(within(dialog).getByRole('button', { name: 'Add to shopping list' }));
+
+      const createNewButton = await screen.findByRole('button', { name: 'Create new' });
+
+      await userEvent.click(createNewButton);
+
+      expect(await screen.findByRole('heading', { name: 'Create new' })).toBeVisible();
+
+      const nameInput = screen.getByRole('textbox', { name: 'Name' });
+      const descriptionInput = screen.getByRole('textbox', { name: 'Description' });
+
+      await userEvent.type(nameInput, 'New Shopping List');
+      await userEvent.type(descriptionInput, 'This is a new shopping list');
+
+      const shoppingList = buildCustomerShoppingListNodeWith({
+        node: { id: '992', name: 'New Shopping List' },
+      });
+
+      when(createCustomerShoppingList)
+        .calledWith({
+          shoppingListData: {
+            name: 'New Shopping List',
+            description: 'This is a new shopping list',
+            channelId: 1,
+          },
+        })
+        .thenResolve({});
+
+      when(getCustomerShoppingLists, { times: 1 })
+        .calledWith(stringContainingAll('first: 50', 'channelId: 1'))
+        .thenReturn(
+          buildCustomerShoppingListResponseWith({
+            data: { customerShoppingLists: { totalCount: 0, edges: [shoppingList] } },
+          }),
+        );
+
+      await userEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+      await userEvent.click(await screen.findByText('New Shopping List'));
+
+      await userEvent.click(screen.getByRole('button', { name: 'OK' }));
+
+      await waitFor(() => {
+        expect(screen.getByText('Products were added to your shopping list')).toBeVisible();
+      });
+    });
+
+    it('can adjust the quantity of a product', async () => {
+      const screamProduct = {
+        entityId: 2001,
+        productEntityId: 3001,
+        variantEntityId: 4001,
+        name: 'Scream Canister',
+        quantity: 2,
+        productOptions: [] as Array<{ name: string; value: string }>,
+      };
+      const laughProduct = {
+        entityId: 2002,
+        productEntityId: 123,
+        variantEntityId: 456,
+        name: 'Laugh Canister',
+        quantity: 1,
+        productOptions: [{ name: 'Color', value: 'bar' }],
+      };
+
+      const order = buildUnifiedOrderWithProducts([screamProduct, laughProduct]);
+
+      const addItemsToCustomerShoppingList = vi.fn();
+
+      const shoppingList = buildCustomerShoppingListNodeWith({
+        node: { id: '992', name: 'Foo Bar Shopping List' },
+      });
+
+      server.use(
+        graphql.query('CustomerShoppingLists', () =>
+          HttpResponse.json(
+            buildCustomerShoppingListResponseWith({
+              data: { customerShoppingLists: { totalCount: 1, edges: [shoppingList] } },
+            }),
+          ),
+        ),
+        graphql.query('SearchProducts', () => HttpResponse.json({ data: { productsSearch: [] } })),
+        graphql.mutation('AddItemsToCustomerShoppingList', ({ variables }) =>
+          HttpResponse.json(addItemsToCustomerShoppingList({ variables })),
+        ),
+      );
+
+      when(addItemsToCustomerShoppingList)
+        .calledWith(
+          expect.objectContaining({
+            variables: expect.objectContaining({
+              shoppingListId: 992,
+              items: expect.arrayContaining([
+                expect.objectContaining({
+                  productId: 123,
+                  variantId: 456,
+                  quantity: 2,
+                  optionList: expect.arrayContaining([
+                    expect.objectContaining({
+                      optionId: 'attribute[0]',
+                      optionValue: 'bar',
+                    }),
+                  ]),
+                }),
+              ]),
+            }),
+          }),
+        )
+        .thenReturn({
+          data: {
+            customerShoppingListsItemsCreate: {
+              shoppingListsItems: [],
+            },
+          },
+        });
+
+      server.use(
+        graphql.query('GetOrderDetail', () =>
+          HttpResponse.json(buildOrderDetailResponseWith({ data: { site: { order } } })),
+        ),
+        graphql.query('GetCustomerOrderStatuses', () =>
+          HttpResponse.json(buildCustomerOrderStatusesWith('WHATEVER_VALUES')),
+        ),
+        graphql.query('AddressConfig', () =>
+          HttpResponse.json(buildAddressConfigResponseWith('WHATEVER_VALUES')),
+        ),
+      );
+
+      renderWithProviders(<OrderDetails />, {
+        preloadedState,
+        initialEntries: [{ state: { isCompanyOrder: false } }],
+        initialGlobalContext: { shoppingListEnabled: true },
+      });
+
+      await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+      await userEvent.click(screen.getByRole('button', { name: 'ADD TO SHOPPING LIST' }));
+
+      const dialog = await screen.findByRole('dialog', { name: 'Add to shopping list' });
+
+      expect(
+        within(dialog).getByText('Select products and quantity to add to shopping list'),
+      ).toBeVisible();
+
+      const productGroup = within(dialog).getByRole('group', { name: 'Laugh Canister' });
+
+      await userEvent.click(within(productGroup).getByRole('checkbox'));
+
+      await userEvent.type(within(productGroup).getByRole('spinbutton'), '2', {
+        initialSelectionStart: 0,
+        initialSelectionEnd: 1,
+      });
+
+      await userEvent.click(await screen.findByRole('button', { name: 'Add to shopping list' }));
+
+      await userEvent.click(await screen.findByText('Foo Bar Shopping List'));
+
+      await userEvent.click(screen.getByText('OK'));
+
+      await waitFor(() => {
+        expect(screen.getByText('Products were added to your shopping list')).toBeVisible();
+      });
+    });
+
+    it('can add all the products in one go', async () => {
+      const screamProduct = {
+        entityId: 2001,
+        productEntityId: 789,
+        variantEntityId: 1011,
+        name: 'Scream Canister',
+        quantity: 2,
+        productOptions: [] as Array<{ name: string; value: string }>,
+      };
+      const laughProduct = {
+        entityId: 2002,
+        productEntityId: 123,
+        variantEntityId: 456,
+        name: 'Laugh Canister',
+        quantity: 1,
+        productOptions: [] as Array<{ name: string; value: string }>,
+      };
+
+      const order = buildUnifiedOrderWithProducts([screamProduct, laughProduct]);
+
+      const addItemsToCustomerShoppingList = vi.fn();
+
+      const shoppingList = buildCustomerShoppingListNodeWith({
+        node: { id: '992', name: 'Foo Bar Shopping List' },
+      });
+
+      server.use(
+        graphql.query('CustomerShoppingLists', () =>
+          HttpResponse.json(
+            buildCustomerShoppingListResponseWith({
+              data: { customerShoppingLists: { totalCount: 1, edges: [shoppingList] } },
+            }),
+          ),
+        ),
+        graphql.query('SearchProducts', () => HttpResponse.json({ data: { productsSearch: [] } })),
+        graphql.mutation('AddItemsToCustomerShoppingList', ({ query, variables }) =>
+          HttpResponse.json(addItemsToCustomerShoppingList({ query, variables })),
+        ),
+      );
+
+      when(addItemsToCustomerShoppingList)
+        .calledWith(
+          expect.objectContaining({
+            variables: expect.objectContaining({
+              shoppingListId: 992,
+              items: expect.arrayContaining([
+                expect.objectContaining({
+                  productId: 123,
+                  variantId: 456,
+                  quantity: 1,
+                  optionList: [],
+                }),
+                expect.objectContaining({
+                  productId: 789,
+                  variantId: 1011,
+                  quantity: 2,
+                  optionList: [],
+                }),
+              ]),
+            }),
+          }),
+        )
+        .thenReturn({
+          data: {
+            customerShoppingListsItemsCreate: {
+              shoppingListsItems: [],
+            },
+          },
+        });
+
+      server.use(
+        graphql.query('GetOrderDetail', () =>
+          HttpResponse.json(buildOrderDetailResponseWith({ data: { site: { order } } })),
+        ),
+        graphql.query('GetCustomerOrderStatuses', () =>
+          HttpResponse.json(buildCustomerOrderStatusesWith('WHATEVER_VALUES')),
+        ),
+        graphql.query('AddressConfig', () =>
+          HttpResponse.json(buildAddressConfigResponseWith('WHATEVER_VALUES')),
+        ),
+      );
+
+      renderWithProviders(<OrderDetails />, {
+        preloadedState,
+        initialEntries: [{ state: { isCompanyOrder: false } }],
+        initialGlobalContext: { shoppingListEnabled: true },
+      });
+
+      await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+      await userEvent.click(screen.getByRole('button', { name: 'ADD TO SHOPPING LIST' }));
+
+      const dialog = await screen.findByRole('dialog', { name: 'Add to shopping list' });
+
+      const checkboxes = await within(dialog).findAllByRole('checkbox');
+
+      await userEvent.click(checkboxes[0]); // Select all checkbox
+
+      await userEvent.click(await screen.findByRole('button', { name: 'Add to shopping list' }));
+
+      await userEvent.click(await screen.findByText('Foo Bar Shopping List'));
+
+      await userEvent.click(screen.getByText('OK'));
+
+      await waitFor(() => {
+        expect(screen.getByText('Products were added to your shopping list')).toBeVisible();
+      });
+    });
+
+    it('can add all products in one go via reorder', async () => {
+      const screamProduct = {
+        entityId: 2001,
+        productEntityId: 3001,
+        variantEntityId: 4001,
+        name: 'Scream Canister',
+        quantity: 2,
+        productOptions: [] as Array<{ name: string; value: string }>,
+      };
+      const laughProduct = {
+        entityId: 2002,
+        productEntityId: 3002,
+        variantEntityId: 4002,
+        name: 'Laugh Canister',
+        quantity: 1,
+        productOptions: [] as Array<{ name: string; value: string }>,
+      };
+
+      const order = buildUnifiedOrderWithProducts([screamProduct, laughProduct]);
+      const createCartSimple = vi.fn();
+
+      server.use(
+        graphql.query('GetOrderDetail', () =>
+          HttpResponse.json(buildOrderDetailResponseWith({ data: { site: { order } } })),
+        ),
+        graphql.query('GetCustomerOrderStatuses', () =>
+          HttpResponse.json(buildCustomerOrderStatusesWith('WHATEVER_VALUES')),
+        ),
+        graphql.query('AddressConfig', () =>
+          HttpResponse.json(buildAddressConfigResponseWith('WHATEVER_VALUES')),
+        ),
+        graphql.query('getCart', () => HttpResponse.json({ data: { site: { cart: null } } })),
+        graphql.mutation('createCartSimple', ({ variables }) =>
+          HttpResponse.json(createCartSimple(variables)),
+        ),
+      );
+
+      createCartSimple.mockReturnValue({
+        data: { cart: { createCart: { cart: { entityId: 'foo-bar' } } } },
+      });
+
+      renderWithProviders(<OrderDetails />, {
+        preloadedState,
+        initialEntries: [{ state: { isCompanyOrder: false } }],
+      });
+
+      await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+      await userEvent.click(screen.getByRole('button', { name: 'Re-Order' }));
+
+      const checkboxes = await screen.findAllByRole('checkbox');
+
+      await userEvent.click(checkboxes[0]); // Select all checkbox
+
+      await userEvent.click(screen.getByRole('button', { name: 'Add to cart' }));
+
+      await waitFor(() => {
+        expect(screen.getByText('Products are added to cart')).toBeVisible();
+      });
+
+      expect(createCartSimple).toHaveBeenCalledWith(
+        expect.objectContaining({
+          createCartInput: expect.objectContaining({
+            lineItems: expect.arrayContaining([
+              expect.objectContaining({
+                quantity: 2,
+                productEntityId: 3001,
+                variantEntityId: 4001,
+              }),
+              expect.objectContaining({
+                quantity: 1,
+                productEntityId: 3002,
+                variantEntityId: 4002,
+              }),
+            ]),
+          }),
+        }),
+      );
+
+      expect(window.b2b.callbacks.dispatchEvent).toHaveBeenCalledWith('on-cart-created', {
+        cartId: 'foo-bar',
+      });
+    });
+
+    it('shows a warning if no product is selected', async () => {
+      const screamProduct = {
+        entityId: 2001,
+        productEntityId: 3001,
+        variantEntityId: 4001,
+        name: 'Scream Canister',
+        quantity: 2,
+        productOptions: [] as Array<{ name: string; value: string }>,
+      };
+      const laughProduct = {
+        entityId: 2002,
+        productEntityId: 3002,
+        variantEntityId: 4002,
+        name: 'Laugh Canister',
+        quantity: 1,
+        productOptions: [] as Array<{ name: string; value: string }>,
+      };
+
+      const order = buildUnifiedOrderWithProducts([screamProduct, laughProduct]);
+
+      server.use(
+        graphql.query('GetOrderDetail', () =>
+          HttpResponse.json(buildOrderDetailResponseWith({ data: { site: { order } } })),
+        ),
+        graphql.query('GetCustomerOrderStatuses', () =>
+          HttpResponse.json(buildCustomerOrderStatusesWith('WHATEVER_VALUES')),
+        ),
+        graphql.query('AddressConfig', () =>
+          HttpResponse.json(buildAddressConfigResponseWith('WHATEVER_VALUES')),
+        ),
+      );
+
+      renderWithProviders(<OrderDetails />, {
+        preloadedState,
+        initialEntries: [{ state: { isCompanyOrder: false } }],
+      });
+
+      await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+      await userEvent.click(screen.getByRole('button', { name: 'Re-Order' }));
+
+      await userEvent.click(screen.getByRole('button', { name: 'Add to cart' }));
+
+      await waitFor(() => {
+        expect(screen.getByText('Please select at least one item')).toBeVisible();
+      });
     });
   });
 });

--- a/apps/storefront/src/pages/OrderDetail/shared/convertOrderDetail.ts
+++ b/apps/storefront/src/pages/OrderDetail/shared/convertOrderDetail.ts
@@ -1,5 +1,6 @@
 import type { LangFormatFunction } from '@/lib/lang';
 import type {
+  Money,
   Order,
   OrderAddress,
   OrderDigitalLineItem,
@@ -164,10 +165,26 @@ function convertAddress(sfAddr: OrderAddress): Address {
 // Product conversion (B2B-4826)
 // ===========================================================================
 
-function convertLineItemToProduct(
-  item: OrderLineItem,
+interface LineItemBase {
+  entityId: number;
+  productEntityId: number;
+  name: string;
+  quantity: number;
+  productOptions: Array<{ name: string; value: string }>;
+  subTotalListPrice: Money;
+}
+
+function buildOrderProduct(
+  item: LineItemBase,
+  productType: 'physical' | 'digital',
   decimalPlaces: number,
   consignmentEntityId: number,
+  physicalFields?: {
+    variantEntityId: number | null;
+    sku: string;
+    brand: string | null;
+    imageUrl: string;
+  },
 ): OrderProductItem {
   const unitPrice = item.quantity > 0 ? item.subTotalListPrice.value / item.quantity : 0;
   const formattedUnitPrice = formatPrice(unitPrice, decimalPlaces);
@@ -176,13 +193,17 @@ function convertLineItemToProduct(
   return {
     id: item.entityId,
     product_id: item.productEntityId,
-    variant_id: item.variantEntityId ?? 0,
-    sku: item.sku ?? '',
+    // Fallback to 0 when variantEntityId is null (gist: "null for legacy
+    // orders or products without variants"). BE is adding variantEntityId
+    // to OrderPhysicalLineItem — until deployed, reorder sends 0 (honest
+    // "no variant") rather than an unrelated ID. Behind FF, tracked in B2B-4787.
+    variant_id: physicalFields?.variantEntityId ?? 0,
+    sku: physicalFields?.sku ?? '',
     name: item.name,
-    brand: item.brand ?? '',
+    brand: physicalFields?.brand ?? '',
     quantity: item.quantity,
-    imageUrl: item.image?.url ?? '',
-    type: 'physical',
+    imageUrl: physicalFields?.imageUrl ?? '',
+    type: productType,
     price_inc_tax: formattedUnitPrice,
     price_ex_tax: formattedUnitPrice,
     price_tax: '0',
@@ -200,7 +221,22 @@ function convertLineItemToProduct(
       optionValue: o.value,
       type: o.name,
     })),
-    product_options: [],
+    product_options: item.productOptions.map((o) => ({
+      id: 0,
+      option_id: 0,
+      order_product_id: item.entityId,
+      product_option_id: 0,
+      name: o.name,
+      value: o.value,
+      display_name: o.name,
+      display_name_customer: o.name,
+      display_name_merchant: o.name,
+      display_style: '',
+      display_value: o.value,
+      display_value_customer: o.value,
+      display_value_merchant: o.value,
+      type: '',
+    })),
     order_address_id: consignmentEntityId,
     order_id: 0,
     parent_order_product_id: 0,
@@ -222,62 +258,25 @@ function convertLineItemToProduct(
   };
 }
 
+function convertLineItemToProduct(
+  item: OrderLineItem,
+  decimalPlaces: number,
+  consignmentEntityId: number,
+): OrderProductItem {
+  return buildOrderProduct(item, 'physical', decimalPlaces, consignmentEntityId, {
+    variantEntityId: item.variantEntityId,
+    sku: item.sku ?? '',
+    brand: item.brand ?? '',
+    imageUrl: item.image?.url ?? '',
+  });
+}
+
 function convertDigitalLineItemToProduct(
   item: OrderDigitalLineItem,
   decimalPlaces: number,
   consignmentEntityId: number,
 ): OrderProductItem {
-  const unitPrice = item.quantity > 0 ? item.subTotalListPrice.value / item.quantity : 0;
-  const formattedUnitPrice = formatPrice(unitPrice, decimalPlaces);
-  const formattedTotal = formatPrice(item.subTotalListPrice.value, decimalPlaces);
-
-  return {
-    id: item.entityId,
-    product_id: item.productEntityId,
-    variant_id: 0,
-    sku: '',
-    name: item.name,
-    brand: '',
-    quantity: item.quantity,
-    imageUrl: '',
-    type: 'digital',
-    price_inc_tax: formattedUnitPrice,
-    price_ex_tax: formattedUnitPrice,
-    price_tax: '0',
-    total_inc_tax: formattedTotal,
-    total_ex_tax: formattedTotal,
-    total_tax: '0',
-    base_price: formattedUnitPrice,
-    base_total: formattedTotal,
-    quantity_shipped: 0,
-    quantity_refunded: 0,
-    refund_amount: '0',
-    return_id: 0,
-    optionList: item.productOptions.map((o) => ({
-      optionId: 0,
-      optionValue: o.value,
-      type: o.name,
-    })),
-    product_options: [],
-    order_address_id: consignmentEntityId,
-    order_id: 0,
-    parent_order_product_id: 0,
-    option_set_id: 0,
-    is_bundled_product: false,
-    is_refunded: false,
-    name_customer: item.name,
-    name_merchant: item.name,
-    configurable_fields: '',
-    cost_price_ex_tax: '0',
-    cost_price_inc_tax: '0',
-    cost_price_tax: '0',
-    wrapping_cost_ex_tax: '0',
-    wrapping_cost_inc_tax: '0',
-    wrapping_cost_tax: '0',
-    wrapping_id: 0,
-    wrapping_message: '',
-    wrapping_name: '',
-  };
+  return buildOrderProduct(item, 'digital', decimalPlaces, consignmentEntityId);
 }
 
 function gatherAllProducts(order: Order, decimalPlaces: number): OrderProductItem[] {
@@ -298,7 +297,12 @@ function gatherAllProducts(order: Order, decimalPlaces: number): OrderProductIte
 
 function deduplicateProducts(products: OrderProductItem[]): OrderProductItem[] {
   return products.reduce<OrderProductItem[]>((seen, product) => {
-    const idx = seen.findIndex((item) => Number(item.variant_id) === Number(product.variant_id));
+    // Skip dedup for variant_id 0 — these are distinct products that lack
+    // variant IDs (variantEntityId null from SF GQL). Legacy path never has
+    // variant_id 0 so this doesn't affect legacy parity.
+    const idx = product.variant_id
+      ? seen.findIndex((item) => Number(item.variant_id) === Number(product.variant_id))
+      : -1;
     if (idx === -1) {
       seen.push(product);
     } else {
@@ -494,7 +498,7 @@ export function convertOrderDetail(
     history: mapHistoryEvents(order.history),
     orderComments: order.customerMessage ?? '',
     shippings: convertShippings(order, decimalPlaces),
-    billings: convertBillings(order, allProducts),
+    billings: convertBillings(order, products),
     products,
     digitalProducts,
     billingAddress: convertAddress(order.billingAddress),

--- a/apps/storefront/src/pages/OrderDetail/shared/convertOrderDetail.ts
+++ b/apps/storefront/src/pages/OrderDetail/shared/convertOrderDetail.ts
@@ -53,7 +53,7 @@ function formatPrice(value: number, decimalPlaces: number): string {
 }
 
 // ===========================================================================
-// Order summary (from B2B-4825)
+// Order summary
 // ===========================================================================
 
 function buildOrderSummary(
@@ -117,7 +117,7 @@ function buildOrderSummary(
 }
 
 // ===========================================================================
-// History (from B2B-4825)
+// History
 // ===========================================================================
 
 function toNumericEventType(type: OrderHistoryEventType): number {
@@ -141,7 +141,7 @@ function mapHistoryEvents(history: Order['history']): OrderHistoryItem[] {
 }
 
 // ===========================================================================
-// Address conversion (B2B-4826)
+// Address conversion
 // ===========================================================================
 
 function convertAddress(sfAddr: OrderAddress): Address {
@@ -316,7 +316,7 @@ function deduplicateProducts(products: OrderProductItem[]): OrderProductItem[] {
 }
 
 // ===========================================================================
-// Shipments conversion (B2B-4826)
+// Shipments conversion
 // ===========================================================================
 
 function convertShippings(order: Order, decimalPlaces: number): OrderShippingsItem[] {
@@ -408,7 +408,7 @@ function convertShippings(order: Order, decimalPlaces: number): OrderShippingsIt
 }
 
 // ===========================================================================
-// Billing conversion (B2B-4826)
+// Billing conversion
 // ===========================================================================
 
 function convertBillings(order: Order, allProducts: OrderProductItem[]): OrderBillings[] {
@@ -421,7 +421,7 @@ function convertBillings(order: Order, allProducts: OrderProductItem[]): OrderBi
 }
 
 // ===========================================================================
-// Payment (expanded for B2B-4826)
+// Payment
 // ===========================================================================
 
 function buildPayment(order: Order): OrderPayment {

--- a/apps/storefront/src/pages/OrderDetail/shared/convertOrderDetail.ts
+++ b/apps/storefront/src/pages/OrderDetail/shared/convertOrderDetail.ts
@@ -1,9 +1,29 @@
 import type { LangFormatFunction } from '@/lib/lang';
-import type { Order } from '@/shared/service/bc/graphql/orders';
+import type {
+  Order,
+  OrderAddress,
+  OrderDigitalLineItem,
+  OrderLineItem,
+} from '@/shared/service/bc/graphql/orders';
 import { OrderHistoryEventType } from '@/shared/service/bc/graphql/orders';
-import type { Currency, MoneyFormat, OrderHistoryItem, OrderPayment, OrderSummary } from '@/types';
+import type {
+  Address,
+  CompanyInfoTypes,
+  Currency,
+  MoneyFormat,
+  OrderBillings,
+  OrderHistoryItem,
+  OrderPayment,
+  OrderProductItem,
+  OrderShippingsItem,
+  OrderSummary,
+} from '@/types';
 
 import type { OrderDetailsState } from '../context/OrderDetailsContext';
+
+// ===========================================================================
+// Shared helpers
+// ===========================================================================
 
 function buildMoneyFormat(currencies: Currency[], currencyCode: string): MoneyFormat {
   const currency = currencies.find((c) => c.currency_code === currencyCode);
@@ -30,6 +50,10 @@ function buildMoneyFormat(currencies: Currency[], currencyCode: string): MoneyFo
 function formatPrice(value: number, decimalPlaces: number): string {
   return value.toFixed(decimalPlaces);
 }
+
+// ===========================================================================
+// Order summary (from B2B-4825)
+// ===========================================================================
 
 function buildOrderSummary(
   order: Order,
@@ -91,6 +115,10 @@ function buildOrderSummary(
   };
 }
 
+// ===========================================================================
+// History (from B2B-4825)
+// ===========================================================================
+
 function toNumericEventType(type: OrderHistoryEventType): number {
   switch (type) {
     case OrderHistoryEventType.ORDER_CREATED:
@@ -111,12 +139,300 @@ function mapHistoryEvents(history: Order['history']): OrderHistoryItem[] {
   }));
 }
 
+// ===========================================================================
+// Address conversion (B2B-4826)
+// ===========================================================================
+
+function convertAddress(sfAddr: OrderAddress): Address {
+  return {
+    first_name: sfAddr.firstName ?? '',
+    last_name: sfAddr.lastName ?? '',
+    company: sfAddr.company ?? '',
+    street_1: sfAddr.address1 ?? '',
+    street_2: sfAddr.address2 ?? '',
+    city: sfAddr.city ?? '',
+    state: sfAddr.stateOrProvince ?? '',
+    zip: sfAddr.postalCode ?? '',
+    country: sfAddr.country ?? '',
+    country_iso2: sfAddr.countryCode ?? '',
+    phone: sfAddr.phone ?? '',
+    email: sfAddr.email ?? '',
+  };
+}
+
+// ===========================================================================
+// Product conversion (B2B-4826)
+// ===========================================================================
+
+function convertLineItemToProduct(
+  item: OrderLineItem,
+  decimalPlaces: number,
+  consignmentEntityId: number,
+): OrderProductItem {
+  const unitPrice = item.quantity > 0 ? item.subTotalListPrice.value / item.quantity : 0;
+  const formattedUnitPrice = formatPrice(unitPrice, decimalPlaces);
+  const formattedTotal = formatPrice(item.subTotalListPrice.value, decimalPlaces);
+
+  return {
+    id: item.entityId,
+    product_id: item.productEntityId,
+    variant_id: item.variantEntityId ?? 0,
+    sku: item.sku ?? '',
+    name: item.name,
+    brand: item.brand ?? '',
+    quantity: item.quantity,
+    imageUrl: item.image?.url ?? '',
+    type: 'physical',
+    price_inc_tax: formattedUnitPrice,
+    price_ex_tax: formattedUnitPrice,
+    price_tax: '0',
+    total_inc_tax: formattedTotal,
+    total_ex_tax: formattedTotal,
+    total_tax: '0',
+    base_price: formattedUnitPrice,
+    base_total: formattedTotal,
+    quantity_shipped: 0,
+    quantity_refunded: 0,
+    refund_amount: '0',
+    return_id: 0,
+    optionList: item.productOptions.map((o) => ({
+      optionId: 0,
+      optionValue: o.value,
+      type: o.name,
+    })),
+    product_options: [],
+    order_address_id: consignmentEntityId,
+    order_id: 0,
+    parent_order_product_id: 0,
+    option_set_id: 0,
+    is_bundled_product: false,
+    is_refunded: false,
+    name_customer: item.name,
+    name_merchant: item.name,
+    configurable_fields: '',
+    cost_price_ex_tax: '0',
+    cost_price_inc_tax: '0',
+    cost_price_tax: '0',
+    wrapping_cost_ex_tax: '0',
+    wrapping_cost_inc_tax: '0',
+    wrapping_cost_tax: '0',
+    wrapping_id: 0,
+    wrapping_message: '',
+    wrapping_name: '',
+  };
+}
+
+function convertDigitalLineItemToProduct(
+  item: OrderDigitalLineItem,
+  decimalPlaces: number,
+  consignmentEntityId: number,
+): OrderProductItem {
+  const unitPrice = item.quantity > 0 ? item.subTotalListPrice.value / item.quantity : 0;
+  const formattedUnitPrice = formatPrice(unitPrice, decimalPlaces);
+  const formattedTotal = formatPrice(item.subTotalListPrice.value, decimalPlaces);
+
+  return {
+    id: item.entityId,
+    product_id: item.productEntityId,
+    variant_id: 0,
+    sku: '',
+    name: item.name,
+    brand: '',
+    quantity: item.quantity,
+    imageUrl: '',
+    type: 'digital',
+    price_inc_tax: formattedUnitPrice,
+    price_ex_tax: formattedUnitPrice,
+    price_tax: '0',
+    total_inc_tax: formattedTotal,
+    total_ex_tax: formattedTotal,
+    total_tax: '0',
+    base_price: formattedUnitPrice,
+    base_total: formattedTotal,
+    quantity_shipped: 0,
+    quantity_refunded: 0,
+    refund_amount: '0',
+    return_id: 0,
+    optionList: item.productOptions.map((o) => ({
+      optionId: 0,
+      optionValue: o.value,
+      type: o.name,
+    })),
+    product_options: [],
+    order_address_id: consignmentEntityId,
+    order_id: 0,
+    parent_order_product_id: 0,
+    option_set_id: 0,
+    is_bundled_product: false,
+    is_refunded: false,
+    name_customer: item.name,
+    name_merchant: item.name,
+    configurable_fields: '',
+    cost_price_ex_tax: '0',
+    cost_price_inc_tax: '0',
+    cost_price_tax: '0',
+    wrapping_cost_ex_tax: '0',
+    wrapping_cost_inc_tax: '0',
+    wrapping_cost_tax: '0',
+    wrapping_id: 0,
+    wrapping_message: '',
+    wrapping_name: '',
+  };
+}
+
+function gatherAllProducts(order: Order, decimalPlaces: number): OrderProductItem[] {
+  const physical = (order.consignments?.shipping?.edges ?? []).flatMap((edge) =>
+    edge.node.lineItems.edges.map((le) =>
+      convertLineItemToProduct(le.node, decimalPlaces, edge.node.entityId),
+    ),
+  );
+
+  const digital = (order.consignments?.downloads?.edges ?? []).flatMap((edge) =>
+    edge.node.lineItems.edges.map((le) =>
+      convertDigitalLineItemToProduct(le.node, decimalPlaces, edge.node.entityId),
+    ),
+  );
+
+  return [...physical, ...digital];
+}
+
+function deduplicateProducts(products: OrderProductItem[]): OrderProductItem[] {
+  return products.reduce<OrderProductItem[]>((seen, product) => {
+    const idx = seen.findIndex((item) => Number(item.variant_id) === Number(product.variant_id));
+    if (idx === -1) {
+      seen.push(product);
+    } else {
+      seen[idx] = {
+        ...seen[idx],
+        quantity: Number(seen[idx].quantity) + Number(product.quantity),
+      };
+    }
+    return seen;
+  }, []);
+}
+
+// ===========================================================================
+// Shipments conversion (B2B-4826)
+// ===========================================================================
+
+function convertShippings(order: Order, decimalPlaces: number): OrderShippingsItem[] {
+  if (!order.consignments?.shipping?.edges?.length) {
+    return [];
+  }
+
+  return order.consignments.shipping.edges.map((edge) => {
+    const consignment = edge.node;
+    const address = convertAddress(consignment.shippingAddress);
+
+    const products = consignment.lineItems.edges.map((le) =>
+      convertLineItemToProduct(le.node, decimalPlaces, consignment.entityId),
+    );
+
+    const hasShipments = consignment.shipments.edges.length > 0;
+
+    const productsWithShipStatus = products.map((p) => ({
+      ...p,
+      quantity_shipped: hasShipments ? p.quantity : 0,
+      not_shipping_number: hasShipments ? 0 : p.quantity,
+    }));
+
+    const shipmentItems = consignment.shipments.edges.map((se) => {
+      const shipment = se.node;
+      return {
+        id: shipment.entityId,
+        order_id: order.entityId,
+        order_address_id: consignment.entityId,
+        date_created: shipment.shippedAt.utc,
+        shipping_method: shipment.shippingMethodName,
+        shipping_provider_display_name: shipment.shippingProviderName,
+        tracking_number: shipment.tracking?.number ?? '',
+        tracking_link: shipment.tracking?.url ?? '',
+        tracking_carrier: shipment.shippingProviderName,
+        generated_tracking_link: shipment.tracking?.url,
+        billing_address: convertAddress(order.billingAddress),
+        comments: '',
+        customer_id: 0,
+        items: products.map((p) => ({
+          order_product_id: p.id,
+          product_id: p.product_id,
+          quantity: p.quantity,
+        })),
+        merchant_shipping_cost: '0',
+        shipping_address: address,
+        itemsInfo: productsWithShipStatus.map((p) => ({
+          ...p,
+          current_quantity_shipped: p.quantity,
+        })),
+      };
+    });
+
+    const notShipItems = hasShipments
+      ? []
+      : productsWithShipStatus.map((p) => ({
+          ...p,
+          not_shipping_number: p.quantity,
+        }));
+
+    const shippingCost = formatPrice(consignment.shippingCost.value, decimalPlaces);
+
+    return {
+      ...address,
+      id: consignment.entityId,
+      order_id: order.entityId,
+      base_cost: shippingCost,
+      base_handling_cost: '0',
+      cost_ex_tax: shippingCost,
+      cost_inc_tax: shippingCost,
+      cost_tax: '0',
+      cost_tax_class_id: 0,
+      handling_cost_ex_tax: '0',
+      handling_cost_inc_tax: '0',
+      handling_cost_tax: '0',
+      handling_cost_tax_class_id: 0,
+      items_shipped: hasShipments ? products.length : 0,
+      items_total: products.length,
+      shipping_method: shipmentItems[0]?.shipping_method ?? '',
+      shipping_quotes: '',
+      shipping_zone_id: 0,
+      shipping_zone_name: '',
+      shipmentItems,
+      notShip: {
+        itemsInfo: notShipItems,
+      },
+    } as OrderShippingsItem;
+  });
+}
+
+// ===========================================================================
+// Billing conversion (B2B-4826)
+// ===========================================================================
+
+function convertBillings(order: Order, allProducts: OrderProductItem[]): OrderBillings[] {
+  return [
+    {
+      billingAddress: convertAddress(order.billingAddress),
+      digitalProducts: allProducts.filter((p) => p.type === 'digital'),
+    },
+  ];
+}
+
+// ===========================================================================
+// Payment (expanded for B2B-4826)
+// ===========================================================================
+
 function buildPayment(order: Order): OrderPayment {
   const dateCreateAt = Math.floor(new Date(order.orderedAt.utc).getTime() / 1000);
   return {
     dateCreateAt: String(dateCreateAt),
+    billingAddress: convertAddress(order.billingAddress),
+    paymentMethod: order.payments?.[0]?.description ?? '',
+    updatedAt: order.updatedAt.utc,
   };
 }
+
+// ===========================================================================
+// Main converter
+// ===========================================================================
 
 export function convertOrderDetail(
   order: Order,
@@ -134,27 +450,60 @@ export function convertOrderDetail(
   | 'history'
   | 'orderComments'
   | 'payment'
+  | 'shippings'
+  | 'billings'
+  | 'products'
+  | 'digitalProducts'
+  | 'billingAddress'
+  | 'canReturn'
+  | 'orderIsDigital'
+  | 'ipStatus'
+  | 'invoiceId'
+  | 'createdEmail'
+  | 'companyInfo'
+  | 'customerId'
 > {
   const moneyFormat = buildMoneyFormat(currencies, order.totalIncTax.currencyCode);
+  const decimalPlaces = moneyFormat.decimal_places;
+
+  const allProducts = gatherAllProducts(order, decimalPlaces);
+  const products = deduplicateProducts(allProducts);
+  const digitalProducts = products.filter((p) => p.type === 'digital');
+
+  const companyInfo: CompanyInfoTypes = {
+    companyId: order.company ? String(order.company.entityId) : '',
+    companyName: order.company?.name ?? '',
+    companyAddress: '',
+    companyCountry: '',
+    companyState: '',
+    companyCity: '',
+    companyZipCode: '',
+    phoneNumber: '',
+    bcId: '',
+  };
 
   return {
     orderId: order.entityId,
-
-    // status.label matches the format the legacy API returns (e.g. "Pending").
-    // getOrderStatusLabel() will look this up against the still-legacy
-    // orderStatus list (getOrderStatusType / getBcOrderStatusType) to resolve
     status: order.status.label,
-
-    // customStatus is not exposed by the unified endpoint.
-    // getOrderStatusLabel() falls back to the status label when this is empty.
     customStatus: '',
-
     poNumber: order.reference ?? '',
     currencyCode: order.totalIncTax.currencyCode,
     money: moneyFormat,
-    orderSummary: buildOrderSummary(order, b3Lang, moneyFormat.decimal_places),
+    orderSummary: buildOrderSummary(order, b3Lang, decimalPlaces),
     payment: buildPayment(order),
     history: mapHistoryEvents(order.history),
     orderComments: order.customerMessage ?? '',
+    shippings: convertShippings(order, decimalPlaces),
+    billings: convertBillings(order, allProducts),
+    products,
+    digitalProducts,
+    billingAddress: convertAddress(order.billingAddress),
+    canReturn: order.canReturn ?? false,
+    orderIsDigital: digitalProducts.length > 0,
+    ipStatus: order.invoice ? 1 : 0,
+    invoiceId: order.invoice ? Number(order.invoice.id) : 0,
+    createdEmail: order.placedBy?.email ?? '',
+    companyInfo,
+    customerId: order.placedBy?.entityId,
   };
 }

--- a/apps/storefront/src/shared/service/bc/graphql/orders.ts
+++ b/apps/storefront/src/shared/service/bc/graphql/orders.ts
@@ -45,14 +45,19 @@ export interface OrderLineItemProductOption {
   value: string;
 }
 
-/** Projects OrderPhysicalLineItem; OrderDigitalLineItem has a similar shape. */
+/** Projects OrderPhysicalLineItem. */
 export interface OrderLineItem {
   entityId: number;
+  productEntityId: number;
+  variantEntityId: number | null;
+  sku: string;
   brand: string | null;
   name: string;
   quantity: number;
   productOptions: OrderLineItemProductOption[];
   subTotalListPrice: Money;
+  image: { url: string } | null;
+  baseCatalogProduct: { path: string } | null;
 }
 
 export interface OrderShipmentTracking {
@@ -77,8 +82,25 @@ export interface ShippingConsignment {
   shipments: { edges: Array<{ node: OrderShipment }> };
 }
 
+/** Projects OrderDigitalLineItem within download consignments. */
+export interface OrderDigitalLineItem {
+  entityId: number;
+  productEntityId: number;
+  name: string;
+  quantity: number;
+  productOptions: OrderLineItemProductOption[];
+  subTotalListPrice: Money;
+}
+
+/** Projects OrderDownloadConsignment. */
+export interface DownloadConsignment {
+  entityId: number;
+  lineItems: { edges: Array<{ node: OrderDigitalLineItem }> };
+}
+
 export interface OrderConsignments {
   shipping: { edges: Array<{ cursor: string; node: ShippingConsignment }> };
+  downloads: { edges: Array<{ cursor: string; node: DownloadConsignment }> } | null;
 }
 
 /** Nested inside OrderDiscounts.couponDiscounts. */
@@ -145,6 +167,10 @@ export interface ExtraFieldValue {
   value: string;
 }
 
+export interface OrderPaymentInfo {
+  description: string;
+}
+
 // ===========================================================================
 // Order (base SF GQL fields + B2B extensions)
 // ===========================================================================
@@ -173,6 +199,9 @@ export interface Order {
   totalProductQuantity: number;
   consignments: OrderConsignments | null;
 
+  // Payments (only on OrderWithPayments via site.order detail query)
+  payments?: OrderPaymentInfo[];
+
   // B2B extensions (null for B2C orders)
   reference: string | null;
   company: OrderCompany | null;
@@ -181,6 +210,7 @@ export interface Order {
   quote: OrderQuote | null;
   invoice: OrderInvoice | null;
   extraFields: ExtraFieldValue[];
+  canReturn: boolean;
 }
 
 // ===========================================================================
@@ -329,6 +359,9 @@ const orderAddressFields = `firstName
     email`;
 
 const orderLineItemFields = `entityId
+      productEntityId
+      variantEntityId
+      sku
       brand
       name
       quantity
@@ -338,6 +371,12 @@ const orderLineItemFields = `entityId
       }
       subTotalListPrice {
         ${moneyFields}
+      }
+      image {
+        url
+      }
+      baseCatalogProduct {
+        path
       }`;
 
 const orderShipmentFields = `entityId
@@ -382,6 +421,31 @@ const orderConsignmentsFields = `consignments {
             edges {
               node {
                 ${orderShipmentFields}
+              }
+            }
+          }
+        }
+      }
+    }
+    downloads {
+      edges {
+        cursor
+        node {
+          entityId
+          lineItems {
+            edges {
+              node {
+                entityId
+                productEntityId
+                name
+                quantity
+                productOptions {
+                  name
+                  value
+                }
+                subTotalListPrice {
+                  ${moneyFields}
+                }
               }
             }
           }
@@ -467,7 +531,8 @@ const orderB2BFields = `reference
   extraFields {
     name
     value
-  }`;
+  }
+  canReturn`;
 
 /** Lightweight fields for order list views. */
 const orderListNodeFields = `entityId
@@ -591,6 +656,9 @@ const GET_ORDER_DETAIL = `query GetOrderDetail($entityId: Int!) {
       totalProductQuantity
       ${orderConsignmentsFields}
       ${orderB2BFields}
+      payments {
+        description
+      }
     }
   }
 }`;

--- a/apps/storefront/src/shared/service/bc/graphql/orders.ts
+++ b/apps/storefront/src/shared/service/bc/graphql/orders.ts
@@ -210,7 +210,7 @@ export interface Order {
   quote: OrderQuote | null;
   invoice: OrderInvoice | null;
   extraFields: ExtraFieldValue[];
-  canReturn: boolean;
+  canReturn?: boolean;
 }
 
 // ===========================================================================


### PR DESCRIPTION
Jira: [B2B-4826](https://bigcommercecloud.atlassian.net/browse/B2B-4826)

## What/Why?

Final slice (Task 3) of the Order Detail migration to the unified SF GQL API. Completes `convertOrderDetail` so it produces a full `OrderDetailsState` from the unified `Order` response, enabling the feature flag to ramp on with parity across all Order Detail sections.

**Converter expansion** (`convertOrderDetail.ts`):
- `convertAddress()` — SF GQL camelCase → legacy snake_case `Address`
- `convertLineItemToProduct()` / `convertDigitalLineItemToProduct()` — full `OrderProductItem` mapping (50+ fields per product) from physical and digital line items
- `gatherAllProducts()` + `deduplicateProducts()` — collects products from all consignment types (shipping + downloads), dedupes by `variant_id` (matching legacy `handleProductQuantity` behavior)
- `convertShippings()` — builds `OrderShippingsItem[]` from SF GQL consignments with shipped/unshipped item tracking, per-shipment tracking links, and "not shipped" sets
- `convertBillings()` — billing address + filtered digital products → `OrderBillings[]`
- `buildPayment()` — expanded to include `billingAddress`, `paymentMethod` (from `OrderWithPayments.payments`), and `updatedAt`
- `product_options` populated from SF GQL `productOptions` so the reorder dialog can build `selectedOptions` for the cart API
- Additional state fields: `canReturn`, `orderIsDigital`, `ipStatus`, `invoiceId`, `createdEmail`, `companyInfo`, `customerId`

**Query expansion** (`orders.ts`):
- `OrderLineItem` type expanded with `productEntityId`, `variantEntityId`, `sku`, `image`, `baseCatalogProduct`
- New types: `OrderDigitalLineItem`, `DownloadConsignment`, `OrderPaymentInfo`
- `orderConsignmentsFields` fragment now selects `downloads` consignment type (for digital products)
- `orderB2BFields` fragment adds `canReturn`
- `GET_ORDER_DETAIL` query adds `payments { description }`

Sub-components (`OrderShipping`, `OrderBilling`, `OrderAction`, `OrderDialog`, `OrderShoppingList`, `OrderCheckboxProduct`, `DownloadDigitalProductsDialog`) are **unchanged** — the converter bridges the unified SF GQL shape to the legacy `OrderDetailsState` types they consume.

**Parent:** B2B-4624 (split into B2B-4824 → B2B-4825 → B2B-4826)
**Depends on:** B2B-4824 (Task 1, merged), B2B-4825 (Task 2, merged)

## Rollout/Rollback

All changes are behind the existing feature flag `B2B-4613.buyer_portal_unified_sf_gql_orders`. Production behavior is unchanged when the flag is off. Rollback is disabling the flag — the legacy `convertB2BOrderDetails` / `convertBCOrderDetails` paths remain intact and unmodified.

Integration validation against live BE data is tracked in B2B-4787 (blocked on BE Stage 4a deployment).

## Testing

**26 new tests** ported from the legacy test file to `index.unified.test.tsx` (36 total in the file, 92 across all affected suites):

| Category | Tests |
|---|---|
| Shipments (shipped section, tracking, address, not-shipped, multiple addresses) | 4 |
| Payment (paid in full, Purchase Order) | 2 |
| Digital products (section, view-files link, no link for physical/no-file) | 3 |
| Reorder — frontend validation (single, adjust qty, all, no selection warning) | 4 |
| Reorder — backend validation (single, error, network error, adjust qty, all, partial, no selection) | 7 |
| Add to shopping list (single to existing, new list, adjust qty, all, all via reorder, no selection) | 6 |

All tests use MSW handlers for `GetOrderDetail` (unified path) instead of `GetCustomerOrder` (legacy path). Existing legacy tests continue to pass unmodified.


https://github.com/user-attachments/assets/527d07b2-37b1-4014-b3d4-37c71085e5db



[B2B-4826]: https://bigcommercecloud.atlassian.net/browse/B2B-4826?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk: the expanded converter drives reorder, cart, returns, and shipment UI for all flag-on traffic; mistakes in product/shipment mapping or variant handling could cause wrong cart lines or display, though rollout remains behind the existing feature flag.
> 
> **Overview**
> Completes the **unified SF GQL Order Detail** path by expanding `convertOrderDetail` so a single `Order` response fills the legacy `OrderDetailsState` shape—**shipments** (tracking, shipped vs not-shipped, multi-address), **billing**, **payment** (method, billing address), **physical and digital line items** (with dedupe), plus flags like **`canReturn`**, invoice/company/placed-by metadata—without changing existing Order Detail UI components.
> 
> **`orders.ts`** grows the detail query and types: download consignments, richer physical line items (`productEntityId`, `variantEntityId`, `sku`, image), **`payments`**, and **`canReturn`**.
> 
> **Tests** add `canReturn` to unified order list builders and a large **B2B-4826** suite on `index.unified.test.tsx` (shipments, payment, digital downloads, reorder with/without `ValidateProduct`, shopping list flows) under `B2B-4613.buyer_portal_unified_sf_gql_orders`. Legacy converters stay when the flag is off.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7aa602e3ad9b526b975e073c8069590129e7b8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->