### PR TITLE
LOCAL-3323: Pre-translated message bundles per locale

### DIFF
--- a/apps/storefront/.dependency-cruiser.cjs
+++ b/apps/storefront/.dependency-cruiser.cjs
@@ -23,7 +23,7 @@ module.exports = {
           '^src/headless.ts',
           // This should be removed once we get proper gql types
           'src/types/gql/index.ts',
-          // Locale bundles are loaded via import.meta.glob, which depcruise can't follow
+          // depcruise can't follow dynamic imports of locale bundles
           '^src/lib/lang/locales/.*\\.json$',
         ],
         numberOfDependentsLessThan: 1,

--- a/apps/storefront/.dependency-cruiser.cjs
+++ b/apps/storefront/.dependency-cruiser.cjs
@@ -23,6 +23,8 @@ module.exports = {
           '^src/headless.ts',
           // This should be removed once we get proper gql types
           'src/types/gql/index.ts',
+          // Locale bundles are loaded via import.meta.glob, which depcruise can't follow
+          '^src/lib/lang/locales/.*\\.json$',
         ],
         numberOfDependentsLessThan: 1,
       },

--- a/apps/storefront/src/components/layout/B3LocaleSwitcher.tsx
+++ b/apps/storefront/src/components/layout/B3LocaleSwitcher.tsx
@@ -1,20 +1,8 @@
 import { useFeatureFlag } from '@/hooks/useFeatureFlag';
+import { getActiveLocale } from '@/lib/lang/getActiveLocale';
 import { useAppSelector } from '@/store';
-import { Locales } from '@/store/slices/global';
 
 import B3DropDown from '../B3DropDown';
