### PR TITLE
feat(orders): BACK-706 Add backorder display to add to shopping list

### DIFF
--- a/apps/storefront/src/pages/OrderDetail/components/OrderCheckboxProduct.tsx
+++ b/apps/storefront/src/pages/OrderDetail/components/OrderCheckboxProduct.tsx
@@ -34,8 +34,8 @@ interface OrderCheckboxProductProps {
   setReturnArr?: (items: ReturnListProps[]) => void;
   textAlign?: string;
   type?: string;
-  reorderInventoryBySku?: Record<string, CatalogQuickVariantSku>;
-  reorderBackorderUiEnabled?: boolean;
+  catalogInventoryBySku?: Record<string, CatalogQuickVariantSku>;
+  backorderUiEnabled?: boolean;
 }
 
 export default function OrderCheckboxProduct(props: OrderCheckboxProductProps) {
@@ -48,8 +48,8 @@ export default function OrderCheckboxProduct(props: OrderCheckboxProductProps) {
     setReturnArr = () => {},
     textAlign = 'left',
     type,
-    reorderInventoryBySku,
-    reorderBackorderUiEnabled = false,
+    catalogInventoryBySku,
+    backorderUiEnabled = false,
   } = props;
 
   const b3Lang = useB3Lang();
@@ -57,6 +57,8 @@ export default function OrderCheckboxProduct(props: OrderCheckboxProductProps) {
   const [isMobile] = useMobile();
 
   const [returnList, setReturnList] = useState<ReturnListProps[]>([]);
+
+  const usesCatalogBackorderInventory = type === 'reOrder' || type === 'shoppingList';
 
   const getProductTotals = (quantity: string | number, price: string | number) => {
     const priceNumber = parseFloat(price.toString()) || 0;
@@ -68,9 +70,7 @@ export default function OrderCheckboxProduct(props: OrderCheckboxProductProps) {
   const itemStyle = isMobile ? mobileItemStyle : defaultItemStyle;
   const qtyStackAlignItems = textAlign === 'right' ? 'flex-end' : 'flex-start';
   const desktopQtyColumnStyle =
-    reorderBackorderUiEnabled && !isMobile
-      ? { width: '22%', minWidth: '160px' }
-      : itemStyle.default;
+    backorderUiEnabled && !isMobile ? { width: '22%', minWidth: '160px' } : itemStyle.default;
 
   const handleSelectAllChange = () => {
     if (checkedArr.length === products.length) {
@@ -205,9 +205,10 @@ export default function OrderCheckboxProduct(props: OrderCheckboxProductProps) {
           qty,
           productHelperText: product.helperText,
           showAvailableToSellHelper: type === 'reOrder',
-          inventoryRow:
-            type === 'reOrder' ? reorderInventoryBySku?.[product.sku.toUpperCase()] : undefined,
-          backorderUiEnabled: reorderBackorderUiEnabled,
+          inventoryRow: usesCatalogBackorderInventory
+            ? catalogInventoryBySku?.[product.sku.toUpperCase()]
+            : undefined,
+          backorderUiEnabled,
           formatOnlyAvailable: (count) => b3Lang('orderDetail.reorder.onlyAvailable', { count }),
         });
 

--- a/apps/storefront/src/pages/OrderDetail/components/OrderDialog.tsx
+++ b/apps/storefront/src/pages/OrderDetail/components/OrderDialog.tsx
@@ -494,7 +494,7 @@ export default function OrderDialog({
     setOpenShoppingList(true);
   };
 
-  const reorderInventoryBySku = useMemo(() => {
+  const catalogInventoryBySku = useMemo(() => {
     const map: Record<string, CatalogQuickVariantSku> = {};
     variantInfoList.forEach((row) => {
       if (row.variantSku) {
@@ -590,9 +590,11 @@ export default function OrderDialog({
             setReturnArr={setReturnArr}
             textAlign={isMobile ? 'left' : 'right'}
             type={type}
-            reorderInventoryBySku={reorderInventoryBySku}
-            reorderBackorderUiEnabled={
-              isBackorderMessagingContextEnabled && hasAnyBackorderDisplay && type === 'reOrder'
+            catalogInventoryBySku={catalogInventoryBySku}
+            backorderUiEnabled={
+              isBackorderMessagingContextEnabled &&
+              hasAnyBackorderDisplay &&
+              (type === 'reOrder' || type === 'shoppingList')
             }
           />
 

--- a/apps/storefront/src/pages/OrderDetail/index.test.tsx
+++ b/apps/storefront/src/pages/OrderDetail/index.test.tsx
@@ -311,6 +311,65 @@ const buildCustomerShoppingListResponseWith = builder(() => {
   };
 });
 
+interface VariantInfo {
+  isStock: '1' | '0';
+  stock: number;
+  calculatedPrice: string;
+  productId: string;
+  variantId: string;
+  baseSku: string;
+  productName: string;
+  categories: string[];
+  option: unknown[];
+  isVisible: '1' | '0';
+  minQuantity: number;
+  maxQuantity: number;
+  modifiers: unknown[];
+  purchasingDisabled: '1' | '0';
+  variantSku: string;
+  imageUrl: string;
+  inventoryTracking?: string;
+  availableToSell?: number;
+  unlimitedBackorder?: boolean;
+  totalOnHand?: number | null;
+  backorderMessage?: string | null;
+}
+
+interface VariantInfoResponse {
+  data: {
+    variantSku: VariantInfo[];
+  };
+}
+
+const buildVariantInfoWith = builder<VariantInfo>(() => ({
+  isStock: faker.helpers.arrayElement(['0', '1']),
+  stock: faker.number.int(),
+  calculatedPrice: faker.commerce.price(),
+  productId: faker.number.int().toString(),
+  variantId: faker.number.int().toString(),
+  baseSku: faker.string.uuid(),
+  productName: faker.commerce.productName(),
+  categories: Array.from({ length: faker.number.int({ min: 0, max: 3 }) }, () =>
+    faker.number.int().toString(),
+  ),
+  imageUrl: faker.image.url(),
+  option: [],
+  isVisible: faker.helpers.arrayElement(['0', '1']),
+  minQuantity: faker.number.int(),
+  maxQuantity: faker.number.int(),
+  modifiers: [],
+  purchasingDisabled: faker.helpers.arrayElement(['0', '1']),
+  variantSku: faker.string.uuid(),
+}));
+
+const buildVariantInfoResponseWith = builder<VariantInfoResponse>(() => ({
+  data: {
+    variantSku: bulk(buildVariantInfoWith, 'WHATEVER_VALUES').times(
+      faker.number.int({ min: 1, max: 5 }),
+    ),
+  },
+}));
+
 beforeEach(() => {
   set(window, 'b2b.callbacks.dispatchEvent', vi.fn());
 });
@@ -3049,6 +3108,137 @@ describe('when a personal customer visits an order', () => {
       await waitFor(() => {
         expect(screen.getByText('Please select at least one item')).toBeVisible();
       });
+    });
+  });
+
+  describe('when backorder messaging is enabled in add to shopping list dialog', () => {
+    const variantSku = 'ORDER-SKU-001';
+    const productName = 'Cast Iron Skillet';
+
+    const backorderPreloadedState = {
+      company: buildCompanyStateWith({
+        customer: {
+          role: CustomerRole.B2C,
+        },
+      }),
+      storeInfo: buildStoreInfoStateWith({ timeFormat: { display: 'j F Y' } }),
+      global: buildGlobalStateWith({
+        backorderEnabled: true,
+        backorderDisplaySettings: {
+          showQuantityOnBackorder: true,
+          showQuantityOnHand: true,
+          showBackorderMessage: true,
+          showDefaultShippingExpectationPrompt: false,
+          defaultShippingExpectationPrompt: '',
+        },
+        featureFlags: {
+          'BACK-134.backorders_phase_1_1_control_messaging_on_storefront': true,
+        },
+      }),
+    };
+
+    const setupAddToShoppingListModal = () => {
+      const skillet = {
+        ...buildProductWith({
+          name: productName,
+          sku: variantSku,
+          quantity: 2,
+          product_options: [],
+        }),
+        isVisible: true,
+      };
+
+      const variantInfo = buildVariantInfoWith({
+        variantSku,
+        inventoryTracking: 'variant',
+        availableToSell: 10,
+        unlimitedBackorder: false,
+        totalOnHand: 9,
+        backorderMessage: 'Lead time: 2-4 weeks',
+      });
+
+      server.use(
+        graphql.query('GetCustomerOrderStatuses', () =>
+          HttpResponse.json(buildCustomerOrderStatusesWith('WHATEVER_VALUES')),
+        ),
+        graphql.query('AddressConfig', () =>
+          HttpResponse.json(buildAddressConfigResponseWith('WHATEVER_VALUES')),
+        ),
+        graphql.query('GetCustomerOrder', () =>
+          HttpResponse.json(
+            buildCustomerOrderResponseWith({
+              data: { customerOrder: { products: [skillet] } },
+            }),
+          ),
+        ),
+        graphql.query('GetVariantInfoBySkus', ({ query }) => {
+          if (query.includes(`"${variantSku}"`)) {
+            return HttpResponse.json(
+              buildVariantInfoResponseWith({ data: { variantSku: [variantInfo] } }),
+            );
+          }
+
+          return HttpResponse.json(buildVariantInfoResponseWith({ data: { variantSku: [] } }));
+        }),
+      );
+    };
+
+    it('shows backorder prompts when qty exceeds on hand', async () => {
+      setupAddToShoppingListModal();
+
+      renderWithProviders(<OrderDetails />, {
+        preloadedState: backorderPreloadedState,
+        initialGlobalContext: { shoppingListEnabled: true },
+      });
+
+      await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+      await userEvent.click(screen.getByRole('button', { name: 'ADD TO SHOPPING LIST' }));
+
+      const dialog = await screen.findByRole('dialog', { name: 'Add to shopping list' });
+      const productGroup = within(dialog).getByRole('group', { name: productName });
+      const quantityInput = within(productGroup).getByRole('spinbutton');
+
+      await userEvent.type(quantityInput, '10', {
+        initialSelectionStart: 0,
+        initialSelectionEnd: Infinity,
+      });
+
+      await waitFor(() => {
+        expect(within(dialog).getByText('9 ready to ship')).toBeVisible();
+      });
+      expect(within(dialog).getByText('1 will be backordered')).toBeVisible();
+      expect(within(dialog).getByText('Lead time: 2-4 weeks')).toBeVisible();
+      expect(quantityInput.closest('.MuiTextField-root')).not.toHaveClass('Mui-error');
+    });
+
+    it('hides backorder lines when messaging is disabled', async () => {
+      setupAddToShoppingListModal();
+
+      renderWithProviders(<OrderDetails />, {
+        preloadedState,
+        initialGlobalContext: { shoppingListEnabled: true },
+      });
+
+      await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+      await userEvent.click(screen.getByRole('button', { name: 'ADD TO SHOPPING LIST' }));
+
+      const dialog = await screen.findByRole('dialog', { name: 'Add to shopping list' });
+      const productGroup = within(dialog).getByRole('group', { name: productName });
+      const quantityInput = within(productGroup).getByRole('spinbutton');
+
+      await userEvent.type(quantityInput, '10', {
+        initialSelectionStart: 0,
+        initialSelectionEnd: Infinity,
+      });
+
+      await waitFor(() => {
+        expect(within(dialog).getByText(productName)).toBeVisible();
+      });
+      expect(
+        within(dialog).queryByText('will be backordered', { exact: false }),
+      ).not.toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
Jira: [BACK-706](https://bigcommercecloud.atlassian.net/browse/BACK-706)

## What/Why?
Add backorder display to "add to shopping list" flow from my orders.

## Rollout/Rollback
Merge/revert. Backorder display is gated by `Feature_Backorder && BACK-134.backorders_phase_1_1_control_messaging_on_storefront`.

## Testing
Backorder display appears as expected.

https://github.com/user-attachments/assets/881d70a7-5b15-45d0-aa02-b3ab97cfb933

Backorder display does not appear for disabled `Feature_Backorder && BACK-134.backorders_phase_1_1_control_messaging_on_storefront`.

https://github.com/user-attachments/assets/e9a93f1c-c61a-4aa3-bb1c-6be2cc855029

Ping @animesh1987 @benpratt77 

[BACK-706]: https://bigcommercecloud.atlassian.net/browse/BACK-706?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only extension of existing backorder display behind the same feature flags; reorder behavior is preserved with renamed props. Risk is mainly regression in order dialogs and messaging gating.
> 
> **Overview**
> Extends the **My Orders** product picker so backorder messaging (on-hand, backordered qty, lead-time text) appears when customers use **Add to shopping list**, not only **Re-Order**.
> 
> `OrderCheckboxProduct` now treats **`reOrder`** and **`shoppingList`** as catalog flows that consume variant inventory from a shared **`catalogInventoryBySku`** map (renamed from reorder-only props). **`OrderDialog`** turns on **`backorderUiEnabled`** for both dialog types when backorder storefront messaging and display settings allow it, reusing the existing **`GetVariantInfoBySkus`** data already loaded when the dialog opens.
> 
> Integration tests cover the add-to-shopping-list modal with backorder flags on (expects ready-to-ship / backorder / message copy) and off (no backorder lines).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7ae3fec8a6fe4fb521bbd1b728539314d310ab0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->