### PR TITLE
feat(quick-order): BACK-619 add backorder display to complex products

### DIFF
--- a/apps/storefront/src/pages/QuickOrder/components/ChooseOptionsDialog.tsx
+++ b/apps/storefront/src/pages/QuickOrder/components/ChooseOptionsDialog.tsx
@@ -5,6 +5,7 @@ import {
   SetStateAction,
   useCallback,
   useEffect,
+  useMemo,
   useRef,
   useState,
 } from 'react';
@@ -15,8 +16,10 @@ import isEqual from 'lodash-es/isEqual';
 
 import { B3CustomForm } from '@/components/B3CustomForm';
 import B3Dialog from '@/components/B3Dialog';
+import BackorderMessage from '@/components/BackorderMessage';
 import B3Spin from '@/components/spin/B3Spin';
 import { PRODUCT_DEFAULT_IMAGE } from '@/constants';
+import { useBackorderStorefrontMessaging } from '@/hooks/useBackorderStorefrontMessaging';
 import { useB3Lang } from '@/lib/lang';
 import { searchProducts } from '@/shared/service/b2b';
 import { useAppSelector } from '@/store';
@@ -27,6 +30,10 @@ import { calculateProductListPrice, getBCPrice } from '@/utils/b3Product/b3Produ
 import { getOptionRequestData, getProductOptionsFields } from '@/utils/b3Product/shared/config';
 import { snackbar } from '@/utils/b3Tip';
 import { Base64 } from '@/utils/base64';
