### PR TITLE
fix(quotes): B2B-4976 Remove the sessionStorage set of quoteCheckoutUuid

### DIFF
--- a/apps/storefront/src/pages/QuoteDetail/index.test.tsx
+++ b/apps/storefront/src/pages/QuoteDetail/index.test.tsx
@@ -1363,7 +1363,7 @@ describe('when the user is a B2B customer', () => {
 
         const checkoutButton = screen.getByRole('button', { name: 'Proceed to checkout' });
         await userEvent.click(checkoutButton);
-        expect(sessionStorage.getItem('quoteCheckoutUuid')).toEqual(uuid);
+
         expect(sessionStorage.getItem('isNewStorefront')).toEqual(JSON.stringify(true));
         expect(sessionStorage.getItem('quoteCheckoutId')).toEqual(id);
         expect(sessionStorage.getItem('quoteDate')).toEqual(dateString);
@@ -1405,7 +1405,6 @@ describe('when the user is a B2B customer', () => {
         await waitForElementToBeRemoved(() => screen.queryByText(/loading/i));
         const checkoutButton = screen.getByRole('button', { name: 'Proceed to checkout' });
         await userEvent.click(checkoutButton);
-        expect(sessionStorage.getItem('quoteCheckoutUuid')).toEqual('');
         expect(sessionStorage.getItem('isNewStorefront')).toEqual(JSON.stringify(true));
         expect(sessionStorage.getItem('quoteCheckoutId')).toEqual(id);
         expect(sessionStorage.getItem('quoteDate')).toEqual(dateString);

--- a/apps/storefront/src/pages/quote/utils/quoteCheckout.ts
+++ b/apps/storefront/src/pages/quote/utils/quoteCheckout.ts
@@ -87,7 +87,7 @@ export const handleQuoteCheckout = async ({
       return;
     }
 
-    setQuoteToStorage(quoteId, date, quoteUuid);
+    setQuoteToStorage(quoteId, date);
     const { checkoutUrl, cartId } = checkout;
 
     if (platform === 'bigcommerce') {

--- a/apps/storefront/src/utils/b3checkout.ts
+++ b/apps/storefront/src/utils/b3checkout.ts
@@ -28,9 +28,8 @@ export const attemptCheckoutLoginAndRedirect = async (
   }
 };
 
-export const setQuoteToStorage = (quoteId: string, date: any, quoteUuid?: string) => {
+export const setQuoteToStorage = (quoteId: string, date: any) => {
   sessionStorage.setItem('isNewStorefront', JSON.stringify(true));
   sessionStorage.setItem('quoteCheckoutId', quoteId);
   sessionStorage.setItem('quoteDate', date?.toString());
-  sessionStorage.setItem('quoteCheckoutUuid', quoteUuid || '');
 };


### PR DESCRIPTION
Jira: [B2B-4976](https://bigcommercecloud.atlassian.net/browse/B2B-4976)

## Prerequisites
A notification is needed if any merchants had already started using the previous implementation in their custom checkouts. They will need to rebase again to have the [new change](https://github.com/b3bc-external/b2b-checkout-app/pull/440) in checkout repo first.


## What/Why?
As we are moving the sessionStorage set into [checkout repo](https://github.com/b3bc-external/b2b-checkout-app/pull/440). This PR is to remove the sessionStorage set in buyer portal to make the checkout set as the only source of truth since now.

## Rollout/Rollback
Revert this PR

## Testing



[B2B-4976]: https://bigcommercecloud.atlassian.net/browse/B2B-4976?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes quote-to-checkout handoff data in sessionStorage; custom checkouts must adopt the checkout repo change or lose uuid persistence from the storefront.
> 
> **Overview**
> Stops writing **`quoteCheckoutUuid`** to `sessionStorage` from the buyer portal so the checkout app is the single place that sets it (paired with checkout repo changes).
> 
> **`setQuoteToStorage`** now only persists `isNewStorefront`, `quoteCheckoutId`, and `quoteDate`; the optional `quoteUuid` argument and `sessionStorage.setItem('quoteCheckoutUuid', …)` are removed. Quote checkout still passes `uuid` to the **`quoteCheckout`** API—only the browser storage side effect is dropped. Tests for “Proceed to checkout” no longer assert `quoteCheckoutUuid`.
> 
> Merchants on custom checkouts that relied on the portal writing this key need the updated checkout implementation first.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ef366d811fcc025fe8f35888f5ec220ec89dc29. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->