### PR TITLE
feat(shopping-lists): BACK-691 add backorder display to shopping list

### DIFF
--- a/apps/storefront/src/lib/lang/locales/en.json
+++ b/apps/storefront/src/lib/lang/locales/en.json
@@ -513,6 +513,7 @@
   "shoppingList.quantityTextField.maxQuantity": "Max is {maxQuantity}",
   "shoppingList.table.total": "Total",
   "shoppingList.table.totalProductCount": "{quantity} products",
+  "shoppingList.table.totalProductCountWithPrice": "{quantity} products ({price})",
   "shoppingList.table.itemsPerPage": "Items per page",
   "shoppingList.table.noProductsFound": "No products found",
   "shoppingList.shoppingDetailCard.price": "Price: {price}",

--- a/apps/storefront/src/pages/ShoppingListDetails/components/ShoppingDetailCard.tsx
+++ b/apps/storefront/src/pages/ShoppingListDetails/components/ShoppingDetailCard.tsx
@@ -2,11 +2,14 @@ import { ReactElement } from 'react';
 import { Delete, Edit, StickyNote2 } from '@mui/icons-material';
 import { Box, CardContent, styled, TextField, Typography } from '@mui/material';
 
+import BackorderMessage from '@/components/BackorderMessage';
 import { PRODUCT_DEFAULT_IMAGE } from '@/constants';
 import { useB3Lang } from '@/lib/lang';
+import type { CatalogQuickVariantSku } from '@/shared/service/b2b/graphql/product';
 import b2bGetVariantImageByVariantInfo from '@/utils/b2bGetVariantImageByVariantInfo';
 import { currencyFormat } from '@/utils/b3CurrencyFormat';
 import { getBCPrice } from '@/utils/b3Product/b3Product';
+import { getCatalogProductRowDisplayState } from '@/utils/catalogBackorderDisplay';
 
 import { getProductOptionsFields } from '../../../utils/b3Product/shared/config';
 
