### PR TITLE
fix(quick-order): BACK-619 fix quick order pad layout

### DIFF
--- a/apps/storefront/src/components/B3ProductList.tsx
+++ b/apps/storefront/src/components/B3ProductList.tsx
@@ -112,6 +112,37 @@ const mobileItemStyle = {
   },
 };
 
+type ProductListItemStyle = typeof defaultItemStyle;
+
+interface BackorderLayoutStyles {
+  qtyColumn: ProductListItemStyle['qty'];
+  qtyColumnSx: FlexItemProps['sx'];
+  numericColumn: ProductListItemStyle['default'];
+  productColumnPadding: string;
+  productColumnSx: FlexItemProps['sx'];
+}
+
+function getBackorderLayoutStyles(
+  desktopBackorderLayoutEnabled: boolean,
+  isMobile: boolean,
+  itemStyle: ProductListItemStyle,
+): BackorderLayoutStyles {
+  let productColumnPadding = '0 6% 0 0';
+  if (isMobile) {
+    productColumnPadding = '0';
+  } else if (desktopBackorderLayoutEnabled) {
+    productColumnPadding = '0 16px 0 0';
+  }
+
+  return {
+    qtyColumn: desktopBackorderLayoutEnabled ? { width: '16%' } : itemStyle.qty,
+    qtyColumnSx: desktopBackorderLayoutEnabled ? { minWidth: '140px' } : undefined,
+    numericColumn: desktopBackorderLayoutEnabled ? { width: '12%' } : itemStyle.default,
+    productColumnPadding,
+    productColumnSx: desktopBackorderLayoutEnabled ? { flex: '1 1 42%', minWidth: 0 } : undefined,
+  };
+}
+
 interface ProductProps<T> {
   products: Array<T & ProductItem>;
   money?: MoneyFormat;
@@ -232,10 +263,13 @@ export function B3ProductList<T>(props: ProductProps<T>) {
   }, [products]);
 
   const itemStyle = isMobile ? mobileItemStyle : defaultItemStyle;
-  const desktopQtyColumnExtraSx: FlexItemProps['sx'] =
-    catalogBackorderUiEnabled && !isMobile ? { minWidth: '160px' } : undefined;
-  const desktopQtyColumnStyle =
-    catalogBackorderUiEnabled && !isMobile ? { width: '22%' } : itemStyle.qty;
+  const {
+    qtyColumn: desktopQtyColumnStyle,
+    qtyColumnSx: desktopQtyColumnExtraSx,
+    numericColumn: desktopNumericColumnStyle,
+    productColumnPadding: desktopProductColumnPadding,
+    productColumnSx: desktopProductColumnSx,
+  } = getBackorderLayoutStyles(catalogBackorderUiEnabled && !isMobile, isMobile, itemStyle);
 
   const showTypePrice = (newMoney: string | number, product: CustomFieldItems): string | number => {
     if (type === 'quote') {
@@ -265,10 +299,10 @@ export function B3ProductList<T>(props: ProductProps<T>) {
           {showCheckbox && (
             <Checkbox checked={list.length === products.length} onChange={handleSelectAllChange} />
           )}
-          <FlexItem padding={isMobile ? '0' : '0 6% 0 0'}>
+          <FlexItem padding={desktopProductColumnPadding} sx={desktopProductColumnSx}>
             <ProductHead>{b3Lang('global.searchProduct.product')}</ProductHead>
           </FlexItem>
-          <FlexItem textAlignLocation={textAlign} {...itemStyle.default}>
+          <FlexItem textAlignLocation={textAlign} {...desktopNumericColumnStyle}>
             <ProductHead>{b3Lang('global.searchProduct.price')}</ProductHead>
           </FlexItem>
           <FlexItem
@@ -278,12 +312,12 @@ export function B3ProductList<T>(props: ProductProps<T>) {
           >
             <ProductHead>{b3Lang('global.searchProduct.qty')}</ProductHead>
           </FlexItem>
-          <FlexItem textAlignLocation={textAlign} {...itemStyle.default}>
+          <FlexItem textAlignLocation={textAlign} {...desktopNumericColumnStyle}>
             <ProductHead>{b3Lang('global.searchProduct.total')}</ProductHead>
           </FlexItem>
           {renderAction && (
             <FlexItem
-              {...itemStyle.default}
+              {...desktopNumericColumnStyle}
               textAlignLocation="right"
               width={isMobile ? '100%' : actionWidth}
             />
@@ -365,7 +399,7 @@ export function B3ProductList<T>(props: ProductProps<T>) {
             <FlexItem
               textAlignLocation={textAlign}
               padding={quantityEditable ? '10px 0 0' : ''}
-              {...itemStyle.default}
+              {...desktopNumericColumnStyle}
               sx={
                 isMobile
                   ? {
@@ -411,11 +445,17 @@ export function B3ProductList<T>(props: ProductProps<T>) {
             {showCheckbox && (
               <Checkbox checked={isChecked(product)} onChange={() => handleSelectChange(product)} />
             )}
-            <FlexItem padding={isMobile ? '0' : '0 6% 0 0'}>
+            <FlexItem padding={desktopProductColumnPadding} sx={desktopProductColumnSx}>
               <ProductImage src={product.imageUrl || PRODUCT_DEFAULT_IMAGE} />
               <Box
                 sx={{
                   marginLeft: '16px',
+                  ...(isMobile
+                    ? {}
+                    : {
+                        flex: 1,
+                        minWidth: 0,
+                      }),
                 }}
               >
                 <Typography
@@ -537,7 +577,7 @@ export function B3ProductList<T>(props: ProductProps<T>) {
             {renderPrice(totalText, totalPrice, discountedTotalPrice)}
             {renderAction && (
               <FlexItem
-                {...itemStyle.default}
+                {...desktopNumericColumnStyle}
                 textAlignLocation="right"
                 width={isMobile ? '100%' : actionWidth}
               >


### PR DESCRIPTION
Jira: [BACK-619](https://bigcommercecloud.atlassian.net/browse/BACK-619)

## What/Why?
In the quick order pad, the addition of the backorder display lines in the quantity column has broken the spacing, notably making the name column especially narrow. This PR will fix this.

<img width="2916" height="1414" alt="image" src="https://github.com/user-attachments/assets/25d92dad-5279-4659-a630-f9256e2ee220" />

## Rollout/Rollback
Merge/revert.

## Testing
Quick order pad now has expected spacing, with ample space for product name, both with and without backorder display.

https://github.com/user-attachments/assets/1fdec72f-6219-4bd2-a3a7-2d4058753c83

Ping @animesh1987 @benpratt77 

[BACK-619]: https://bigcommercecloud.atlassian.net/browse/BACK-619?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only layout changes in B3ProductList gated by existing catalogBackorderUiEnabled on desktop; no auth, API, or data logic changes.
> 
> **Overview**
> Fixes **desktop quick order pad** column spacing when **catalog backorder UI** is on by centralizing layout in `getBackorderLayoutStyles` instead of only widening the qty column.
> 
> When backorder layout is active, the **product** column gets more room (`flex: 1 1 42%`, adjusted padding), **qty** uses a dedicated width/min-width, and **price/total/action** columns share a narrower numeric width—applied consistently on the header and each row. The product name block beside the image also uses **flex growth and `minWidth: 0`** on desktop so long names don’t collapse the column.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0e9ae89f768382213978e78801c47731e14c91a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->