-
-const getActiveLocale = (locales: Locales) =>
-  [...locales]
-    .sort((a, b) => b.fullPath.length - a.fullPath.length)
-    .find((l) => {
-      const { href } = window.location;
-      if (!href.startsWith(l.fullPath)) {
-        return false;
-      }
-      const next = href[l.fullPath.length];
-      return next === undefined || next === '/' || next === '#' || next === '?';
-    });
 
 export default function B3LocaleSwitcher() {
   const isMultiLocaleEnabled = useFeatureFlag('LOCAL-3191.B2B_multi_language');

--- a/apps/storefront/src/lib/lang/LangProvider.test.tsx
+++ b/apps/storefront/src/lib/lang/LangProvider.test.tsx
@@ -1,9 +1,22 @@
 import { FormattedMessage } from 'react-intl';
 import { buildGlobalStateWith, renderWithProviders, screen, waitFor } from 'tests/test-utils';
 
+import { clearLocaleBundleCache } from './useLocaleBundle';
+
 const TEST_KEY = 'test.langprovider.service.override';
 const EN_DEFAULT = 'en-default-text';
 const SERVICE_VALUE = 'service-translated-text';
+
+// Ensure TEST_KEY exists in the en bundle so react-intl never fires
+// MISSING_TRANSLATION when a non-en locale is active. This mirrors production
+// where every message key is present in en.json.
+vi.mock('./locales', async (importOriginal) => {
+  const original = await importOriginal<typeof import('./locales')>();
+  return {
+    ...original,
+    en: { ...original.en, 'test.langprovider.service.override': 'en-default-text' },
+  };
+});
 
 function Msg() {
   return <FormattedMessage id={TEST_KEY} defaultMessage={EN_DEFAULT} />;
@@ -22,6 +35,10 @@ const setHref = (href: string) => {
 
 describe('LangProvider — service translation inclusion by locale type', () => {
   const originalLocation = window.location;
+
+  beforeEach(() => {
+    clearLocaleBundleCache();
+  });
 
   afterEach(() => {
     Object.defineProperty(window, 'location', { value: originalLocation, writable: true });

--- a/apps/storefront/src/lib/lang/LangProvider.test.tsx
+++ b/apps/storefront/src/lib/lang/LangProvider.test.tsx
@@ -78,6 +78,24 @@ describe('LangProvider — service translation inclusion by locale type', () => 
     await waitFor(() => expect(screen.getByText(EN_DEFAULT)).toBeVisible());
   });
 
+  it('excludes service translations when en is a non-default locale (fr-default store)', async () => {
+    setHref('http://localhost/en');
+    renderWithProviders(<Msg />, {
+      preloadedState: {
+        global: buildGlobalStateWith({
+          featureFlags: { 'LOCAL-3191.B2B_multi_language': true },
+          locales: [
+            { code: 'fr', isDefault: true, fullPath: 'http://localhost/' },
+            { code: 'en', isDefault: false, fullPath: 'http://localhost/en' },
+          ],
+        }),
+        lang: withServiceTranslations,
+      },
+    });
+
+    await waitFor(() => expect(screen.getByText(EN_DEFAULT)).toBeVisible());
+  });
+
   it('includes service translations for a non-default locale without a static bundle (ro)', async () => {
     setHref('http://localhost/ro');
     renderWithProviders(<Msg />, {

--- a/apps/storefront/src/lib/lang/LangProvider.test.tsx
+++ b/apps/storefront/src/lib/lang/LangProvider.test.tsx
@@ -1,0 +1,79 @@
+import { FormattedMessage } from 'react-intl';
+import { buildGlobalStateWith, renderWithProviders, screen, waitFor } from 'tests/test-utils';
+
+const TEST_KEY = 'test.langprovider.service.override';
+const EN_DEFAULT = 'en-default-text';
+const SERVICE_VALUE = 'service-translated-text';
+
+function Msg() {
+  return <FormattedMessage id={TEST_KEY} defaultMessage={EN_DEFAULT} />;
+}
+
+const withServiceTranslations = {
+  translations: { [TEST_KEY]: SERVICE_VALUE },
+  fetchedPages: ['global'],
+  translationVersion: 1,
+};
+
+const setHref = (href: string) => {
+  Object.defineProperty(window, 'location', { value: { href }, writable: true });
+};
+
+describe('LangProvider — service translation inclusion by locale type', () => {
+  const originalLocation = window.location;
+
+  afterEach(() => {
+    Object.defineProperty(window, 'location', { value: originalLocation, writable: true });
+  });
+
+  it('includes service translations for the default locale', async () => {
+    setHref('http://localhost/');
+    renderWithProviders(<Msg />, {
+      preloadedState: {
+        global: buildGlobalStateWith({
+          featureFlags: { 'LOCAL-3191.B2B_multi_language': true },
+          locales: [{ code: 'en', isDefault: true, fullPath: 'http://localhost/' }],
+        }),
+        lang: withServiceTranslations,
+      },
+    });
+
+    await waitFor(() => expect(screen.getByText(SERVICE_VALUE)).toBeVisible());
+  });
+
+  it('excludes service translations for a non-default locale that has a static bundle (fr)', async () => {
+    setHref('http://localhost/fr');
+    renderWithProviders(<Msg />, {
+      preloadedState: {
+        global: buildGlobalStateWith({
+          featureFlags: { 'LOCAL-3191.B2B_multi_language': true },
+          locales: [
+            { code: 'en', isDefault: true, fullPath: 'http://localhost/' },
+            { code: 'fr', isDefault: false, fullPath: 'http://localhost/fr' },
+          ],
+        }),
+        lang: withServiceTranslations,
+      },
+    });
+
+    await waitFor(() => expect(screen.getByText(EN_DEFAULT)).toBeVisible());
+  });
+
+  it('includes service translations for a non-default locale without a static bundle (ro)', async () => {
+    setHref('http://localhost/ro');
+    renderWithProviders(<Msg />, {
+      preloadedState: {
+        global: buildGlobalStateWith({
+          featureFlags: { 'LOCAL-3191.B2B_multi_language': true },
+          locales: [
+            { code: 'en', isDefault: true, fullPath: 'http://localhost/' },
+            { code: 'ro', isDefault: false, fullPath: 'http://localhost/ro' },
+          ],
+        }),
+        lang: withServiceTranslations,
+      },
+    });
+
+    await waitFor(() => expect(screen.getByText(SERVICE_VALUE)).toBeVisible());
+  });
+});

--- a/apps/storefront/src/lib/lang/LangProvider.test.tsx
+++ b/apps/storefront/src/lib/lang/LangProvider.test.tsx
@@ -13,6 +13,7 @@ const withServiceTranslations = {
   translations: { [TEST_KEY]: SERVICE_VALUE },
   fetchedPages: ['global'],
   translationVersion: 1,
+  _persist: { version: -1, rehydrated: true },
 };
 
 const setHref = (href: string) => {

--- a/apps/storefront/src/lib/lang/LangProvider.test.tsx
+++ b/apps/storefront/src/lib/lang/LangProvider.test.tsx
@@ -60,6 +60,24 @@ describe('LangProvider — service translation inclusion by locale type', () => 
     await waitFor(() => expect(screen.getByText(EN_DEFAULT)).toBeVisible());
   });
 
+  it('excludes service translations for a regional variant whose base language has a static bundle (fr-CA)', async () => {
+    setHref('http://localhost/fr-CA');
+    renderWithProviders(<Msg />, {
+      preloadedState: {
+        global: buildGlobalStateWith({
+          featureFlags: { 'LOCAL-3191.B2B_multi_language': true },
+          locales: [
+            { code: 'en', isDefault: true, fullPath: 'http://localhost/' },
+            { code: 'fr-CA', isDefault: false, fullPath: 'http://localhost/fr-CA' },
+          ],
+        }),
+        lang: withServiceTranslations,
+      },
+    });
+
+    await waitFor(() => expect(screen.getByText(EN_DEFAULT)).toBeVisible());
+  });
+
   it('includes service translations for a non-default locale without a static bundle (ro)', async () => {
     setHref('http://localhost/ro');
     renderWithProviders(<Msg />, {

--- a/apps/storefront/src/lib/lang/LangProvider.tsx
+++ b/apps/storefront/src/lib/lang/LangProvider.tsx
@@ -5,7 +5,7 @@ import { useFeatureFlag } from '@/hooks/useFeatureFlag';
 import { useAppSelector } from '@/store';
 
 import { getActiveLocale } from './getActiveLocale';
-import { en } from './locales';
+import { en, localeLoaders } from './locales';
 import { pickLocaleBundle } from './pickLocaleBundle';
 import { useLocaleBundle } from './useLocaleBundle';
 
@@ -28,7 +28,7 @@ function LangProvider({ children, customText = {} }: LangProviderProps) {
   const localeMessages = isMultiLang && ready ? pickLocaleBundle(code, bundles) : {};
   const activeLocaleCode = ready ? code : 'en';
   let messages = { ...en, ...localeMessages, ...customText, ...translations };
-  if (isMultiLang && activeLocale?.isDefault === false) {
+  if (isMultiLang && activeLocale?.isDefault === false && activeLocale.code in localeLoaders) {
     messages = { ...en, ...localeMessages, ...customText };
   }
   return (

--- a/apps/storefront/src/lib/lang/LangProvider.tsx
+++ b/apps/storefront/src/lib/lang/LangProvider.tsx
@@ -26,13 +26,12 @@ function LangProvider({ children, customText = {} }: LangProviderProps) {
   // the locale bundle is loading. Until the bundle resolves we fall back to
   // English; once it lands react-intl swaps the messages in place.
   const localeMessages = isMultiLang && ready ? pickLocaleBundle(code, bundles) : {};
-  const activeLocaleCode = ready ? code : 'en';
   let messages = { ...en, ...localeMessages, ...customText, ...translations };
   if (isMultiLang && activeLocale?.isDefault === false && hasLocaleBundle(activeLocale.code)) {
     messages = { ...en, ...localeMessages, ...customText };
   }
   return (
-    <IntlProvider defaultLocale="en" locale={activeLocaleCode} messages={messages}>
+    <IntlProvider defaultLocale="en" locale={ready ? code : 'en'} messages={messages}>
       {children}
     </IntlProvider>
   );

--- a/apps/storefront/src/lib/lang/LangProvider.tsx
+++ b/apps/storefront/src/lib/lang/LangProvider.tsx
@@ -5,7 +5,7 @@ import { useFeatureFlag } from '@/hooks/useFeatureFlag';
 import { useAppSelector } from '@/store';
 
 import { getActiveLocale } from './getActiveLocale';
-import { en, hasLocaleBundle } from './locales';
+import { en, isSupportedLocale } from './locales';
 import { pickLocaleBundle } from './pickLocaleBundle';
 import { useLocaleBundle } from './useLocaleBundle';
 
@@ -27,7 +27,7 @@ function LangProvider({ children, customText = {} }: LangProviderProps) {
   // English; once it lands react-intl swaps the messages in place.
   const localeMessages = isMultiLang && ready ? pickLocaleBundle(code, bundles) : {};
   let messages = { ...en, ...localeMessages, ...customText, ...translations };
-  if (isMultiLang && activeLocale?.isDefault === false && hasLocaleBundle(activeLocale.code)) {
+  if (isMultiLang && activeLocale?.isDefault === false && isSupportedLocale(activeLocale.code)) {
     messages = { ...en, ...localeMessages, ...customText };
   }
   return (

--- a/apps/storefront/src/lib/lang/LangProvider.tsx
+++ b/apps/storefront/src/lib/lang/LangProvider.tsx
@@ -1,31 +1,38 @@
 import { ReactNode } from 'react';
 import { IntlProvider } from 'react-intl';
-import { useSelector } from 'react-redux';
 
-import locales from './locales';
+import { useFeatureFlag } from '@/hooks/useFeatureFlag';
+import { useAppSelector } from '@/store';
+
+import { getActiveLocale } from './getActiveLocale';
+import { en } from './locales';
+import { pickLocaleBundle } from './pickLocaleBundle';
+import { useLocaleBundle } from './useLocaleBundle';
 
 interface LangProviderProps {
   readonly children: ReactNode;
   readonly customText?: Record<string, string>;
 }
 
-type Translations = Record<string, string>;
-
-interface RootState {
-  lang: {
-    translations: Translations;
-  };
-}
-
 function LangProvider({ children, customText = {} }: LangProviderProps) {
-  const translations = useSelector<RootState, Translations>(({ lang }) => lang.translations);
+  const translations = useAppSelector(({ lang }) => lang.translations);
+  const isMultiLang = useFeatureFlag('LOCAL-3191.B2B_multi_language');
+  const localesList = useAppSelector(({ global }) => global.locales);
+  const activeLocale = isMultiLang ? getActiveLocale(localesList) : undefined;
+  const code = isMultiLang ? (activeLocale?.code ?? 'en') : 'en';
+  const { ready, bundles } = useLocaleBundle(code);
 
+  // Render unconditionally so children (notably B3PageMask) stay mounted while
+  // the locale bundle is loading. Until the bundle resolves we fall back to
+  // English; once it lands react-intl swaps the messages in place.
+  const localeMessages = isMultiLang && ready ? pickLocaleBundle(code, bundles) : {};
+  const activeLocaleCode = ready ? code : 'en';
+  let messages = { ...en, ...localeMessages, ...customText, ...translations };
+  if (isMultiLang && activeLocale?.isDefault === false) {
+    messages = { ...en, ...localeMessages, ...customText };
+  }
   return (
-    <IntlProvider
-      defaultLocale="en"
-      locale="en"
-      messages={{ ...locales.en, ...customText, ...translations }}
-    >
+    <IntlProvider defaultLocale="en" locale={activeLocaleCode} messages={messages}>
       {children}
     </IntlProvider>
   );

--- a/apps/storefront/src/lib/lang/LangProvider.tsx
+++ b/apps/storefront/src/lib/lang/LangProvider.tsx
@@ -5,7 +5,7 @@ import { useFeatureFlag } from '@/hooks/useFeatureFlag';
 import { useAppSelector } from '@/store';
 
 import { getActiveLocale } from './getActiveLocale';
-import { en, localeLoaders } from './locales';
+import { en, hasLocaleBundle } from './locales';
 import { pickLocaleBundle } from './pickLocaleBundle';
 import { useLocaleBundle } from './useLocaleBundle';
 
@@ -28,7 +28,7 @@ function LangProvider({ children, customText = {} }: LangProviderProps) {
   const localeMessages = isMultiLang && ready ? pickLocaleBundle(code, bundles) : {};
   const activeLocaleCode = ready ? code : 'en';
   let messages = { ...en, ...localeMessages, ...customText, ...translations };
-  if (isMultiLang && activeLocale?.isDefault === false && activeLocale.code in localeLoaders) {
+  if (isMultiLang && activeLocale?.isDefault === false && hasLocaleBundle(activeLocale.code)) {
     messages = { ...en, ...localeMessages, ...customText };
   }
   return (

--- a/apps/storefront/src/lib/lang/getActiveLocale.test.ts
+++ b/apps/storefront/src/lib/lang/getActiveLocale.test.ts
@@ -1,0 +1,55 @@
+import { getActiveLocale } from './getActiveLocale';
+
+const LOCALES = [
+  { code: 'fr', isDefault: true, fullPath: 'https://store.example.com/' },
+  { code: 'fr-CA', isDefault: false, fullPath: 'https://store.example.com/fr-ca' },
+  { code: 'en', isDefault: false, fullPath: 'https://store.example.com/en' },
+];
+
+const setHref = (href: string) => {
+  Object.defineProperty(window, 'location', {
+    value: { href },
+    writable: true,
+  });
+};
+
+describe('getActiveLocale', () => {
+  const originalLocation = window.location;
+
+  afterEach(() => {
+    Object.defineProperty(window, 'location', { value: originalLocation, writable: true });
+  });
+
+  it('matches the longest fullPath prefix', () => {
+    setHref('https://store.example.com/fr-ca/orders');
+    expect(getActiveLocale(LOCALES)?.code).toBe('fr-CA');
+  });
+
+  it('matches the root locale at the bare default root', () => {
+    setHref('https://store.example.com/');
+    expect(getActiveLocale(LOCALES)?.code).toBe('fr');
+  });
+
+  it('does not match a partial-segment prefix (/english should not match /en); falls through to the default', () => {
+    setHref('https://store.example.com/english');
+    expect(getActiveLocale(LOCALES)?.code).toBe('fr');
+  });
+
+  it('matches the default language for arbitrary sub-paths under the default root', () => {
+    setHref('https://store.example.com/my-page');
+    expect(getActiveLocale(LOCALES)?.code).toBe('fr');
+  });
+
+  it('returns undefined when the URL host does not match any fullPath', () => {
+    setHref('https://other-store.example.com/');
+    expect(getActiveLocale(LOCALES)).toBeUndefined();
+  });
+
+  it('does not mutate the input locales array', () => {
+    setHref('https://store.example.com/fr-ca/orders');
+    const input = [...LOCALES];
+    const snapshot = [...input];
+    getActiveLocale(input);
+    expect(input).toEqual(snapshot);
+  });
+});

--- a/apps/storefront/src/lib/lang/getActiveLocale.ts
+++ b/apps/storefront/src/lib/lang/getActiveLocale.ts
@@ -1,0 +1,16 @@
+import type { Locale, Locales } from '@/store/slices/global';
+
+export const getActiveLocale = (locales: Locales): Locale | undefined =>
+  [...locales]
+    .sort((a, b) => b.fullPath.length - a.fullPath.length)
+    .find(({ fullPath }) => {
+      const { href } = window.location;
+      if (!href.startsWith(fullPath)) {
+        return false;
+      }
+      if (fullPath.endsWith('/')) {
+        return true;
+      }
+      const next = href[fullPath.length];
+      return next === undefined || next === '/' || next === '#' || next === '?';
+    });

--- a/apps/storefront/src/lib/lang/locales/es.json
+++ b/apps/storefront/src/lib/lang/locales/es.json
@@ -1,5 +1,6 @@
 {
   "global.navMenu.orders": "Mis pedidos",
   "global.orders.title": "Mis pedidos",
+  "global.tips.loading": "Cargando...",
   "login.loginText.forgotPasswordText": "¿Olvidaste tu contraseña?"
 }

--- a/apps/storefront/src/lib/lang/locales/es.json
+++ b/apps/storefront/src/lib/lang/locales/es.json
@@ -1,0 +1,5 @@
+{
+  "global.navMenu.orders": "Mis pedidos",
+  "global.orders.title": "Mis pedidos",
+  "login.loginText.forgotPasswordText": "¿Olvidaste tu contraseña?"
+}

--- a/apps/storefront/src/lib/lang/locales/fr.json
+++ b/apps/storefront/src/lib/lang/locales/fr.json
@@ -1,0 +1,5 @@
+{
+  "global.navMenu.orders": "Mes commandes",
+  "global.orders.title": "Mes commandes",
+  "login.loginText.forgotPasswordText": "Mot de passe oublié ?"
+}

--- a/apps/storefront/src/lib/lang/locales/fr.json
+++ b/apps/storefront/src/lib/lang/locales/fr.json
@@ -1,4 +1,5 @@
 {
+  "global.tips.loading": "Chargement...",
   "global.navMenu.orders": "Mes commandes",
   "global.orders.title": "Mes commandes",
   "login.loginText.forgotPasswordText": "Mot de passe oublié ?"

--- a/apps/storefront/src/lib/lang/locales/index.ts
+++ b/apps/storefront/src/lib/lang/locales/index.ts
@@ -8,4 +8,16 @@ const localeLoaders: Record<string, () => Promise<LocaleMessages>> = {
   es: () => import('./es.json').then((m) => m.default),
 };
 
-export { en, localeLoaders };
+// Returns true when a static bundle covers the given code — either an exact
+// match or via the base-language fallback (mirrors pickLocaleBundle's logic).
+function hasLocaleBundle(code: string): boolean {
+  if (code in localeLoaders) return true;
+  const dashIdx = code.indexOf('-');
+  if (dashIdx > 0) {
+    const lang = code.slice(0, dashIdx);
+    if (lang in localeLoaders) return true;
+  }
+  return false;
+}
+
+export { en, hasLocaleBundle, localeLoaders };

--- a/apps/storefront/src/lib/lang/locales/index.ts
+++ b/apps/storefront/src/lib/lang/locales/index.ts
@@ -13,10 +13,12 @@ const localeLoaders: Record<string, () => Promise<LocaleMessages>> = {
 // Returns true when a static bundle covers the given code — either an exact
 // match or via the base-language fallback (mirrors pickLocaleBundle's logic).
 // en is always covered by the statically imported bundle even though it has no localeLoader entry.
-function hasLocaleBundle(code: string): boolean {
-  if (code === 'en' || code in localeLoaders) return true;
+function isSupportedLocale(code: string): boolean {
+  if (code === 'en' || code in localeLoaders) {
+    return true;
+  }
   const fallback = getFallbackLocale(code);
   return fallback !== null && (fallback === 'en' || fallback in localeLoaders);
 }
 
-export { en, hasLocaleBundle, localeLoaders };
+export { en, isSupportedLocale, localeLoaders };

--- a/apps/storefront/src/lib/lang/locales/index.ts
+++ b/apps/storefront/src/lib/lang/locales/index.ts
@@ -1,6 +1,6 @@
-import en from './en.json';
-
 import { getFallbackLocale } from '../pickLocaleBundle';
+
+import en from './en.json';
 
 type LocaleMessages = Record<string, string>;
 

--- a/apps/storefront/src/lib/lang/locales/index.ts
+++ b/apps/storefront/src/lib/lang/locales/index.ts
@@ -12,11 +12,15 @@ const localeLoaders: Record<string, () => Promise<LocaleMessages>> = {
 // match or via the base-language fallback (mirrors pickLocaleBundle's logic).
 // en is always covered by the statically imported bundle even though it has no localeLoader entry.
 function hasLocaleBundle(code: string): boolean {
-  if (code === 'en' || code in localeLoaders) return true;
+  if (code === 'en' || code in localeLoaders) {
+    return true;
+  }
   const dashIdx = code.indexOf('-');
   if (dashIdx > 0) {
     const lang = code.slice(0, dashIdx);
-    if (lang === 'en' || lang in localeLoaders) return true;
+    if (lang === 'en' || lang in localeLoaders) {
+      return true;
+    }
   }
   return false;
 }

--- a/apps/storefront/src/lib/lang/locales/index.ts
+++ b/apps/storefront/src/lib/lang/locales/index.ts
@@ -1,5 +1,7 @@
 import en from './en.json';
 
+import { getFallbackLocale } from '../pickLocaleBundle';
+
 type LocaleMessages = Record<string, string>;
 
 // Filenames use underscores for BCP-47 region tags (fr_FR.json); runtime codes use dashes (fr-FR).
@@ -12,17 +14,9 @@ const localeLoaders: Record<string, () => Promise<LocaleMessages>> = {
 // match or via the base-language fallback (mirrors pickLocaleBundle's logic).
 // en is always covered by the statically imported bundle even though it has no localeLoader entry.
 function hasLocaleBundle(code: string): boolean {
-  if (code === 'en' || code in localeLoaders) {
-    return true;
-  }
-  const dashIdx = code.indexOf('-');
-  if (dashIdx > 0) {
-    const lang = code.slice(0, dashIdx);
-    if (lang === 'en' || lang in localeLoaders) {
-      return true;
-    }
-  }
-  return false;
+  if (code === 'en' || code in localeLoaders) return true;
+  const fallback = getFallbackLocale(code);
+  return fallback !== null && (fallback === 'en' || fallback in localeLoaders);
 }
 
 export { en, hasLocaleBundle, localeLoaders };

--- a/apps/storefront/src/lib/lang/locales/index.ts
+++ b/apps/storefront/src/lib/lang/locales/index.ts
@@ -1,3 +1,11 @@
 import en from './en.json';
 
-export default { en, custom: undefined };
+type LocaleMessages = Record<string, string>;
+
+// Filenames use underscores for BCP-47 region tags (fr_FR.json); runtime codes use dashes (fr-FR).
+const localeLoaders: Record<string, () => Promise<LocaleMessages>> = {
+  fr: () => import('./fr.json').then((m) => m.default),
+  es: () => import('./es.json').then((m) => m.default),
+};
+
+export { en, localeLoaders };

--- a/apps/storefront/src/lib/lang/locales/index.ts
+++ b/apps/storefront/src/lib/lang/locales/index.ts
@@ -10,12 +10,13 @@ const localeLoaders: Record<string, () => Promise<LocaleMessages>> = {
 
 // Returns true when a static bundle covers the given code — either an exact
 // match or via the base-language fallback (mirrors pickLocaleBundle's logic).
+// en is always covered by the statically imported bundle even though it has no localeLoader entry.
 function hasLocaleBundle(code: string): boolean {
-  if (code in localeLoaders) return true;
+  if (code === 'en' || code in localeLoaders) return true;
   const dashIdx = code.indexOf('-');
   if (dashIdx > 0) {
     const lang = code.slice(0, dashIdx);
-    if (lang in localeLoaders) return true;
+    if (lang === 'en' || lang in localeLoaders) return true;
   }
   return false;
 }

--- a/apps/storefront/src/lib/lang/pickLocaleBundle.test.ts
+++ b/apps/storefront/src/lib/lang/pickLocaleBundle.test.ts
@@ -1,0 +1,143 @@
+import { pickLocaleBundle } from './pickLocaleBundle';
+
+// LangProvider merges English first, then the picked bundle on top:
+//   { ...locales.en, ...pickLocaleBundle(active, locales), ...customText, ...translations }
+// pickLocaleBundle returns the most specific available bundle: the exact
+// regional match if present, otherwise the bare-language bundle, otherwise {}.
+// Per-key gaps within the picked bundle fall through to en via the merge —
+// they do NOT cascade through the regional → bare chain at key level.
+const merge = (en: Record<string, string>, picked: Record<string, string>) => ({
+  ...en,
+  ...picked,
+});
+
+describe('pickLocaleBundle — regional bundle present', () => {
+  const bundles = {
+    en: { greeting: 'Hello', farewell: 'Goodbye' },
+    es: { greeting: 'Hola (es)', farewell: 'Adiós (es)' },
+    'es-MX': { greeting: 'Hola (es-MX)' },
+  };
+
+  it('s1: returns the exact regional bundle when the phrase is present', () => {
+    const picked = pickLocaleBundle('es-MX', bundles);
+    expect(merge(bundles.en, picked).greeting).toBe('Hola (es-MX)');
+  });
+
+  it('s2: missing key in the regional bundle falls through to en, not to the bare-language bundle', () => {
+    const picked = pickLocaleBundle('es-MX', bundles);
+    expect(merge(bundles.en, picked).farewell).toBe('Goodbye');
+  });
+
+  it('s3: phrase missing from both regional and bare resolves to en', () => {
+    const onlyEn = {
+      en: { onlyEnKey: 'only-en' },
+      es: {},
+      'es-MX': {},
+    };
+    const picked = pickLocaleBundle('es-MX', onlyEn);
+    expect(merge(onlyEn.en, picked).onlyEnKey).toBe('only-en');
+  });
+});
+
+describe('pickLocaleBundle — bare-language locale', () => {
+  it('s4: returns the bare bundle when active locale is bare', () => {
+    const bundles = {
+      en: { greeting: 'Hello' },
+      es: { greeting: 'Hola (es)' },
+    };
+    const picked = pickLocaleBundle('es', bundles);
+    expect(merge(bundles.en, picked).greeting).toBe('Hola (es)');
+  });
+
+  it('s5: missing key in bare bundle falls back to en', () => {
+    const bundles = {
+      en: { greeting: 'Hello', farewell: 'Goodbye' },
+      es: { greeting: 'Hola (es)' },
+    };
+    const picked = pickLocaleBundle('es', bundles);
+    expect(merge(bundles.en, picked).farewell).toBe('Goodbye');
+  });
+});
+
+describe('pickLocaleBundle — numeric region subtag', () => {
+  const bundles = {
+    en: { greeting: 'Hello', farewell: 'Goodbye' },
+    es: { farewell: 'Adiós (es)' },
+    'es-419': { greeting: 'Hola (es-419)' },
+  };
+
+  it('s6: matches es-419 without dropping the numeric subtag', () => {
+    const picked = pickLocaleBundle('es-419', bundles);
+    expect(merge(bundles.en, picked).greeting).toBe('Hola (es-419)');
+  });
+
+  it('s7: missing key in es-419 falls to en (per-key bare-language fallback is not applied when the regional bundle exists)', () => {
+    const picked = pickLocaleBundle('es-419', bundles);
+    expect(merge(bundles.en, picked).farewell).toBe('Goodbye');
+  });
+});
+
+describe('pickLocaleBundle — regional bundle missing, bare bundle present', () => {
+  it('s9: es-ES with no es-ES bundle now falls back to the bare es bundle', () => {
+    const bundles = {
+      en: { greeting: 'Hello' },
+      es: { greeting: 'Hola (es)' },
+    };
+    const picked = pickLocaleBundle('es-ES', bundles);
+    expect(merge(bundles.en, picked).greeting).toBe('Hola (es)');
+  });
+
+  it('fr-CA with no fr-CA bundle uses the shipped fr bundle', () => {
+    const bundles = {
+      en: { greeting: 'Hello' },
+      fr: { greeting: 'Bonjour (fr)' },
+    };
+    const picked = pickLocaleBundle('fr-CA', bundles);
+    expect(merge(bundles.en, picked).greeting).toBe('Bonjour (fr)');
+  });
+
+  it('fr-FR with no fr-FR bundle uses the shipped fr bundle', () => {
+    const bundles = {
+      en: { greeting: 'Hello' },
+      fr: { greeting: 'Bonjour (fr)' },
+    };
+    const picked = pickLocaleBundle('fr-FR', bundles);
+    expect(merge(bundles.en, picked).greeting).toBe('Bonjour (fr)');
+  });
+});
+
+describe('pickLocaleBundle — admin-forced regional default', () => {
+  it('s10: admin-forced es-MX with empty regional bundle still falls back to en, not bare es', () => {
+    const bundles = {
+      en: { greeting: 'Hello' },
+      es: { greeting: 'Hola (es)' },
+      'es-MX': {},
+    };
+    const picked = pickLocaleBundle('es-MX', bundles);
+    expect(merge(bundles.en, picked).greeting).toBe('Hello');
+  });
+});
+
+describe('pickLocaleBundle — edge cases', () => {
+  it('returns {} when the active locale has no bundle and no bare-language bundle exists', () => {
+    expect(pickLocaleBundle('zh-CN', { en: {} })).toEqual({});
+  });
+
+  it('returns {} when bundles is empty', () => {
+    expect(pickLocaleBundle('zh-CN', {})).toEqual({});
+  });
+
+  it('skips a key registered with undefined and falls through to the next candidate', () => {
+    const bundles: Record<string, Record<string, string> | undefined> = {
+      en: { greeting: 'Hello' },
+      fr: { greeting: 'Bonjour' },
+      'fr-CA': undefined,
+    };
+    expect(pickLocaleBundle('fr-CA', bundles)).toBe(bundles.fr);
+  });
+
+  it('returns the en bundle when active locale is en', () => {
+    const bundles = { en: { greeting: 'Hello' } };
+    expect(pickLocaleBundle('en', bundles)).toBe(bundles.en);
+  });
+});

--- a/apps/storefront/src/lib/lang/pickLocaleBundle.ts
+++ b/apps/storefront/src/lib/lang/pickLocaleBundle.ts
@@ -1,6 +1,11 @@
 type LocaleCode = string;
 type LocaleBundles = Record<LocaleCode, Record<string, string> | undefined>;
 
+export function getFallbackLocale(code: string): string | null {
+  const dashIdx = code.indexOf('-');
+  return dashIdx > 0 ? code.slice(0, dashIdx) : null;
+}
+
 export function pickLocaleBundle(
   activeLocaleCode: string,
   bundles: LocaleBundles,
@@ -10,13 +15,11 @@ export function pickLocaleBundle(
     return direct;
   }
 
-  const dashIdx = activeLocaleCode.indexOf('-');
-  const language = dashIdx > 0 ? activeLocaleCode.slice(0, dashIdx) : '';
-
-  if (language && activeLocaleCode !== language) {
-    const directLang = bundles[language];
-    if (directLang) {
-      return directLang;
+  const fallback = getFallbackLocale(activeLocaleCode);
+  if (fallback) {
+    const fallbackBundle = bundles[fallback];
+    if (fallbackBundle) {
+      return fallbackBundle;
     }
   }
 

--- a/apps/storefront/src/lib/lang/pickLocaleBundle.ts
+++ b/apps/storefront/src/lib/lang/pickLocaleBundle.ts
@@ -1,0 +1,24 @@
+type LocaleCode = string;
+type LocaleBundles = Record<LocaleCode, Record<string, string> | undefined>;
+
+export function pickLocaleBundle(
+  activeLocaleCode: string,
+  bundles: LocaleBundles,
+): Record<string, string> {
+  const direct = bundles[activeLocaleCode];
+  if (direct) {
+    return direct;
+  }
+
+  const dashIdx = activeLocaleCode.indexOf('-');
+  const language = dashIdx > 0 ? activeLocaleCode.slice(0, dashIdx) : '';
+
+  if (language && activeLocaleCode !== language) {
+    const directLang = bundles[language];
+    if (directLang) {
+      return directLang;
+    }
+  }
+
+  return {};
+}

--- a/apps/storefront/src/lib/lang/useLocaleBundle.test.ts
+++ b/apps/storefront/src/lib/lang/useLocaleBundle.test.ts
@@ -1,0 +1,28 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { useLocaleBundle } from './useLocaleBundle';
+
+// Access the module-level cache via a side-effect reset between tests.
+// Each test re-imports fresh by clearing the module registry.
+afterEach(() => {
+  vi.resetModules();
+});
+
+describe('useLocaleBundle — loader failure recovery', () => {
+  it('sets ready=true and returns an empty bundle when the dynamic import rejects', async () => {
+    vi.doMock('./locales', () => ({
+      en: { greeting: 'Hello' },
+      localeLoaders: {
+        fr: () => Promise.reject(new Error('network error')),
+      },
+    }));
+
+    const { useLocaleBundle: hook } = await import('./useLocaleBundle');
+    const { result } = renderHook(() => hook('fr'));
+
+    await waitFor(() => expect(result.current.ready).toBe(true));
+    // Failed import → no fr bundle → pickLocaleBundle returns {} → falls back to en
+    expect(result.current.bundles.fr).toBeUndefined();
+  });
+});

--- a/apps/storefront/src/lib/lang/useLocaleBundle.test.ts
+++ b/apps/storefront/src/lib/lang/useLocaleBundle.test.ts
@@ -1,10 +1,8 @@
 import { renderHook, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { useLocaleBundle } from './useLocaleBundle';
-
-// Access the module-level cache via a side-effect reset between tests.
-// Each test re-imports fresh by clearing the module registry.
+// Each test dynamically imports useLocaleBundle after mocking locales,
+// so the module registry must be reset between tests.
 afterEach(() => {
   vi.resetModules();
 });

--- a/apps/storefront/src/lib/lang/useLocaleBundle.test.ts
+++ b/apps/storefront/src/lib/lang/useLocaleBundle.test.ts
@@ -23,4 +23,20 @@ describe('useLocaleBundle — loader failure recovery', () => {
     // Failed import → no fr bundle → pickLocaleBundle returns {} → falls back to en
     expect(result.current.bundles.fr).toBeUndefined();
   });
+
+  it('sets ready=true even when all loaders reject (Promise.all .catch path)', async () => {
+    vi.doMock('./locales', () => ({
+      en: { greeting: 'Hello' },
+      localeLoaders: {
+        fr: () => Promise.reject(new Error('chunk load failure')),
+        es: () => Promise.reject(new Error('chunk load failure')),
+      },
+    }));
+
+    const { useLocaleBundle: hook } = await import('./useLocaleBundle');
+    const { result } = renderHook(() => hook('fr'));
+
+    await waitFor(() => expect(result.current.ready).toBe(true));
+    expect(result.current.bundles.fr).toBeUndefined();
+  });
 });

--- a/apps/storefront/src/lib/lang/useLocaleBundle.test.ts
+++ b/apps/storefront/src/lib/lang/useLocaleBundle.test.ts
@@ -24,19 +24,21 @@ describe('useLocaleBundle — loader failure recovery', () => {
     expect(result.current.bundles.fr).toBeUndefined();
   });
 
-  it('sets ready=true even when all loaders reject (Promise.all .catch path)', async () => {
+  it('sets ready=true when fallback loader exists but rejects', async () => {
+    vi.doMock('./pickLocaleBundle', () => ({
+      getFallbackLocale: () => 'es',
+    }));
     vi.doMock('./locales', () => ({
       en: { greeting: 'Hello' },
       localeLoaders: {
-        fr: () => Promise.reject(new Error('chunk load failure')),
         es: () => Promise.reject(new Error('chunk load failure')),
       },
     }));
 
     const { useLocaleBundle: hook } = await import('./useLocaleBundle');
-    const { result } = renderHook(() => hook('fr'));
+    const { result } = renderHook(() => hook('es-MX'));
 
     await waitFor(() => expect(result.current.ready).toBe(true));
-    expect(result.current.bundles.fr).toBeUndefined();
+    expect(result.current.bundles.es).toBeUndefined();
   });
 });

--- a/apps/storefront/src/lib/lang/useLocaleBundle.ts
+++ b/apps/storefront/src/lib/lang/useLocaleBundle.ts
@@ -67,6 +67,7 @@ export function useLocaleBundle(code: string): UseLocaleBundleResult {
       result[key] = value;
     });
     return result;
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- tick is a version counter signalling cache mutation; cache is a stable module-level ref
   }, [tick]);
 
   return { ready, bundles };

--- a/apps/storefront/src/lib/lang/useLocaleBundle.ts
+++ b/apps/storefront/src/lib/lang/useLocaleBundle.ts
@@ -29,7 +29,11 @@ export function useLocaleBundle(code: string): UseLocaleBundleResult {
     Promise.all(
       missing.map(async (c) => {
         const loader = localeLoaders[c];
-        cache.set(c, loader ? await loader() : undefined);
+        try {
+          cache.set(c, loader ? await loader() : undefined);
+        } catch {
+          cache.set(c, undefined);
+        }
       }),
     ).then(() => {
       if (!cancelled) setTick((t) => t + 1);

--- a/apps/storefront/src/lib/lang/useLocaleBundle.ts
+++ b/apps/storefront/src/lib/lang/useLocaleBundle.ts
@@ -1,6 +1,7 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 import { en, localeLoaders } from './locales';
+import { getFallbackLocale } from './pickLocaleBundle';
 
 type LocaleMessages = Record<string, string>;
 
@@ -13,9 +14,8 @@ export const clearLocaleBundleCache = () => {
 };
 
 const candidatesFor = (code: string): string[] => {
-  const dashIdx = code.indexOf('-');
-  const lang = dashIdx > 0 ? code.slice(0, dashIdx) : '';
-  return lang && lang !== code ? [code, lang] : [code];
+  const fallback = getFallbackLocale(code);
+  return fallback ? [code, fallback] : [code];
 };
 
 interface UseLocaleBundleResult {
@@ -24,7 +24,7 @@ interface UseLocaleBundleResult {
 }
 
 export function useLocaleBundle(code: string): UseLocaleBundleResult {
-  const [, setTick] = useState(0);
+  const [tick, setTick] = useState(0);
 
   useEffect(() => {
     if (code === 'en') return undefined;
@@ -61,10 +61,13 @@ export function useLocaleBundle(code: string): UseLocaleBundleResult {
       (c) => c === 'en' || !localeLoaders[c] || cache.has(c) || failed.has(c),
     );
 
-  const bundles: Record<string, LocaleMessages | undefined> = { en };
-  cache.forEach((value, key) => {
-    bundles[key] = value;
-  });
+  const bundles = useMemo(() => {
+    const result: Record<string, LocaleMessages | undefined> = { en };
+    cache.forEach((value, key) => {
+      result[key] = value;
+    });
+    return result;
+  }, [tick]);
 
   return { ready, bundles };
 }

--- a/apps/storefront/src/lib/lang/useLocaleBundle.ts
+++ b/apps/storefront/src/lib/lang/useLocaleBundle.ts
@@ -4,9 +4,13 @@ import { en, localeLoaders } from './locales';
 
 type LocaleMessages = Record<string, string>;
 
-const cache = new Map<string, LocaleMessages | undefined>();
+const cache = new Map<string, LocaleMessages>();
+const failed = new Set<string>();
 
-export const clearLocaleBundleCache = () => cache.clear();
+export const clearLocaleBundleCache = () => {
+  cache.clear();
+  failed.clear();
+};
 
 const candidatesFor = (code: string): string[] => {
   const dashIdx = code.indexOf('-');
@@ -24,7 +28,9 @@ export function useLocaleBundle(code: string): UseLocaleBundleResult {
 
   useEffect(() => {
     if (code === 'en') return undefined;
-    const missing = candidatesFor(code).filter((c) => c !== 'en' && !cache.has(c));
+    const missing = candidatesFor(code).filter(
+      (c) => c !== 'en' && localeLoaders[c] && !cache.has(c) && !failed.has(c),
+    );
     if (missing.length === 0) return undefined;
 
     let cancelled = false;
@@ -32,9 +38,9 @@ export function useLocaleBundle(code: string): UseLocaleBundleResult {
       missing.map(async (c) => {
         const loader = localeLoaders[c];
         try {
-          cache.set(c, loader ? await loader() : undefined);
+          cache.set(c, await loader());
         } catch {
-          cache.set(c, undefined);
+          failed.add(c);
         }
       }),
     )
@@ -49,7 +55,11 @@ export function useLocaleBundle(code: string): UseLocaleBundleResult {
     };
   }, [code]);
 
-  const ready = code === 'en' || candidatesFor(code).every((c) => c === 'en' || cache.has(c));
+  const ready =
+    code === 'en' ||
+    candidatesFor(code).every(
+      (c) => c === 'en' || !localeLoaders[c] || cache.has(c) || failed.has(c),
+    );
 
   const bundles: Record<string, LocaleMessages | undefined> = { en };
   cache.forEach((value, key) => {

--- a/apps/storefront/src/lib/lang/useLocaleBundle.ts
+++ b/apps/storefront/src/lib/lang/useLocaleBundle.ts
@@ -13,9 +13,15 @@ export const clearLocaleBundleCache = () => {
   failed.clear();
 };
 
-const candidatesFor = (code: string): string[] => {
+const determineLocaleToLoad = (code: string): string | null => {
+  if (localeLoaders[code]) {
+    return code;
+  }
   const fallback = getFallbackLocale(code);
-  return fallback ? [code, fallback] : [code];
+  if (fallback && localeLoaders[fallback]) {
+    return fallback;
+  }
+  return null;
 };
 
 interface UseLocaleBundleResult {
@@ -28,28 +34,29 @@ export function useLocaleBundle(code: string): UseLocaleBundleResult {
 
   useEffect(() => {
     if (code === 'en') return undefined;
-    const missing = candidatesFor(code).filter(
-      (c) => c !== 'en' && localeLoaders[c] && !cache.has(c) && !failed.has(c),
-    );
-    if (missing.length === 0) return undefined;
+
+    const toLoad = determineLocaleToLoad(code);
+    if (!toLoad || cache.has(toLoad) || failed.has(toLoad)) {
+      return undefined;
+    }
 
     let cancelled = false;
-    Promise.all(
-      missing.map(async (c) => {
-        const loader = localeLoaders[c];
-        try {
-          cache.set(c, await loader());
-        } catch {
-          failed.add(c);
+    const loader = localeLoaders[toLoad];
+
+    loader()
+      .then((messages) => {
+        if (!cancelled) {
+          cache.set(toLoad, messages);
+          setTick((t) => t + 1);
         }
-      }),
-    )
-      .then(() => {
-        if (!cancelled) setTick((t) => t + 1);
       })
       .catch(() => {
-        if (!cancelled) setTick((t) => t + 1);
+        if (!cancelled) {
+          failed.add(toLoad);
+          setTick((t) => t + 1);
+        }
       });
+
     return () => {
       cancelled = true;
     };
@@ -57,9 +64,10 @@ export function useLocaleBundle(code: string): UseLocaleBundleResult {
 
   const ready =
     code === 'en' ||
-    candidatesFor(code).every(
-      (c) => c === 'en' || !localeLoaders[c] || cache.has(c) || failed.has(c),
-    );
+    (() => {
+      const toLoad = determineLocaleToLoad(code);
+      return !toLoad || cache.has(toLoad) || failed.has(toLoad);
+    })();
 
   const bundles = useMemo(() => {
     const result: Record<string, LocaleMessages | undefined> = { en };

--- a/apps/storefront/src/lib/lang/useLocaleBundle.ts
+++ b/apps/storefront/src/lib/lang/useLocaleBundle.ts
@@ -1,0 +1,50 @@
+import { useEffect, useState } from 'react';
+
+import { en, localeLoaders } from './locales';
+
+type LocaleMessages = Record<string, string>;
+
+const cache = new Map<string, LocaleMessages | undefined>();
+
+const candidatesFor = (code: string): string[] => {
+  const dashIdx = code.indexOf('-');
+  const lang = dashIdx > 0 ? code.slice(0, dashIdx) : '';
+  return lang && lang !== code ? [code, lang] : [code];
+};
+
+interface UseLocaleBundleResult {
+  ready: boolean;
+  bundles: Record<string, LocaleMessages | undefined>;
+}
+
+export function useLocaleBundle(code: string): UseLocaleBundleResult {
+  const [, setTick] = useState(0);
+
+  useEffect(() => {
+    if (code === 'en') return undefined;
+    const missing = candidatesFor(code).filter((c) => c !== 'en' && !cache.has(c));
+    if (missing.length === 0) return undefined;
+
+    let cancelled = false;
+    Promise.all(
+      missing.map(async (c) => {
+        const loader = localeLoaders[c];
+        cache.set(c, loader ? await loader() : undefined);
+      }),
+    ).then(() => {
+      if (!cancelled) setTick((t) => t + 1);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [code]);
+
+  const ready = code === 'en' || candidatesFor(code).every((c) => c === 'en' || cache.has(c));
+
+  const bundles: Record<string, LocaleMessages | undefined> = { en };
+  cache.forEach((value, key) => {
+    bundles[key] = value;
+  });
+
+  return { ready, bundles };
+}

--- a/apps/storefront/src/lib/lang/useLocaleBundle.ts
+++ b/apps/storefront/src/lib/lang/useLocaleBundle.ts
@@ -6,6 +6,8 @@ type LocaleMessages = Record<string, string>;
 
 const cache = new Map<string, LocaleMessages | undefined>();
 
+export const clearLocaleBundleCache = () => cache.clear();
+
 const candidatesFor = (code: string): string[] => {
   const dashIdx = code.indexOf('-');
   const lang = dashIdx > 0 ? code.slice(0, dashIdx) : '';
@@ -35,9 +37,13 @@ export function useLocaleBundle(code: string): UseLocaleBundleResult {
           cache.set(c, undefined);
         }
       }),
-    ).then(() => {
-      if (!cancelled) setTick((t) => t + 1);
-    });
+    )
+      .then(() => {
+        if (!cancelled) setTick((t) => t + 1);
+      })
+      .catch(() => {
+        if (!cancelled) setTick((t) => t + 1);
+      });
     return () => {
       cancelled = true;
     };

--- a/apps/storefront/vite.config.ts
+++ b/apps/storefront/vite.config.ts
@@ -116,8 +116,16 @@ export default defineConfig(({ mode }): UserConfig & Pick<ViteUserConfig, 'test'
             eCache: ['@emotion/cache'],
           },
           chunkFileNames(chunk) {
-            if (chunk.name === 'index' && chunk.facadeModuleId) {
-              const folderName = path.basename(path.dirname(chunk.facadeModuleId));
+            const id = chunk.facadeModuleId;
+
+            if (id && /\/lib\/lang\/locales\/[^/]+\.json$/.test(id)) {
+              const base = path.basename(id, '.json');
+
+              return `chunks/locale-${base}.[hash].js`;
+            }
+
+            if (chunk.name === 'index' && id) {
+              const folderName = path.basename(path.dirname(id));
 
               return `chunks/${folderName}.[hash].js`;
             }


### PR DESCRIPTION
Jira: [LOCAL-3323](https://bigcommercecloud.atlassian.net/browse/LOCAL-3323)

## What/Why?

Locale switching was already wired behind `LOCAL-3191.B2B_multi_language`, but `LangProvider` stayed hardcoded to English, so choosing a non-English locale left the B2B UI in English while the rest of the storefront switched. This ships per-locale message bundles and renders the B2B UI in the active storefront locale.

Bundles load on demand (`en` is the baseline; others are fetched via dynamic import) so a French storefront never ships Spanish strings. `fr` and `es` start with a small translated set and grow over time; until a key is translated it falls back to English.

## Rollout/Rollback

Gated entirely behind the existing `LOCAL-3191.B2B_multi_language` feature flag (declared in `apps/storefront/src/utils/featureFlags.ts`). With the flag off, `LangProvider` resolves to `en` and the old behavior is preserved. Rollback is flipping the flag; no DB or schema changes.

## Testing
- [x] Unit tests
- [x] Manual testing

__Important:__ I have translated just a few phrases in `fr.json` and `es.json`, when we get more phrases translated, all static strings in b2b portal will be translated. 
**Case 1**: phrases uploaded by merchant used for the main locale

```
VARIABLE,DEFAULT_VALUE,CUSTOM_VALUE
login.loginText.forgotPasswordText,Forgot your password?,CUSTOM_FORGOT_PASSWORD_PHRASE
login.loginText.signInHeader,Sign in,CUSTOM_SIGN_IN
```
`/fr#/login`
FR locale set as default, all custom translations are visible on this page. 
<img width="3024" height="1738" alt="image" src="https://github.com/user-attachments/assets/be5771a0-7371-4832-aad5-6fdbbedcb16c" />
*Notice:* Right now we do not pre-translate strings for default locale, this will be addressed in next PRs. Task created in jira. 



**Case 2**: pre-translated dictionaries used on the additional languages
`/es#/login`

In `es.json` we have just a few pre-translated phrases. In the next PRs we will deliver more translated phrases in `es.json` 
<img width="3010" height="1738" alt="image" src="https://github.com/user-attachments/assets/67d35a1a-d535-48c9-bad0-b19eccb29656" />


**Case 3**: English phrases
`/#/login`

<img width="3014" height="1752" alt="image" src="https://github.com/user-attachments/assets/7afe7c42-8b90-4355-acff-22b9ea6ced75" />

**Case 3**: Ukrainian phrases
`/uk#/login`
Ukrainian language is not supported, thats why we fallback to the main context and show english + customized phrases
<img width="3008" height="1740" alt="image" src="https://github.com/user-attachments/assets/b8f69b6c-b0e0-4b50-b05f-5c499930cc14" />


**Case 4**: Fr locale is additional and en is main one
`/fr#/login`

<img width="3024" height="1740" alt="image" src="https://github.com/user-attachments/assets/70fd6e3c-f08b-4421-96f5-598032dfbb1e" />

`/fr/account.php?action=order_status#/orders`
<img width="2988" height="1746" alt="image" src="https://github.com/user-attachments/assets/f7a6796e-8ba6-4dd7-97b5-df1935a2bce6" />


**Case 5**: en locale is a main one, all customizations are visible
`/#/login`

<img width="3000" height="1740" alt="image" src="https://github.com/user-attachments/assets/74ea32c1-2033-4dc9-a00b-f1877d6584d3" />


**Case 6**: fr locale, disabled experiment
`/#/login`
<img width="3014" height="1748" alt="image" src="https://github.com/user-attachments/assets/68a795bb-1276-4e51-8b24-91bb159f52c3" />



[LOCAL-3323]: https://bigcommercecloud.atlassian.net/browse/LOCAL-3323?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