+import {
+  getCatalogInventoryRowFromSearchProduct,
+  getCatalogProductRowDisplayState,
+} from '@/utils/catalogBackorderDisplay';
 
 const Flex = styled('div')({
   display: 'flex',
@@ -117,7 +124,34 @@ export default function ChooseOptionsDialog(props: ChooseOptionsDialogProps) {
   const [chooseOptionsProduct, setChooseOptionsProduct] = useState<ChooseOptionsProductProps[]>([]);
   const [isRequestLoading, setIsRequestLoading] = useState<boolean>(false);
 
+  const { isBackorderMessagingContextEnabled, hasAnyBackorderDisplay } =
+    useBackorderStorefrontMessaging();
+  const backorderUiEnabled = isBackorderMessagingContextEnabled && hasAnyBackorderDisplay;
+
   const isShowPrice = Boolean(product?.isPriceHidden);
+
+  const formatOnlyAvailable = useCallback(
+    (count: number) =>
+      b3Lang('purchasedProducts.quickAdd.inlineErrors.insufficientStockSku', { count }),
+    [b3Lang],
+  );
+
+  const inventoryRow = useMemo(
+    () => (product ? getCatalogInventoryRowFromSearchProduct(product, variantInfo) : undefined),
+    [product, variantInfo],
+  );
+
+  const { qtyHelperText, backorderFields } = useMemo(
+    () =>
+      getCatalogProductRowDisplayState({
+        qty: Number(quantity) || 0,
+        showAvailableToSellHelper: backorderUiEnabled,
+        inventoryRow,
+        backorderUiEnabled,
+        formatOnlyAvailable,
+      }),
+    [quantity, inventoryRow, backorderUiEnabled, formatOnlyAvailable],
+  );
 
   const setChooseOptionsForm = async (product: ShoppingListProductItem) => {
     try {
@@ -493,10 +527,16 @@ export default function ChooseOptionsDialog(props: ChooseOptionsDialogProps) {
               <Box
                 sx={{
                   display: 'flex',
+                  minWidth: 0,
                 }}
               >
                 <ProductImage src={currentImage || product.imageUrl || PRODUCT_DEFAULT_IMAGE} />
-                <Flex>
+                <Flex
+                  style={{
+                    flex: 1,
+                    minWidth: 0,
+                  }}
+                >
                   <FlexItem padding="0">
                     <Box
                       sx={{
@@ -524,22 +564,66 @@ export default function ChooseOptionsDialog(props: ChooseOptionsDialogProps) {
                       : currencyFormat(newPrice * Number(quantity) || getProductPrice(product))}
                   </FlexItem>
 
-                  <FlexItem>
-                    <StyleTextField
-                      type="number"
-                      variant="filled"
-                      label={b3Lang('shoppingList.chooseOptionsDialog.quantity')}
-                      value={quantity}
-                      onChange={handleProductQuantityChange}
-                      onKeyDown={handleNumberInputKeyDown}
-                      onBlur={handleNumberInputBlur}
-                      size="small"
+                  <Box
+                    sx={{
+                      flexGrow: 0,
+                      flexShrink: 0,
+                      minWidth: 0,
+                      overflow: 'visible',
+                      padding: '0 0 0 16px',
+                    }}
+                  >
+                    <Box
                       sx={{
-                        width: '60%',
-                        maxWidth: '100px',
+                        display: 'grid',
+                        gridTemplateColumns: '100px',
+                        justifyItems: 'start',
+                        rowGap: 0.5,
+                        overflow: 'visible',
                       }}
-                    />
-                  </FlexItem>
+                    >
+                      <StyleTextField
+                        type="number"
+                        variant="filled"
+                        label={b3Lang('shoppingList.chooseOptionsDialog.quantity')}
+                        value={quantity}
+                        onChange={handleProductQuantityChange}
+                        onKeyDown={handleNumberInputKeyDown}
+                        onBlur={handleNumberInputBlur}
+                        size="small"
+                        fullWidth
+                        error={Boolean(qtyHelperText)}
+                      />
+                      {(qtyHelperText || backorderFields) && (
+                        <Box
+                          sx={{
+                            width: 'max-content',
+                            maxWidth: 'none',
+                            overflow: 'visible',
+                          }}
+                        >
+                          {qtyHelperText && (
+                            <Typography
+                              variant="caption"
+                              color="error"
+                              component="p"
+                              sx={{ m: 0, whiteSpace: 'nowrap' }}
+                            >
+                              {qtyHelperText}
+                            </Typography>
+                          )}
+                          {backorderFields && (
+                            <BackorderMessage
+                              totalOnHand={backorderFields.totalOnHand}
+                              quantityBackordered={backorderFields.quantityBackordered}
+                              backorderMessage={backorderFields.backorderMessage}
+                              visible
+                            />
+                          )}
+                        </Box>
+                      )}
+                    </Box>
+                  </Box>
                 </Flex>
               </Box>
 

--- a/apps/storefront/src/pages/QuickOrder/index.quickpad.test.tsx
+++ b/apps/storefront/src/pages/QuickOrder/index.quickpad.test.tsx
@@ -571,4 +571,183 @@ describe('when backorder messaging is enabled', () => {
     expect(within(dialog).queryByText('Lead time: 2-4 weeks')).not.toBeInTheDocument();
     expect(within(dialog).queryByText('4 available')).not.toBeInTheDocument();
   });
+
+  it('shows backorder prompts in choose options when a variant is selected', async () => {
+    renderWithProviders(<QuickOrderPad />, { preloadedState: backorderPreloadedState });
+
+    const productId = 9001;
+    const optionId = 50;
+    const sizeM = 102;
+    const variantSku = 'TOWEL-M';
+
+    const variantM = buildVariantWith({
+      product_id: productId,
+      sku: variantSku,
+      purchasing_disabled: false,
+      option_values: [
+        {
+          id: sizeM,
+          label: 'M',
+          option_id: optionId,
+          option_display_name: 'Size',
+        },
+      ],
+      available_to_sell: 10,
+      unlimited_backorder: false,
+      total_on_hand: 2,
+      backorder_message: 'Lead time: 2-4 weeks',
+      bc_calculated_price: {
+        tax_exclusive: 50,
+        tax_inclusive: 55,
+        as_entered: 50,
+        entered_inclusive: false,
+      },
+    });
+
+    const variantS = buildVariantWith({
+      product_id: productId,
+      sku: 'TOWEL-S',
+      purchasing_disabled: false,
+      option_values: [
+        {
+          id: 101,
+          label: 'S',
+          option_id: optionId,
+          option_display_name: 'Size',
+        },
+      ],
+      available_to_sell: 5,
+      unlimited_backorder: false,
+      total_on_hand: 5,
+      bc_calculated_price: {
+        tax_exclusive: 45,
+        tax_inclusive: 50,
+        as_entered: 45,
+        entered_inclusive: false,
+      },
+    });
+
+    const sizeOption = buildSearchProductV3OptionWith({
+      id: optionId,
+      product_id: productId,
+      type: 'rectangles',
+      display_name: 'Size',
+      option_values: [
+        buildSearchProductV3OptionValueWith({
+          id: 101,
+          label: 'S',
+          is_default: false,
+        }),
+        buildSearchProductV3OptionValueWith({
+          id: sizeM,
+          label: 'M',
+          is_default: true,
+        }),
+      ],
+    });
+
+    const searchProducts = vi.fn<(...arg: unknown[]) => SearchProductsResponse>();
+
+    when(searchProducts)
+      .calledWith(stringContainingAll('search: "Fog Towel"', 'currencyCode: "USD"'))
+      .thenReturn({
+        data: {
+          productsSearch: [
+            buildSearchProductWith({
+              id: productId,
+              name: 'Fog Towel',
+              sku: 'TOWEL-BASE',
+              inventoryTracking: 'variant',
+              optionsV3: [sizeOption],
+              isPriceHidden: false,
+              orderQuantityMinimum: 0,
+              orderQuantityMaximum: 0,
+              inventoryLevel: 100,
+              variants: [variantS, variantM],
+            }),
+          ],
+        },
+      });
+
+    const getPriceProducts = vi.fn<(...arg: unknown[]) => PriceProductsResponse>();
+
+    when(getPriceProducts)
+      .calledWith(
+        expect.objectContaining({
+          items: [
+            expect.objectContaining({
+              productId,
+              variantId: variantM.variant_id,
+            }),
+          ],
+        }),
+      )
+      .thenReturn({
+        data: {
+          priceProducts: [
+            buildProductPriceWith({
+              productId,
+              variantId: variantM.variant_id,
+            }),
+          ],
+        },
+      });
+
+    server.use(
+      graphql.query('SearchProducts', ({ query }) => HttpResponse.json(searchProducts(query))),
+      graphql.query('priceProducts', ({ variables }) =>
+        HttpResponse.json(getPriceProducts(variables)),
+      ),
+    );
+
+    const searchBox = screen.getByPlaceholderText('Search products');
+    await userEvent.type(searchBox, 'Fog Towel');
+    await userEvent.click(screen.getByRole('button', { name: 'Search product' }));
+
+    const listDialog = await screen.findByRole('dialog', { name: 'Quick order pad' });
+    await userEvent.click(within(listDialog).getByRole('button', { name: 'Choose options' }));
+
+    const chooseOptionsDialog = await screen.findByRole('dialog', { name: 'Choose options' });
+    const quantityInput = within(chooseOptionsDialog).getByRole('spinbutton');
+
+    await waitFor(() => {
+      expect(within(chooseOptionsDialog).getByText(variantSku)).toBeInTheDocument();
+    });
+
+    await userEvent.type(quantityInput, '4', {
+      initialSelectionStart: 0,
+      initialSelectionEnd: Infinity,
+    });
+
+    await waitFor(() => {
+      expect(within(chooseOptionsDialog).getByText('2 ready to ship')).toBeVisible();
+    });
+    expect(within(chooseOptionsDialog).getByText('2 will be backordered')).toBeVisible();
+    expect(within(chooseOptionsDialog).getByText('Lead time: 2-4 weeks')).toBeVisible();
+
+    await userEvent.type(quantityInput, '15', {
+      initialSelectionStart: 0,
+      initialSelectionEnd: Infinity,
+    });
+
+    await waitFor(() => {
+      expect(within(chooseOptionsDialog).getByText('10 available')).toBeVisible();
+    });
+    expect(within(chooseOptionsDialog).getByText('2 ready to ship')).toBeVisible();
+    expect(within(chooseOptionsDialog).getByText('8 will be backordered')).toBeVisible();
+
+    await userEvent.type(quantityInput, '2', {
+      initialSelectionStart: 0,
+      initialSelectionEnd: Infinity,
+    });
+
+    await waitFor(() => {
+      expect(within(chooseOptionsDialog).queryByText('2 ready to ship')).not.toBeInTheDocument();
+    });
+    expect(
+      within(chooseOptionsDialog).queryByText('2 will be backordered'),
+    ).not.toBeInTheDocument();
+    expect(within(chooseOptionsDialog).queryByText('Lead time: 2-4 weeks')).not.toBeInTheDocument();
+    expect(within(chooseOptionsDialog).queryByText('10 available')).not.toBeInTheDocument();
+  });
 });

--- a/apps/storefront/src/types/shoppingList.ts
+++ b/apps/storefront/src/types/shoppingList.ts
@@ -38,6 +38,11 @@ export interface ShoppingListProductItem extends ProductItem {
   orderQuantityMaximum?: number;
   orderQuantityMinimum?: number;
   variantId?: number | string;
+  inventoryTracking?: string;
+  availableToSell?: number;
+  unlimitedBackorder?: boolean;
+  totalOnHand?: number | null;
+  backorderMessage?: string | null;
 }
 
 export interface ShoppingListAddProductOption {

--- a/apps/storefront/src/utils/catalogBackorderDisplay.test.ts
+++ b/apps/storefront/src/utils/catalogBackorderDisplay.test.ts
@@ -1,11 +1,14 @@
 import { describe, expect, it } from 'vitest';
 
 import type { CatalogQuickVariantSku } from '@/shared/service/b2b/graphql/product';
+import type { Variant } from '@/types/products';
+import type { ShoppingListProductItem } from '@/types/shoppingList';
 
 import {
   getCatalogBackorderDisplayFields,
   getCatalogBackorderDisplayQuantity,
   getCatalogBackorderFieldsForVariantSku,
+  getCatalogInventoryRowFromSearchProduct,
   getCatalogProductRowDisplayState,
   quantityExceedsAvailableToSell,
 } from './catalogBackorderDisplay';
@@ -153,6 +156,85 @@ describe('catalogBackorderDisplay', () => {
       totalOnHand: -3,
       quantityBackordered: 13,
       backorderMessage: undefined,
+    });
+  });
+
+  describe('getCatalogInventoryRowFromSearchProduct', () => {
+    const productBase = {
+      inventoryTracking: 'variant',
+      availableToSell: 0,
+      unlimitedBackorder: false,
+      totalOnHand: null,
+      backorderMessage: null,
+    } as Pick<
+      ShoppingListProductItem,
+      | 'inventoryTracking'
+      | 'availableToSell'
+      | 'unlimitedBackorder'
+      | 'totalOnHand'
+      | 'backorderMessage'
+    >;
+
+    const variant = {
+      available_to_sell: 10,
+      unlimited_backorder: false,
+      total_on_hand: 3,
+      backorder_message: 'Lead time: 2 weeks',
+    } as Variant;
+
+    it('returns undefined when inventory tracking is none', () => {
+      expect(
+        getCatalogInventoryRowFromSearchProduct(
+          { ...productBase, inventoryTracking: 'none' },
+          variant,
+        ),
+      ).toBeUndefined();
+    });
+
+    it('maps product-level fields when tracking is product', () => {
+      expect(
+        getCatalogInventoryRowFromSearchProduct(
+          {
+            ...productBase,
+            inventoryTracking: 'product',
+            availableToSell: 8,
+            unlimitedBackorder: true,
+            totalOnHand: 5,
+            backorderMessage: 'Ships soon',
+          },
+          variant,
+        ),
+      ).toEqual({
+        inventoryTracking: 'product',
+        availableToSell: 8,
+        unlimitedBackorder: true,
+        totalOnHand: 5,
+        backorderMessage: 'Ships soon',
+      });
+    });
+
+    it('maps variant-level fields when tracking is variant', () => {
+      expect(
+        getCatalogInventoryRowFromSearchProduct(
+          { ...productBase, inventoryTracking: 'variant' },
+          variant,
+        ),
+      ).toEqual({
+        inventoryTracking: 'variant',
+        availableToSell: 10,
+        unlimitedBackorder: false,
+        totalOnHand: 3,
+        backorderMessage: 'Lead time: 2 weeks',
+      });
+    });
+
+    it('returns undefined for variant tracking when variant is not resolved', () => {
+      expect(
+        getCatalogInventoryRowFromSearchProduct(
+          { ...productBase, inventoryTracking: 'variant' },
+          null,
+        ),
+      ).toBeUndefined();
     });
   });
 

--- a/apps/storefront/src/utils/catalogBackorderDisplay.ts
+++ b/apps/storefront/src/utils/catalogBackorderDisplay.ts
@@ -1,6 +1,45 @@
 import type { CatalogQuickVariantSku } from '@/shared/service/b2b/graphql/product';
+import type { Variant } from '@/types/products';
+import type { ShoppingListProductItem } from '@/types/shoppingList';
 import type { BackorderDisplayFields } from '@/utils/backorderDisplayFromInventory';
 import { getBackorderDisplayFieldsFromOnHand } from '@/utils/backorderDisplayFromInventory';
+
+type SearchProductInventorySource = Pick<
+  ShoppingListProductItem,
+  | 'inventoryTracking'
+  | 'availableToSell'
+  | 'unlimitedBackorder'
+  | 'totalOnHand'
+  | 'backorderMessage'
+>;
+
+export function getCatalogInventoryRowFromSearchProduct(
+  product: SearchProductInventorySource,
+  variant?: Partial<Variant> | null,
+): CatalogQuickVariantSku | undefined {
+  const tracking = product.inventoryTracking || 'none';
+  if (tracking !== 'product' && tracking !== 'variant') return undefined;
+
+  if (tracking === 'product') {
+    return {
+      inventoryTracking: tracking,
+      availableToSell: product.availableToSell ?? 0,
+      unlimitedBackorder: product.unlimitedBackorder ?? false,
+      totalOnHand: product.totalOnHand,
+      backorderMessage: product.backorderMessage,
+    };
+  }
+
+  if (!variant) return undefined;
+
+  return {
+    inventoryTracking: tracking,
+    availableToSell: variant.available_to_sell ?? 0,
+    unlimitedBackorder: variant.unlimited_backorder ?? false,
+    totalOnHand: variant.total_on_hand,
+    backorderMessage: variant.backorder_message,
+  };
+}
 
 export function quantityExceedsAvailableToSell(
   quantity: number,


### PR DESCRIPTION
Jira: [BACK-619](https://bigcommercecloud.atlassian.net/browse/BACK-619)

## What/Why?
Adding backorder display lines to complex products on the quick order pad, i.e. the "Choose Options" flow.

## Rollout/Rollback
Merge/revert. Backorder display is gated by `Feature_Backorder && BACK-134.backorders_phase_1_1_control_messaging_on_storefront`.

## Testing
Backorder display is show for variants, with varying on-hand, backorder limit, and message.

https://github.com/user-attachments/assets/4ff3f737-6a27-44c4-a329-339e602ade64

Backorder display does not appear for disabled `Feature_Backorder && BACK-134.backorders_phase_1_1_control_messaging_on_storefront`.

https://github.com/user-attachments/assets/c72e137e-6b4f-449a-8905-85f536277a32

Ping @animesh1987 @benpratt77 

[BACK-619]: https://bigcommercecloud.atlassian.net/browse/BACK-619?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Storefront-only UI aligned with existing quick-order backorder patterns; behavior is feature-flag gated and covered by new tests.
> 
> **Overview**
> Extends **Quick Order “Choose options”** for multi-variant products so quantity entry shows the same **backorder / available-to-sell messaging** as simple SKUs, gated by existing storefront backorder flags.
> 
> Adds `getCatalogInventoryRowFromSearchProduct` to build a catalog inventory row from **search product + selected variant** (product- vs variant-level tracking), extends `ShoppingListProductItem` with inventory fields, and wires `ChooseOptionsDialog` through `getCatalogProductRowDisplayState`, `BackorderMessage`, and stock helper/error on the quantity field. Layout tweaks keep helper text visible beside the qty input. **Integration test** covers prompts updating as qty and default variant change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a97f8d10c64eb4a3ac231f520e3169d294b3601. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->