### PR TITLE
feat(quotes): BACK-516 Write flag to session when Backorder information has changed between quote and checkout.

### DIFF
--- a/apps/storefront/src/pages/QuoteDetail/index.tsx
+++ b/apps/storefront/src/pages/QuoteDetail/index.tsx
@@ -52,6 +52,7 @@ import {
   QUOTE_VALIDATION_ERROR_CODES,
   QUOTE_VALIDATION_MESSAGE_CONTEXTS,
 } from '../quote/shared/getQuoteValidationErrorMessage';
+import { buildQuoteStockSnapshot } from '../quote/utils/buildQuoteStockSnapshot';
 import getB2BQuoteExtraFields from '../quote/utils/getQuoteExtraFields';
 import { handleQuoteCheckout } from '../quote/utils/quoteCheckout';
 
@@ -135,36 +136,23 @@ function useData() {
 
   const { purchasabilityPermission } = useAppSelector(rolePermissionSelector);
 
-  const handleGetProductsById = async (listProducts: ProductInfoProps[]) => {
-    if (listProducts.length > 0) {
-      const productIds: number[] = [];
+  const fetchProductsWithSearch = async (
+    listProducts: ProductInfoProps[],
+  ): Promise<ProductInfoProps[]> => {
+    if (listProducts.length === 0) return [];
 
-      listProducts.forEach((item) => {
-        if (!productIds.includes(item.productId)) {
-          productIds.push(item.productId);
-        }
-      });
+    const productIds = Array.from(new Set(listProducts.map((item) => item.productId)));
+    const options = { productIds, currencyCode, companyId, customerGroupId };
 
-      const options = { productIds, currencyCode, companyId, customerGroupId };
+    const { productsSearch } = await searchProducts(options);
+    const newProductsSearch = conversionProductsList(productsSearch);
 
-      const { productsSearch } = await searchProducts(options);
-
-      const newProductsSearch = conversionProductsList(productsSearch);
-
-      listProducts.forEach((item) => {
-        const listProduct = item;
-        const productInfo = newProductsSearch.find((search: CustomFieldItems) => {
-          const { id: productId } = search;
-
-          return Number(item.productId) === Number(productId);
-        });
-
-        listProduct.productsSearch = productInfo || {};
-      });
-
-      return listProducts;
-    }
-    return undefined;
+    return listProducts.map((item) => {
+      const productInfo = newProductsSearch.find(
+        (search: CustomFieldItems) => Number(item.productId) === Number(search.id),
+      );
+      return { ...item, productsSearch: productInfo || {} };
+    });
   };
 
   const location = useLocation();
@@ -201,7 +189,7 @@ function useData() {
     enteredInclusiveTax,
     isEnableProduct,
     purchasabilityPermission,
-    handleGetProductsById,
+    fetchProductsWithSearch,
     getQuote,
   };
 }
@@ -279,7 +267,7 @@ function QuoteDetail() {
     enteredInclusiveTax,
     isEnableProduct,
     purchasabilityPermission,
-    handleGetProductsById,
+    fetchProductsWithSearch,
     getQuote,
   } = useData();
 
@@ -289,6 +277,9 @@ function QuoteDetail() {
 
   const isCurrencySymbolPlacementFixEnabled = useFeatureFlag(
     'B2B-3876.fix_quote_currency_symbol_placement',
+  );
+  const isBackorderMessagingEnabled = useFeatureFlag(
+    'BACK-134.backorders_phase_1_1_control_messaging_on_storefront',
   );
 
   const [quoteDetail, setQuoteDetail] = useState<any>({});
@@ -540,10 +531,11 @@ function QuoteDetail() {
 
     try {
       const quote = await getQuote();
-      const productsWithMoreInfo = await handleGetProductsById(quote.productsList).catch(() => {
-        return undefined;
-      });
+      const productsWithMoreInfo = await fetchProductsWithSearch(quote.productsList).catch(
+        () => undefined,
+      );
       const quoteExtraFieldInfos = await getQuoteExtraFields(quote.extraFields);
+      const productListResponse = productsWithMoreInfo ?? [];
       setQuoteDetail({
         ...quote,
         extraFields: quoteExtraFieldInfos,
@@ -556,7 +548,6 @@ function QuoteDetail() {
         totalAmount: quote.totalAmount,
       });
 
-      const productListResponse = productsWithMoreInfo ?? [];
       setProductList(productListResponse);
 
       const { salesRep, salesRepEmail } = quote;
@@ -615,7 +606,9 @@ function QuoteDetail() {
 
       setFileList(newFileList);
 
-      return quote;
+      // On enrichment failure, fall back to the original (unenriched) productsList so the
+      // table's empty-state fallback in getQuoteTableDetails still has items to render.
+      return { ...quote, productsList: productsWithMoreInfo ?? quote.productsList };
     } catch (error: unknown) {
       if (error instanceof Error) {
         snackbar.error(error.message);
@@ -756,6 +749,11 @@ function QuoteDetail() {
       context: QUOTE_VALIDATION_MESSAGE_CONTEXTS.QUOTE,
     });
 
+  const fetchCurrentStockSnapshot = async () => {
+    const refreshed = await fetchProductsWithSearch(productList);
+    return buildQuoteStockSnapshot(refreshed);
+  };
+
   const quoteGotoCheckout = async () => {
     try {
       if (hasQuoteValidationErrors()) return;
@@ -768,6 +766,9 @@ function QuoteDetail() {
         navigate,
         b3Lang,
         formatValidationError: formatQuoteValidationError,
+        isBackorderMessagingEnabled,
+        quoteStockSnapshot: buildQuoteStockSnapshot(productList),
+        fetchCurrentStockSnapshot,
       });
     } finally {
       setQuoteCheckoutLoading(false);
@@ -1024,6 +1025,9 @@ function QuoteDetail() {
                     navigate,
                     b3Lang,
                     formatValidationError: formatQuoteValidationError,
+                    isBackorderMessagingEnabled,
+                    quoteStockSnapshot: buildQuoteStockSnapshot(productList),
+                    fetchCurrentStockSnapshot,
                   });
                 }}
               >

--- a/apps/storefront/src/pages/quote/utils/buildQuoteStockSnapshot.test.ts
+++ b/apps/storefront/src/pages/quote/utils/buildQuoteStockSnapshot.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildQuoteStockSnapshot } from './buildQuoteStockSnapshot';
+
+describe('buildQuoteStockSnapshot', () => {
+  it('extracts totalOnHand from productsSearch for product-level tracking', () => {
+    const result = buildQuoteStockSnapshot([
+      {
+        id: 'line-1',
+        productId: 1,
+        variantId: 10,
+        variantSku: 'SKU-1',
+        quantity: 5,
+        productsSearch: { inventoryTracking: 'product', totalOnHand: 7 },
+      },
+    ]);
+
+    expect(result).toEqual([
+      {
+        lineId: 'line-1',
+        productId: 1,
+        variantId: 10,
+        variantSku: 'SKU-1',
+        quantity: 5,
+        inventoryTracking: 'product',
+        totalOnHand: 7,
+      },
+    ]);
+  });
+
+  it('looks up variant by SKU for variant-level tracking', () => {
+    const result = buildQuoteStockSnapshot([
+      {
+        id: 'line-2',
+        productId: 2,
+        variantId: 22,
+        variantSku: 'SKU-V',
+        quantity: 3,
+        productsSearch: {
+          inventoryTracking: 'variant',
+          variants: [
+            { sku: 'SKU-X', total_on_hand: 99 },
+            { sku: 'SKU-V', total_on_hand: 2 },
+          ],
+        },
+      },
+    ]);
+
+    expect(result[0].totalOnHand).toBe(2);
+  });
+
+  it('returns totalOnHand null when variant not found', () => {
+    const result = buildQuoteStockSnapshot([
+      {
+        id: 'line-3',
+        productId: 3,
+        variantId: 33,
+        variantSku: 'MISSING',
+        quantity: 1,
+        productsSearch: {
+          inventoryTracking: 'variant',
+          variants: [{ sku: 'OTHER', total_on_hand: 5 }],
+        },
+      },
+    ]);
+
+    expect(result[0].totalOnHand).toBeNull();
+  });
+
+  it('marks inventoryTracking unknown when productsSearch is missing', () => {
+    const result = buildQuoteStockSnapshot([
+      { id: 'line-4', productId: 4, variantId: 44, quantity: 2 },
+    ]);
+
+    expect(result[0].inventoryTracking).toBe('unknown');
+    expect(result[0].totalOnHand).toBeNull();
+  });
+
+  it('marks inventoryTracking none when productsSearch is present but tracking is none', () => {
+    const result = buildQuoteStockSnapshot([
+      {
+        id: 'line-5a',
+        productId: 5,
+        variantId: 50,
+        quantity: 1,
+        productsSearch: { inventoryTracking: 'none' },
+      },
+    ]);
+
+    expect(result[0].inventoryTracking).toBe('none');
+  });
+
+  it('marks inventoryTracking unknown for an unexpected tracking value (fail safe)', () => {
+    const result = buildQuoteStockSnapshot([
+      {
+        id: 'line-5b',
+        productId: 5,
+        variantId: 50,
+        quantity: 1,
+        productsSearch: { inventoryTracking: 'multi-location' },
+      },
+    ]);
+
+    expect(result[0].inventoryTracking).toBe('unknown');
+  });
+
+  it('coerces string quantity to number', () => {
+    const result = buildQuoteStockSnapshot([
+      {
+        id: 'line-5b',
+        productId: 5,
+        variantId: 55,
+        quantity: '7',
+        productsSearch: { inventoryTracking: 'product', totalOnHand: 10 },
+      },
+    ]);
+
+    expect(result[0].quantity).toBe(7);
+  });
+
+  it('falls back to lineItem.sku when variantSku is an empty string', () => {
+    // Some upstream shapes type variantSku as required `string` and may initialize it to "" rather
+    // than leaving it undefined — || (not ??) is needed for the fallback to engage.
+    const result = buildQuoteStockSnapshot([
+      {
+        productId: 114,
+        variantId: 82,
+        variantSku: '',
+        sku: 'VGI-BL',
+        quantity: 2,
+        productsSearch: {
+          inventoryTracking: 'variant',
+          variants: [
+            { sku: 'VGI-RE', total_on_hand: 2 },
+            { sku: 'VGI-BL', total_on_hand: 1 },
+          ],
+        },
+      },
+    ]);
+
+    expect(result[0].variantSku).toBe('VGI-BL');
+    expect(result[0].totalOnHand).toBe(1);
+  });
+
+  it('falls back to lineItem.sku when variantSku is missing (real quote-line shape)', () => {
+    // Real quote-line items do not carry a `variantSku` field — the variant SKU lives on `sku`.
+    const result = buildQuoteStockSnapshot([
+      {
+        productId: 114,
+        variantId: 82,
+        sku: 'VGI-BL',
+        quantity: 2,
+        productsSearch: {
+          inventoryTracking: 'variant',
+          variants: [
+            { sku: 'VGI-RE', total_on_hand: 2 },
+            { sku: 'VGI-GR', total_on_hand: 2 },
+            { sku: 'VGI-BL', total_on_hand: 1 },
+          ],
+        },
+      },
+    ]);
+
+    expect(result[0].variantSku).toBe('VGI-BL');
+    expect(result[0].totalOnHand).toBe(1);
+  });
+
+  it('prefers variantSku over sku when both are present', () => {
+    const result = buildQuoteStockSnapshot([
+      {
+        productId: 1,
+        variantId: 10,
+        variantSku: 'EXPLICIT',
+        sku: 'FALLBACK',
+        quantity: 1,
+        productsSearch: { inventoryTracking: 'none' },
+      },
+    ]);
+
+    expect(result[0].variantSku).toBe('EXPLICIT');
+  });
+
+  it('synthesizes lineId from variantId and index when id is missing', () => {
+    const result = buildQuoteStockSnapshot([
+      { productId: 1, variantId: 10, quantity: 1 },
+      { productId: 1, variantId: 10, quantity: 1 },
+    ]);
+
+    expect(result[0].lineId).toBe('10::0');
+    expect(result[1].lineId).toBe('10::1');
+  });
+
+  it('coerces string productId to number', () => {
+    // Real quote-line items carry productId as a string.
+    const result = buildQuoteStockSnapshot([{ productId: '114', variantId: 82, quantity: 1 }]);
+
+    expect(result[0].productId).toBe(114);
+  });
+});

--- a/apps/storefront/src/pages/quote/utils/buildQuoteStockSnapshot.ts
+++ b/apps/storefront/src/pages/quote/utils/buildQuoteStockSnapshot.ts
@@ -1,0 +1,67 @@
+import type { QuoteStockSnapshotItem } from './detectQuoteStockChange';
+
+interface SnapshotInput {
+  id?: number | string;
+  productId: number | string;
+  variantId: number;
+  variantSku?: string;
+  sku?: string;
+  quantity: number | string;
+  productsSearch?: {
+    inventoryTracking?: string;
+    totalOnHand?: number | null;
+    variants?: Array<{
+      sku?: string;
+      total_on_hand?: number | null;
+    }>;
+  };
+}
+
+function resolveTracking(lineItem: SnapshotInput): QuoteStockSnapshotItem['inventoryTracking'] {
+  if (!lineItem.productsSearch) {
+    return 'unknown';
+  }
+
+  const tracking = lineItem.productsSearch.inventoryTracking;
+  if (tracking === 'none') {
+    return 'none';
+  }
+  if (tracking === 'product' || tracking === 'variant') {
+    return tracking;
+  }
+  // Unexpected value (e.g. a future BC tracking mode) — fail safe by not comparing.
+  return 'unknown';
+}
+
+function extractTotalOnHand(lineItem: SnapshotInput): number | null {
+  const search = lineItem.productsSearch;
+  if (!search) {
+    return null;
+  }
+
+  const tracking = search.inventoryTracking;
+  if (tracking === 'product') {
+    return search.totalOnHand ?? null;
+  }
+
+  if (tracking === 'variant') {
+    const lookupSku = lineItem.variantSku || lineItem.sku;
+    const variant = (search.variants || []).find((v) => v.sku === lookupSku);
+
+    return variant?.total_on_hand ?? null;
+  }
+
+  return null;
+}
+
+export function buildQuoteStockSnapshot(lineItems: SnapshotInput[]): QuoteStockSnapshotItem[] {
+  return lineItems.map((lineItem, index) => ({
+    lineId: lineItem.id ?? `${lineItem.variantId}::${index}`,
+    productId: Number(lineItem.productId),
+    variantId: lineItem.variantId,
+    variantSku: lineItem.variantSku || lineItem.sku,
+    quantity: Number(lineItem.quantity ?? 0),
+    inventoryTracking: resolveTracking(lineItem),
+    totalOnHand: extractTotalOnHand(lineItem),
+  }));
+}

--- a/apps/storefront/src/pages/quote/utils/detectQuoteStockChange.test.ts
+++ b/apps/storefront/src/pages/quote/utils/detectQuoteStockChange.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest';
+
+import { detectQuoteStockChange, QuoteStockSnapshotItem } from './detectQuoteStockChange';
+
+const item = (
+  productId: number,
+  variantId: number,
+  quantity: number,
+  totalOnHand: number | null,
+  inventoryTracking: QuoteStockSnapshotItem['inventoryTracking'] = 'product',
+  lineId: number | string = `${productId}:${variantId}`,
+): QuoteStockSnapshotItem => ({
+  lineId,
+  productId,
+  variantId,
+  quantity,
+  totalOnHand,
+  inventoryTracking,
+});
+
+describe('detectQuoteStockChange', () => {
+  it('returns false when after is empty', () => {
+    expect(detectQuoteStockChange([item(1, 1, 5, 10)], [])).toBe(false);
+  });
+
+  it('returns false when stock state is unchanged', () => {
+    expect(detectQuoteStockChange([item(1, 1, 5, 10)], [item(1, 1, 5, 10)])).toBe(false);
+  });
+
+  it('returns true when fulfillable quantity differs (stock decreased)', () => {
+    expect(detectQuoteStockChange([item(1, 1, 10, 10)], [item(1, 1, 10, 2)])).toBe(true);
+  });
+
+  it('returns true when fulfillable quantity differs (stock increased)', () => {
+    expect(detectQuoteStockChange([item(1, 1, 10, 2)], [item(1, 1, 10, 50)])).toBe(true);
+  });
+
+  it('returns false when stock decreases but remains above cart quantity', () => {
+    // qty=5 on both sides; stock 50 → 30, but min(5, 50) === min(5, 30), so fulfillable is unchanged.
+    expect(detectQuoteStockChange([item(1, 1, 5, 50)], [item(1, 1, 5, 30)])).toBe(false);
+  });
+
+  it('returns true when one of multiple items changed', () => {
+    expect(
+      detectQuoteStockChange(
+        [item(1, 1, 5, 10), item(2, 2, 5, 10)],
+        [item(1, 1, 5, 10), item(2, 2, 5, 2)],
+      ),
+    ).toBe(true);
+  });
+
+  it('skips items with inventoryTracking none', () => {
+    expect(detectQuoteStockChange([item(1, 1, 5, 0, 'none')], [item(1, 1, 5, 0, 'none')])).toBe(
+      false,
+    );
+  });
+
+  it('skips items when previous snapshot tracking is unknown', () => {
+    expect(
+      detectQuoteStockChange([item(1, 1, 5, null, 'unknown')], [item(1, 1, 5, 2, 'product')]),
+    ).toBe(false);
+  });
+
+  it('skips comparison when both sides have null totalOnHand (lookup failed)', () => {
+    expect(detectQuoteStockChange([item(1, 1, 5, null)], [item(1, 1, 5, null)])).toBe(false);
+  });
+
+  it('skips comparison when previous totalOnHand is null but current is resolved', () => {
+    expect(detectQuoteStockChange([item(1, 1, 5, null)], [item(1, 1, 5, 2)])).toBe(false);
+  });
+
+  it('skips comparison when current totalOnHand is null but previous is resolved', () => {
+    expect(detectQuoteStockChange([item(1, 1, 5, 10)], [item(1, 1, 5, null)])).toBe(false);
+  });
+
+  it('compares each line independently when two lines share productId and variantId', () => {
+    // Two quote lines, same product+variant but different lineIds (e.g. different modifier selections).
+    // If we keyed by productId+variantId, the second line would overwrite the first in the map and
+    // one line would be silently skipped.
+    expect(
+      detectQuoteStockChange(
+        [item(1, 1, 5, 10, 'product', 'line-a'), item(1, 1, 5, 10, 'product', 'line-b')],
+        [item(1, 1, 5, 10, 'product', 'line-a'), item(1, 1, 5, 2, 'product', 'line-b')],
+      ),
+    ).toBe(true);
+  });
+
+  it('treats negative totalOnHand as zero fulfillable (oversold inventory)', () => {
+    // qty=5; before stock=-3, after stock=-5. Both clamp to fulfillable=0, so no detectable change.
+    expect(detectQuoteStockChange([item(1, 1, 5, -3)], [item(1, 1, 5, -5)])).toBe(false);
+  });
+
+  it('returns true when stock crosses from negative to positive (oversold → restocked)', () => {
+    // qty=5; before stock=-2 (fulfillable=0), after stock=3 (fulfillable=3). Differs.
+    expect(detectQuoteStockChange([item(1, 1, 5, -2)], [item(1, 1, 5, 3)])).toBe(true);
+  });
+});

--- a/apps/storefront/src/pages/quote/utils/detectQuoteStockChange.ts
+++ b/apps/storefront/src/pages/quote/utils/detectQuoteStockChange.ts
@@ -1,0 +1,50 @@
+export interface QuoteStockSnapshotItem {
+  lineId: number | string;
+  productId: number;
+  variantId: number;
+  variantSku?: string;
+  quantity: number;
+  inventoryTracking: 'none' | 'product' | 'variant' | 'unknown';
+  totalOnHand: number | null;
+}
+
+function computeFulfillableQuantity(quantity: number, totalOnHand: number): number {
+  // Clamp at 0 so oversold stock (negative totalOnHand) doesn't produce a negative fulfillable
+  // quantity — every negative value collapses to "nothing shippable" instead of comparing as distinct.
+  return Math.max(0, Math.min(quantity, totalOnHand));
+}
+
+export function detectQuoteStockChange(
+  previousSnapshot: QuoteStockSnapshotItem[],
+  currentSnapshot: QuoteStockSnapshotItem[],
+): boolean {
+  const currentItemsByLineId = new Map<number | string, QuoteStockSnapshotItem>();
+  currentSnapshot.forEach((p) => currentItemsByLineId.set(p.lineId, p));
+
+  return previousSnapshot.some((previousItem) => {
+    if (previousItem.inventoryTracking === 'none' || previousItem.inventoryTracking === 'unknown') {
+      return false;
+    }
+
+    const currentItem = currentItemsByLineId.get(previousItem.lineId);
+    if (!currentItem) {
+      return false;
+    }
+
+    // For tracked items, a null totalOnHand means the stock lookup didn't resolve.
+    if (previousItem.totalOnHand === null || currentItem.totalOnHand === null) {
+      return false;
+    }
+
+    const previousFulfillable = computeFulfillableQuantity(
+      previousItem.quantity,
+      previousItem.totalOnHand,
+    );
+    const currentFulfillable = computeFulfillableQuantity(
+      currentItem.quantity,
+      currentItem.totalOnHand,
+    );
+
+    return previousFulfillable !== currentFulfillable;
+  });
+}

--- a/apps/storefront/src/pages/quote/utils/quoteCheckout.test.ts
+++ b/apps/storefront/src/pages/quote/utils/quoteCheckout.test.ts
@@ -1,0 +1,191 @@
+import type { Location } from 'react-router-dom';
+import { graphql, HttpResponse, startMockServer } from 'tests/test-utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { LangFormatFunction } from '@/lib/lang';
+import type { ProductValidationError } from '@/shared/service/request/b3Fetch';
+
+import { QuoteStockSnapshotItem } from './detectQuoteStockChange';
+import { handleQuoteCheckout, QUOTE_BACKORDER_CHANGE_STORAGE_KEY } from './quoteCheckout';
+
+vi.mock('@/store', () => ({
+  store: {
+    dispatch: vi.fn(),
+    getState: vi.fn(() => ({ company: { tokens: { B2BToken: 'test-token' } } })),
+  },
+  setQuoteDetailToCheckoutUrl: vi.fn((payload) => ({
+    type: 'setQuoteDetailToCheckoutUrl',
+    payload,
+  })),
+}));
+
+vi.mock('@/store/selectors', () => ({
+  isLoggedInSelector: vi.fn(() => true),
+}));
+
+vi.mock('@/utils/b3checkout', () => ({
+  attemptCheckoutLoginAndRedirect: vi.fn(),
+  setQuoteToStorage: vi.fn(),
+}));
+
+vi.mock('@/utils/b3Logger', () => ({
+  default: { error: vi.fn() },
+}));
+
+vi.mock('@/utils/b3Tip', () => ({
+  snackbar: { error: vi.fn() },
+}));
+
+vi.mock('@/utils/basicConfig', () => ({
+  platform: 'bigcommerce',
+  storeHash: 'test-store',
+  channelId: 1,
+  disableLogoutButton: false,
+  BigCommerceStorefrontAPIBaseURL: 'https://store-test-store.mybigcommerce.com',
+}));
+
+vi.mock('@/utils/loginInfo', () => ({
+  getSearchVal: vi.fn(() => ''),
+}));
+
+const { server } = startMockServer();
+
+const stockSnapshot = (totalOnHand: number): QuoteStockSnapshotItem[] => [
+  {
+    lineId: 'line-1',
+    productId: 1,
+    variantId: 10,
+    quantity: 5,
+    inventoryTracking: 'product',
+    totalOnHand,
+  },
+];
+
+const b3Lang: LangFormatFunction = (key) => key as unknown as string;
+const formatValidationError = (err: ProductValidationError) => `error-${err.code}`;
+
+const baseArgs = {
+  quoteId: '42',
+  role: 0,
+  location: { search: '', pathname: '/quote/42' } as Location,
+  b3Lang,
+  formatValidationError,
+};
+
+describe('handleQuoteCheckout backorder snapshot detection', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+
+    server.use(
+      graphql.query('getStorefrontProductSettings', () =>
+        HttpResponse.json({
+          data: {
+            storefrontProductSettings: { hidePriceFromGuests: false },
+          },
+        }),
+      ),
+      graphql.mutation('CheckoutQuote', () =>
+        HttpResponse.json({
+          data: {
+            quoteCheckout: {
+              quoteCheckout: { checkoutUrl: '/checkout', cartId: 'cart-1' },
+            },
+          },
+        }),
+      ),
+    );
+  });
+
+  it('writes the backorder flag when fulfillable quantity differs between snapshots', async () => {
+    await handleQuoteCheckout({
+      ...baseArgs,
+      isBackorderMessagingEnabled: true,
+      quoteStockSnapshot: stockSnapshot(10),
+      fetchCurrentStockSnapshot: async () => stockSnapshot(2),
+    });
+
+    expect(sessionStorage.getItem(QUOTE_BACKORDER_CHANGE_STORAGE_KEY)).toBe('true');
+  });
+
+  it('does not write the flag when fulfillable quantity is unchanged', async () => {
+    await handleQuoteCheckout({
+      ...baseArgs,
+      isBackorderMessagingEnabled: true,
+      quoteStockSnapshot: stockSnapshot(10),
+      fetchCurrentStockSnapshot: async () => stockSnapshot(10),
+    });
+
+    expect(sessionStorage.getItem(QUOTE_BACKORDER_CHANGE_STORAGE_KEY)).toBeNull();
+  });
+
+  it('does not refetch or write the flag when the feature flag is off', async () => {
+    const fetcher = vi.fn(async () => stockSnapshot(2));
+
+    await handleQuoteCheckout({
+      ...baseArgs,
+      isBackorderMessagingEnabled: false,
+      quoteStockSnapshot: stockSnapshot(10),
+      fetchCurrentStockSnapshot: fetcher,
+    });
+
+    expect(fetcher).not.toHaveBeenCalled();
+    expect(sessionStorage.getItem(QUOTE_BACKORDER_CHANGE_STORAGE_KEY)).toBeNull();
+  });
+
+  it('does not refetch when the previous snapshot is empty', async () => {
+    const fetcher = vi.fn(async () => stockSnapshot(2));
+
+    await handleQuoteCheckout({
+      ...baseArgs,
+      isBackorderMessagingEnabled: true,
+      quoteStockSnapshot: [],
+      fetchCurrentStockSnapshot: fetcher,
+    });
+
+    expect(fetcher).not.toHaveBeenCalled();
+    expect(sessionStorage.getItem(QUOTE_BACKORDER_CHANGE_STORAGE_KEY)).toBeNull();
+  });
+
+  it('clears a stale flag from a previous attempt when the current verdict is no-change', async () => {
+    sessionStorage.setItem(QUOTE_BACKORDER_CHANGE_STORAGE_KEY, 'true');
+
+    await handleQuoteCheckout({
+      ...baseArgs,
+      isBackorderMessagingEnabled: true,
+      quoteStockSnapshot: stockSnapshot(10),
+      fetchCurrentStockSnapshot: async () => stockSnapshot(10),
+    });
+
+    expect(sessionStorage.getItem(QUOTE_BACKORDER_CHANGE_STORAGE_KEY)).toBeNull();
+  });
+
+  it('clears a stale flag even when the feature flag is off', async () => {
+    sessionStorage.setItem(QUOTE_BACKORDER_CHANGE_STORAGE_KEY, 'true');
+
+    await handleQuoteCheckout({
+      ...baseArgs,
+      isBackorderMessagingEnabled: false,
+      quoteStockSnapshot: stockSnapshot(10),
+      fetchCurrentStockSnapshot: async () => stockSnapshot(2),
+    });
+
+    expect(sessionStorage.getItem(QUOTE_BACKORDER_CHANGE_STORAGE_KEY)).toBeNull();
+  });
+
+  it('does not throw or write the flag when fetchCurrentStockSnapshot rejects', async () => {
+    const fetcher = vi.fn(async () => {
+      throw new Error('network down');
+    });
+
+    await expect(
+      handleQuoteCheckout({
+        ...baseArgs,
+        isBackorderMessagingEnabled: true,
+        quoteStockSnapshot: stockSnapshot(10),
+        fetchCurrentStockSnapshot: fetcher,
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(sessionStorage.getItem(QUOTE_BACKORDER_CHANGE_STORAGE_KEY)).toBeNull();
+  });
+});

--- a/apps/storefront/src/pages/quote/utils/quoteCheckout.ts
+++ b/apps/storefront/src/pages/quote/utils/quoteCheckout.ts
@@ -11,6 +11,10 @@ import { snackbar } from '@/utils/b3Tip';
 import { platform } from '@/utils/basicConfig';
 import { getSearchVal } from '@/utils/loginInfo';
 
+import { detectQuoteStockChange, QuoteStockSnapshotItem } from './detectQuoteStockChange';
+
+export const QUOTE_BACKORDER_CHANGE_STORAGE_KEY = 'b2b.quote.backorderChange';
+
 type ValidationErrorResponse = {
   error?: {
     extensions?: {
@@ -38,6 +42,9 @@ interface QuoteCheckout {
   navigate?: NavigateFunction;
   b3Lang: LangFormatFunction;
   formatValidationError: (err: ProductValidationError) => string;
+  isBackorderMessagingEnabled?: boolean;
+  quoteStockSnapshot?: QuoteStockSnapshotItem[];
+  fetchCurrentStockSnapshot?: () => Promise<QuoteStockSnapshotItem[]>;
 }
 
 export const handleQuoteCheckout = async ({
@@ -48,8 +55,14 @@ export const handleQuoteCheckout = async ({
   navigate,
   b3Lang,
   formatValidationError,
+  isBackorderMessagingEnabled = false,
+  quoteStockSnapshot,
+  fetchCurrentStockSnapshot,
 }: QuoteCheckout) => {
   try {
+    // Clear any stale flag from a previous attempt so this checkout produces a fresh verdict.
+    sessionStorage.removeItem(QUOTE_BACKORDER_CHANGE_STORAGE_KEY);
+
     store.dispatch(setQuoteDetailToCheckoutUrl(''));
 
     const {
@@ -89,6 +102,24 @@ export const handleQuoteCheckout = async ({
 
     setQuoteToStorage(quoteId, date, quoteUuid);
     const { checkoutUrl, cartId } = checkout;
+
+    if (
+      isBackorderMessagingEnabled &&
+      quoteStockSnapshot &&
+      quoteStockSnapshot.length &&
+      fetchCurrentStockSnapshot
+    ) {
+      try {
+        const afterSnapshot = await fetchCurrentStockSnapshot();
+        const stockChange = detectQuoteStockChange(quoteStockSnapshot, afterSnapshot);
+
+        if (stockChange) {
+          sessionStorage.setItem(QUOTE_BACKORDER_CHANGE_STORAGE_KEY, 'true');
+        }
+      } catch (e) {
+        b2bLogger.error(e);
+      }
+    }
 
     if (platform === 'bigcommerce') {
       window.location.href = checkoutUrl;


### PR DESCRIPTION
Jira: [BACK-516](https://bigcommercecloud.atlassian.net/browse/BACK-516)

## What/Why?
Write flag to session when stock level backorder information has changed when clicking on the proceed to checkout button for b2b quotes for a submitted quote.

Customers should be informed that the previous messaging was out of date.
So for instance buying 2 of X product.

One is in stock.
One will require backordering.
They have been informed at the cart (or checkout) step of this stock situation and know what to expect.
Before they proceed, a purchase is made by another customer in the background taking the last in stock item.
Both items now require backordering.
Under this situation expectations have changed and they should be notified.

Theses are the buyer portal changes: See https://github.com/b3bc-external/b2b-checkout-app/pull/438 for the checkout. Note these should work independently, so any revert will be safe to do.

## Rollout/Rollback
Revert this PR if there are issues.

## Testing
### Before:
Quote to checkout with stock level change shows no message:
<img width="1253" height="830" alt="cartcheckoutNoChangeNoMessage" src="https://github.com/user-attachments/assets/5e344fe5-8b7c-47e2-ab93-df8ffd9506e9" />

### After:
Cart to checkout with no stock level change leads to no message displayed.
<img width="1253" height="830" alt="cartcheckoutNoChangeNoMessage" src="https://github.com/user-attachments/assets/5e344fe5-8b7c-47e2-ab93-df8ffd9506e9" />

Cart to checkout with a stock level change in between still shows the message.
<img width="1273" height="809" alt="cartCheckoutStockChangeShows" src="https://github.com/user-attachments/assets/35ceab54-77f8-4cee-8d63-f5689cc22196" />

Quote to checkout with no stock level change leads to no message displayed.
<img width="1345" height="839" alt="QuoteNoMessageAsNoChange" src="https://github.com/user-attachments/assets/7d072461-cca9-42d9-a03b-3b4e1ef393dd" />

Quote to checkout with a stock level change in between shows new message.
<img width="1371" height="824" alt="QuoteCheckoutShowsMessageAfterStockChange" src="https://github.com/user-attachments/assets/e353008a-d9df-4309-966d-90123f52a07b" />

Variants also work:
<img width="1282" height="835" alt="variants" src="https://github.com/user-attachments/assets/c36cd419-c024-44d7-8210-1e92c104f238" />

ping @animesh1987 @bigcommerce/team-b2b 

[BACK-516]: https://bigcommercecloud.atlassian.net/browse/BACK-516?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the quote-to-checkout path with an extra product search and sessionStorage side effects, but behavior is gated by a feature flag and failures during refetch are logged without blocking redirect.
> 
> **Overview**
> When **Proceed to checkout** runs on quote detail (and the backorder messaging feature flag is on), the flow now snapshots each line’s **fulfillable** quantity from enriched product search data, refetches inventory right after a successful quote checkout, and compares before vs after. If fulfillable quantity changed in a way that affects what the buyer was told about stock/backorder, it sets `sessionStorage` key `b2b.quote.backorderChange` so checkout can show updated messaging; stale flags are cleared at the start of each attempt and refetch is skipped when the flag is off or the snapshot is empty.
> 
> New helpers **`buildQuoteStockSnapshot`** and **`detectQuoteStockChange`** handle product/variant tracking, SKU fallbacks, per-line IDs, and safe skips when tracking or stock lookup is unknown. **`handleQuoteCheckout`** accepts the snapshot, optional refetch callback, and flag; **`QuoteDetail`** wires them from the current product list and reuses a refactored **`fetchProductsWithSearch`** (with a fallback to unenriched lines when enrichment fails).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit caa95cf46318ecc50f46bd6bcbe2ea04ffd0408e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->