### PR TITLE
feat(shopping-lists): BACK-695 add backorder display to choose options

### DIFF
--- a/apps/storefront/src/hooks/useCatalogChooseOptionsBackorderDisplay.ts
+++ b/apps/storefront/src/hooks/useCatalogChooseOptionsBackorderDisplay.ts
@@ -1,0 +1,60 @@
+import { useCallback, useMemo } from 'react';
+
+import { useBackorderStorefrontMessaging } from '@/hooks/useBackorderStorefrontMessaging';
+import { useB3Lang } from '@/lib/lang';
+import type { ShoppingListProductItem, Variant } from '@/types';
+import type { BackorderDisplayFields } from '@/utils/backorderDisplayFromInventory';
+import {
+  getCatalogInventoryRowFromSearchProduct,
+  getCatalogProductRowDisplayState,
+} from '@/utils/catalogBackorderDisplay';
+
+interface UseCatalogChooseOptionsBackorderDisplayOptions {
+  product?: ShoppingListProductItem;
+  variantInfo?: Partial<Variant> | null;
+  quantity: number | string;
+  showAvailableToSellHelper?: boolean;
+}
+
+interface CatalogChooseOptionsBackorderDisplay {
+  backorderUiEnabled: boolean;
+  qtyHelperText: string;
+  backorderFields: BackorderDisplayFields | null;
+}
+
+export function useCatalogChooseOptionsBackorderDisplay({
+  product,
+  variantInfo,
+  quantity,
+  showAvailableToSellHelper = true,
+}: UseCatalogChooseOptionsBackorderDisplayOptions): CatalogChooseOptionsBackorderDisplay {
+  const b3Lang = useB3Lang();
+  const { isBackorderMessagingContextEnabled, hasAnyBackorderDisplay } =
+    useBackorderStorefrontMessaging();
+  const backorderUiEnabled = isBackorderMessagingContextEnabled && hasAnyBackorderDisplay;
+
+  const formatOnlyAvailable = useCallback(
+    (count: number) =>
+      b3Lang('purchasedProducts.quickAdd.inlineErrors.insufficientStockSku', { count }),
+    [b3Lang],
+  );
+
+  const inventoryRow = useMemo(
+    () => (product ? getCatalogInventoryRowFromSearchProduct(product, variantInfo) : undefined),
+    [product, variantInfo],
+  );
+
+  return useMemo(
+    () => ({
+      backorderUiEnabled,
+      ...getCatalogProductRowDisplayState({
+        qty: Number(quantity) || 0,
+        showAvailableToSellHelper: showAvailableToSellHelper && backorderUiEnabled,
+        inventoryRow,
+        backorderUiEnabled,
+        formatOnlyAvailable,
+      }),
+    }),
+    [quantity, inventoryRow, backorderUiEnabled, formatOnlyAvailable, showAvailableToSellHelper],
+  );
+}

--- a/apps/storefront/src/pages/QuickOrder/components/ChooseOptionsDialog.tsx
+++ b/apps/storefront/src/pages/QuickOrder/components/ChooseOptionsDialog.tsx
@@ -5,7 +5,6 @@ import {
   SetStateAction,
   useCallback,
   useEffect,
-  useMemo,
   useRef,
   useState,
 } from 'react';
@@ -19,7 +18,7 @@ import B3Dialog from '@/components/B3Dialog';
 import BackorderMessage from '@/components/BackorderMessage';
 import B3Spin from '@/components/spin/B3Spin';
 import { PRODUCT_DEFAULT_IMAGE } from '@/constants';
-import { useBackorderStorefrontMessaging } from '@/hooks/useBackorderStorefrontMessaging';
+import { useCatalogChooseOptionsBackorderDisplay } from '@/hooks/useCatalogChooseOptionsBackorderDisplay';
 import { useB3Lang } from '@/lib/lang';
 import { searchProducts } from '@/shared/service/b2b';
 import { useAppSelector } from '@/store';
@@ -30,10 +29,6 @@ import { calculateProductListPrice, getBCPrice } from '@/utils/b3Product/b3Produ
 import { getOptionRequestData, getProductOptionsFields } from '@/utils/b3Product/shared/config';
 import { snackbar } from '@/utils/b3Tip';
 import { Base64 } from '@/utils/base64';
