### PR TITLE
feat(quick-order): BACK-676 add backorder display to quick order

### DIFF
--- a/apps/storefront/src/pages/QuickOrder/components/QuickOrderB2BTable.tsx
+++ b/apps/storefront/src/pages/QuickOrder/components/QuickOrderB2BTable.tsx
@@ -1,14 +1,20 @@
-import { Dispatch, SetStateAction, useRef, useState } from 'react';
-import { Box, styled, TextField, Typography } from '@mui/material';
+import { Dispatch, SetStateAction, useCallback, useMemo, useRef, useState } from 'react';
+import { Box, FormControlLabel, styled, Switch, TextField, Typography } from '@mui/material';
 
+import BackorderMessage from '@/components/BackorderMessage';
 import B3Spin from '@/components/spin/B3Spin';
 import { B3PaginationTable, GetRequestList } from '@/components/table/B3PaginationTable';
 import { TableColumnItem } from '@/components/table/B3Table';
 import { PRODUCT_DEFAULT_IMAGE } from '@/constants';
+import { useBackorderStorefrontMessaging } from '@/hooks/useBackorderStorefrontMessaging';
 import { useMobile } from '@/hooks/useMobile';
 import { useSort } from '@/hooks/useSort';
 import { useB3Lang } from '@/lib/lang';
 import { getOrderedProducts, searchProducts } from '@/shared/service/b2b';
+import {
+  type CatalogQuickVariantSku,
+  getVariantInfoBySkus,
+} from '@/shared/service/b2b/graphql/product';
 import { activeCurrencyInfoSelector, useAppSelector } from '@/store';
 import { ProductInfoType } from '@/types/gql/graphql';
 import b2bGetVariantImageByVariantInfo from '@/utils/b2bGetVariantImageByVariantInfo';
@@ -19,6 +25,10 @@ import { getProductPriceIncTaxOrExTaxBySetting } from '@/utils/b3Price';
 import { getDisplayPrice } from '@/utils/b3Product/b3Product';
 import { conversionProductsList } from '@/utils/b3Product/shared/config';
 import { snackbar } from '@/utils/b3Tip';
+import {
+  catalogListHasBackorderedItemsForDisplay,
+  getCatalogProductRowDisplayState,
+} from '@/utils/catalogBackorderDisplay';
 
 import B3FilterMore from '../../../components/filter/B3FilterMore';
 import B3FilterPicker from '../../../components/filter/B3FilterPicker';