@@ -26,6 +29,9 @@ interface ShoppingDetailCardProps {
   setNotes: (value: string) => void;
   showPrice: (price: string, row: CustomFieldItems) => string | number;
   b2bAndBcShoppingListActionsPermissions: boolean;
+  inventoryBySku?: Record<string, CatalogQuickVariantSku>;
+  backorderUiEnabled?: boolean;
+  showBackorderDetails?: boolean;
 }
 
 const StyledImage = styled('img')(() => ({
@@ -52,6 +58,9 @@ function ShoppingDetailCard(props: ShoppingDetailCardProps) {
     setNotes,
     showPrice,
     b2bAndBcShoppingListActionsPermissions,
+    inventoryBySku = {},
+    backorderUiEnabled = false,
+    showBackorderDetails = false,
   } = props;
 
   const {
@@ -89,6 +98,15 @@ function ShoppingDetailCard(props: ShoppingDetailCardProps) {
 
   const currentImage =
     b2bGetVariantImageByVariantInfo(currentVariants, { variantId, variantSku }) || primaryImage;
+
+  const inventoryRow = inventoryBySku[variantSku?.toUpperCase()];
+  const { backorderFields } = getCatalogProductRowDisplayState({
+    qty: Number(quantity) || 0,
+    showAvailableToSellHelper: false,
+    inventoryRow,
+    backorderUiEnabled,
+    formatOnlyAvailable: () => '',
+  });
 
   return (
     <Box
@@ -214,6 +232,16 @@ function ShoppingDetailCard(props: ShoppingDetailCardProps) {
               handleUpdateShoppingListItem(itemId);
             }}
           />
+          {backorderFields && (
+            <Box sx={{ mt: -0.5, mb: 1, width: '100%' }}>
+              <BackorderMessage
+                totalOnHand={backorderFields.totalOnHand}
+                quantityBackordered={backorderFields.quantityBackordered}
+                backorderMessage={backorderFields.backorderMessage}
+                visible={showBackorderDetails}
+              />
+            </Box>
+          )}
           <Typography
             sx={{
               color: '#212121',

--- a/apps/storefront/src/pages/ShoppingListDetails/components/ShoppingDetailTable.tsx
+++ b/apps/storefront/src/pages/ShoppingListDetails/components/ShoppingDetailTable.tsx
@@ -3,15 +3,18 @@ import {
   forwardRef,
   Ref,
   SetStateAction,
+  useCallback,
   useEffect,
   useImperativeHandle,
+  useMemo,
   useRef,
   useState,
 } from 'react';
 import { Delete, Edit, StickyNote2 } from '@mui/icons-material';
-import { Box, Grid, styled, TextField, Typography } from '@mui/material';
+import { Box, FormControlLabel, Grid, styled, Switch, TextField, Typography } from '@mui/material';
 import cloneDeep from 'lodash-es/cloneDeep';
 
+import BackorderMessage from '@/components/BackorderMessage';
 import {
   B3PaginationTable,
   GetRequestList,
@@ -19,16 +22,25 @@ import {
 } from '@/components/table/B3PaginationTable';
 import { TableColumnItem } from '@/components/table/B3Table';
 import { PRODUCT_DEFAULT_IMAGE } from '@/constants';
+import { useBackorderStorefrontMessaging } from '@/hooks/useBackorderStorefrontMessaging';
 import { useMobile } from '@/hooks/useMobile';
 import { useSort } from '@/hooks/useSort';
 import { useB3Lang } from '@/lib/lang';
 import { updateB2BShoppingListsItem, updateBcShoppingListsItem } from '@/shared/service/b2b';
+import {
+  type CatalogQuickVariantSku,
+  getVariantInfoBySkus,
+} from '@/shared/service/b2b/graphql/product';
 import { rolePermissionSelector, useAppSelector } from '@/store';
 import b2bGetVariantImageByVariantInfo from '@/utils/b2bGetVariantImageByVariantInfo';
 import { currencyFormat } from '@/utils/b3CurrencyFormat';
 import { getBCPrice, getDisplayPrice, getValidOptionsList } from '@/utils/b3Product/b3Product';
 import { getProductOptionsFields, ProductsProps } from '@/utils/b3Product/shared/config';
 import { snackbar } from '@/utils/b3Tip';
+import {
+  catalogListHasBackorderedItemsForDisplay,
+  getCatalogProductRowDisplayState,
+} from '@/utils/catalogBackorderDisplay';
 
 import B3FilterSearch from '../../../components/filter/B3FilterSearch';
 
@@ -94,7 +106,9 @@ interface SearchProps {
 
 interface PaginationTableRefProps extends HTMLInputElement {
   getList: () => void;
+  getCacheList: () => ListItemProps[];
   setList: (items?: ListItemProps[]) => void;
+  setCacheAllList: (items?: ListItemProps[]) => void;
   getSelectedValue: () => void;
   refresh: (type?: TableRefreshConfig) => void;
 }
@@ -195,8 +209,102 @@ function ShoppingDetailTable(props: ShoppingDetailTableProps, ref: Ref<unknown>)
   const [disabledSelectAll, setDisabledSelectAll] = useState<boolean>(false);
 
   const [priceHidden, setPriceHidden] = useState<boolean>(false);
+  const [variantInfoList, setVariantInfoList] = useState<CatalogQuickVariantSku[]>([]);
+  const fetchedInventorySkusRef = useRef<Set<string>>(new Set());
+  const [showBackorderDetails, setShowBackorderDetails] = useState(false);
+  const [tableDataVersion, setTableDataVersion] = useState(0);
 
   const [handleSetOrderBy, order, orderBy] = useSort(sortKeys, defaultSortKey, search, setSearch);
+
+  const {
+    isBackorderMessagingContextEnabled,
+    isBackorderMessagingEnabled,
+    hasAnyBackorderDisplay,
+  } = useBackorderStorefrontMessaging();
+  const backorderUiEnabled = isBackorderMessagingContextEnabled && hasAnyBackorderDisplay;
+
+  const inventoryBySku = useMemo(() => {
+    const map: Record<string, CatalogQuickVariantSku> = {};
+    variantInfoList.forEach((row) => {
+      if (row.variantSku) {
+        map[row.variantSku.toUpperCase()] = row;
+      }
+    });
+    return map;
+  }, [variantInfoList]);
+
+  const fetchInventoryForSkus = useCallback(
+    async (skus: string[]) => {
+      if (!backorderUiEnabled || skus.length === 0) return;
+
+      const existingSkus = fetchedInventorySkusRef.current;
+
+      const newSkus = [...new Set(skus.map((sku) => sku.toUpperCase()))].filter(
+        (sku) => !existingSkus.has(sku),
+      );
+
+      if (newSkus.length === 0) return;
+
+      newSkus.forEach((sku) => existingSkus.add(sku));
+
+      try {
+        const { variantSku: nextVariantInfoList = [] } = await getVariantInfoBySkus(newSkus);
+        setVariantInfoList((prev) => [...prev, ...nextVariantInfoList]);
+      } catch {
+        newSkus.forEach((sku) => existingSkus.delete(sku));
+        // Inventory fetch failure should not block the product list
+      }
+    },
+    [backorderUiEnabled],
+  );
+
+  const hasBackorderedItems = useMemo(() => {
+    if (!isBackorderMessagingEnabled) {
+      return false;
+    }
+
+    const cacheList: ListItemProps[] = paginationTableRef.current?.getCacheList() || [];
+    const items = cacheList.map(({ node }) => ({
+      qty: Number(node.quantity) || 0,
+      variantSku: node.variantSku,
+    }));
+
+    return catalogListHasBackorderedItemsForDisplay(items, inventoryBySku);
+    // tableDataVersion drives re-evaluation when list or qty changes
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [inventoryBySku, isBackorderMessagingEnabled, tableDataVersion]);
+
+  const showBackorderToggle = backorderUiEnabled && hasBackorderedItems;
+
+  const productCountTitle = priceHidden
+    ? b3Lang('shoppingList.table.totalProductCount', {
+        quantity: shoppingListInfo?.products?.totalCount || 0,
+      })
+    : b3Lang('shoppingList.table.totalProductCountWithPrice', {
+        quantity: shoppingListInfo?.products?.totalCount || 0,
+        price: currencyFormat(shoppingListTotalPrice || 0.0),
+      });
+
+  const getListWithInventory = useCallback(
+    async (params: SearchProps) => {
+      const result = await getShoppingListDetails(params);
+      const listProducts = result?.edges as ListItemProps[] | undefined;
+
+      if (backorderUiEnabled && listProducts?.length) {
+        const skus = listProducts
+          .map((item) => item.node.variantSku)
+          .filter((sku): sku is string => Boolean(sku));
+        fetchInventoryForSkus(skus).catch(() => {
+          // Inventory fetch failure should not block the product list
+        });
+      }
+
+      setTableDataVersion((version) => version + 1);
+
+      return result;
+    },
+    [backorderUiEnabled, fetchInventoryForSkus, getShoppingListDetails],
+  );
 
   const handleUpdateProductQty = (id: number | string, value: number | string) => {
     if (Number(value) < 0) return;
@@ -210,7 +318,17 @@ function ShoppingDetailTable(props: ShoppingDetailTableProps, ref: Ref<unknown>)
     setQtyNotChangeFlag(Number(currentQty) === Number(value));
 
     const listItems: ListItemProps[] = paginationTableRef.current?.getList() || [];
+    const listCacheItems: ListItemProps[] = paginationTableRef.current?.getCacheList() || [];
     const newListItems = listItems?.map((item: ListItemProps) => {
+      const { node } = item;
+      if (node?.id === id) {
+        node.quantity = `${Number(value)}`;
+        node.disableCurrentCheckbox = Number(value) === 0;
+      }
+
+      return item;
+    });
+    const newListCacheItems = listCacheItems?.map((item: ListItemProps) => {
       const { node } = item;
       if (node?.id === id) {
         node.quantity = `${Number(value)}`;
@@ -225,6 +343,8 @@ function ShoppingDetailTable(props: ShoppingDetailTableProps, ref: Ref<unknown>)
     );
     setDisabledSelectAll(nonNumberProducts.length === newListItems.length);
     paginationTableRef.current?.setList([...newListItems]);
+    paginationTableRef.current?.setCacheAllList([...newListCacheItems]);
+    setTableDataVersion((version) => version + 1);
   };
 
   const initSearch = (type?: TableRefreshConfig) => {
@@ -538,31 +658,61 @@ function ShoppingDetailTable(props: ShoppingDetailTableProps, ref: Ref<unknown>)
     {
       key: 'Qty',
       title: b3Lang('shoppingList.table.quantity'),
-      render: (row) => (
-        <StyledTextField
-          size="small"
-          type="number"
-          variant="filled"
-          sx={{
-            width: '72px',
-          }}
-          disabled={
-            b2bAndBcShoppingListActionsPermissions ? isReadForApprove || isJuniorApprove : true
-          }
-          value={row.quantity}
-          inputProps={{
-            inputMode: 'numeric',
-            pattern: '[0-9]*',
-          }}
-          onChange={(e) => {
-            handleUpdateProductQty(row.id, e.target.value);
-          }}
-          onBlur={() => {
-            handleUpdateShoppingListItemQty(row.itemId);
-          }}
-        />
-      ),
-      width: '15%',
+      render: (row) => {
+        const inventoryRow = inventoryBySku[row.variantSku?.toUpperCase()];
+        const { backorderFields } = getCatalogProductRowDisplayState({
+          qty: Number(row.quantity) || 0,
+          showAvailableToSellHelper: false,
+          inventoryRow,
+          backorderUiEnabled,
+          formatOnlyAvailable: () => '',
+        });
+
+        return (
+          <Box
+            sx={{
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'flex-end',
+              width: '100%',
+            }}
+          >
+            <StyledTextField
+              size="small"
+              type="number"
+              variant="filled"
+              sx={{
+                width: '72px',
+              }}
+              disabled={
+                b2bAndBcShoppingListActionsPermissions ? isReadForApprove || isJuniorApprove : true
+              }
+              value={row.quantity}
+              inputProps={{
+                inputMode: 'numeric',
+                pattern: '[0-9]*',
+              }}
+              onChange={(e) => {
+                handleUpdateProductQty(row.id, e.target.value);
+              }}
+              onBlur={() => {
+                handleUpdateShoppingListItemQty(row.itemId);
+              }}
+            />
+            {backorderFields && (
+              <Box sx={{ mt: 1, width: '100%', textAlign: 'right' }}>
+                <BackorderMessage
+                  totalOnHand={backorderFields.totalOnHand}
+                  quantityBackordered={backorderFields.quantityBackordered}
+                  backorderMessage={backorderFields.backorderMessage}
+                  visible={showBackorderDetails}
+                />
+              </Box>
+            )}
+          </Box>
+        );
+      },
+      width: backorderUiEnabled ? '18%' : '15%',
       style: {
         textAlign: 'right',
       },
@@ -714,17 +864,21 @@ function ShoppingDetailTable(props: ShoppingDetailTableProps, ref: Ref<unknown>)
             fontSize: '24px',
           }}
         >
-          {b3Lang('shoppingList.table.totalProductCount', {
-            quantity: shoppingListInfo?.products?.totalCount || 0,
-          })}
+          {productCountTitle}
         </Typography>
-        <Typography
-          sx={{
-            fontSize: '24px',
-          }}
-        >
-          {priceHidden ? '' : currencyFormat(shoppingListTotalPrice || 0.0)}
-        </Typography>
+        {showBackorderToggle && (
+          <FormControlLabel
+            control={
+              <Switch
+                checked={showBackorderDetails}
+                onChange={(e) => setShowBackorderDetails(e.target.checked)}
+              />
+            }
+            label={b3Lang('quoteDetail.table.backorderDetails')}
+            labelPlacement="start"
+            sx={{ mr: 0, gap: '0.5rem', flexShrink: 0 }}
+          />
+        )}
       </Box>
       <Box
         sx={{
@@ -743,7 +897,7 @@ function ShoppingDetailTable(props: ShoppingDetailTableProps, ref: Ref<unknown>)
         ref={paginationTableRef}
         columnItems={columnItems}
         rowsPerPageOptions={[10, 20, 50]}
-        getRequestList={getShoppingListDetails}
+        getRequestList={getListWithInventory}
         searchParams={search}
         isCustomRender={false}
         showCheckbox
@@ -783,6 +937,9 @@ function ShoppingDetailTable(props: ShoppingDetailTableProps, ref: Ref<unknown>)
             handleUpdateShoppingListItem={handleUpdateShoppingListItemQty}
             isReadForApprove={isReadForApprove || isJuniorApprove}
             b2bAndBcShoppingListActionsPermissions={b2bAndBcShoppingListActionsPermissions}
+            inventoryBySku={inventoryBySku}
+            backorderUiEnabled={backorderUiEnabled}
+            showBackorderDetails={showBackorderDetails}
           />
         )}
       />

--- a/apps/storefront/src/pages/ShoppingListDetails/index.test.tsx
+++ b/apps/storefront/src/pages/ShoppingListDetails/index.test.tsx
@@ -399,12 +399,8 @@ it('displays a summary of products within the shopping list', async () => {
 
   await waitForElementToBeRemoved(() => screen.queryByText(/loading/i));
 
-  expect(screen.getByText('2 products')).toBeVisible();
-
-  // This is a workaround for the fact that the total price is not immediately available.
-  // The price is set after a useEffect and can fail during tests.
   await waitFor(() => {
-    expect(screen.getByText('$460.00')).toBeVisible();
+    expect(screen.getByText(/2 products \(\$460\.00\)/)).toBeVisible();
   });
 
   expect(screen.getByRole('row', { name: /Lovely socks/ })).toBeVisible();
@@ -2157,7 +2153,8 @@ describe('when backend validation is enabled', () => {
 
     await waitForElementToBeRemoved(() => screen.queryByText(/loading/i));
 
-    await userEvent.click(screen.getAllByRole('checkbox')[0]); // select-all checkbox
+    const table = screen.getByRole('table');
+    await userEvent.click(within(table).getAllByRole('checkbox')[0]); // select-all checkbox
 
     await userEvent.click(screen.getByRole('button', { name: /Add selected to/ }));
 
@@ -2283,7 +2280,8 @@ describe('when backend validation is enabled', () => {
       expect.stringContaining('productIds: [73737]'),
     );
 
-    await userEvent.click(screen.getAllByRole('checkbox')[0]); // select-all checkbox
+    const table = screen.getByRole('table');
+    await userEvent.click(within(table).getAllByRole('checkbox')[0]); // select-all checkbox
 
     await userEvent.click(screen.getByRole('button', { name: /Add selected to/ }));
 
@@ -2397,7 +2395,8 @@ describe('when backend validation is enabled', () => {
 
     await waitForElementToBeRemoved(() => screen.queryByText(/loading/i));
 
-    await userEvent.click(screen.getAllByRole('checkbox')[0]); // select-all checkbox
+    const table = screen.getByRole('table');
+    await userEvent.click(within(table).getAllByRole('checkbox')[0]); // select-all checkbox
 
     await userEvent.click(screen.getByRole('button', { name: /Add selected to/ }));
 
@@ -2512,7 +2511,8 @@ describe('when backend validation is enabled', () => {
 
     await waitForElementToBeRemoved(() => screen.queryByText(/loading/i));
 
-    await userEvent.click(screen.getAllByRole('checkbox')[0]); // select-all checkbox
+    const table = screen.getByRole('table');
+    await userEvent.click(within(table).getAllByRole('checkbox')[0]); // select-all checkbox
 
     await userEvent.click(screen.getByRole('button', { name: /Add selected to/ }));
 
@@ -2626,7 +2626,8 @@ describe('when backend validation is enabled', () => {
 
     await waitForElementToBeRemoved(() => screen.queryByText(/loading/i));
 
-    await userEvent.click(screen.getAllByRole('checkbox')[0]); // select-all checkbox
+    const table = screen.getByRole('table');
+    await userEvent.click(within(table).getAllByRole('checkbox')[0]); // select-all checkbox
 
     await userEvent.click(screen.getByRole('button', { name: /Add selected to/ }));
 
@@ -2864,7 +2865,8 @@ describe('when backend validation is enabled', () => {
 
     await waitForElementToBeRemoved(() => screen.queryByText(/loading/i));
 
-    await userEvent.click(screen.getAllByRole('checkbox')[0]); // select-all checkbox
+    const table = screen.getByRole('table');
+    await userEvent.click(within(table).getAllByRole('checkbox')[0]); // select-all checkbox
 
     await userEvent.click(screen.getByRole('button', { name: /Add selected to/ }));
     await userEvent.click(screen.getByRole('menuitem', { name: /Add selected to cart/ }));
@@ -2998,7 +3000,8 @@ describe('when backend validation is enabled', () => {
 
     await waitForElementToBeRemoved(() => screen.queryByText(/loading/i));
 
-    await userEvent.click(screen.getAllByRole('checkbox')[0]); // select-all checkbox
+    const table = screen.getByRole('table');
+    await userEvent.click(within(table).getAllByRole('checkbox')[0]); // select-all checkbox
 
     await userEvent.click(screen.getByRole('button', { name: /Add selected to/ }));
     await userEvent.click(screen.getByRole('menuitem', { name: /Add selected to cart/ }));
@@ -3128,7 +3131,8 @@ describe('when backend validation is enabled', () => {
 
     await waitForElementToBeRemoved(() => screen.queryByText(/loading/i));
 
-    await userEvent.click(screen.getAllByRole('checkbox')[0]); // select-all checkbox
+    const table = screen.getByRole('table');
+    await userEvent.click(within(table).getAllByRole('checkbox')[0]); // select-all checkbox
 
     await userEvent.click(screen.getByRole('button', { name: /Add selected to/ }));
     await userEvent.click(screen.getByRole('menuitem', { name: /Add selected to cart/ }));
@@ -3224,7 +3228,8 @@ describe('when backend validation is enabled', () => {
 
     await waitForElementToBeRemoved(() => screen.queryByText(/loading/i));
 
-    await userEvent.click(screen.getAllByRole('checkbox')[0]); // select-all checkbox
+    const table = screen.getByRole('table');
+    await userEvent.click(within(table).getAllByRole('checkbox')[0]); // select-all checkbox
 
     await userEvent.click(screen.getByRole('button', { name: /Add selected to/ }));
     await userEvent.click(screen.getByRole('menuitem', { name: /Add selected to cart/ }));
@@ -3323,7 +3328,8 @@ describe('when backend validation is enabled', () => {
 
     await waitForElementToBeRemoved(() => screen.queryByText(/loading/i));
 
-    await userEvent.click(screen.getAllByRole('checkbox')[0]); // select-all checkbox
+    const table = screen.getByRole('table');
+    await userEvent.click(within(table).getAllByRole('checkbox')[0]); // select-all checkbox
 
     await userEvent.click(screen.getByRole('button', { name: /Add selected to/ }));
     await userEvent.click(screen.getByRole('menuitem', { name: /Add selected to cart/ }));
@@ -3386,7 +3392,8 @@ describe('when backend validation is enabled', () => {
 
     await waitForElementToBeRemoved(() => screen.queryByText(/loading/i));
 
-    await userEvent.click(screen.getAllByRole('checkbox')[0]); // select-all checkbox
+    const table = screen.getByRole('table');
+    await userEvent.click(within(table).getAllByRole('checkbox')[0]); // select-all checkbox
 
     await userEvent.click(screen.getByRole('button', { name: /Add selected to/ }));
     await userEvent.click(screen.getByRole('menuitem', { name: /Add selected to cart/ }));
@@ -3397,5 +3404,257 @@ describe('when backend validation is enabled', () => {
       within(dialog).getByText('1 product(s) were not added to cart, please change the quantity'),
     ).toBeVisible();
     expect(within(dialog).getByText('Happy Product')).toBeVisible();
+  });
+});
+
+describe('when backorder messaging is enabled on shopping list products', () => {
+  const variantSku = 'SL-BO-123';
+
+  const backorderPreloadedState = {
+    company: b2bCompanyWithShoppingListPermissions,
+    global: buildGlobalStateWith({
+      backorderEnabled: true,
+      backorderDisplaySettings: {
+        showQuantityOnBackorder: true,
+        showQuantityOnHand: true,
+        showBackorderMessage: true,
+        showDefaultShippingExpectationPrompt: false,
+        defaultShippingExpectationPrompt: '',
+      },
+      featureFlags: {
+        'BACK-134.backorders_phase_1_1_control_messaging_on_storefront': true,
+      },
+    }),
+  };
+
+  const setupShoppingListTable = ({
+    totalOnHand = 2,
+    availableToSell = 4,
+    backorderMessage = 'Lead time: 2-4 weeks',
+    inventoryFetchFails = false,
+  }: {
+    totalOnHand?: number;
+    availableToSell?: number;
+    backorderMessage?: string;
+    inventoryFetchFails?: boolean;
+  } = {}) => {
+    vitest.mocked(useParams).mockReturnValue({ id: '272989' });
+
+    const productEdge = buildShoppingListProductEdgeWith({
+      node: {
+        productName: 'Bistro Pro Literide Clog',
+        productId: 73737,
+        variantSku,
+        quantity: 1,
+        basePrice: '100',
+      },
+    });
+
+    const shoppingListResponse = buildShoppingListGraphQLResponseWith({
+      data: {
+        shoppingList: {
+          products: { totalCount: 1, edges: [productEdge] },
+          status: 0,
+          grandTotal: '100',
+          totalTax: '0',
+        },
+      },
+    });
+
+    const variantInfo = buildVariantInfoWith({
+      variantSku,
+      inventoryTracking: 'variant',
+      availableToSell,
+      unlimitedBackorder: false,
+      totalOnHand,
+      backorderMessage,
+    });
+
+    const getVariantInfoBySkus = when(vi.fn())
+      .calledWith(expect.stringContaining(`variantSkus: ["${variantSku}"]`))
+      .thenReturn(buildVariantInfoResponseWith({ data: { variantSku: [variantInfo] } }));
+
+    server.use(
+      graphql.query('B2BShoppingListDetails', () => HttpResponse.json(shoppingListResponse)),
+      graphql.query('SearchProducts', () =>
+        HttpResponse.json(buildSearchProductsResponseWith({ data: { productsSearch: [] } })),
+      ),
+      graphql.query('GetVariantInfoBySkus', ({ query }) =>
+        inventoryFetchFails ? HttpResponse.error() : HttpResponse.json(getVariantInfoBySkus(query)),
+      ),
+    );
+  };
+
+  it('shows backorder lines when toggle is on and qty exceeds on hand', async () => {
+    setupShoppingListTable();
+
+    renderWithProviders(<ShoppingListDetailsContent setOpenPage={() => {}} />, {
+      preloadedState: backorderPreloadedState,
+    });
+
+    await waitForElementToBeRemoved(() => screen.queryByText(/loading/i));
+
+    expect(await screen.findByText('Bistro Pro Literide Clog')).toBeInTheDocument();
+
+    const table = screen.getByRole('table');
+    const quantityInput = within(table).getByRole('spinbutton');
+
+    await userEvent.type(quantityInput, '10', {
+      initialSelectionStart: 0,
+      initialSelectionEnd: Infinity,
+    });
+
+    const backorderToggle = await screen.findByRole('checkbox', { name: /Backorder details/i });
+    await userEvent.click(backorderToggle);
+
+    await waitFor(() => {
+      expect(screen.getByText('2 ready to ship')).toBeVisible();
+    });
+    expect(screen.getByText('2 will be backordered')).toBeVisible();
+    expect(screen.getByText('Lead time: 2-4 weeks')).toBeVisible();
+  });
+
+  it('hides backorder lines when toggle is off', async () => {
+    setupShoppingListTable();
+
+    renderWithProviders(<ShoppingListDetailsContent setOpenPage={() => {}} />, {
+      preloadedState: backorderPreloadedState,
+    });
+
+    await waitForElementToBeRemoved(() => screen.queryByText(/loading/i));
+
+    expect(await screen.findByText('Bistro Pro Literide Clog')).toBeInTheDocument();
+
+    const table = screen.getByRole('table');
+    const quantityInput = within(table).getByRole('spinbutton');
+
+    await userEvent.type(quantityInput, '10', {
+      initialSelectionStart: 0,
+      initialSelectionEnd: Infinity,
+    });
+
+    await screen.findByRole('checkbox', { name: /Backorder details/i });
+
+    expect(screen.queryByText('2 ready to ship')).not.toBeInTheDocument();
+    expect(screen.queryByText('2 will be backordered')).not.toBeInTheDocument();
+    expect(screen.queryByText('Lead time: 2-4 weeks')).not.toBeInTheDocument();
+  });
+
+  it('hides backorder toggle and lines when qty is within on hand', async () => {
+    setupShoppingListTable({ totalOnHand: 9, availableToSell: 10 });
+
+    renderWithProviders(<ShoppingListDetailsContent setOpenPage={() => {}} />, {
+      preloadedState: backorderPreloadedState,
+    });
+
+    await waitForElementToBeRemoved(() => screen.queryByText(/loading/i));
+
+    expect(await screen.findByText('Bistro Pro Literide Clog')).toBeInTheDocument();
+
+    const table = screen.getByRole('table');
+    const quantityInput = within(table).getByRole('spinbutton');
+
+    await userEvent.type(quantityInput, '2', {
+      initialSelectionStart: 0,
+      initialSelectionEnd: Infinity,
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole('checkbox', { name: /Backorder details/i }),
+      ).not.toBeInTheDocument();
+    });
+    expect(screen.queryByText('will be backordered', { exact: false })).not.toBeInTheDocument();
+  });
+
+  it('hides backorder toggle and lines when messaging is disabled', async () => {
+    setupShoppingListTable();
+
+    renderWithProviders(<ShoppingListDetailsContent setOpenPage={() => {}} />, {
+      preloadedState: { company: b2bCompanyWithShoppingListPermissions },
+    });
+
+    await waitForElementToBeRemoved(() => screen.queryByText(/loading/i));
+
+    expect(await screen.findByText('Bistro Pro Literide Clog')).toBeInTheDocument();
+
+    const table = screen.getByRole('table');
+    const quantityInput = within(table).getByRole('spinbutton');
+
+    await userEvent.type(quantityInput, '10', {
+      initialSelectionStart: 0,
+      initialSelectionEnd: Infinity,
+    });
+
+    expect(screen.queryByRole('checkbox', { name: /Backorder details/i })).not.toBeInTheDocument();
+    expect(screen.queryByText('will be backordered', { exact: false })).not.toBeInTheDocument();
+  });
+
+  it('still shows shopping list products without backorder UI when inventory fetch fails', async () => {
+    setupShoppingListTable({ inventoryFetchFails: true });
+
+    renderWithProviders(<ShoppingListDetailsContent setOpenPage={() => {}} />, {
+      preloadedState: backorderPreloadedState,
+    });
+
+    await waitForElementToBeRemoved(() => screen.queryByText(/loading/i));
+
+    expect(await screen.findByText('Bistro Pro Literide Clog')).toBeInTheDocument();
+
+    const table = screen.getByRole('table');
+    const quantityInput = within(table).getByRole('spinbutton');
+
+    await userEvent.type(quantityInput, '10', {
+      initialSelectionStart: 0,
+      initialSelectionEnd: Infinity,
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole('checkbox', { name: /Backorder details/i }),
+      ).not.toBeInTheDocument();
+    });
+    expect(screen.queryByText('will be backordered', { exact: false })).not.toBeInTheDocument();
+  });
+
+  describe('on mobile', () => {
+    beforeEach(() => {
+      vi.spyOn(document.body, 'clientWidth', 'get').mockReturnValue(500);
+    });
+
+    it('shows backorder lines in the card view when toggle is on and qty exceeds on hand', async () => {
+      setupShoppingListTable();
+
+      renderWithProviders(<ShoppingListDetailsContent setOpenPage={() => {}} />, {
+        preloadedState: backorderPreloadedState,
+      });
+
+      await waitForElementToBeRemoved(() => screen.queryByText(/loading/i));
+
+      expect(await screen.findByText('Bistro Pro Literide Clog')).toBeInTheDocument();
+
+      await waitFor(() => {
+        expect(screen.queryByRole('table')).not.toBeInTheDocument();
+      });
+
+      const productCard = screen
+        .getByText('Bistro Pro Literide Clog')
+        .closest('.MuiCardContent-root');
+      const quantityInput = within(productCard as HTMLElement).getByRole('spinbutton');
+
+      await userEvent.type(quantityInput, '10', {
+        initialSelectionStart: 0,
+        initialSelectionEnd: Infinity,
+      });
+
+      const backorderToggle = await screen.findByRole('checkbox', { name: /Backorder details/i });
+      await userEvent.click(backorderToggle);
+
+      await waitFor(() => {
+        expect(screen.getByText('2 ready to ship')).toBeVisible();
+      });
+      expect(screen.getByText('2 will be backordered')).toBeVisible();
+      expect(screen.getByText('Lead time: 2-4 weeks')).toBeVisible();
+    });
   });
 });


### PR DESCRIPTION
Jira: [BACK-691](https://bigcommercecloud.atlassian.net/browse/BACK-691)

## What/Why?
Adding backorder display lines + toggle to the quick order purchased products table.

>[!NOTE]
>Additionally changing header to display price as `N products ($XX.XX)`, rather than having displaying price in the top right of the card.

## Rollout/Rollback
Merge/revert. Backorder display is gated by `Feature_Backorder && BACK-134.backorders_phase_1_1_control_messaging_on_storefront`.

## Testing
Backorder appears/disappears with backordered quantities and toggle. Quantities update and do not exceed stock.

https://github.com/user-attachments/assets/09c3c30a-652c-4d69-bd7d-de5f47717fcc

Same functionality on mobile view.

https://github.com/user-attachments/assets/9ca70b41-d0e6-449e-a55d-a569c7f17b93

Backorder display does not appear for disabled `Feature_Backorder && BACK-134.backorders_phase_1_1_control_messaging_on_storefront`.

https://github.com/user-attachments/assets/ebc9ee2d-0465-4345-934d-cbaf9f4099d5

Ping @animesh1987 @benpratt77 

[BACK-691]: https://bigcommercecloud.atlassian.net/browse/BACK-691?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only storefront changes behind existing backorder feature flags; inventory fetch errors are non-blocking and patterns match quote/quick-order flows.
> 
> **Overview**
> Shopping list detail now surfaces **backorder messaging** (ready to ship, backordered qty, lead time) when storefront backorder flags and display settings allow it, aligned with quote detail behavior.
> 
> **Inventory** is loaded per variant SKU via `getVariantInfoBySkus` when the list loads; failures do not block the product table. A **Backorder details** switch appears only when at least one line has backorder display; toggling it shows or hides `BackorderMessage` under quantity in both the desktop table and mobile cards.
> 
> The list header is consolidated into one string: **`{quantity} products ({price})`** when prices are visible (new i18n key), instead of separate count and total on the right. Quantity edits keep the pagination **cache** in sync so backorder detection updates correctly.
> 
> Tests cover backorder toggle behavior, feature-flag gating, inventory fetch failure, mobile cards, and scoping select-all checkboxes to the table.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c93862349e85bab7c6073f29925fa6901439cd07. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->