-import {
-  getCatalogInventoryRowFromSearchProduct,
-  getCatalogProductRowDisplayState,
-} from '@/utils/catalogBackorderDisplay';
 
 const Flex = styled('div')({
   display: 'flex',
@@ -124,34 +119,13 @@ export default function ChooseOptionsDialog(props: ChooseOptionsDialogProps) {
   const [chooseOptionsProduct, setChooseOptionsProduct] = useState<ChooseOptionsProductProps[]>([]);
   const [isRequestLoading, setIsRequestLoading] = useState<boolean>(false);
 
-  const { isBackorderMessagingContextEnabled, hasAnyBackorderDisplay } =
-    useBackorderStorefrontMessaging();
-  const backorderUiEnabled = isBackorderMessagingContextEnabled && hasAnyBackorderDisplay;
+  const isShowPrice = !product?.isPriceHidden;
 
-  const isShowPrice = Boolean(product?.isPriceHidden);
-
-  const formatOnlyAvailable = useCallback(
-    (count: number) =>
-      b3Lang('purchasedProducts.quickAdd.inlineErrors.insufficientStockSku', { count }),
-    [b3Lang],
-  );
-
-  const inventoryRow = useMemo(
-    () => (product ? getCatalogInventoryRowFromSearchProduct(product, variantInfo) : undefined),
-    [product, variantInfo],
-  );
-
-  const { qtyHelperText, backorderFields } = useMemo(
-    () =>
-      getCatalogProductRowDisplayState({
-        qty: Number(quantity) || 0,
-        showAvailableToSellHelper: backorderUiEnabled,
-        inventoryRow,
-        backorderUiEnabled,
-        formatOnlyAvailable,
-      }),
-    [quantity, inventoryRow, backorderUiEnabled, formatOnlyAvailable],
-  );
+  const { qtyHelperText, backorderFields } = useCatalogChooseOptionsBackorderDisplay({
+    product,
+    variantInfo,
+    quantity,
+  });
 
   const setChooseOptionsForm = async (product: ShoppingListProductItem) => {
     try {

--- a/apps/storefront/src/pages/ShoppingListDetails/components/ChooseOptionsDialog.tsx
+++ b/apps/storefront/src/pages/ShoppingListDetails/components/ChooseOptionsDialog.tsx
@@ -15,8 +15,10 @@ import isEqual from 'lodash-es/isEqual';
 
 import { B3CustomForm } from '@/components/B3CustomForm';
 import B3Dialog from '@/components/B3Dialog';
+import BackorderMessage from '@/components/BackorderMessage';
 import B3Spin from '@/components/spin/B3Spin';
 import { PRODUCT_DEFAULT_IMAGE } from '@/constants';
+import { useCatalogChooseOptionsBackorderDisplay } from '@/hooks/useCatalogChooseOptionsBackorderDisplay';
 import { useIsBackorderEnabled } from '@/hooks/useIsBackorderEnabled';
 import { useB3Lang } from '@/lib/lang';
 import { searchProducts } from '@/shared/service/b2b';
@@ -143,6 +145,13 @@ export default function ChooseOptionsDialog(props: ChooseOptionsDialogProps) {
   const [chooseOptionsProduct, setChooseOptionsProduct] = useState<ChooseOptionsProductProps[]>([]);
   const [isRequestLoading, setIsRequestLoading] = useState<boolean>(false);
   const isBackorderEnabled = useIsBackorderEnabled();
+
+  const { qtyHelperText, backorderFields } = useCatalogChooseOptionsBackorderDisplay({
+    product,
+    variantInfo,
+    quantity,
+    showAvailableToSellHelper: false,
+  });
 
   useEffect(() => {
     if (type === 'quote' && product) {
@@ -553,10 +562,16 @@ export default function ChooseOptionsDialog(props: ChooseOptionsDialogProps) {
               <Box
                 sx={{
                   display: 'flex',
+                  minWidth: 0,
                 }}
               >
                 <ProductImage src={currentImage || product.imageUrl || PRODUCT_DEFAULT_IMAGE} />
-                <Flex>
+                <Flex
+                  style={{
+                    flex: 1,
+                    minWidth: 0,
+                  }}
+                >
                   <FlexItem padding="0">
                     <Box
                       sx={{
@@ -584,22 +599,66 @@ export default function ChooseOptionsDialog(props: ChooseOptionsDialogProps) {
                       : currencyFormat(newPrice * Number(quantity) || getProductPrice(product))}
                   </FlexItem>
 
-                  <FlexItem>
-                    <StyleTextField
-                      type="number"
-                      variant="filled"
-                      label={b3Lang('shoppingList.chooseOptionsDialog.quantity')}
-                      value={quantity}
-                      onChange={handleProductQuantityChange}
-                      onKeyDown={handleNumberInputKeyDown}
-                      onBlur={handleNumberInputBlur}
-                      size="small"
+                  <Box
+                    sx={{
+                      flexGrow: 0,
+                      flexShrink: 0,
+                      minWidth: 0,
+                      overflow: 'visible',
+                      padding: '0 0 0 16px',
+                    }}
+                  >
+                    <Box
                       sx={{
-                        width: '60%',
-                        maxWidth: '100px',
+                        display: 'grid',
+                        gridTemplateColumns: '100px',
+                        justifyItems: 'start',
+                        rowGap: 0.5,
+                        overflow: 'visible',
                       }}
-                    />
-                  </FlexItem>
+                    >
+                      <StyleTextField
+                        type="number"
+                        variant="filled"
+                        label={b3Lang('shoppingList.chooseOptionsDialog.quantity')}
+                        value={quantity}
+                        onChange={handleProductQuantityChange}
+                        onKeyDown={handleNumberInputKeyDown}
+                        onBlur={handleNumberInputBlur}
+                        size="small"
+                        fullWidth
+                        error={Boolean(qtyHelperText)}
+                      />
+                      {(qtyHelperText || backorderFields) && (
+                        <Box
+                          sx={{
+                            width: 'max-content',
+                            maxWidth: 'none',
+                            overflow: 'visible',
+                          }}
+                        >
+                          {qtyHelperText && (
+                            <Typography
+                              variant="caption"
+                              color="error"
+                              component="p"
+                              sx={{ m: 0, whiteSpace: 'nowrap' }}
+                            >
+                              {qtyHelperText}
+                            </Typography>
+                          )}
+                          {backorderFields && (
+                            <BackorderMessage
+                              totalOnHand={backorderFields.totalOnHand}
+                              quantityBackordered={backorderFields.quantityBackordered}
+                              backorderMessage={backorderFields.backorderMessage}
+                              visible
+                            />
+                          )}
+                        </Box>
+                      )}
+                    </Box>
+                  </Box>
                 </Flex>
               </Box>
 

--- a/apps/storefront/src/pages/ShoppingListDetails/index.test.tsx
+++ b/apps/storefront/src/pages/ShoppingListDetails/index.test.tsx
@@ -4114,3 +4114,256 @@ describe('when backorder messaging is enabled in add to list search modal', () =
     });
   });
 });
+
+describe('when backorder messaging is enabled in choose options dialog', () => {
+  const searchTerm = 'Fog Towel';
+  const productId = 9001;
+  const optionId = 50;
+  const sizeM = 102;
+  const variantSku = 'TOWEL-M';
+  const variantId = 5001;
+
+  const backorderPreloadedState = {
+    company: b2bCompanyWithShoppingListPermissions,
+    global: buildGlobalStateWith({
+      backorderEnabled: true,
+      backorderDisplaySettings: {
+        showQuantityOnBackorder: true,
+        showQuantityOnHand: true,
+        showBackorderMessage: true,
+        showDefaultShippingExpectationPrompt: false,
+        defaultShippingExpectationPrompt: '',
+      },
+      featureFlags: {
+        'BACK-134.backorders_phase_1_1_control_messaging_on_storefront': true,
+      },
+    }),
+  };
+
+  const setupChooseOptionsModal = () => {
+    vitest.mocked(useParams).mockReturnValue({ id: '272989' });
+
+    const listProductEdge = buildShoppingListProductEdgeWith({
+      node: {
+        productName: 'Existing list item',
+        productId: 8000,
+        variantSku: 'LIST-SKU-001',
+        quantity: 1,
+        basePrice: '10.00',
+      },
+    });
+
+    const variantM = buildSearchB2BProductVariantWith({
+      variant_id: variantId,
+      product_id: productId,
+      sku: variantSku,
+      purchasing_disabled: false,
+      option_values: [
+        {
+          id: sizeM,
+          label: 'M',
+          option_id: optionId,
+          option_display_name: 'Size',
+        },
+      ],
+      available_to_sell: 10,
+      unlimited_backorder: false,
+      total_on_hand: 2,
+      backorder_message: 'Lead time: 2-4 weeks',
+      bc_calculated_price: {
+        tax_exclusive: 50,
+        tax_inclusive: 55,
+        as_entered: 50,
+        entered_inclusive: false,
+      },
+    });
+
+    const variantS = buildSearchB2BProductVariantWith({
+      product_id: productId,
+      sku: 'TOWEL-S',
+      purchasing_disabled: false,
+      option_values: [
+        {
+          id: 101,
+          label: 'S',
+          option_id: optionId,
+          option_display_name: 'Size',
+        },
+      ],
+      available_to_sell: 5,
+      unlimited_backorder: false,
+      total_on_hand: 5,
+      bc_calculated_price: {
+        tax_exclusive: 45,
+        tax_inclusive: 50,
+        as_entered: 45,
+        entered_inclusive: false,
+      },
+    });
+
+    const sizeOption = buildSearchB2BProductV3OptionWith({
+      id: optionId,
+      product_id: productId,
+      type: 'rectangles',
+      display_name: 'Size',
+      option_values: [
+        buildSearchB2BProductV3OptionValueWith({
+          id: 101,
+          label: 'S',
+          is_default: false,
+        }),
+        buildSearchB2BProductV3OptionValueWith({
+          id: sizeM,
+          label: 'M',
+          is_default: true,
+        }),
+      ],
+    });
+
+    const searchProduct = buildSearchB2BProductWith({
+      id: productId,
+      name: 'Fog Towel',
+      sku: 'TOWEL-BASE',
+      inventoryTracking: 'variant',
+      optionsV3: [sizeOption],
+      isPriceHidden: false,
+      orderQuantityMinimum: 0,
+      orderQuantityMaximum: 0,
+      variants: [variantS, variantM],
+    });
+
+    const shoppingListResponse = buildShoppingListGraphQLResponseWith({
+      data: {
+        shoppingList: {
+          products: { totalCount: 1, edges: [listProductEdge] },
+          status: 0,
+          grandTotal: '10.00',
+          totalTax: '0',
+        },
+      },
+    });
+
+    server.use(
+      graphql.query('B2BShoppingListDetails', () => HttpResponse.json(shoppingListResponse)),
+      graphql.query('SearchProducts', ({ query }) => {
+        if (/productIds: \[\d/.test(query)) {
+          return HttpResponse.json(
+            buildSearchProductsResponseWith({ data: { productsSearch: [] } }),
+          );
+        }
+
+        return HttpResponse.json(
+          buildSearchProductsResponseWith({ data: { productsSearch: [searchProduct] } }),
+        );
+      }),
+      graphql.query('priceProducts', () =>
+        HttpResponse.json({
+          data: {
+            priceProducts: [
+              buildProductPriceWith({
+                productId,
+                variantId,
+              }),
+            ],
+          },
+        }),
+      ),
+    );
+  };
+
+  const openChooseOptionsDialog = async () => {
+    await screen.findByRole('heading', { name: /add to list/i });
+
+    const searchBox = screen.getByPlaceholderText('Search products');
+    await userEvent.type(searchBox, searchTerm);
+    await userEvent.click(screen.getByRole('button', { name: /Search product/i }));
+
+    const listDialog = await screen.findByRole('dialog', { name: 'Add to list' });
+    await userEvent.click(within(listDialog).getByRole('button', { name: 'Choose options' }));
+
+    return screen.findByRole('dialog', { name: 'Choose options' });
+  };
+
+  it('shows backorder prompts when a variant is selected', async () => {
+    setupChooseOptionsModal();
+
+    renderWithProviders(<ShoppingListDetailsContent setOpenPage={() => {}} />, {
+      preloadedState: backorderPreloadedState,
+    });
+
+    await waitForElementToBeRemoved(() => screen.queryByText(/loading/i));
+
+    const chooseOptionsDialog = await openChooseOptionsDialog();
+    const quantityInput = within(chooseOptionsDialog).getByRole('spinbutton');
+
+    await waitFor(() => {
+      expect(within(chooseOptionsDialog).getByText(variantSku)).toBeInTheDocument();
+    });
+
+    await userEvent.type(quantityInput, '4', {
+      initialSelectionStart: 0,
+      initialSelectionEnd: Infinity,
+    });
+
+    await waitFor(() => {
+      expect(within(chooseOptionsDialog).getByText('2 ready to ship')).toBeVisible();
+    });
+    expect(within(chooseOptionsDialog).getByText('2 will be backordered')).toBeVisible();
+    expect(within(chooseOptionsDialog).getByText('Lead time: 2-4 weeks')).toBeVisible();
+
+    await userEvent.type(quantityInput, '15', {
+      initialSelectionStart: 0,
+      initialSelectionEnd: Infinity,
+    });
+
+    await waitFor(() => {
+      expect(within(chooseOptionsDialog).getByText('2 ready to ship')).toBeVisible();
+    });
+    expect(within(chooseOptionsDialog).getByText('8 will be backordered')).toBeVisible();
+    expect(within(chooseOptionsDialog).queryByText('10 available')).not.toBeInTheDocument();
+    expect(quantityInput.closest('.MuiTextField-root')).not.toHaveClass('Mui-error');
+
+    await userEvent.type(quantityInput, '2', {
+      initialSelectionStart: 0,
+      initialSelectionEnd: Infinity,
+    });
+
+    await waitFor(() => {
+      expect(within(chooseOptionsDialog).queryByText('2 ready to ship')).not.toBeInTheDocument();
+    });
+    expect(
+      within(chooseOptionsDialog).queryByText('2 will be backordered'),
+    ).not.toBeInTheDocument();
+    expect(within(chooseOptionsDialog).queryByText('Lead time: 2-4 weeks')).not.toBeInTheDocument();
+    expect(within(chooseOptionsDialog).queryByText('10 available')).not.toBeInTheDocument();
+  });
+
+  it('hides backorder lines when messaging is disabled', async () => {
+    setupChooseOptionsModal();
+
+    renderWithProviders(<ShoppingListDetailsContent setOpenPage={() => {}} />, {
+      preloadedState: { company: b2bCompanyWithShoppingListPermissions },
+    });
+
+    await waitForElementToBeRemoved(() => screen.queryByText(/loading/i));
+
+    const chooseOptionsDialog = await openChooseOptionsDialog();
+    const quantityInput = within(chooseOptionsDialog).getByRole('spinbutton');
+
+    await waitFor(() => {
+      expect(within(chooseOptionsDialog).getByText(variantSku)).toBeInTheDocument();
+    });
+
+    await userEvent.type(quantityInput, '10', {
+      initialSelectionStart: 0,
+      initialSelectionEnd: Infinity,
+    });
+
+    await waitFor(() => {
+      expect(within(chooseOptionsDialog).getByText('Fog Towel')).toBeVisible();
+    });
+    expect(
+      within(chooseOptionsDialog).queryByText('will be backordered', { exact: false }),
+    ).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Jira: [BACK-695](https://bigcommercecloud.atlassian.net/browse/BACK-695)

## What/Why?
Adding backorder display to the choose options flow for complex products. Introducing `useCatalogChooseOptionsBackorderDisplay` for shared inventory-fetch logic in both shopping list and quick order flows.

## Rollout/Rollback
Merge/revert. Backorder display is gated by `Feature_Backorder && BACK-134.backorders_phase_1_1_control_messaging_on_storefront`.

## Testing
Backorder display is show for variants, with varying on-hand, backorder limit, and message.

https://github.com/user-attachments/assets/1fca738a-a515-4c5b-b612-8b761ab8a807

Regression - quick order flow works as before.

https://github.com/user-attachments/assets/693588a2-1da6-4dbd-ab4e-dc6f25f328a9

Backorder display does not appear for disabled `Feature_Backorder && BACK-134.backorders_phase_1_1_control_messaging_on_storefront`.

https://github.com/user-attachments/assets/9f364a48-c262-4350-964e-9521fecc5fe9

Ping @animesh1987 @benpratt77 

[BACK-695]: https://bigcommercecloud.atlassian.net/browse/BACK-695?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches quantity/inventory UX on shopping list and quick-order add flows; behavior is feature-flagged but incorrect messaging could mislead buyers about stock/backorder.
> 
> **Overview**
> Introduces **`useCatalogChooseOptionsBackorderDisplay`** so Quick Order and Shopping List **Choose options** dialogs share the same inventory/backorder messaging (on-hand, backordered qty, lead-time text) behind existing storefront backorder flags.
> 
> **Shopping List** `ChooseOptionsDialog` now renders **`BackorderMessage`** and stock helper text under quantity (with **`showAvailableToSellHelper: false`** so ATS errors are not shown in this flow), plus layout tweaks so messages don’t clip. **Quick Order** dialog drops inlined backorder logic in favor of the hook and corrects **hidden-price** handling (`isShowPrice` now uses `!product?.isPriceHidden`).
> 
> Adds integration tests on **Shopping List details** for choose-options backorder visibility when messaging is on vs off.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8923ab56c12611e06a0f08e176d399f2a5503e18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->