@@ -132,10 +142,72 @@ function QuickOrderTable({
   const [handleSetOrderBy, order, orderBy] = useSort(sortKeys, defaultSortKey, search, setSearch);
 
   const [total, setTotalCount] = useState<number>(0);
+  const [variantInfoList, setVariantInfoList] = useState<CatalogQuickVariantSku[]>([]);
+  const [showBackorderDetails, setShowBackorderDetails] = useState(false);
+  const [tableDataVersion, setTableDataVersion] = useState(0);
 
   const [isMobile] = useMobile();
 
   const b3Lang = useB3Lang();
+
+  const {
+    isBackorderMessagingContextEnabled,
+    isBackorderMessagingEnabled,
+    hasAnyBackorderDisplay,
+  } = useBackorderStorefrontMessaging();
+  const backorderUiEnabled = isBackorderMessagingContextEnabled && hasAnyBackorderDisplay;
+
+  const inventoryBySku = useMemo(() => {
+    const map: Record<string, CatalogQuickVariantSku> = {};
+    variantInfoList.forEach((row) => {
+      if (row.variantSku) {
+        map[row.variantSku.toUpperCase()] = row;
+      }
+    });
+    return map;
+  }, [variantInfoList]);
+
+  const fetchInventoryForSkus = useCallback(
+    async (skus: string[]) => {
+      if (!backorderUiEnabled || skus.length === 0) return;
+
+      const existingSkus = new Set(
+        variantInfoList.flatMap((row) => (row.variantSku ? [row.variantSku.toUpperCase()] : [])),
+      );
+
+      const newSkus = [...new Set(skus.map((sku) => sku.toUpperCase()))].filter(
+        (sku) => !existingSkus.has(sku),
+      );
+
+      if (newSkus.length === 0) return;
+
+      try {
+        const { variantSku: nextVariantInfoList = [] } = await getVariantInfoBySkus(newSkus);
+        setVariantInfoList((prev) => [...prev, ...nextVariantInfoList]);
+      } catch {
+        // Inventory fetch failure should not block the product list
+      }
+    },
+    [backorderUiEnabled, variantInfoList],
+  );
+
+  const hasBackorderedItems = useMemo(() => {
+    if (!isBackorderMessagingEnabled) {
+      return false;
+    }
+
+    const cacheList: ListItemProps[] = paginationTableRef.current?.getCacheList() || [];
+    const items = cacheList.map(({ node }) => ({
+      qty: Number(node.quantity) || 0,
+      variantSku: node.variantSku,
+    }));
+
+    return catalogListHasBackorderedItemsForDisplay(items, inventoryBySku);
+    // tableDataVersion drives re-evaluation when list or qty changes
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [inventoryBySku, isBackorderMessagingEnabled, tableDataVersion]);
+
+  const showBackorderToggle = backorderUiEnabled && hasBackorderedItems;
 
   const { currency_code: currencyCode } = useAppSelector(activeCurrencyInfoSelector);
 
@@ -190,6 +262,17 @@ function QuickOrderTable({
     const listProducts = await handleGetProductsById(edges);
 
     setTotalCount(totalCount);
+
+    if (backorderUiEnabled && listProducts?.length) {
+      const skus = listProducts
+        .map((item) => item.node.variantSku)
+        .filter((sku): sku is string => Boolean(sku));
+      fetchInventoryForSkus(skus).catch(() => {
+        // Inventory fetch failure should not block the product list
+      });
+    }
+
+    setTableDataVersion((version) => version + 1);
 
     return {
       edges: listProducts,
@@ -273,6 +356,7 @@ function QuickOrderTable({
     });
     paginationTableRef.current?.setList([...newListItems]);
     paginationTableRef.current?.setCacheAllList([...newListCacheItems]);
+    setTableDataVersion((version) => version + 1);
   };
 
   const showPrice = (price: string, row: CustomFieldItems): string | number => {
@@ -399,24 +483,51 @@ function QuickOrderTable({
       title: b3Lang('purchasedProducts.qty'),
       render: (row) => {
         const qty = handleSetCheckedQty(row);
+        const inventoryRow = inventoryBySku[row.variantSku?.toUpperCase()];
+        const { backorderFields } = getCatalogProductRowDisplayState({
+          qty: Number(qty) || 0,
+          showAvailableToSellHelper: false,
+          inventoryRow,
+          backorderUiEnabled,
+          formatOnlyAvailable: () => '',
+        });
 
         return (
-          <StyledTextField
-            size="small"
-            type="number"
-            variant="filled"
-            value={qty}
-            inputProps={{
-              inputMode: 'numeric',
-              pattern: '[0-9]*',
+          <Box
+            sx={{
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'flex-end',
+              width: '100%',
             }}
-            onChange={(e) => {
-              handleUpdateProductQty(row.id, e.target.value);
-            }}
-          />
+          >
+            <StyledTextField
+              size="small"
+              type="number"
+              variant="filled"
+              value={qty}
+              inputProps={{
+                inputMode: 'numeric',
+                pattern: '[0-9]*',
+              }}
+              onChange={(e) => {
+                handleUpdateProductQty(row.id, e.target.value);
+              }}
+            />
+            {backorderFields && (
+              <Box sx={{ mt: 1, width: '100%', textAlign: 'right' }}>
+                <BackorderMessage
+                  totalOnHand={backorderFields.totalOnHand}
+                  quantityBackordered={backorderFields.quantityBackordered}
+                  backorderMessage={backorderFields.backorderMessage}
+                  visible={showBackorderDetails}
+                />
+              </Box>
+            )}
+          </Box>
         );
       },
-      width: '15%',
+      width: backorderUiEnabled ? '18%' : '15%',
       style: {
         textAlign: 'right',
       },
@@ -446,14 +557,36 @@ function QuickOrderTable({
   return (
     <B3Spin isSpinning={isRequestLoading}>
       <StyleQuickOrderTable>
-        <Typography
+        <Box
           sx={{
-            fontSize: '24px',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
             height: '50px',
+            marginBottom: '0.5rem',
           }}
         >
-          {b3Lang('purchasedProducts.totalProducts', { total })}
-        </Typography>
+          <Typography
+            sx={{
+              fontSize: '24px',
+            }}
+          >
+            {b3Lang('purchasedProducts.totalProducts', { total })}
+          </Typography>
+          {showBackorderToggle && (
+            <FormControlLabel
+              control={
+                <Switch
+                  checked={showBackorderDetails}
+                  onChange={(e) => setShowBackorderDetails(e.target.checked)}
+                />
+              }
+              label={b3Lang('quoteDetail.table.backorderDetails')}
+              labelPlacement="start"
+              sx={{ mr: 0, gap: '0.5rem', flexShrink: 0 }}
+            />
+          )}
+        </Box>
         <Box
           sx={{
             marginBottom: '5px',
@@ -557,6 +690,9 @@ function QuickOrderTable({
               item={row}
               checkBox={checkBox}
               handleUpdateProductQty={handleUpdateProductQty}
+              inventoryBySku={inventoryBySku}
+              backorderUiEnabled={backorderUiEnabled}
+              showBackorderDetails={showBackorderDetails}
             />
           )}
         />

--- a/apps/storefront/src/pages/QuickOrder/components/QuickOrderCard.tsx
+++ b/apps/storefront/src/pages/QuickOrder/components/QuickOrderCard.tsx
@@ -1,16 +1,22 @@
 import { ReactElement } from 'react';
 import { Box, CardContent, styled, TextField, Typography } from '@mui/material';
 
+import BackorderMessage from '@/components/BackorderMessage';
 import { PRODUCT_DEFAULT_IMAGE } from '@/constants';
 import { useB3Lang } from '@/lib/lang';
+import type { CatalogQuickVariantSku } from '@/shared/service/b2b/graphql/product';
 import b2bGetVariantImageByVariantInfo from '@/utils/b2bGetVariantImageByVariantInfo';
 import { currencyFormat } from '@/utils/b3CurrencyFormat';
 import { displayFormat } from '@/utils/b3DateFormat';
+import { getCatalogProductRowDisplayState } from '@/utils/catalogBackorderDisplay';
 
 interface QuickOrderCardProps {
   item: any;
   checkBox?: () => ReactElement;
   handleUpdateProductQty: (id: number, val: string) => void;
+  inventoryBySku?: Record<string, CatalogQuickVariantSku>;
+  backorderUiEnabled?: boolean;
+  showBackorderDetails?: boolean;
 }
 
 const StyledImage = styled('img')(() => ({
@@ -20,7 +26,14 @@ const StyledImage = styled('img')(() => ({
 }));
 
 function QuickOrderCard(props: QuickOrderCardProps) {
-  const { item: shoppingDetail, checkBox, handleUpdateProductQty } = props;
+  const {
+    item: shoppingDetail,
+    checkBox,
+    handleUpdateProductQty,
+    inventoryBySku = {},
+    backorderUiEnabled = false,
+    showBackorderDetails = false,
+  } = props;
   const b3Lang = useB3Lang();
 
   const {
@@ -38,6 +51,15 @@ function QuickOrderCard(props: QuickOrderCardProps) {
   const price = Number(basePrice) * Number(quantity);
   const currentVariants = productsSearch.variants || [];
   const currentImage = b2bGetVariantImageByVariantInfo(currentVariants, { variantId }) || imageUrl;
+
+  const inventoryRow = inventoryBySku[variantSku?.toUpperCase()];
+  const { backorderFields } = getCatalogProductRowDisplayState({
+    qty: Number(quantity) || 0,
+    showAvailableToSellHelper: false,
+    inventoryRow,
+    backorderUiEnabled,
+    formatOnlyAvailable: () => '',
+  });
 
   return (
     <Box
@@ -132,6 +154,16 @@ function QuickOrderCard(props: QuickOrderCardProps) {
                 handleUpdateProductQty(shoppingDetail.id, e.target.value);
               }}
             />
+            {backorderFields && (
+              <Box sx={{ mt: -0.5, mb: 1, width: '100%' }}>
+                <BackorderMessage
+                  totalOnHand={backorderFields.totalOnHand}
+                  quantityBackordered={backorderFields.quantityBackordered}
+                  backorderMessage={backorderFields.backorderMessage}
+                  visible={showBackorderDetails}
+                />
+              </Box>
+            )}
           </Box>
 
           <Typography sx={{ fontSize: '14px' }}>

--- a/apps/storefront/src/pages/QuickOrder/index.main.test.tsx
+++ b/apps/storefront/src/pages/QuickOrder/index.main.test.tsx
@@ -115,6 +115,11 @@ interface VariantInfo {
   purchasingDisabled: '1' | '0';
   variantSku: string;
   imageUrl: string;
+  inventoryTracking?: string;
+  availableToSell?: number;
+  unlimitedBackorder?: boolean;
+  totalOnHand?: number | null;
+  backorderMessage?: string | null;
 }
 
 interface VariantInfoResponse {
@@ -425,6 +430,24 @@ const buildAddCartLineItemsResponseWith = builder(() => ({
 const storeInfoWithDateFormat = buildStoreInfoStateWith({ timeFormat: { display: 'j F Y' } });
 
 const preloadedState = { company: approvedB2BCompany, storeInfo: storeInfoWithDateFormat };
+
+const backorderPreloadedState = {
+  company: approvedB2BCompany,
+  storeInfo: storeInfoWithDateFormat,
+  global: buildGlobalStateWith({
+    backorderEnabled: true,
+    backorderDisplaySettings: {
+      showQuantityOnBackorder: true,
+      showQuantityOnHand: true,
+      showBackorderMessage: true,
+      showDefaultShippingExpectationPrompt: false,
+      defaultShippingExpectationPrompt: '',
+    },
+    featureFlags: {
+      'BACK-134.backorders_phase_1_1_control_messaging_on_storefront': true,
+    },
+  }),
+};
 
 beforeEach(() => {
   set(window, 'b2b.callbacks.dispatchEvent', vi.fn());
@@ -5257,6 +5280,229 @@ describe('when backorder validation is enabled', () => {
       await waitFor(() => {
         expect(screen.getByText(/Products were added to cart/i)).toBeInTheDocument();
       });
+    });
+  });
+});
+
+describe('when backorder messaging is enabled on purchased products', () => {
+  const variantSku = 'PP-123';
+
+  const setupPurchasedProductsTable = ({
+    totalOnHand = 2,
+    availableToSell = 4,
+    backorderMessage = 'Lead time: 2-4 weeks',
+    inventoryFetchFails = false,
+  }: {
+    totalOnHand?: number;
+    availableToSell?: number;
+    backorderMessage?: string;
+    inventoryFetchFails?: boolean;
+  } = {}) => {
+    const orderedProduct = buildRecentlyOrderedProductNodeWith({
+      node: {
+        productName: 'Laugh Canister',
+        variantSku,
+        sku: variantSku,
+        basePrice: '100',
+      },
+    });
+
+    const getRecentlyOrderedProducts = vi.fn().mockReturnValue(
+      buildGetRecentlyOrderedProductsWith({
+        data: { orderedProducts: { totalCount: 1, edges: [orderedProduct] } },
+      }),
+    );
+
+    const searchProducts = vi.fn().mockReturnValue({
+      data: {
+        productsSearch: [
+          buildSearchProductWith({
+            id: Number(orderedProduct.node.productId),
+            name: orderedProduct.node.productName,
+            sku: variantSku,
+            variants: [
+              buildVariantWith({
+                sku: variantSku,
+                variant_id: Number(orderedProduct.node.variantId),
+                product_id: Number(orderedProduct.node.productId),
+                purchasing_disabled: false,
+              }),
+            ],
+          }),
+        ],
+      },
+    });
+
+    const variantInfo = buildVariantInfoWith({
+      variantSku,
+      inventoryTracking: 'variant',
+      availableToSell,
+      unlimitedBackorder: false,
+      totalOnHand,
+      backorderMessage,
+    });
+
+    const getVariantInfoBySkus = when(vi.fn())
+      .calledWith(expect.stringContaining(`variantSkus: ["${variantSku}"]`))
+      .thenReturn(buildVariantInfoResponseWith({ data: { variantSku: [variantInfo] } }));
+
+    server.use(
+      graphql.query('RecentlyOrderedProducts', ({ query }) =>
+        HttpResponse.json(getRecentlyOrderedProducts(query)),
+      ),
+      graphql.query('SearchProducts', ({ query }) => HttpResponse.json(searchProducts(query))),
+      graphql.query('GetVariantInfoBySkus', ({ query }) =>
+        inventoryFetchFails ? HttpResponse.error() : HttpResponse.json(getVariantInfoBySkus(query)),
+      ),
+    );
+
+    return { orderedProduct };
+  };
+
+  it('shows backorder lines when toggle is on and qty exceeds on hand', async () => {
+    setupPurchasedProductsTable();
+
+    renderWithProviders(<QuickOrder />, { preloadedState: backorderPreloadedState });
+
+    expect(await screen.findByText('Laugh Canister')).toBeInTheDocument();
+
+    const table = screen.getByRole('table');
+    const quantityInput = within(table).getByRole('spinbutton');
+
+    await userEvent.type(quantityInput, '10', {
+      initialSelectionStart: 0,
+      initialSelectionEnd: Infinity,
+    });
+
+    const backorderToggle = await screen.findByRole('checkbox', { name: /Backorder details/i });
+    await userEvent.click(backorderToggle);
+
+    await waitFor(() => {
+      expect(screen.getByText('2 ready to ship')).toBeVisible();
+    });
+    expect(screen.getByText('2 will be backordered')).toBeVisible();
+    expect(screen.getByText('Lead time: 2-4 weeks')).toBeVisible();
+  });
+
+  it('hides backorder lines when toggle is off', async () => {
+    setupPurchasedProductsTable();
+
+    renderWithProviders(<QuickOrder />, { preloadedState: backorderPreloadedState });
+
+    expect(await screen.findByText('Laugh Canister')).toBeInTheDocument();
+
+    const table = screen.getByRole('table');
+    const quantityInput = within(table).getByRole('spinbutton');
+
+    await userEvent.type(quantityInput, '10', {
+      initialSelectionStart: 0,
+      initialSelectionEnd: Infinity,
+    });
+
+    await screen.findByRole('checkbox', { name: /Backorder details/i });
+
+    expect(screen.queryByText('2 ready to ship')).not.toBeInTheDocument();
+    expect(screen.queryByText('2 will be backordered')).not.toBeInTheDocument();
+    expect(screen.queryByText('Lead time: 2-4 weeks')).not.toBeInTheDocument();
+  });
+
+  it('hides backorder toggle and lines when qty is within on hand', async () => {
+    setupPurchasedProductsTable({ totalOnHand: 9, availableToSell: 10 });
+
+    renderWithProviders(<QuickOrder />, { preloadedState: backorderPreloadedState });
+
+    expect(await screen.findByText('Laugh Canister')).toBeInTheDocument();
+
+    const table = screen.getByRole('table');
+    const quantityInput = within(table).getByRole('spinbutton');
+
+    await userEvent.type(quantityInput, '2', {
+      initialSelectionStart: 0,
+      initialSelectionEnd: Infinity,
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole('checkbox', { name: /Backorder details/i }),
+      ).not.toBeInTheDocument();
+    });
+    expect(screen.queryByText('will be backordered', { exact: false })).not.toBeInTheDocument();
+  });
+
+  it('hides backorder toggle and lines when messaging is disabled', async () => {
+    setupPurchasedProductsTable();
+
+    renderWithProviders(<QuickOrder />, { preloadedState });
+
+    expect(await screen.findByText('Laugh Canister')).toBeInTheDocument();
+
+    const table = screen.getByRole('table');
+    const quantityInput = within(table).getByRole('spinbutton');
+
+    await userEvent.type(quantityInput, '10', {
+      initialSelectionStart: 0,
+      initialSelectionEnd: Infinity,
+    });
+
+    expect(screen.queryByRole('checkbox', { name: /Backorder details/i })).not.toBeInTheDocument();
+    expect(screen.queryByText('will be backordered', { exact: false })).not.toBeInTheDocument();
+  });
+
+  it('still shows purchased products without backorder UI when inventory fetch fails', async () => {
+    setupPurchasedProductsTable({ inventoryFetchFails: true });
+
+    renderWithProviders(<QuickOrder />, { preloadedState: backorderPreloadedState });
+
+    expect(await screen.findByText('Laugh Canister')).toBeInTheDocument();
+
+    const table = screen.getByRole('table');
+    const quantityInput = within(table).getByRole('spinbutton');
+
+    await userEvent.type(quantityInput, '10', {
+      initialSelectionStart: 0,
+      initialSelectionEnd: Infinity,
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole('checkbox', { name: /Backorder details/i }),
+      ).not.toBeInTheDocument();
+    });
+    expect(screen.queryByText('will be backordered', { exact: false })).not.toBeInTheDocument();
+  });
+
+  describe('on mobile', () => {
+    beforeEach(() => {
+      vi.spyOn(document.body, 'clientWidth', 'get').mockReturnValue(500);
+    });
+
+    it('shows backorder lines in the card view when toggle is on and qty exceeds on hand', async () => {
+      setupPurchasedProductsTable();
+
+      renderWithProviders(<QuickOrder />, { preloadedState: backorderPreloadedState });
+
+      expect(await screen.findByText('Laugh Canister')).toBeInTheDocument();
+
+      await waitFor(() => {
+        expect(screen.queryByRole('table')).not.toBeInTheDocument();
+      });
+
+      const productCard = screen.getByText('Laugh Canister').closest('.MuiCardContent-root');
+      const quantityInput = within(productCard as HTMLElement).getByRole('spinbutton');
+
+      await userEvent.type(quantityInput, '10', {
+        initialSelectionStart: 0,
+        initialSelectionEnd: Infinity,
+      });
+
+      const backorderToggle = await screen.findByRole('checkbox', { name: /Backorder details/i });
+      await userEvent.click(backorderToggle);
+
+      await waitFor(() => {
+        expect(screen.getByText('2 ready to ship')).toBeVisible();
+      });
+      expect(screen.getByText('2 will be backordered')).toBeVisible();
+      expect(screen.getByText('Lead time: 2-4 weeks')).toBeVisible();
     });
   });
 });

--- a/apps/storefront/src/utils/catalogBackorderDisplay.test.ts
+++ b/apps/storefront/src/utils/catalogBackorderDisplay.test.ts
@@ -5,6 +5,7 @@ import type { Variant } from '@/types/products';
 import type { ShoppingListProductItem } from '@/types/shoppingList';
 
 import {
+  catalogListHasBackorderedItemsForDisplay,
   getCatalogBackorderDisplayFields,
   getCatalogBackorderDisplayQuantity,
   getCatalogBackorderFieldsForVariantSku,
@@ -328,6 +329,46 @@ describe('catalogBackorderDisplay', () => {
           formatOnlyAvailable,
         }).backorderFields,
       ).toBeNull();
+    });
+  });
+
+  describe('catalogListHasBackorderedItemsForDisplay', () => {
+    const inventoryRow = {
+      inventoryTracking: 'variant',
+      variantSku: 'SKU-1',
+      availableToSell: 10,
+      totalOnHand: 3,
+      backorderMessage: '2 weeks',
+    } as CatalogQuickVariantSku;
+
+    const inventoryBySku = { 'SKU-1': inventoryRow };
+
+    it('returns false for an empty list', () => {
+      expect(catalogListHasBackorderedItemsForDisplay([], inventoryBySku)).toBe(false);
+    });
+
+    it('returns true when any item has backordered quantity', () => {
+      expect(
+        catalogListHasBackorderedItemsForDisplay(
+          [{ qty: 10, variantSku: 'SKU-1' }],
+          inventoryBySku,
+        ),
+      ).toBe(true);
+    });
+
+    it('returns false when qty is within on hand', () => {
+      expect(
+        catalogListHasBackorderedItemsForDisplay([{ qty: 3, variantSku: 'SKU-1' }], inventoryBySku),
+      ).toBe(false);
+    });
+
+    it('returns false when sku is missing from inventory map', () => {
+      expect(
+        catalogListHasBackorderedItemsForDisplay(
+          [{ qty: 10, variantSku: 'UNKNOWN' }],
+          inventoryBySku,
+        ),
+      ).toBe(false);
     });
   });
 });

--- a/apps/storefront/src/utils/catalogBackorderDisplay.ts
+++ b/apps/storefront/src/utils/catalogBackorderDisplay.ts
@@ -142,3 +142,18 @@ export function getCatalogProductRowDisplayState({
 
   return { qtyHelperText, backorderFields };
 }
+
+export function catalogListHasBackorderedItemsForDisplay(
+  items: Array<{ qty: number; variantSku?: string }>,
+  inventoryBySku: Record<string, CatalogQuickVariantSku>,
+): boolean {
+  return items.some(({ qty, variantSku }) =>
+    Boolean(
+      getCatalogBackorderFieldsForVariantSku({
+        quantity: qty,
+        variantSku,
+        inventoryBySku,
+      }),
+    ),
+  );
+}


### PR DESCRIPTION
Jira: [BACK-676](https://bigcommercecloud.atlassian.net/browse/BACK-676)

## What/Why?
Adding backorder display lines + toggle to the quick order purchased products table. Fetches inventory by SKU per page load, failures are silent and hide backorder display.

## Rollout/Rollback
Merge/revert. Backorder display is gated by `Feature_Backorder && BACK-134.backorders_phase_1_1_control_messaging_on_storefront`.

## Testing
Backorder appears/disappears with backordered quantities and toggle. Quantities update and do not exceed stock.

https://github.com/user-attachments/assets/83c08c2d-4097-4f8c-aef2-7a8b4afccd4e

Same functionality on mobile view.

https://github.com/user-attachments/assets/a1728057-47a7-4a18-8f0c-daa9a42c131b

Backorder display does not appear for disabled `Feature_Backorder && BACK-134.backorders_phase_1_1_control_messaging_on_storefront`.

https://github.com/user-attachments/assets/00e1e166-e4f9-4c63-8a73-25b169995576

Ping @animesh1987 @benpratt77 

[BACK-676]: https://bigcommercecloud.atlassian.net/browse/BACK-676?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds inventory GraphQL calls and quantity-dependent backorder UI on a core ordering flow, but behavior is feature-flagged and inventory errors are non-blocking.
> 
> **Overview**
> Adds **backorder messaging** to Quick Order purchased products (desktop table and mobile cards), aligned with existing catalog backorder display utilities.
> 
> When backorder storefront messaging is enabled, the table loads variant inventory via `getVariantInfoBySkus` for SKUs on each page; failures are swallowed so the product list still renders. Rows use `getCatalogProductRowDisplayState` and `BackorderMessage` under the qty field. A **Backorder details** switch appears only when at least one line has backordered quantity; toggling it shows or hides on-hand, backordered qty, and lead-time text.
> 
> `catalogListHasBackorderedItemsForDisplay` is added to drive that toggle. Integration tests cover toggle on/off, qty within on-hand, disabled messaging, failed inventory fetch, and mobile card view.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f81f5e2290423982e33f9fd54dc6a067f9cd7dc7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->