### PR TITLE
feat(shopping-lists): BACK-695 add backorder display to add to list

### DIFF
--- a/apps/storefront/src/hooks/useCatalogInventoryBySku.ts
+++ b/apps/storefront/src/hooks/useCatalogInventoryBySku.ts
@@ -1,0 +1,67 @@
+import { useEffect, useMemo, useState } from 'react';
+
+import {
+  type CatalogQuickVariantSku,
+  getVariantInfoBySkus,
+} from '@/shared/service/b2b/graphql/product';
+
+function buildInventoryBySkuMap(
+  variantInfoList: CatalogQuickVariantSku[],
+): Record<string, CatalogQuickVariantSku> {
+  const map: Record<string, CatalogQuickVariantSku> = {};
+
+  variantInfoList.forEach((row) => {
+    if (row.variantSku) {
+      map[row.variantSku.toUpperCase()] = row;
+    }
+  });
+
+  return map;
+}
+
+interface UseCatalogInventoryBySkuOptions {
+  isActive: boolean;
+  enabled: boolean;
+  skuDependencyKey: string;
+}
+
+export function useCatalogInventoryBySku({
+  isActive,
+  enabled,
+  skuDependencyKey,
+}: UseCatalogInventoryBySkuOptions): Record<string, CatalogQuickVariantSku> {
+  const [variantInfoList, setVariantInfoList] = useState<CatalogQuickVariantSku[]>([]);
+
+  useEffect(() => {
+    setVariantInfoList([]);
+
+    if (!isActive || !enabled || !skuDependencyKey) {
+      return () => {};
+    }
+
+    let cancelled = false;
+    const skus = skuDependencyKey.split('|');
+
+    const fetchVariantInfo = async () => {
+      try {
+        const { variantSku: nextVariantInfoList = [] } = await getVariantInfoBySkus(skus);
+
+        if (!cancelled) {
+          setVariantInfoList(nextVariantInfoList);
+        }
+      } catch {
+        if (!cancelled) {
+          setVariantInfoList([]);
+        }
+      }
+    };
+
+    fetchVariantInfo();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isActive, enabled, skuDependencyKey]);
+
+  return useMemo(() => buildInventoryBySkuMap(variantInfoList), [variantInfoList]);
+}

--- a/apps/storefront/src/pages/QuickOrder/components/ProductListDialog.tsx
+++ b/apps/storefront/src/pages/QuickOrder/components/ProductListDialog.tsx
@@ -1,12 +1,4 @@
-import {
-  ChangeEvent,
-  KeyboardEvent,
-  useCallback,
-  useContext,
-  useEffect,
-  useMemo,
-  useState,
-} from 'react';
+import { ChangeEvent, KeyboardEvent, useCallback, useContext, useMemo } from 'react';
 import { Search as SearchIcon } from '@mui/icons-material';
 import { Box, InputAdornment, TextField, Typography } from '@mui/material';
 
@@ -15,16 +7,14 @@ import { B3ProductList } from '@/components/B3ProductList';
 import CustomButton from '@/components/button/CustomButton';
 import B3Spin from '@/components/spin/B3Spin';
 import { useBackorderStorefrontMessaging } from '@/hooks/useBackorderStorefrontMessaging';
+import { useCatalogInventoryBySku } from '@/hooks/useCatalogInventoryBySku';
 import { useMobile } from '@/hooks/useMobile';
 import { useB3Lang } from '@/lib/lang';
 import { ShoppingListDetailsContext } from '@/pages/ShoppingListDetails/context/ShoppingListDetailsContext';
-import {
-  type CatalogQuickVariantSku,
-  getVariantInfoBySkus,
-} from '@/shared/service/b2b/graphql/product';
 import { useAppSelector } from '@/store';
 import { ShoppingListProductItem } from '@/types';
 import { snackbar } from '@/utils/b3Tip';
