### PR TITLE
fix(register): B2B-4870 Buyer Portal: Default Buyer Portal Styling Loading First on Login Page Version 2

### DIFF
--- a/apps/storefront/src/App.tsx
+++ b/apps/storefront/src/App.tsx
@@ -31,7 +31,7 @@ import { isUserGotoLogin } from './utils/b3logout';
 import { isCompanyError } from './utils/companyUtils';
 import { getCompanyInfo, getCurrentCustomerInfo, loginInfo } from './utils/loginInfo';
 import { logoutSession } from './utils/logoutSession';
-import { removePreMountLoginMask } from './utils/preMountLoginMask';
+import { removePreMountLoginMask, shouldUseDefaultLoginStyling } from './utils/preMountLoginMask';
 import { getGlobalStoreTax, getStoreConfigs, setStorefrontConfig } from './utils/storefrontConfig';
 import { getStoreSettings } from './utils/storefrontSettings';
 import { CHECKOUT_URL, PATH_ROUTES } from './constants';
@@ -62,6 +62,7 @@ export default function App() {
   const b2bId = useAppSelector((state) => state.company.customer.b2bId);
   const isClickEnterBtn = useAppSelector(({ global }) => global.isClickEnterBtn);
   const isPageComplete = useAppSelector(({ global }) => global.isPageComplete);
+  const [isDefaultLoginStyling] = useState(shouldUseDefaultLoginStyling);
   const currentClickedUrl = useAppSelector(({ global }) => global.currentClickedUrl);
   const isRegisterAndLogin = useAppSelector(({ global }) => global.isRegisterAndLogin);
   const bcGraphqlToken = useAppSelector(({ company }) => company.tokens.bcGraphqlToken);
@@ -298,10 +299,10 @@ export default function App() {
   // loading — removing it earlier (on isOpen) caused the native form to flicker
   // through. See utils/preMountLoginMask.
   useEffect(() => {
-    if (isPageComplete) {
+    if (isPageComplete && isDefaultLoginStyling) {
       removePreMountLoginMask();
     }
-  }, [isPageComplete]);
+  }, [isPageComplete, isDefaultLoginStyling]);
 
   useEffect(() => {
     const init = async () => {

--- a/apps/storefront/src/App.tsx
+++ b/apps/storefront/src/App.tsx
@@ -1,4 +1,4 @@
-import { useContext, useEffect, useMemo, useState } from 'react';
+import { useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { HashRouter } from 'react-router-dom';
 
 import B3GlobalTip from '@/components/B3GlobalTip';
@@ -62,7 +62,7 @@ export default function App() {
   const b2bId = useAppSelector((state) => state.company.customer.b2bId);
   const isClickEnterBtn = useAppSelector(({ global }) => global.isClickEnterBtn);
   const isPageComplete = useAppSelector(({ global }) => global.isPageComplete);
-  const [isDefaultLoginStyling] = useState(shouldUseDefaultLoginStyling);
+  const isDefaultLoginStyling = useRef(shouldUseDefaultLoginStyling()).current;
   const currentClickedUrl = useAppSelector(({ global }) => global.currentClickedUrl);
   const isRegisterAndLogin = useAppSelector(({ global }) => global.isRegisterAndLogin);
   const bcGraphqlToken = useAppSelector(({ company }) => company.tokens.bcGraphqlToken);

--- a/apps/storefront/src/App.tsx
+++ b/apps/storefront/src/App.tsx
@@ -31,6 +31,7 @@ import { isUserGotoLogin } from './utils/b3logout';
 import { isCompanyError } from './utils/companyUtils';
 import { getCompanyInfo, getCurrentCustomerInfo, loginInfo } from './utils/loginInfo';
 import { logoutSession } from './utils/logoutSession';
+import { removePreMountLoginMask } from './utils/preMountLoginMask';
 import { getGlobalStoreTax, getStoreConfigs, setStorefrontConfig } from './utils/storefrontConfig';
 import { getStoreSettings } from './utils/storefrontSettings';
 import { CHECKOUT_URL, PATH_ROUTES } from './constants';
@@ -289,6 +290,18 @@ export default function App() {
     // ignore dispatch due it's function that doesn't not depend on any reactive value
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isOpen]);
+
+  // Remove the pre-mount login mask only once initialization has finished. The
+  // mask sits just below the iframe, so keeping it until init completes is
+  // invisible to the user once the iframe paints, but it crucially still covers
+  // the native login.php form while the (transparent) in-iframe login page is
+  // loading — removing it earlier (on isOpen) caused the native form to flicker
+  // through. See utils/preMountLoginMask.
+  useEffect(() => {
+    if (isPageComplete) {
+      removePreMountLoginMask();
+    }
+  }, [isPageComplete]);
 
   useEffect(() => {
     const init = async () => {

--- a/apps/storefront/src/components/B3StoreContainer.tsx
+++ b/apps/storefront/src/components/B3StoreContainer.tsx
@@ -10,6 +10,7 @@ import {
   setTimeFormat,
   useAppDispatch,
 } from '@/store';
+import { removePreMountLoginMask } from '@/utils/preMountLoginMask';
 
 import { B3PageMask, usePageMask } from './loading';
 
@@ -73,6 +74,9 @@ export default function B3StoreContainer(props: B3StoreContainerProps) {
 
         if (!isEnabled) {
           showPageMask(false);
+          // B2B is disabled for this store/channel, so App never mounts to clear
+          // the pre-mount mask. Reveal the native login.php form here instead.
+          removePreMountLoginMask();
         }
 
         storeDispatch(
@@ -86,6 +90,9 @@ export default function B3StoreContainer(props: B3StoreContainerProps) {
         sessionStorage.setItem('currentB2BEnabled', JSON.stringify(isEnabled));
       } catch (error) {
         showPageMask(false);
+        // Failed to resolve store info: don't leave the native login.php form
+        // hidden behind the pre-mount mask.
+        removePreMountLoginMask();
       }
     };
     setZIndexVariables();

--- a/apps/storefront/src/components/B3StoreContainer.tsx
+++ b/apps/storefront/src/components/B3StoreContainer.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useContext, useLayoutEffect } from 'react';
+import { ReactNode, useContext, useLayoutEffect, useState } from 'react';
 
 import { Z_INDEX } from '@/constants';
 import { GlobalContext } from '@/shared/global';
@@ -10,7 +10,7 @@ import {
   setTimeFormat,
   useAppDispatch,
 } from '@/store';
-import { removePreMountLoginMask } from '@/utils/preMountLoginMask';
+import { removePreMountLoginMask, shouldUseDefaultLoginStyling } from '@/utils/preMountLoginMask';
 
 import { B3PageMask, usePageMask } from './loading';
 
@@ -36,6 +36,8 @@ export default function B3StoreContainer(props: B3StoreContainerProps) {
   } = useContext(GlobalContext);
   const storeDispatch = useAppDispatch();
 
+  const [isDefaultLoginStyling] = useState(shouldUseDefaultLoginStyling);
+
   useLayoutEffect(() => {
     const getStoreBasicInfo = async () => {
       if (
@@ -49,7 +51,12 @@ export default function B3StoreContainer(props: B3StoreContainerProps) {
         const { storeBasicInfo } = await getBCStoreChannelId();
         const [storeInfo] = storeBasicInfo.storeSites;
 
-        if (!storeInfo) return;
+        if (!storeInfo) {
+          // No store site resolved, so App never mounts to clear the pre-mount
+          // mask. Reveal the native login.php form instead of leaving it blocked.
+          if (isDefaultLoginStyling) removePreMountLoginMask();
+          return;
+        }
         storeDispatch(setStoreInfo(storeInfo));
         storeDispatch(setBackorderEnabled(storeBasicInfo.backorderEnabled ?? false));
 
@@ -76,7 +83,7 @@ export default function B3StoreContainer(props: B3StoreContainerProps) {
           showPageMask(false);
           // B2B is disabled for this store/channel, so App never mounts to clear
           // the pre-mount mask. Reveal the native login.php form here instead.
-          removePreMountLoginMask();
+          if (isDefaultLoginStyling) removePreMountLoginMask();
         }
 
         storeDispatch(
@@ -92,7 +99,7 @@ export default function B3StoreContainer(props: B3StoreContainerProps) {
         showPageMask(false);
         // Failed to resolve store info: don't leave the native login.php form
         // hidden behind the pre-mount mask.
-        removePreMountLoginMask();
+        if (isDefaultLoginStyling) removePreMountLoginMask();
       }
     };
     setZIndexVariables();

--- a/apps/storefront/src/components/B3StoreContainer.tsx
+++ b/apps/storefront/src/components/B3StoreContainer.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useContext, useLayoutEffect, useState } from 'react';
+import { ReactNode, useContext, useLayoutEffect, useRef } from 'react';
 
 import { Z_INDEX } from '@/constants';
 import { GlobalContext } from '@/shared/global';
@@ -36,7 +36,7 @@ export default function B3StoreContainer(props: B3StoreContainerProps) {
   } = useContext(GlobalContext);
   const storeDispatch = useAppDispatch();
 
-  const [isDefaultLoginStyling] = useState(shouldUseDefaultLoginStyling);
+  const isDefaultLoginStyling = useRef(shouldUseDefaultLoginStyling()).current;
 
   useLayoutEffect(() => {
     const getStoreBasicInfo = async () => {

--- a/apps/storefront/src/main.ts
+++ b/apps/storefront/src/main.ts
@@ -1,4 +1,10 @@
+import { injectPreMountLoginMask } from './utils/preMountLoginMask';
 import { bindLinks, initApp, requestIdleCallbackFunction, unbindLinks } from './load-functions';
+
+// Paint the pre-mount mask as early as possible (before React mounts) so the
+// merchant never sees BC's native login.php form before the buyer-portal iframe
+// takes over. See utils/preMountLoginMask for the masking/removal contract.
+injectPreMountLoginMask();
 
 export enum Environment {
   Production = 'production',
@@ -36,8 +42,12 @@ window.b2b = {
 };
 
 (async function bootstrap() {
-  // check if the accessed url contains a hashtag
-  if (window.location.hash.startsWith('#/')) {
+  const { pathname, search } = window.location;
+  const isLoginPage = pathname.includes('login.php') && !search.includes('change_password');
+
+  // check if the accessed url contains a hashtag, or if we're on a login.php URL
+  // (eager init avoids the idle-callback delay while the BC native form is visible)
+  if (window.location.hash.startsWith('#/') || isLoginPage) {
     initApp();
   } else {
     // load the app when the browser is free

--- a/apps/storefront/src/main.ts
+++ b/apps/storefront/src/main.ts
@@ -1,4 +1,4 @@
-import { injectPreMountLoginMask } from './utils/preMountLoginMask';
+import { injectPreMountLoginMask, shouldUseDefaultLoginStyling } from './utils/preMountLoginMask';
 import { bindLinks, initApp, requestIdleCallbackFunction, unbindLinks } from './load-functions';
 
 // Paint the pre-mount mask as early as possible (before React mounts) so the
@@ -42,12 +42,11 @@ window.b2b = {
 };
 
 (async function bootstrap() {
-  const { pathname, search } = window.location;
-  const isLoginPage = pathname.includes('login.php') && !search.includes('change_password');
-
-  // check if the accessed url contains a hashtag, or if we're on a login.php URL
-  // (eager init avoids the idle-callback delay while the BC native form is visible)
-  if (window.location.hash.startsWith('#/') || isLoginPage) {
+  // check if the accessed url contains a hashtag, or if the buyer portal is
+  // taking over the login page (eager init avoids the idle-callback delay while
+  // the masked BC native form is visible). The login-page branch is gated on the
+  // default-login-styling feature flag via shouldUseDefaultLoginStyling().
+  if (window.location.hash.startsWith('#/') || shouldUseDefaultLoginStyling()) {
     initApp();
   } else {
     // load the app when the browser is free

--- a/apps/storefront/src/pages/Login/index.test.tsx
+++ b/apps/storefront/src/pages/Login/index.test.tsx
@@ -25,6 +25,17 @@ vi.mock('@/utils/loginInfo');
 
 const { server } = startMockServer();
 
+// The login page now gates its content on `isLogoLoaded` (set true once the
+// merchant login config resolves during app init). That flow doesn't run in
+// these unit tests, so default it to true — otherwise the page stays stuck on
+// the loading spinner and never renders the form. Tests that specifically care
+// about the logo/loaded state can override `initialGlobalContext`.
+const renderLoginPage = (options: Parameters<typeof renderWithProviders>[1] = {}) =>
+  renderWithProviders(<LoginPage setOpenPage={vi.fn()} />, {
+    ...options,
+    initialGlobalContext: { isLogoLoaded: true, ...options.initialGlobalContext },
+  });
+
 describe('LoginPage', () => {
   beforeEach(() => {
     vi.spyOn(snackbar, 'error');
@@ -56,7 +67,7 @@ describe('LoginPage', () => {
         companyRoleName: 'Junior Buyer',
       });
 
-      const { navigation } = renderWithProviders(<LoginPage setOpenPage={vi.fn()} />);
+      const { navigation } = renderLoginPage();
 
       await userEvent.type(screen.getByLabelText('Email address *'), 'test@example.com');
       await userEvent.type(screen.getByLabelText('Password *'), 'Password123');
@@ -96,7 +107,7 @@ describe('LoginPage', () => {
         companyRoleName: 'SuperAdmin',
       });
 
-      const { navigation } = renderWithProviders(<LoginPage setOpenPage={vi.fn()} />);
+      const { navigation } = renderLoginPage();
 
       await userEvent.type(screen.getByLabelText('Email address *'), 'test@example.com');
       await userEvent.type(screen.getByLabelText('Password *'), 'Password123');
@@ -114,7 +125,7 @@ describe('LoginPage', () => {
 
   describe('failed login attempts show appropriate error messages', () => {
     const renderLoginAndSubmit = async () => {
-      renderWithProviders(<LoginPage setOpenPage={vi.fn()} />);
+      renderLoginPage();
 
       await userEvent.type(screen.getByLabelText('Email address *'), 'test@example.com');
       await userEvent.type(screen.getByLabelText('Password *'), 'Password123');
@@ -287,7 +298,7 @@ describe('LoginPage', () => {
 
   describe('loading state prevents duplicate submit', () => {
     it('passes isLoading to LoginForm so Sign In button can be disabled', async () => {
-      renderWithProviders(<LoginPage setOpenPage={vi.fn()} />);
+      renderLoginPage();
 
       await waitFor(() => {
         expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
@@ -350,7 +361,7 @@ describe('LoginPage', () => {
         }),
       };
 
-      renderWithProviders(<LoginPage setOpenPage={vi.fn()} />, {
+      renderLoginPage({
         preloadedState,
         initialEntries: ['/?loginFlag=loggedOutLogin'],
       });
@@ -386,7 +397,7 @@ describe('LoginPage', () => {
           }),
         };
 
-        renderWithProviders(<LoginPage setOpenPage={vi.fn()} />, {
+        renderLoginPage({
           preloadedState,
           initialEntries: [`/?loginFlag=${loginFlag}`],
         });
@@ -414,7 +425,7 @@ describe('LoginPage', () => {
         }),
       };
 
-      renderWithProviders(<LoginPage setOpenPage={vi.fn()} />, {
+      renderLoginPage({
         preloadedState,
         initialEntries: ['/?loginFlag=accountIncorrect'],
       });
@@ -432,7 +443,7 @@ describe('LoginPage', () => {
     it('renders the merchant logo when isLogoLoaded is true and logo is set', async () => {
       const merchantLogoUrl = 'https://cdn.example.com/b2bLogo.png';
 
-      renderWithProviders(<LoginPage setOpenPage={vi.fn()} />, {
+      renderLoginPage({
         initialGlobalContext: {
           isLogoLoaded: true,
           logo: merchantLogoUrl,
@@ -442,6 +453,31 @@ describe('LoginPage', () => {
       const logoImage = await screen.findByAltText('register Logo');
       expect(logoImage).toBeVisible();
       expect(logoImage).toHaveAttribute('src', merchantLogoUrl);
+    });
+  });
+
+  describe('login config gating', () => {
+    it('shows the loading spinner and hides the form until the login config has loaded', async () => {
+      renderWithProviders(<LoginPage setOpenPage={vi.fn()} />, {
+        initialGlobalContext: { isLogoLoaded: false },
+      });
+
+      // Spinner stays up and the form is not rendered while the config is loading.
+      await waitFor(() => {
+        expect(screen.getByText('Loading...')).toBeInTheDocument();
+      });
+      expect(screen.queryByRole('button', { name: 'SIGN IN' })).not.toBeInTheDocument();
+    });
+
+    it('renders the login form once the login config has loaded', async () => {
+      renderLoginPage({
+        initialGlobalContext: { isLogoLoaded: true },
+      });
+
+      await waitFor(() => {
+        expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
+      });
+      expect(screen.getByRole('button', { name: 'SIGN IN' })).toBeInTheDocument();
     });
   });
 });

--- a/apps/storefront/src/pages/Login/index.test.tsx
+++ b/apps/storefront/src/pages/Login/index.test.tsx
@@ -1,6 +1,7 @@
 import userEvent from '@testing-library/user-event';
 import {
   buildCompanyStateWith,
+  buildGlobalStateWith,
   graphql,
   HttpResponse,
   renderWithProviders,
@@ -12,6 +13,7 @@ import {
 import { CustomerRole } from '@/types';
 import { snackbar } from '@/utils/b3Tip';
 import { getCurrentCustomerInfo } from '@/utils/loginInfo';
+import { setDefaultLoginStylingEnabled } from '@/utils/preMountLoginMask';
 
 import LoginPage from './index';
 import LoginForm from './LoginForm';
@@ -25,11 +27,12 @@ vi.mock('@/utils/loginInfo');
 
 const { server } = startMockServer();
 
-// The login page now gates its content on `isLogoLoaded` (set true once the
-// merchant login config resolves during app init). That flow doesn't run in
-// these unit tests, so default it to true — otherwise the page stays stuck on
-// the loading spinner and never renders the form. Tests that specifically care
-// about the logo/loaded state can override `initialGlobalContext`.
+// When the default-login-styling feature flag is on, the login page gates its
+// content on `isLogoLoaded` (set true once the merchant login config resolves
+// during app init). That flow doesn't run in these unit tests, so default it to
+// true — otherwise, if a test enables the flag, the page would stay stuck on the
+// loading spinner and never render the form. Tests that specifically care about
+// the logo/loaded state can override `initialGlobalContext`.
 const renderLoginPage = (options: Parameters<typeof renderWithProviders>[1] = {}) =>
   renderWithProviders(<LoginPage setOpenPage={vi.fn()} />, {
     ...options,
@@ -457,9 +460,23 @@ describe('LoginPage', () => {
   });
 
   describe('login config gating', () => {
+    // The gate reads the cached feature value synchronously (see
+    // isDefaultLoginStylingActive); the cache is optimistic, so an uncached value
+    // is treated as active. We control it via localStorage rather than the Redux
+    // flag, which is still false on first render before getStoreConfigs resolves.
+    const buildGlobalStateWithPageComplete = (isPageComplete: boolean) =>
+      buildGlobalStateWith({ isPageComplete });
+
+    afterEach(() => {
+      localStorage.clear();
+    });
+
     it('shows the loading spinner and hides the form until the login config has loaded', async () => {
+      setDefaultLoginStylingEnabled(true);
+
       renderWithProviders(<LoginPage setOpenPage={vi.fn()} />, {
         initialGlobalContext: { isLogoLoaded: false },
+        preloadedState: { global: buildGlobalStateWithPageComplete(false) },
       });
 
       // Spinner stays up and the form is not rendered while the config is loading.
@@ -470,8 +487,43 @@ describe('LoginPage', () => {
     });
 
     it('renders the login form once the login config has loaded', async () => {
-      renderLoginPage({
+      setDefaultLoginStylingEnabled(true);
+
+      renderWithProviders(<LoginPage setOpenPage={vi.fn()} />, {
         initialGlobalContext: { isLogoLoaded: true },
+        preloadedState: { global: buildGlobalStateWithPageComplete(false) },
+      });
+
+      await waitFor(() => {
+        expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
+      });
+      expect(screen.getByRole('button', { name: 'SIGN IN' })).toBeInTheDocument();
+    });
+
+    it('renders the login form when app init completes even if the config failed to load', async () => {
+      // getStoreConfigs failing leaves isLogoLoaded false, but app init still
+      // flips isPageComplete true — the form must render rather than leaving the
+      // user on an endless spinner with no sign-in form.
+      setDefaultLoginStylingEnabled(true);
+
+      renderWithProviders(<LoginPage setOpenPage={vi.fn()} />, {
+        initialGlobalContext: { isLogoLoaded: false },
+        preloadedState: { global: buildGlobalStateWithPageComplete(true) },
+      });
+
+      await waitFor(() => {
+        expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
+      });
+      expect(screen.getByRole('button', { name: 'SIGN IN' })).toBeInTheDocument();
+    });
+
+    it('renders the login form immediately when the feature is cached off', async () => {
+      // With the feature explicitly off, the form is not gated on isLogoLoaded.
+      setDefaultLoginStylingEnabled(false);
+
+      renderWithProviders(<LoginPage setOpenPage={vi.fn()} />, {
+        initialGlobalContext: { isLogoLoaded: false },
+        preloadedState: { global: buildGlobalStateWithPageComplete(false) },
       });
 
       await waitFor(() => {

--- a/apps/storefront/src/pages/Login/index.tsx
+++ b/apps/storefront/src/pages/Login/index.tsx
@@ -20,6 +20,7 @@ import { snackbar } from '@/utils/b3Tip';
 import { platform } from '@/utils/basicConfig';
 import { isCompanyError } from '@/utils/companyUtils';
 import { getCurrentCustomerInfo } from '@/utils/loginInfo';
+import { isDefaultLoginStylingActive } from '@/utils/preMountLoginMask';
 
 import { type PageProps } from '../PageProps';
 
@@ -70,6 +71,23 @@ function Login(props: PageProps) {
   const {
     state: { isCheckout, registerEnabled, isLogoLoaded },
   } = useContext(GlobalContext);
+
+  // Read the feature signal synchronously (not from Redux), since the Redux flag
+  // is still false on the first render — before getStoreConfigs resolves — which
+  // would let the form render with hardcoded defaults and then flicker as the
+  // real config swaps in. isDefaultLoginStylingActive() mirrors the pre-mount
+  // mask's optimistic gate, so the in-iframe content and the mask stay in step.
+  const [isDefaultLoginStyling] = useState(isDefaultLoginStylingActive);
+  const isPageComplete = useAppSelector(({ global }) => global.isPageComplete);
+
+  // When the default-login-styling feature is on, hold the form back until the
+  // merchant login config has loaded (isLogoLoaded) to avoid a flicker as the
+  // hardcoded context defaults are swapped for the real config. We also reveal
+  // the form once app init has finished (isPageComplete) so that a failed
+  // getStoreConfigs — which leaves isLogoLoaded false — doesn't strand the user
+  // on an endless spinner with no sign-in form. When the feature is off we keep
+  // the previous behaviour of rendering the form immediately.
+  const isLoginConfigReady = !isDefaultLoginStyling || isLogoLoaded || isPageComplete;
 
   const {
     state: {
@@ -188,7 +206,7 @@ function Login(props: PageProps) {
     <B3Card setOpenPage={setOpenPage}>
       <LoginContainer paddings={isMobile ? '0' : '20px 20px'}>
         <B3Spin
-          isSpinning={isLoading || !isLogoLoaded}
+          isSpinning={isLoading || !isLoginConfigReady}
           tip={b3Lang('global.tips.loading')}
           background="transparent"
         >
@@ -208,8 +226,10 @@ function Login(props: PageProps) {
               defaults until getStoreConfigs() resolves, and rendering them first causes a
               flicker as the real config swaps in. isLogoLoaded flips true in the same dispatch
               that merges the CustomStyleContext config, so it gates the whole login config.
+              This gating only applies when the default-login-styling feature flag is on; see
+              isLoginConfigReady for the flag/fallback behaviour.
             */}
-            {isLogoLoaded && (
+            {isLoginConfigReady && (
               <>
                 <LoginTip showTipInfo={showTipInfo} flag={flag} loginAccount={loginAccount} />
                 {quoteDetailToCheckoutUrl && (

--- a/apps/storefront/src/pages/Login/index.tsx
+++ b/apps/storefront/src/pages/Login/index.tsx
@@ -187,7 +187,11 @@ function Login(props: PageProps) {
   return (
     <B3Card setOpenPage={setOpenPage}>
       <LoginContainer paddings={isMobile ? '0' : '20px 20px'}>
-        <B3Spin isSpinning={isLoading} tip={b3Lang('global.tips.loading')} background="transparent">
+        <B3Spin
+          isSpinning={isLoading || !isLogoLoaded}
+          tip={b3Lang('global.tips.loading')}
+          background="transparent"
+        >
           <Box
             sx={{
               display: 'flex',
@@ -198,84 +202,95 @@ function Login(props: PageProps) {
               minWidth: '343px',
             }}
           >
-            <LoginTip showTipInfo={showTipInfo} flag={flag} loginAccount={loginAccount} />
-            {quoteDetailToCheckoutUrl && (
-              <Alert severity="error" variant="filled">
-                {b3Lang('login.loginText.quoteDetailToCheckoutUrl')}
-              </Alert>
-            )}
-            <Box sx={{ margin: '20px 0', minHeight: '150px' }}>
-              {isLogoLoaded && loginInfo.logo && (
-                <LoginImage
-                  maxWidth={isMobile ? '70%' : '250px'}
-                  src={loginInfo.logo}
-                  alt={b3Lang('login.registerLogo')}
-                  onClick={() => {
-                    window.location.href = '/';
-                  }}
-                />
-              )}
-            </Box>
-            {loginInfo.widgetHeadText && (
-              <LoginWidget
-                sx={{
-                  minHeight: '48px',
-                  width: registerEnabled || isMobile ? '100%' : '50%',
-                }}
-                html={loginInfo.widgetHeadText}
-              />
-            )}
-            <Box
-              sx={{
-                backgroundColor: '#FFFFFF',
-                borderRadius: '4px',
-                margin: '20px 0',
-                display: 'flex',
-                flexDirection: isMobile ? 'column' : 'row',
-                justifyContent: 'center',
-                width: isMobile ? 'auto' : loginAndRegisterContainerWidth,
-              }}
-            >
-              <Box
-                sx={{
-                  width: isMobile ? 'auto' : loginContainerWidth,
-                  paddingRight: isMobile ? 0 : '2%',
-                  ml: '16px',
-                  mr: isMobile ? '16px' : undefined,
-                  pb: registerEnabled ? undefined : '36px',
-                }}
-              >
-                <LoginForm
-                  loginBtn={loginInfo.loginBtn}
-                  handleLoginSubmit={handleLoginSubmit}
-                  backgroundColor={backgroundColor}
-                  isLoading={isLoading}
-                />
-              </Box>
-
-              {registerEnabled && (
+            {/*
+              Wait for the merchant login config (logo, button text, HTML regions, create
+              account panel) to load before rendering the form. The contexts hold hardcoded
+              defaults until getStoreConfigs() resolves, and rendering them first causes a
+              flicker as the real config swaps in. isLogoLoaded flips true in the same dispatch
+              that merges the CustomStyleContext config, so it gates the whole login config.
+            */}
+            {isLogoLoaded && (
+              <>
+                <LoginTip showTipInfo={showTipInfo} flag={flag} loginAccount={loginAccount} />
+                {quoteDetailToCheckoutUrl && (
+                  <Alert severity="error" variant="filled">
+                    {b3Lang('login.loginText.quoteDetailToCheckoutUrl')}
+                  </Alert>
+                )}
+                <Box sx={{ margin: '20px 0', minHeight: '150px' }}>
+                  {isLogoLoaded && loginInfo.logo && (
+                    <LoginImage
+                      maxWidth={isMobile ? '70%' : '250px'}
+                      src={loginInfo.logo}
+                      alt={b3Lang('login.registerLogo')}
+                      onClick={() => {
+                        window.location.href = '/';
+                      }}
+                    />
+                  )}
+                </Box>
+                {loginInfo.widgetHeadText && (
+                  <LoginWidget
+                    sx={{
+                      minHeight: '48px',
+                      width: registerEnabled || isMobile ? '100%' : '50%',
+                    }}
+                    html={loginInfo.widgetHeadText}
+                  />
+                )}
                 <Box
                   sx={{
-                    flex: '1',
-                    paddingLeft: isMobile ? 0 : '2%',
-                    mb: '20px',
+                    backgroundColor: '#FFFFFF',
+                    borderRadius: '4px',
+                    margin: '20px 0',
+                    display: 'flex',
+                    flexDirection: isMobile ? 'column' : 'row',
+                    justifyContent: 'center',
+                    width: isMobile ? 'auto' : loginAndRegisterContainerWidth,
                   }}
                 >
-                  <LoginPanel
-                    createAccountButtonText={loginInfo.createAccountButtonText}
-                    widgetBodyText={loginInfo.widgetBodyText}
-                  />
+                  <Box
+                    sx={{
+                      width: isMobile ? 'auto' : loginContainerWidth,
+                      paddingRight: isMobile ? 0 : '2%',
+                      ml: '16px',
+                      mr: isMobile ? '16px' : undefined,
+                      pb: registerEnabled ? undefined : '36px',
+                    }}
+                  >
+                    <LoginForm
+                      loginBtn={loginInfo.loginBtn}
+                      handleLoginSubmit={handleLoginSubmit}
+                      backgroundColor={backgroundColor}
+                      isLoading={isLoading}
+                    />
+                  </Box>
+
+                  {registerEnabled && (
+                    <Box
+                      sx={{
+                        flex: '1',
+                        paddingLeft: isMobile ? 0 : '2%',
+                        mb: '20px',
+                      }}
+                    >
+                      <LoginPanel
+                        createAccountButtonText={loginInfo.createAccountButtonText}
+                        widgetBodyText={loginInfo.widgetBodyText}
+                      />
+                    </Box>
+                  )}
                 </Box>
-              )}
-            </Box>
-            {loginInfo.widgetFooterText && (
-              <LoginWidget
-                sx={{
-                  minHeight: '48px',
-                  width: registerEnabled || isMobile ? '100%' : '50%',
-                }}
-                html={loginInfo.widgetFooterText}
-              />
+                {loginInfo.widgetFooterText && (
+                  <LoginWidget
+                    sx={{
+                      minHeight: '48px',
+                      width: registerEnabled || isMobile ? '100%' : '50%',
+                    }}
+                    html={loginInfo.widgetFooterText}
+                  />
+                )}
+              </>
             )}
           </Box>
         </B3Spin>

--- a/apps/storefront/src/utils/featureFlags.ts
+++ b/apps/storefront/src/utils/featureFlags.ts
@@ -47,6 +47,10 @@ export const featureFlags = [
     key: 'PROJECT-7920.use_bc_login_and_authorisation',
     name: 'useBcLoginAndAuthorisation',
   },
+  {
+    key: 'B2B-4870.default_buyer_portal_styling_on_login_page',
+    name: 'defaultBuyerPortalStylingOnLoginPage',
+  },
 ] as const;
 
 export type FeatureFlagKey = (typeof featureFlags)[number]['key'];

--- a/apps/storefront/src/utils/preMountLoginMask.test.ts
+++ b/apps/storefront/src/utils/preMountLoginMask.test.ts
@@ -1,11 +1,22 @@
-import { injectPreMountLoginMask, removePreMountLoginMask } from './preMountLoginMask';
+import {
+  injectPreMountLoginMask,
+  isDefaultLoginStylingActive,
+  removePreMountLoginMask,
+  setDefaultLoginStylingEnabled,
+  shouldUseDefaultLoginStyling,
+} from './preMountLoginMask';
 
 const MASK_ID = 'b2b-pre-mount-login-mask';
 
 const getMask = () => document.getElementById(MASK_ID);
 
+// The pre-mount mask is gated behind the default-login-styling feature flag,
+// cached in localStorage. The gate is optimistic: it masks unless the flag has
+// been explicitly cached as 'false'. Tests start from a clean (uncached) state
+// and opt into the cached values they need.
 afterEach(() => {
   getMask()?.remove();
+  localStorage.clear();
 });
 
 describe('injectPreMountLoginMask', () => {
@@ -51,6 +62,71 @@ describe('injectPreMountLoginMask', () => {
     injectPreMountLoginMask();
 
     expect(document.querySelectorAll(`#${MASK_ID}`)).toHaveLength(1);
+  });
+
+  it('does not inject when the flag is explicitly cached as off', () => {
+    setDefaultLoginStylingEnabled(false);
+    window.location.assign('/login.php');
+
+    injectPreMountLoginMask();
+
+    expect(getMask()).toBeNull();
+  });
+
+  it('injects optimistically when the flag has never been cached', () => {
+    localStorage.clear();
+    window.location.assign('/login.php');
+
+    injectPreMountLoginMask();
+
+    expect(getMask()).not.toBeNull();
+  });
+});
+
+describe('isDefaultLoginStylingActive', () => {
+  it('is true when the flag is cached as on', () => {
+    setDefaultLoginStylingEnabled(true);
+
+    expect(isDefaultLoginStylingActive()).toBe(true);
+  });
+
+  it('is true (optimistic) when the flag has never been cached', () => {
+    localStorage.clear();
+
+    expect(isDefaultLoginStylingActive()).toBe(true);
+  });
+
+  it('is false only when the flag is explicitly cached as off', () => {
+    setDefaultLoginStylingEnabled(false);
+
+    expect(isDefaultLoginStylingActive()).toBe(false);
+  });
+});
+
+describe('shouldUseDefaultLoginStyling', () => {
+  it('is true on the login page when the feature is active', () => {
+    window.location.assign('/login.php');
+
+    expect(shouldUseDefaultLoginStyling()).toBe(true);
+  });
+
+  it('is false when the flag is explicitly cached as off', () => {
+    setDefaultLoginStylingEnabled(false);
+    window.location.assign('/login.php');
+
+    expect(shouldUseDefaultLoginStyling()).toBe(false);
+  });
+
+  it('is false when not on the login page even if the feature is active', () => {
+    window.location.assign('/cart.php');
+
+    expect(shouldUseDefaultLoginStyling()).toBe(false);
+  });
+
+  it('is false on the change password flow', () => {
+    window.location.assign('/login.php?action=change_password');
+
+    expect(shouldUseDefaultLoginStyling()).toBe(false);
   });
 });
 

--- a/apps/storefront/src/utils/preMountLoginMask.test.ts
+++ b/apps/storefront/src/utils/preMountLoginMask.test.ts
@@ -1,0 +1,75 @@
+import { injectPreMountLoginMask, removePreMountLoginMask } from './preMountLoginMask';
+
+const MASK_ID = 'b2b-pre-mount-login-mask';
+
+const getMask = () => document.getElementById(MASK_ID);
+
+afterEach(() => {
+  getMask()?.remove();
+});
+
+describe('injectPreMountLoginMask', () => {
+  it('injects the mask style element when on the login page', () => {
+    window.location.assign('/login.php');
+
+    injectPreMountLoginMask();
+
+    const mask = getMask();
+    expect(mask).not.toBeNull();
+    expect(mask?.tagName).toBe('STYLE');
+    expect(mask?.parentElement).toBe(document.head);
+  });
+
+  it('does not inject when not on the login page', () => {
+    window.location.assign('/cart.php');
+
+    injectPreMountLoginMask();
+
+    expect(getMask()).toBeNull();
+  });
+
+  it('does not inject on the change password flow', () => {
+    window.location.assign('/login.php?action=change_password');
+
+    injectPreMountLoginMask();
+
+    expect(getMask()).toBeNull();
+  });
+
+  it('still injects for other login.php query params', () => {
+    window.location.assign('/login.php?action=create_account');
+
+    injectPreMountLoginMask();
+
+    expect(getMask()).not.toBeNull();
+  });
+
+  it('does not inject a second mask when one already exists', () => {
+    window.location.assign('/login.php');
+
+    injectPreMountLoginMask();
+    injectPreMountLoginMask();
+
+    expect(document.querySelectorAll(`#${MASK_ID}`)).toHaveLength(1);
+  });
+});
+
+describe('removePreMountLoginMask', () => {
+  it('removes the mask once it has been injected', () => {
+    window.location.assign('/login.php');
+    injectPreMountLoginMask();
+    expect(getMask()).not.toBeNull();
+
+    removePreMountLoginMask();
+
+    expect(getMask()).toBeNull();
+  });
+
+  it('is a no-op when no mask is present', () => {
+    expect(getMask()).toBeNull();
+
+    expect(() => removePreMountLoginMask()).not.toThrow();
+
+    expect(getMask()).toBeNull();
+  });
+});

--- a/apps/storefront/src/utils/preMountLoginMask.ts
+++ b/apps/storefront/src/utils/preMountLoginMask.ts
@@ -1,20 +1,84 @@
-// A pre-mount mask that hides the storefront's native login.php content as soon
-// as the bundle parses, so the merchant doesn't see a flash of BC's native form
-// before React mounts and the buyer-portal iframe activates.
-//
-// The mask is painted at z-index 11999, i.e. *just below* the iframe
-// (--z-index-IFRAME = 12000). That ordering is deliberate: once the iframe is
-// active and opaque it paints on top of the mask, so the mask can safely stay
-// mounted as an opaque backdrop while the in-iframe login page is still loading
-// (its B3Spin uses a transparent background). It must therefore only be removed
-// once the buyer portal has either rendered its login page or decided not to
-// take over the page — removing it on `isOpen` is too early and lets the native
-// form flash through the still-loading, transparent iframe.
+/*
+  A pre-mount mask that hides the storefront's native login.php content as soon
+  as the bundle parses, so the merchant doesn't see a flash of BC's native form
+  before React mounts and the buyer-portal iframe activates.
+
+  Gated behind the `B2B-4870.default_buyer_portal_styling_on_login_page` feature
+  flag. That flag lives in StoreConfig and is only fetched (asynchronously)
+  after React mounts, so it is not available at bundle-parse time when the mask
+  must be painted. We therefore cache the resolved flag value in localStorage
+  (see setDefaultLoginStylingEnabled, called from storefrontConfig once configs
+  load) and read it back synchronously here.
+
+  Because the flag is unknown on the very first visit (nothing cached yet), the
+  gate is *optimistic*: we apply the styling unless we have explicitly cached
+  that the feature is OFF. This guarantees that a flag-on store never flashes
+  the native form, even on the first load. A flag-off store therefore shows the
+  loading state once on its first ever visit; once getStoreConfigs caches
+  'false', it reverts to the plain native flow on every subsequent load.
+
+  The mask is painted at z-index 11999, i.e. *just below* the iframe
+  (--z-index-IFRAME = 12000). That ordering is deliberate: once the iframe is
+  active and opaque it paints on top of the mask, so the mask can safely stay
+  mounted as an opaque backdrop while the in-iframe login page is still loading
+  (its B3Spin uses a transparent background). It must therefore only be removed
+  once the buyer portal has either rendered its login page or decided not to
+  take over the page — removing it on `isOpen` is too early and lets the native
+  form flash through the still-loading, transparent iframe.
+*/
 const PRE_MOUNT_LOGIN_MASK_ID = 'b2b-pre-mount-login-mask';
 
-export const injectPreMountLoginMask = () => {
+/*
+  localStorage key caching the last-known value of the
+  B2B-4870.default_buyer_portal_styling_on_login_page feature flag, so the
+  pre-mount code can gate itself synchronously before StoreConfig is fetched.
+*/
+const DEFAULT_LOGIN_STYLING_STORAGE_KEY = 'b2b-default-login-styling-enabled';
+
+/*
+  Persist the resolved feature-flag value so the next page load can gate the
+  pre-mount mask synchronously. Best-effort: localStorage can throw (e.g. Safari
+  private mode or storage disabled), in which case the feature simply stays off
+  until the flag can be read from StoreConfig after mount.
+*/
+export const setDefaultLoginStylingEnabled = (enabled: boolean) => {
+  try {
+    localStorage.setItem(DEFAULT_LOGIN_STYLING_STORAGE_KEY, String(enabled));
+  } catch {
+    // ignore: persistence is best-effort
+  }
+};
+
+/*
+  Whether the default-login-styling feature should be treated as active. We only
+  back off when the flag has been explicitly cached as 'false'; an unknown
+  (uncached) value is treated as active so flag-on stores never flash the native
+  form on a cold start. Exported for the in-app login gate so it stays in lockstep
+  with the pre-mount mask.
+*/
+export const isDefaultLoginStylingActive = (): boolean => {
+  try {
+    return localStorage.getItem(DEFAULT_LOGIN_STYLING_STORAGE_KEY) !== 'false';
+  } catch {
+    return true;
+  }
+};
+
+const isLoginPage = (): boolean => {
   const { pathname, search } = window.location;
-  if (!pathname.includes('login.php') || search.includes('change_password')) return;
+  return pathname.includes('login.php') && !search.includes('change_password');
+};
+
+/*
+  True when the buyer portal should take over the native login.php form with its
+  own styling: we're on the login page and the feature isn't explicitly off.
+  Drives both the pre-mount mask and the eager app init in main.ts.
+*/
+export const shouldUseDefaultLoginStyling = (): boolean =>
+  isLoginPage() && isDefaultLoginStylingActive();
+
+export const injectPreMountLoginMask = () => {
+  if (!shouldUseDefaultLoginStyling()) return;
   if (document.getElementById(PRE_MOUNT_LOGIN_MASK_ID)) return;
 
   const style = document.createElement('style');

--- a/apps/storefront/src/utils/preMountLoginMask.ts
+++ b/apps/storefront/src/utils/preMountLoginMask.ts
@@ -1,0 +1,53 @@
+// A pre-mount mask that hides the storefront's native login.php content as soon
+// as the bundle parses, so the merchant doesn't see a flash of BC's native form
+// before React mounts and the buyer-portal iframe activates.
+//
+// The mask is painted at z-index 11999, i.e. *just below* the iframe
+// (--z-index-IFRAME = 12000). That ordering is deliberate: once the iframe is
+// active and opaque it paints on top of the mask, so the mask can safely stay
+// mounted as an opaque backdrop while the in-iframe login page is still loading
+// (its B3Spin uses a transparent background). It must therefore only be removed
+// once the buyer portal has either rendered its login page or decided not to
+// take over the page — removing it on `isOpen` is too early and lets the native
+// form flash through the still-loading, transparent iframe.
+const PRE_MOUNT_LOGIN_MASK_ID = 'b2b-pre-mount-login-mask';
+
+export const injectPreMountLoginMask = () => {
+  const { pathname, search } = window.location;
+  if (!pathname.includes('login.php') || search.includes('change_password')) return;
+  if (document.getElementById(PRE_MOUNT_LOGIN_MASK_ID)) return;
+
+  const style = document.createElement('style');
+  style.id = PRE_MOUNT_LOGIN_MASK_ID;
+  style.textContent = `
+    body::before {
+      content: '';
+      position: fixed;
+      inset: 0;
+      background: #FEF9F5;
+      z-index: 11999;
+    }
+    body::after {
+      content: '';
+      position: fixed;
+      top: 50%;
+      left: 50%;
+      width: 40px;
+      height: 40px;
+      margin: -20px 0 0 -20px;
+      border: 3px solid rgba(0, 0, 0, 0.1);
+      border-top-color: #292a25;
+      border-radius: 50%;
+      animation: b2b-pre-mount-spin 0.8s linear infinite;
+      z-index: 11999;
+    }
+    @keyframes b2b-pre-mount-spin {
+      to { transform: rotate(360deg); }
+    }
+  `;
+  document.head.appendChild(style);
+};
+
+export const removePreMountLoginMask = () => {
+  document.getElementById(PRE_MOUNT_LOGIN_MASK_ID)?.remove();
+};

--- a/apps/storefront/src/utils/storefrontConfig.ts
+++ b/apps/storefront/src/utils/storefrontConfig.ts
@@ -30,6 +30,7 @@ import { setActiveCurrency, setCurrencies } from '@/store/slices/storeConfigs';
 import { B3SStorage } from '@/utils/b3Storage';
 import { channelId } from '@/utils/basicConfig';
 import { FeatureFlagKey, featureFlags } from '@/utils/featureFlags';
+import { setDefaultLoginStylingEnabled } from '@/utils/preMountLoginMask';
 
 import { checkEveryPermissionsCode } from './b3CheckPermissions/check';
 
@@ -294,6 +295,15 @@ const getStoreConfigs = async (dispatch: any, dispatchGlobal: any) => {
       };
     }
   });
+
+  // Cache the default-login-styling flag so the next page load can gate the
+  // pre-mount login mask synchronously, before StoreConfig is fetched again.
+  // Read from the store (rather than the loop) so an absent flag resolves to
+  // false rather than leaving a stale cached value.
+  setDefaultLoginStylingEnabled(
+    store.getState().global.featureFlags['B2B-4870.default_buyer_portal_styling_on_login_page'] ??
+      false,
+  );
 
   dispatchGlobal({
     type: 'common',


### PR DESCRIPTION


Jira: [B2B-4870 ](https://bigcommercecloud.atlassian.net/browse/B2B-4870 )

## What/Why?
<!--
  A description about what this pull request implements and its purpose.
  Try to be detailed and describe any technical details to simplify the job
  of the reviewer and the individual on production support.
-->

The change adds a premount login mask that appears the moment the JS bundle loads, covering the native PHP login form with a backdrop and spinner before React even starts. 

It’s injected early in main.ts via injectPreMountLoginMask and sits just under the iframe (z‑index 11999 vs. 12000), so it stays visible until the iframe’s transparent login UI renders over it.

The mask is removed only when it’s safe, either when App.tsx tells isPageComplete or when B3StoreContainer.tsx detects that the app won’t mount (like when B2B is off or store info fails).

main.ts also now calls initApp immediately on login.php routes to reduce delay before the php UI appears.


## Rollout/Rollback
<!--
Detail how this change will be rolled out. Include reference to any
experiments and how the success will be measured as the experiment is
ramped.

Document rollback procedures. Is rolling back the change as simple as
rolling back an experiment or does it require reverting code? Are there
database migrations that may change our decision to roll forward instead of
back?
-->
Revert
## Testing
<!--
Provide as much information as you can about how you tested and how another
Engineer can test your change. Include screenshots, or test run output
where appropriate.
-->
Before


https://github.com/user-attachments/assets/404e0338-465d-4664-9058-bcd01d74ec47



After


https://github.com/user-attachments/assets/bc4e95ee-f23c-4873-b759-3089e478e9b8




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes login.php bootstrap timing, DOM overlay z-index, and first-visit behavior when the feature flag is off (one-time optimistic mask); failures are mitigated by fallback mask removal paths.
> 
> **Overview**
> Adds a **pre-mount login mask** (backdrop + spinner) injected in `main.ts` before React loads, gated by `B2B-4870.default_buyer_portal_styling_on_login_page` via an optimistic **localStorage** cache so `login.php` never flashes the native BigCommerce form on cold start when the flag is on.
> 
> **`login.php`** now **eagerly** calls `initApp()` (not idle callback) when default login styling applies. The mask is removed only when safe: **`App`** after `isPageComplete`, or **`B3StoreContainer`** when the buyer portal never mounts (B2B off, missing store, fetch errors).
> 
> The in-iframe **Login** page waits for merchant login config (`isLogoLoaded`) or init completion (`isPageComplete`) before rendering the form, using the same synchronous flag read as the mask to avoid default-config flicker. Store config load persists the flag to localStorage; tests cover mask behavior and login gating.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a481fd11de5a5b50b6a73e0e97f90cdbba1a8bad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->