### PR TITLE
feat(common): B2B-4931 Add authorisation schema and types for permissions

### DIFF
--- a/apps/storefront/src/shared/service/bc/graphql/cart.ts
+++ b/apps/storefront/src/shared/service/bc/graphql/cart.ts
@@ -6,6 +6,8 @@ import { platform } from '@/utils/basicConfig';
 
 import B3Request from '../../request/b3Fetch';
 
+import { storefrontGQLRequest } from './client';
+
 const lineItemsFragment = `lineItems {
   physicalItems {
     entityId
@@ -349,34 +351,19 @@ export const getCart = async (cartId?: string): Promise<GetCart> => {
 };
 
 export const createNewCart = (data: CreateCartInput): any =>
-  platform === 'bigcommerce'
-    ? B3Request.graphqlBC({
-        query: createCart,
-        variables: data,
-      })
-    : B3Request.graphqlBCProxy({
-        query: createCart,
-        variables: data,
-      });
+  storefrontGQLRequest({
+    query: createCart,
+    variables: data,
+  });
 
 export const addNewLineToCart = (data: any): any =>
-  platform === 'bigcommerce'
-    ? B3Request.graphqlBC({
-        query: addLineItemToCart,
-        variables: data,
-      })
-    : B3Request.graphqlBCProxy({
-        query: addLineItemToCart,
-        variables: data,
-      });
+  storefrontGQLRequest({
+    query: addLineItemToCart,
+    variables: data,
+  });
 
 export const deleteCart = (data: DeleteCartInput): any =>
-  platform === 'bigcommerce'
-    ? B3Request.graphqlBC({
-        query: deleteCartQuery,
-        variables: data,
-      })
-    : B3Request.graphqlBCProxy({
-        query: deleteCartQuery,
-        variables: data,
-      });
+  storefrontGQLRequest({
+    query: deleteCartQuery,
+    variables: data,
+  });

--- a/apps/storefront/src/shared/service/bc/graphql/client.ts
+++ b/apps/storefront/src/shared/service/bc/graphql/client.ts
@@ -2,7 +2,7 @@ import { platform } from '@/utils/basicConfig';
 
 import B3Request from '../../request/b3Fetch';
 
-export function graphqlRequest<T>(data: { query: string; variables?: object }): Promise<T> {
+export function storefrontGQLRequest<T>(data: { query: string; variables?: object }): Promise<T> {
   return platform === 'bigcommerce'
     ? B3Request.graphqlBC<T>(data)
     : B3Request.graphqlBCProxy<T>(data);

--- a/apps/storefront/src/shared/service/bc/graphql/client.ts
+++ b/apps/storefront/src/shared/service/bc/graphql/client.ts
@@ -2,7 +2,10 @@ import { platform } from '@/utils/basicConfig';
 
 import B3Request from '../../request/b3Fetch';
 
-export function storefrontGQLRequest<T>(data: { query: string; variables?: object }): Promise<T> {
+export function storefrontGQLRequest<T = any>(data: {
+  query: string;
+  variables?: object;
+}): Promise<T> {
   return platform === 'bigcommerce'
     ? B3Request.graphqlBC<T>(data)
     : B3Request.graphqlBCProxy<T>(data);

--- a/apps/storefront/src/shared/service/bc/graphql/client.ts
+++ b/apps/storefront/src/shared/service/bc/graphql/client.ts
@@ -1,0 +1,9 @@
+import { platform } from '@/utils/basicConfig';
+
+import B3Request from '../../request/b3Fetch';
+
+export function graphqlRequest<T>(data: { query: string; variables?: object }): Promise<T> {
+  return platform === 'bigcommerce'
+    ? B3Request.graphqlBC<T>(data)
+    : B3Request.graphqlBCProxy<T>(data);
+}

--- a/apps/storefront/src/shared/service/bc/graphql/company.ts
+++ b/apps/storefront/src/shared/service/bc/graphql/company.ts
@@ -1,6 +1,4 @@
-import { platform } from '@/utils/basicConfig';
-
-import B3Request from '../../request/b3Fetch';
+import { storefrontGQLRequest } from './client';
 
 /**
  * GraphQL Storefront API: Company Account Registration
@@ -98,13 +96,8 @@ export async function registerCompany(
   input: RegisterCompanyInput,
 ): Promise<RegisterCompanyMutationResponse> {
   const variables = { input };
-  return platform === 'bigcommerce'
-    ? B3Request.graphqlBC<RegisterCompanyMutationResponse>({
-        query: REGISTER_COMPANY_MUTATION,
-        variables,
-      })
-    : B3Request.graphqlBCProxy<RegisterCompanyMutationResponse>({
-        query: REGISTER_COMPANY_MUTATION,
-        variables,
-      });
+  return storefrontGQLRequest<RegisterCompanyMutationResponse>({
+    query: REGISTER_COMPANY_MUTATION,
+    variables,
+  });
 }

--- a/apps/storefront/src/shared/service/bc/graphql/currency.ts
+++ b/apps/storefront/src/shared/service/bc/graphql/currency.ts
@@ -1,6 +1,4 @@
-import { platform } from '@/utils/basicConfig';
-
-import B3Request from '../../request/b3Fetch';
+import { storefrontGQLRequest } from './client';
 
 const bcCurrencies = `query {
   site{
@@ -16,12 +14,8 @@ const bcCurrencies = `query {
 }`;
 
 const getActiveBcCurrency = () =>
-  platform === 'bigcommerce'
-    ? B3Request.graphqlBC({
-        query: bcCurrencies,
-      })
-    : B3Request.graphqlBCProxy({
-        query: bcCurrencies,
-      });
+  storefrontGQLRequest({
+    query: bcCurrencies,
+  });
 
 export default getActiveBcCurrency;

--- a/apps/storefront/src/shared/service/bc/graphql/locales.ts
+++ b/apps/storefront/src/shared/service/bc/graphql/locales.ts
@@ -1,6 +1,4 @@
-import { platform } from '@/utils/basicConfig';
-
-import B3Request from '../../request/b3Fetch';
+import { storefrontGQLRequest } from './client';
 
 interface Locale {
   code: string;
@@ -31,9 +29,6 @@ query GetLocales {
   }
 }`;
 
-const getLocales = () =>
-  platform === 'bigcommerce'
-    ? B3Request.graphqlBC<LocalesResponse>({ query: getLocalesQuery })
-    : B3Request.graphqlBCProxy<LocalesResponse>({ query: getLocalesQuery });
+const getLocales = () => storefrontGQLRequest<LocalesResponse>({ query: getLocalesQuery });
 
 export default getLocales;

--- a/apps/storefront/src/shared/service/bc/graphql/login.ts
+++ b/apps/storefront/src/shared/service/bc/graphql/login.ts
@@ -1,4 +1,3 @@
-import { platform } from '@/utils/basicConfig';
 import { mapToCompanyError } from '@/utils/companyUtils';
 
 import B3Request from '../../request/b3Fetch';
@@ -77,22 +76,16 @@ interface LoginVariables {
   password: string;
 }
 
-export const bcLogin = (variables: LoginVariables) => {
-  const query = getBcLogin();
-
-  return platform === 'bigcommerce'
-    ? B3Request.graphqlBC({ query, variables })
-    : B3Request.graphqlBCProxy({ query, variables });
-};
+export const bcLogin = (variables: LoginVariables) =>
+  storefrontGQLRequest({
+    query: getBcLogin(),
+    variables,
+  });
 
 export const bcLogoutLogin = () =>
-  platform === 'bigcommerce'
-    ? B3Request.graphqlBC({
-        query: logoutLogin(),
-      })
-    : B3Request.graphqlBCProxy({
-        query: logoutLogin(),
-      });
+  storefrontGQLRequest({
+    query: logoutLogin(),
+  });
 
 interface BCPermission {
   code: string;

--- a/apps/storefront/src/shared/service/bc/graphql/login.ts
+++ b/apps/storefront/src/shared/service/bc/graphql/login.ts
@@ -3,6 +3,8 @@ import { mapToCompanyError } from '@/utils/companyUtils';
 
 import B3Request from '../../request/b3Fetch';
 
+import { graphqlRequest } from './client';
+
 interface LoginData {
   loginData: {
     storeHash: string;
@@ -125,12 +127,6 @@ const GET_BC_AUTHORIZATION = `mutation BCAuthorization($authData: UserAuthType!)
     }
   }
 }`;
-
-function graphqlRequest<T>(data: { query: string; variables?: object }): Promise<T> {
-  return platform === 'bigcommerce'
-    ? B3Request.graphqlBC<T>(data)
-    : B3Request.graphqlBCProxy<T>(data);
-}
 
 /** @public Reserved for follow-up ticket; remove when wired into login flow. */
 export async function bcAuthorization(

--- a/apps/storefront/src/shared/service/bc/graphql/login.ts
+++ b/apps/storefront/src/shared/service/bc/graphql/login.ts
@@ -3,7 +3,7 @@ import { mapToCompanyError } from '@/utils/companyUtils';
 
 import B3Request from '../../request/b3Fetch';
 
-import { graphqlRequest } from './client';
+import { storefrontGQLRequest } from './client';
 
 interface LoginData {
   loginData: {
@@ -132,7 +132,7 @@ const GET_BC_AUTHORIZATION = `mutation BCAuthorization($authData: UserAuthType!)
 export async function bcAuthorization(
   authData: BCAuthorizationInput,
 ): Promise<BCAuthorizationResponse> {
-  return graphqlRequest<BCAuthorizationResponse>({
+  return storefrontGQLRequest<BCAuthorizationResponse>({
     query: GET_BC_AUTHORIZATION,
     variables: { authData },
   });

--- a/apps/storefront/src/shared/service/bc/graphql/login.ts
+++ b/apps/storefront/src/shared/service/bc/graphql/login.ts
@@ -91,3 +91,53 @@ export const bcLogoutLogin = () =>
     : B3Request.graphqlBCProxy({
         query: logoutLogin(),
       });
+
+interface BCPermission {
+  code: string;
+  permissionLevel: number;
+}
+
+interface BCAuthorizationInput {
+  bcToken: string;
+  channelId: number;
+}
+
+interface BCAuthorizationResponse {
+  data?: {
+    authorization?: {
+      __typename: string;
+      result?: {
+        permissions: BCPermission[];
+      };
+    };
+  };
+  errors?: Array<{ message: string }>;
+}
+
+const GET_BC_AUTHORIZATION = `mutation BCAuthorization($authData: UserAuthType!) {
+  authorization(authData: $authData) {
+    __typename
+    result {
+      permissions {
+        code
+        permissionLevel
+      }
+    }
+  }
+}`;
+
+function graphqlRequest<T>(data: { query: string; variables?: object }): Promise<T> {
+  return platform === 'bigcommerce'
+    ? B3Request.graphqlBC<T>(data)
+    : B3Request.graphqlBCProxy<T>(data);
+}
+
+/** @public Reserved for follow-up ticket; remove when wired into login flow. */
+export async function bcAuthorization(
+  authData: BCAuthorizationInput,
+): Promise<BCAuthorizationResponse> {
+  return graphqlRequest<BCAuthorizationResponse>({
+    query: GET_BC_AUTHORIZATION,
+    variables: { authData },
+  });
+}

--- a/apps/storefront/src/shared/service/bc/graphql/orders.ts
+++ b/apps/storefront/src/shared/service/bc/graphql/orders.ts
@@ -8,7 +8,7 @@
  */
 
 import type { CollectionInfo, DateTimeExtended, Money, PageInfo } from './base';
-import { graphqlRequest } from './client';
+import { storefrontGQLRequest } from './client';
 
 export type { CollectionInfo, DateTimeExtended, Money, PageInfo } from './base';
 
@@ -706,7 +706,7 @@ export async function getCompanyOrders(variables: {
   last?: number;
   before?: string;
 }): Promise<GetCompanyOrdersResponse> {
-  return graphqlRequest<GetCompanyOrdersResponse>({
+  return storefrontGQLRequest<GetCompanyOrdersResponse>({
     query: GET_COMPANY_ORDERS,
     variables,
   });
@@ -721,7 +721,7 @@ export async function getCustomerOrders(variables: {
   last?: number;
   before?: string;
 }): Promise<GetCustomerOrdersResponse> {
-  return graphqlRequest<GetCustomerOrdersResponse>({
+  return storefrontGQLRequest<GetCustomerOrdersResponse>({
     query: GET_CUSTOMER_ORDERS,
     variables,
   });
@@ -731,7 +731,7 @@ export async function getCustomerOrders(variables: {
 export async function getOrderDetail(variables: {
   entityId: number;
 }): Promise<GetOrderDetailResponse> {
-  return graphqlRequest<GetOrderDetailResponse>({
+  return storefrontGQLRequest<GetOrderDetailResponse>({
     query: GET_ORDER_DETAIL,
     variables,
   });
@@ -743,7 +743,7 @@ export async function getCustomersWithOrders(variables: {
   first?: number;
   after?: string;
 }): Promise<GetCustomersWithOrdersResponse> {
-  return graphqlRequest<GetCustomersWithOrdersResponse>({
+  return storefrontGQLRequest<GetCustomersWithOrdersResponse>({
     query: GET_CUSTOMERS_WITH_ORDERS,
     variables,
   });

--- a/apps/storefront/src/shared/service/bc/graphql/orders.ts
+++ b/apps/storefront/src/shared/service/bc/graphql/orders.ts
@@ -7,11 +7,8 @@
  * @see https://docs.bigcommerce.com/developer/api-reference/graphql/storefront/queries/node#fields.body.Order
  */
 
-import { platform } from '@/utils/basicConfig';
-
-import B3Request from '../../request/b3Fetch';
-
 import type { CollectionInfo, DateTimeExtended, Money, PageInfo } from './base';
+import { graphqlRequest } from './client';
 
 export type { CollectionInfo, DateTimeExtended, Money, PageInfo } from './base';
 
@@ -699,12 +696,6 @@ const GET_CUSTOMERS_WITH_ORDERS = `query GetCustomersWithOrders(
 // ===========================================================================
 // Service functions
 // ===========================================================================
-
-function graphqlRequest<T>(data: { query: string; variables?: object }): Promise<T> {
-  return platform === 'bigcommerce'
-    ? B3Request.graphqlBC<T>(data)
-    : B3Request.graphqlBCProxy<T>(data);
-}
 
 /** Company Orders — all orders from all company members (B2B only). */
 export async function getCompanyOrders(variables: {

--- a/apps/storefront/src/shared/service/bc/graphql/tax.ts
+++ b/apps/storefront/src/shared/service/bc/graphql/tax.ts
@@ -1,8 +1,6 @@
 import { z } from 'zod';
 
-import { platform } from '@/utils/basicConfig';
-
-import B3Request from '../../request/b3Fetch';
+import { storefrontGQLRequest } from './client';
 
 const taxDisplayTypeEnumSchema = z.enum(['INC', 'EX', 'BOTH']);
 
@@ -25,14 +23,9 @@ const queryGetTaxDisplayType = `query GetTaxDisplayType {
 }`;
 
 export const getStorefrontTaxDisplayType = async (): Promise<StorefrontTaxDisplayType> => {
-  const response =
-    platform === 'bigcommerce'
-      ? await B3Request.graphqlBC({
-          query: queryGetTaxDisplayType,
-        })
-      : await B3Request.graphqlBCProxy({
-          query: queryGetTaxDisplayType,
-        });
+  const response = await storefrontGQLRequest({
+    query: queryGetTaxDisplayType,
+  });
 
   return storefrontTaxDisplayTypeSchema.parse(response.data.site.settings.tax);
 };


### PR DESCRIPTION
Jira: [B2B-4931](https://bigcommercecloud.atlassian.net/browse/B2B-4931)

## What/Why?
Currently, permissions are fetched via two B2B API paths in src/utils/loginInfo.ts. The new BC Storefront GQL authorisation mutation will replace both.

This PR adds only the service layer: the schema, types and service function for next task 1c [B2B-4930](https://bigcommercecloud.atlassian.net/browse/B2B-4930)


## Rollout/Rollback
Haven't touched any functional code here, only define schema, types and helpers/functions. Revert if needed.

## Testing
Only schema defined, aligned which what endpoints returned
https://bigcommerce.slack.com/archives/C079AR329M2/p1779148521247129

[B2B-4931]: https://bigcommercecloud.atlassian.net/browse/B2B-4931?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[B2B-4930]: https://bigcommercecloud.atlassian.net/browse/B2B-4930?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly deduplication of request routing with no login-flow behavior change; new authorization API is unused until a later ticket.
> 
> **Overview**
> Introduces a shared **`storefrontGQLRequest`** helper that picks **direct BC GraphQL** vs **proxy** based on `platform`, and **routes existing storefront GQL callers** (cart mutations, company registration, currency, locales, login/logout, orders, tax) through it instead of repeating `platform === 'bigcommerce' ? graphqlBC : graphqlBCProxy`.
> 
> Adds an **`bcAuthorization`** Storefront GQL mutation wrapper plus **input/response types** for `permissions` (`code`, `permissionLevel`); it is **exported but not wired** into login yet (reserved for B2B-4930).
> 
> **Cart `getCart`** still uses the prior split logic (BC without `entityId` variable vs proxy with cookie `cartId`); only create/add/delete cart paths move to the shared helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a312021d1d1aa6e2bec8388cdc6e90f67e0119a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->