+import { buildVariantSkuDependencyKey } from '@/utils/catalogBackorderDisplay';
 
 interface ProductTableActionProps {
   product: ShoppingListProductItem;
@@ -113,64 +103,20 @@ export default function ProductListDialog(props: ProductListDialogProps) {
   const { isBackorderMessagingContextEnabled, hasAnyBackorderDisplay } =
     useBackorderStorefrontMessaging();
   const backorderUiEnabled = isBackorderMessagingContextEnabled && hasAnyBackorderDisplay;
-  const [variantInfoList, setVariantInfoList] = useState<CatalogQuickVariantSku[]>([]);
 
-  const variantSkuDependencyKey = useMemo(() => {
-    return [
-      ...new Set(
-        productList
-          .map((product) => product.variants?.[0]?.sku ?? product.sku)
-          .filter((sku): sku is string => Boolean(sku)),
+  const variantSkuDependencyKey = useMemo(
+    () =>
+      buildVariantSkuDependencyKey(
+        productList.map((product) => product.variants?.[0]?.sku ?? product.sku),
       ),
-    ]
-      .sort()
-      .join('|');
-  }, [productList]);
+    [productList],
+  );
 
-  useEffect(() => {
-    if (!isOpen) {
-      setVariantInfoList([]);
-
-      return () => {};
-    }
-
-    if (!backorderUiEnabled || !variantSkuDependencyKey) {
-      return () => {};
-    }
-
-    let cancelled = false;
-    const skus = variantSkuDependencyKey.split('|');
-
-    const fetchVariantInfo = async () => {
-      try {
-        const { variantSku: nextVariantInfoList = [] } = await getVariantInfoBySkus(skus);
-
-        if (!cancelled) {
-          setVariantInfoList(nextVariantInfoList);
-        }
-      } catch {
-        if (!cancelled) {
-          setVariantInfoList([]);
-        }
-      }
-    };
-
-    fetchVariantInfo();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [isOpen, backorderUiEnabled, variantSkuDependencyKey]);
-
-  const inventoryBySku = useMemo(() => {
-    const map: Record<string, CatalogQuickVariantSku> = {};
-    variantInfoList.forEach((row) => {
-      if (row.variantSku) {
-        map[row.variantSku.toUpperCase()] = row;
-      }
-    });
-    return map;
-  }, [variantInfoList]);
+  const inventoryBySku = useCatalogInventoryBySku({
+    isActive: isOpen,
+    enabled: backorderUiEnabled,
+    skuDependencyKey: variantSkuDependencyKey,
+  });
 
   const handleCancelClicked = () => {
     onCancel();

--- a/apps/storefront/src/pages/ShoppingListDetails/components/ProductListDialog.tsx
+++ b/apps/storefront/src/pages/ShoppingListDetails/components/ProductListDialog.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, KeyboardEvent, useCallback, useContext } from 'react';
+import { ChangeEvent, KeyboardEvent, useCallback, useContext, useMemo } from 'react';
 import { Search as SearchIcon } from '@mui/icons-material';
 import { Box, InputAdornment, TextField, Typography } from '@mui/material';
 
@@ -6,10 +6,13 @@ import B3Dialog from '@/components/B3Dialog';
 import { B3ProductList } from '@/components/B3ProductList';
 import CustomButton from '@/components/button/CustomButton';
 import B3Spin from '@/components/spin/B3Spin';
+import { useBackorderStorefrontMessaging } from '@/hooks/useBackorderStorefrontMessaging';
+import { useCatalogInventoryBySku } from '@/hooks/useCatalogInventoryBySku';
 import { useMobile } from '@/hooks/useMobile';
 import { useB3Lang } from '@/lib/lang';
 import { useAppSelector } from '@/store';
 import { snackbar } from '@/utils/b3Tip';
+import { buildVariantSkuDependencyKey } from '@/utils/catalogBackorderDisplay';
 
 import { ShoppingListProductItem } from '../../../types';
 import { ShoppingListDetailsContext } from '../context/ShoppingListDetailsContext';
@@ -103,6 +106,23 @@ export default function ProductListDialog(props: ProductListDialogProps) {
   );
 
   const [isMobile] = useMobile();
+  const { isBackorderMessagingContextEnabled, hasAnyBackorderDisplay } =
+    useBackorderStorefrontMessaging();
+  const backorderUiEnabled = isBackorderMessagingContextEnabled && hasAnyBackorderDisplay;
+
+  const variantSkuDependencyKey = useMemo(
+    () =>
+      buildVariantSkuDependencyKey(
+        productList.map((product) => product.variants?.[0]?.sku ?? product.sku),
+      ),
+    [productList],
+  );
+
+  const inventoryBySku = useCatalogInventoryBySku({
+    isActive: isOpen,
+    enabled: backorderUiEnabled,
+    skuDependencyKey: variantSkuDependencyKey,
+  });
 
   const handleCancelClicked = () => {
     onCancel();
@@ -201,6 +221,8 @@ export default function ProductListDialog(props: ProductListDialogProps) {
               type={type}
               textAlign={isMobile ? 'left' : 'right'}
               canToProduct
+              catalogBackorderUiEnabled={backorderUiEnabled}
+              catalogInventoryBySku={inventoryBySku}
               onProductQuantityChange={onProductQuantityChange}
               renderAction={(product) => (
                 <ProductTableAction

--- a/apps/storefront/src/pages/ShoppingListDetails/components/ReAddToCart.tsx
+++ b/apps/storefront/src/pages/ShoppingListDetails/components/ReAddToCart.tsx
@@ -10,17 +10,17 @@ import CustomButton from '@/components/button/CustomButton';
 import B3Spin from '@/components/spin/B3Spin';
 import { PRODUCT_DEFAULT_IMAGE } from '@/constants';
 import { useBackorderStorefrontMessaging } from '@/hooks/useBackorderStorefrontMessaging';
+import { useCatalogInventoryBySku } from '@/hooks/useCatalogInventoryBySku';
 import { useMobile } from '@/hooks/useMobile';
 import { useB3Lang } from '@/lib/lang';
-import {
-  type CatalogQuickVariantSku,
-  getVariantInfoBySkus,
-} from '@/shared/service/b2b/graphql/product';
 import { activeCurrencyInfoSelector, useAppSelector } from '@/store';
 import { currencyFormat } from '@/utils/b3CurrencyFormat';
 import { setModifierQtyPrice } from '@/utils/b3Product/b3Product';
 import { getProductOptionsFields, ProductsProps } from '@/utils/b3Product/shared/config';
-import { getCatalogBackorderFieldsForVariantSku } from '@/utils/catalogBackorderDisplay';
+import {
+  buildVariantSkuDependencyKey,
+  getCatalogBackorderFieldsForVariantSku,
+} from '@/utils/catalogBackorderDisplay';
 
 import { B3QuantityTextField } from './B3QuantityTextField';
 
@@ -178,65 +178,21 @@ export default function ReAddToCart({
     backorderUiEnabled && !isMobile ? { width: '22%', minWidth: '160px' } : itemStyle.default;
 
   const [internalProducts, setInternalProducts] = useState<ProductsProps[]>([]);
-  const [variantInfoList, setVariantInfoList] = useState<CatalogQuickVariantSku[]>([]);
 
   useEffect(() => {
     setInternalProducts(cloneDeep(products));
   }, [products]);
 
-  const variantSkuDependencyKey = useMemo(() => {
-    return [
-      ...new Set(
-        internalProducts
-          .map((product) => product.node.variantSku)
-          .filter((sku): sku is string => Boolean(sku)),
-      ),
-    ]
-      .sort()
-      .join('|');
-  }, [internalProducts]);
+  const variantSkuDependencyKey = useMemo(
+    () => buildVariantSkuDependencyKey(internalProducts.map((product) => product.node.variantSku)),
+    [internalProducts],
+  );
 
-  useEffect(() => {
-    if (!isOpen || !backorderUiEnabled || !variantSkuDependencyKey) {
-      if (!isOpen) {
-        setVariantInfoList([]);
-      }
-      return () => {};
-    }
-
-    let cancelled = false;
-    const skus = variantSkuDependencyKey.split('|');
-
-    const fetchVariantInfo = async () => {
-      try {
-        const { variantSku: nextVariantInfoList = [] } = await getVariantInfoBySkus(skus);
-
-        if (!cancelled) {
-          setVariantInfoList(nextVariantInfoList);
-        }
-      } catch {
-        if (!cancelled) {
-          setVariantInfoList([]);
-        }
-      }
-    };
-
-    fetchVariantInfo();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [isOpen, backorderUiEnabled, variantSkuDependencyKey]);
-
-  const inventoryBySku = useMemo(() => {
-    const map: Record<string, CatalogQuickVariantSku> = {};
-    variantInfoList.forEach((row) => {
-      if (row.variantSku) {
-        map[row.variantSku.toUpperCase()] = row;
-      }
-    });
-    return map;
-  }, [variantInfoList]);
+  const inventoryBySku = useCatalogInventoryBySku({
+    isActive: isOpen,
+    enabled: backorderUiEnabled,
+    skuDependencyKey: variantSkuDependencyKey,
+  });
 
   const handleUpdateProductQty = async (
     index: number,

--- a/apps/storefront/src/pages/ShoppingListDetails/index.test.tsx
+++ b/apps/storefront/src/pages/ShoppingListDetails/index.test.tsx
@@ -3658,3 +3658,459 @@ describe('when backorder messaging is enabled on shopping list products', () => 
     });
   });
 });
+
+describe('when backorder messaging is enabled in add to list search modal', () => {
+  const variantSku = 'SL-SEARCH-123';
+  const productName = 'Cast Iron Skillet';
+  const searchTerm = 'Skillet';
+
+  const backorderPreloadedState = {
+    company: b2bCompanyWithShoppingListPermissions,
+    global: buildGlobalStateWith({
+      backorderEnabled: true,
+      backorderDisplaySettings: {
+        showQuantityOnBackorder: true,
+        showQuantityOnHand: true,
+        showBackorderMessage: true,
+        showDefaultShippingExpectationPrompt: false,
+        defaultShippingExpectationPrompt: '',
+      },
+      featureFlags: {
+        'BACK-134.backorders_phase_1_1_control_messaging_on_storefront': true,
+      },
+    }),
+  };
+
+  const setupSearchAddToListModal = ({
+    totalOnHand = 2,
+    availableToSell = 4,
+    backorderMessage = 'Lead time: 2-4 weeks',
+    inventoryFetchFails = false,
+  }: {
+    totalOnHand?: number;
+    availableToSell?: number;
+    backorderMessage?: string;
+    inventoryFetchFails?: boolean;
+  } = {}) => {
+    vitest.mocked(useParams).mockReturnValue({ id: '272989' });
+
+    const listProductEdge = buildShoppingListProductEdgeWith({
+      node: {
+        productName: 'Existing list item',
+        productId: 8000,
+        variantSku: 'LIST-SKU-001',
+        quantity: 1,
+        basePrice: '10.00',
+      },
+    });
+
+    const variant = buildSearchB2BProductVariantWith({
+      sku: variantSku,
+      purchasing_disabled: false,
+      bc_calculated_price: {
+        as_entered: 199.95,
+        tax_inclusive: 199.95,
+        tax_exclusive: 199.95,
+        entered_inclusive: false,
+      },
+    });
+
+    const searchProduct = buildSearchB2BProductWith({
+      id: 9001,
+      name: productName,
+      sku: variantSku,
+      optionsV3: [],
+      isPriceHidden: false,
+      variants: [variant],
+    });
+
+    const shoppingListResponse = buildShoppingListGraphQLResponseWith({
+      data: {
+        shoppingList: {
+          products: { totalCount: 1, edges: [listProductEdge] },
+          status: 0,
+          grandTotal: '10.00',
+          totalTax: '0',
+        },
+      },
+    });
+
+    const searchVariantInfo = buildVariantInfoWith({
+      variantSku,
+      inventoryTracking: 'variant',
+      availableToSell,
+      unlimitedBackorder: false,
+      totalOnHand,
+      backorderMessage,
+    });
+
+    const getVariantInfoBySkus = vi.fn(({ query }: { query: string }) => {
+      if (inventoryFetchFails) {
+        return HttpResponse.error();
+      }
+
+      if (query.includes(`"${variantSku}"`)) {
+        return HttpResponse.json(
+          buildVariantInfoResponseWith({ data: { variantSku: [searchVariantInfo] } }),
+        );
+      }
+
+      return HttpResponse.json(buildVariantInfoResponseWith({ data: { variantSku: [] } }));
+    });
+
+    server.use(
+      graphql.query('B2BShoppingListDetails', () => HttpResponse.json(shoppingListResponse)),
+      graphql.query('SearchProducts', ({ query }) => {
+        if (/productIds: \[\d/.test(query)) {
+          return HttpResponse.json(
+            buildSearchProductsResponseWith({ data: { productsSearch: [] } }),
+          );
+        }
+
+        return HttpResponse.json(
+          buildSearchProductsResponseWith({ data: { productsSearch: [searchProduct] } }),
+        );
+      }),
+      graphql.query('GetVariantInfoBySkus', ({ query }) => getVariantInfoBySkus({ query })),
+    );
+  };
+
+  const openAddToListSearchDialog = async () => {
+    await screen.findByRole('heading', { name: /add to list/i });
+
+    const searchBox = screen.getByPlaceholderText('Search products');
+    await userEvent.type(searchBox, searchTerm);
+    await userEvent.click(screen.getByRole('button', { name: /Search product/i }));
+
+    return screen.findByRole('dialog', { name: 'Add to list' });
+  };
+
+  it('shows backorder lines when qty exceeds on hand', async () => {
+    setupSearchAddToListModal();
+
+    renderWithProviders(<ShoppingListDetailsContent setOpenPage={() => {}} />, {
+      preloadedState: backorderPreloadedState,
+    });
+
+    await waitForElementToBeRemoved(() => screen.queryByText(/loading/i));
+
+    const dialog = await openAddToListSearchDialog();
+    const quantityInput = within(dialog).getByRole('spinbutton');
+
+    await userEvent.type(quantityInput, '10', {
+      initialSelectionStart: 0,
+      initialSelectionEnd: Infinity,
+    });
+
+    await waitFor(() => {
+      expect(within(dialog).getByText('2 ready to ship')).toBeVisible();
+    });
+    expect(within(dialog).getByText('2 will be backordered')).toBeVisible();
+    expect(within(dialog).getByText('Lead time: 2-4 weeks')).toBeVisible();
+  });
+
+  it('does not show ATS error helper when qty exceeds available to sell', async () => {
+    setupSearchAddToListModal();
+
+    renderWithProviders(<ShoppingListDetailsContent setOpenPage={() => {}} />, {
+      preloadedState: backorderPreloadedState,
+    });
+
+    await waitForElementToBeRemoved(() => screen.queryByText(/loading/i));
+
+    const dialog = await openAddToListSearchDialog();
+    const quantityInput = within(dialog).getByRole('spinbutton');
+
+    await userEvent.type(quantityInput, '10', {
+      initialSelectionStart: 0,
+      initialSelectionEnd: Infinity,
+    });
+
+    await waitFor(() => {
+      expect(within(dialog).getByText('2 will be backordered')).toBeVisible();
+    });
+
+    expect(within(dialog).queryByText('4 available')).not.toBeInTheDocument();
+    expect(quantityInput.closest('.MuiTextField-root')).not.toHaveClass('Mui-error');
+  });
+
+  it('hides backorder lines when qty is within on hand', async () => {
+    setupSearchAddToListModal({ totalOnHand: 9, availableToSell: 10 });
+
+    renderWithProviders(<ShoppingListDetailsContent setOpenPage={() => {}} />, {
+      preloadedState: backorderPreloadedState,
+    });
+
+    await waitForElementToBeRemoved(() => screen.queryByText(/loading/i));
+
+    const dialog = await openAddToListSearchDialog();
+    const quantityInput = within(dialog).getByRole('spinbutton');
+
+    await userEvent.type(quantityInput, '2', {
+      initialSelectionStart: 0,
+      initialSelectionEnd: Infinity,
+    });
+
+    await waitFor(() => {
+      expect(
+        within(dialog).queryByText('will be backordered', { exact: false }),
+      ).not.toBeInTheDocument();
+    });
+    expect(within(dialog).queryByText('ready to ship', { exact: false })).not.toBeInTheDocument();
+  });
+
+  it('hides backorder lines when messaging is disabled', async () => {
+    setupSearchAddToListModal();
+
+    renderWithProviders(<ShoppingListDetailsContent setOpenPage={() => {}} />, {
+      preloadedState: { company: b2bCompanyWithShoppingListPermissions },
+    });
+
+    await waitForElementToBeRemoved(() => screen.queryByText(/loading/i));
+
+    const dialog = await openAddToListSearchDialog();
+    const quantityInput = within(dialog).getByRole('spinbutton');
+
+    await userEvent.type(quantityInput, '10', {
+      initialSelectionStart: 0,
+      initialSelectionEnd: Infinity,
+    });
+
+    await waitFor(() => {
+      expect(within(dialog).getByText(productName)).toBeVisible();
+    });
+    expect(
+      within(dialog).queryByText('will be backordered', { exact: false }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('still shows search results without backorder UI when inventory fetch fails', async () => {
+    setupSearchAddToListModal({ inventoryFetchFails: true });
+
+    renderWithProviders(<ShoppingListDetailsContent setOpenPage={() => {}} />, {
+      preloadedState: backorderPreloadedState,
+    });
+
+    await waitForElementToBeRemoved(() => screen.queryByText(/loading/i));
+
+    const dialog = await openAddToListSearchDialog();
+    const quantityInput = within(dialog).getByRole('spinbutton');
+
+    await userEvent.type(quantityInput, '10', {
+      initialSelectionStart: 0,
+      initialSelectionEnd: Infinity,
+    });
+
+    await waitFor(() => {
+      expect(within(dialog).getByText(productName)).toBeVisible();
+    });
+    expect(
+      within(dialog).queryByText('will be backordered', { exact: false }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('clears stale backorder inventory while refetching after a new search', async () => {
+    const sharedSku = 'SL-SHARED-SKU';
+    const otherSku = 'SL-OTHER-SKU';
+    const secondProductName = 'Cast Iron Pan';
+    let resolveSecondInventoryFetch!: (value: HttpResponse<VariantInfoResponse>) => void;
+    let sharedSkuFetchCount = 0;
+
+    const pendingSecondInventoryFetch = new Promise<HttpResponse<VariantInfoResponse>>(
+      (resolve) => {
+        resolveSecondInventoryFetch = resolve;
+      },
+    );
+
+    vitest.mocked(useParams).mockReturnValue({ id: '272989' });
+
+    const listProductEdge = buildShoppingListProductEdgeWith({
+      node: {
+        productName: 'Existing list item',
+        productId: 8000,
+        variantSku: 'LIST-SKU-001',
+        quantity: 1,
+        basePrice: '10.00',
+      },
+    });
+
+    const buildSearchVariant = (sku: string) =>
+      buildSearchB2BProductVariantWith({
+        sku,
+        purchasing_disabled: false,
+        bc_calculated_price: {
+          as_entered: 199.95,
+          tax_inclusive: 199.95,
+          tax_exclusive: 199.95,
+          entered_inclusive: false,
+        },
+      });
+
+    const firstSearchProduct = buildSearchB2BProductWith({
+      id: 9001,
+      name: productName,
+      sku: sharedSku,
+      optionsV3: [],
+      isPriceHidden: false,
+      variants: [buildSearchVariant(sharedSku)],
+    });
+
+    const secondSearchProduct = buildSearchB2BProductWith({
+      id: 9002,
+      name: secondProductName,
+      sku: sharedSku,
+      optionsV3: [],
+      isPriceHidden: false,
+      variants: [buildSearchVariant(sharedSku)],
+    });
+
+    const otherSearchProduct = buildSearchB2BProductWith({
+      id: 9003,
+      name: 'Silicone Spatula',
+      sku: otherSku,
+      optionsV3: [],
+      isPriceHidden: false,
+      variants: [buildSearchVariant(otherSku)],
+    });
+
+    const lowInventoryVariantInfo = buildVariantInfoWith({
+      variantSku: sharedSku,
+      inventoryTracking: 'variant',
+      availableToSell: 4,
+      unlimitedBackorder: false,
+      totalOnHand: 2,
+      backorderMessage: 'Lead time: 2-4 weeks',
+    });
+
+    const highInventoryVariantInfo = buildVariantInfoWith({
+      variantSku: sharedSku,
+      inventoryTracking: 'variant',
+      availableToSell: 10,
+      unlimitedBackorder: false,
+      totalOnHand: 9,
+      backorderMessage: 'Lead time: 2-4 weeks',
+    });
+
+    const otherInventoryVariantInfo = buildVariantInfoWith({
+      variantSku: otherSku,
+      inventoryTracking: 'variant',
+      availableToSell: 10,
+      unlimitedBackorder: false,
+      totalOnHand: 9,
+    });
+
+    const getVariantInfoBySkus = vi.fn(
+      ({
+        query,
+      }: {
+        query: string;
+      }): HttpResponse<VariantInfoResponse> | Promise<HttpResponse<VariantInfoResponse>> => {
+        if (!query.includes(`"${sharedSku}"`)) {
+          return HttpResponse.json(buildVariantInfoResponseWith({ data: { variantSku: [] } }));
+        }
+
+        sharedSkuFetchCount += 1;
+
+        if (sharedSkuFetchCount === 1) {
+          return HttpResponse.json(
+            buildVariantInfoResponseWith({ data: { variantSku: [lowInventoryVariantInfo] } }),
+          );
+        }
+
+        return pendingSecondInventoryFetch;
+      },
+    );
+
+    server.use(
+      graphql.query('B2BShoppingListDetails', () =>
+        HttpResponse.json(
+          buildShoppingListGraphQLResponseWith({
+            data: {
+              shoppingList: {
+                products: { totalCount: 1, edges: [listProductEdge] },
+                status: 0,
+                grandTotal: '10.00',
+                totalTax: '0',
+              },
+            },
+          }),
+        ),
+      ),
+      graphql.query('SearchProducts', ({ query }) => {
+        if (/productIds: \[\d/.test(query)) {
+          return HttpResponse.json(
+            buildSearchProductsResponseWith({ data: { productsSearch: [] } }),
+          );
+        }
+
+        if (query.includes('Pan')) {
+          return HttpResponse.json(
+            buildSearchProductsResponseWith({
+              data: { productsSearch: [secondSearchProduct, otherSearchProduct] },
+            }),
+          );
+        }
+
+        return HttpResponse.json(
+          buildSearchProductsResponseWith({ data: { productsSearch: [firstSearchProduct] } }),
+        );
+      }),
+      graphql.query('GetVariantInfoBySkus', ({ query }) => getVariantInfoBySkus({ query })),
+    );
+
+    renderWithProviders(<ShoppingListDetailsContent setOpenPage={() => {}} />, {
+      preloadedState: backorderPreloadedState,
+    });
+
+    await waitForElementToBeRemoved(() => screen.queryByText(/loading/i));
+
+    const dialog = await openAddToListSearchDialog();
+    const quantityInput = within(dialog).getByRole('spinbutton');
+
+    await userEvent.type(quantityInput, '10', {
+      initialSelectionStart: 0,
+      initialSelectionEnd: Infinity,
+    });
+
+    await waitFor(() => {
+      expect(within(dialog).getByText('2 ready to ship')).toBeVisible();
+    });
+
+    const dialogSearchBox = within(dialog).getByDisplayValue(searchTerm);
+    await userEvent.clear(dialogSearchBox);
+    await userEvent.type(dialogSearchBox, 'Pan{Enter}');
+
+    await waitFor(() => {
+      expect(within(dialog).getByText(secondProductName)).toBeVisible();
+    });
+
+    const refreshedQuantityInput = within(dialog).getAllByRole('spinbutton')[0];
+    await userEvent.type(refreshedQuantityInput, '10', {
+      initialSelectionStart: 0,
+      initialSelectionEnd: Infinity,
+    });
+
+    expect(within(dialog).queryByText('2 ready to ship')).not.toBeInTheDocument();
+    expect(
+      within(dialog).queryByText('will be backordered', { exact: false }),
+    ).not.toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(sharedSkuFetchCount).toBeGreaterThan(1);
+    });
+
+    resolveSecondInventoryFetch(
+      HttpResponse.json(
+        buildVariantInfoResponseWith({
+          data: { variantSku: [highInventoryVariantInfo, otherInventoryVariantInfo] },
+        }),
+      ),
+    );
+
+    await waitFor(() => {
+      expect(
+        within(dialog).queryByText('will be backordered', { exact: false }),
+      ).not.toBeInTheDocument();
+    });
+  });
+});

--- a/apps/storefront/src/utils/catalogBackorderDisplay.test.ts
+++ b/apps/storefront/src/utils/catalogBackorderDisplay.test.ts
@@ -5,6 +5,7 @@ import type { Variant } from '@/types/products';
 import type { ShoppingListProductItem } from '@/types/shoppingList';
 
 import {
+  buildVariantSkuDependencyKey,
   catalogListHasBackorderedItemsForDisplay,
   getCatalogBackorderDisplayFields,
   getCatalogBackorderDisplayQuantity,
@@ -15,6 +16,12 @@ import {
 } from './catalogBackorderDisplay';
 
 describe('catalogBackorderDisplay', () => {
+  it('buildVariantSkuDependencyKey deduplicates, filters empty values, and sorts skus', () => {
+    expect(buildVariantSkuDependencyKey(['B-SKU', 'A-SKU', 'B-SKU', '', null, undefined])).toBe(
+      'A-SKU|B-SKU',
+    );
+  });
+
   it('quantityExceedsAvailableToSell is false when unlimited backorder', () => {
     const row = {
       inventoryTracking: 'variant',

--- a/apps/storefront/src/utils/catalogBackorderDisplay.ts
+++ b/apps/storefront/src/utils/catalogBackorderDisplay.ts
@@ -4,6 +4,10 @@ import type { ShoppingListProductItem } from '@/types/shoppingList';
 import type { BackorderDisplayFields } from '@/utils/backorderDisplayFromInventory';
 import { getBackorderDisplayFieldsFromOnHand } from '@/utils/backorderDisplayFromInventory';
 
+export function buildVariantSkuDependencyKey(skus: readonly (string | undefined | null)[]): string {
+  return [...new Set(skus.filter((sku): sku is string => Boolean(sku)))].sort().join('|');
+}
+
 type SearchProductInventorySource = Pick<
   ShoppingListProductItem,
   | 'inventoryTracking'


### PR DESCRIPTION
Jira: [BACK-695](https://bigcommercecloud.atlassian.net/browse/BACK-695)

## What/Why?
Add backorder display lines to shopping list "add to list" modal. Introducing `useCatalogInventoryBySku` for shared inventory-fetch logic.

## Rollout/Rollback
Merge/revert. Backorder display is gated by `Feature_Backorder && BACK-134.backorders_phase_1_1_control_messaging_on_storefront`.

## Testing
Expected backorder lines appear for product with 5 on-hand, 5 backorder limit.

https://github.com/user-attachments/assets/3b4a9691-3cd2-4635-ba96-fcb02abb6e59

Backorder display does not appear for disabled `Feature_Backorder && BACK-134.backorders_phase_1_1_control_messaging_on_storefront`.

https://github.com/user-attachments/assets/f6807458-91e8-4622-8035-ff5d1bae322d

Regression test, quick order and shopping list add-to-cart modal.

https://github.com/user-attachments/assets/9f946ad9-6c06-4c10-b75f-5649d78f2c25

[BACK-695]: https://bigcommercecloud.atlassian.net/browse/BACK-695?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Customer-facing quantity and backorder messaging in list/search flows depends on async inventory fetches and feature flags; regressions could mislead buyers about stock or ATS errors.
> 
> **Overview**
> Introduces shared **`useCatalogInventoryBySku`** and **`buildVariantSkuDependencyKey`** so catalog modals load variant inventory once and clear it when the dialog closes or SKUs change, instead of duplicating fetch/effect logic in each screen.
> 
> **Shopping list “Add to list” search** now wires that inventory into **`B3ProductList`** (with existing backorder feature flags), so search results can show ready-to-ship / backorder messaging and avoid treating over-ATS qty as a stock error when backorder UI is on. **Quick Order** and **Re-add to cart** are refactored to the same hook; behavior should match prior patterns with less duplication.
> 
> Adds unit coverage for the SKU key helper and broad integration tests for the search modal (gating, ATS vs on-hand, failed fetch, stale inventory on re-search).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5471ee39ddb6b3866faaa0750e68c5de95e15797. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->