### PR TITLE
feat(quotes): BACK-657 Implement backorder display for picklist items within purchased products.

### DIFF
--- a/apps/storefront/src/components/PicklistBackorderMessages.test.tsx
+++ b/apps/storefront/src/components/PicklistBackorderMessages.test.tsx
@@ -1,0 +1,163 @@
+import { buildGlobalStateWith, renderWithProviders, screen } from 'tests/test-utils';
+
+import type { ProductSearch } from '@/shared/service/b2b/graphql/product';
+import type { PicklistSelection } from '@/utils/catalogBackorderDisplay';
+
+import PicklistBackorderMessages from './PicklistBackorderMessages';
+
+const withAllBackorderDisplayEnabled = {
+  preloadedState: {
+    global: buildGlobalStateWith({
+      backorderDisplaySettings: {
+        showQuantityOnBackorder: true,
+        showQuantityOnHand: true,
+        showBackorderMessage: true,
+      },
+    }),
+  },
+};
+
+const buildPicklistProduct = (overrides: Partial<ProductSearch> = {}) =>
+  ({
+    inventoryTracking: 'product',
+    availableToSell: 10,
+    unlimitedBackorder: false,
+    totalOnHand: 9,
+    backorderMessage: 'Lead time: 2-4 weeks',
+    variants: [],
+    ...overrides,
+  }) as unknown as ProductSearch;
+
+const bundleOption1: PicklistSelection = {
+  modifierId: 1,
+  displayName: 'Bundle option 1',
+  productId: 555,
+};
+
+const bundleOption2: PicklistSelection = {
+  modifierId: 2,
+  displayName: 'Bundle option 2',
+  productId: 666,
+};
+
+describe('PicklistBackorderMessages', () => {
+  it('renders nothing when backorder UI is disabled', () => {
+    renderWithProviders(
+      <PicklistBackorderMessages
+        selections={[bundleOption1]}
+        picklistProductsById={{ 555: buildPicklistProduct() }}
+        qty={10}
+        visible
+        backorderUiEnabled={false}
+      />,
+      withAllBackorderDisplayEnabled,
+    );
+
+    expect(screen.queryByText('Bundle option 1:')).toBeNull();
+    expect(screen.queryByText('will be backordered', { exact: false })).toBeNull();
+  });
+
+  it('renders nothing when there are no selections', () => {
+    renderWithProviders(
+      <PicklistBackorderMessages
+        selections={[]}
+        picklistProductsById={{}}
+        qty={10}
+        visible
+        backorderUiEnabled
+      />,
+      withAllBackorderDisplayEnabled,
+    );
+
+    expect(screen.queryByText('will be backordered', { exact: false })).toBeNull();
+  });
+
+  it('renders a labeled backorder block for a backordered picklist item', () => {
+    renderWithProviders(
+      <PicklistBackorderMessages
+        selections={[bundleOption1]}
+        picklistProductsById={{ 555: buildPicklistProduct() }}
+        qty={10}
+        visible
+        backorderUiEnabled
+      />,
+      withAllBackorderDisplayEnabled,
+    );
+
+    expect(screen.getByText('Bundle option 1:')).toBeVisible();
+    expect(screen.getByText('9 ready to ship')).toBeVisible();
+    expect(screen.getByText('1 will be backordered')).toBeVisible();
+    expect(screen.getByText('Lead time: 2-4 weeks')).toBeVisible();
+  });
+
+  it('renders a labeled block for each backordered picklist selection', () => {
+    renderWithProviders(
+      <PicklistBackorderMessages
+        selections={[bundleOption1, bundleOption2]}
+        picklistProductsById={{
+          555: buildPicklistProduct(),
+          666: buildPicklistProduct({ backorderMessage: 'Lead time: 6 weeks' }),
+        }}
+        qty={10}
+        visible
+        backorderUiEnabled
+      />,
+      withAllBackorderDisplayEnabled,
+    );
+
+    expect(screen.getByText('Bundle option 1:')).toBeVisible();
+    expect(screen.getByText('Bundle option 2:')).toBeVisible();
+    expect(screen.getByText('Lead time: 2-4 weeks')).toBeVisible();
+    expect(screen.getByText('Lead time: 6 weeks')).toBeVisible();
+  });
+
+  it('skips a selection whose product is missing from the map', () => {
+    renderWithProviders(
+      <PicklistBackorderMessages
+        selections={[bundleOption1]}
+        picklistProductsById={{}}
+        qty={10}
+        visible
+        backorderUiEnabled
+      />,
+      withAllBackorderDisplayEnabled,
+    );
+
+    expect(screen.queryByText('Bundle option 1:')).toBeNull();
+    expect(screen.queryByText('will be backordered', { exact: false })).toBeNull();
+  });
+
+  it('skips a selection that is not backordered', () => {
+    renderWithProviders(
+      <PicklistBackorderMessages
+        selections={[bundleOption1]}
+        picklistProductsById={{
+          555: buildPicklistProduct({ totalOnHand: 100, availableToSell: 100 }),
+        }}
+        qty={10}
+        visible
+        backorderUiEnabled
+      />,
+      withAllBackorderDisplayEnabled,
+    );
+
+    expect(screen.queryByText('Bundle option 1:')).toBeNull();
+    expect(screen.queryByText('will be backordered', { exact: false })).toBeNull();
+  });
+
+  it('hides the label and lines when visible is false', () => {
+    renderWithProviders(
+      <PicklistBackorderMessages
+        selections={[bundleOption1]}
+        picklistProductsById={{ 555: buildPicklistProduct() }}
+        qty={10}
+        visible={false}
+        backorderUiEnabled
+      />,
+      withAllBackorderDisplayEnabled,
+    );
+
+    expect(screen.queryByText('Bundle option 1:')).toBeNull();
+    expect(screen.queryByText('1 will be backordered')).toBeNull();
+  });
+});

--- a/apps/storefront/src/components/PicklistBackorderMessages.tsx
+++ b/apps/storefront/src/components/PicklistBackorderMessages.tsx
@@ -1,0 +1,38 @@
+import PicklistSelectionBackorderMessage from '@/components/PicklistSelectionBackorderMessage';
+import type { ProductSearch } from '@/shared/service/b2b/graphql/product';
+import type { PicklistSelection } from '@/utils/catalogBackorderDisplay';
+
+interface PicklistBackorderMessagesProps {
+  selections: PicklistSelection[];
+  picklistProductsById: Record<number, ProductSearch>;
+  qty: number;
+  visible: boolean;
+  backorderUiEnabled: boolean;
+}
+
+function PicklistBackorderMessages({
+  selections,
+  picklistProductsById,
+  qty,
+  visible,
+  backorderUiEnabled,
+}: PicklistBackorderMessagesProps) {
+  if (!backorderUiEnabled || selections.length === 0 || !visible) {
+    return null;
+  }
+
+  return (
+    <>
+      {selections.map((selection) => (
+        <PicklistSelectionBackorderMessage
+          key={selection.modifierId}
+          selection={selection}
+          product={picklistProductsById[selection.productId]}
+          qty={qty}
+        />
+      ))}
+    </>
+  );
+}
+
+export default PicklistBackorderMessages;

--- a/apps/storefront/src/components/PicklistSelectionBackorderMessage.test.tsx
+++ b/apps/storefront/src/components/PicklistSelectionBackorderMessage.test.tsx
@@ -1,0 +1,77 @@
+import { buildGlobalStateWith, renderWithProviders, screen } from 'tests/test-utils';
+
+import type { ProductSearch } from '@/shared/service/b2b/graphql/product';
+import type { PicklistSelection } from '@/utils/catalogBackorderDisplay';
+
+import PicklistSelectionBackorderMessage from './PicklistSelectionBackorderMessage';
+
+const withAllBackorderDisplayEnabled = {
+  preloadedState: {
+    global: buildGlobalStateWith({
+      backorderDisplaySettings: {
+        showQuantityOnBackorder: true,
+        showQuantityOnHand: true,
+        showBackorderMessage: true,
+      },
+    }),
+  },
+};
+
+const buildPicklistProduct = (overrides: Partial<ProductSearch> = {}) =>
+  ({
+    inventoryTracking: 'product',
+    availableToSell: 10,
+    unlimitedBackorder: false,
+    totalOnHand: 9,
+    backorderMessage: 'Lead time: 2-4 weeks',
+    variants: [],
+    ...overrides,
+  }) as unknown as ProductSearch;
+
+const bundleOption1: PicklistSelection = {
+  modifierId: 1,
+  displayName: 'Bundle option 1',
+  productId: 555,
+};
+
+describe('PicklistSelectionBackorderMessage', () => {
+  it('renders a labeled backorder block for a backordered picklist product', () => {
+    renderWithProviders(
+      <PicklistSelectionBackorderMessage
+        selection={bundleOption1}
+        product={buildPicklistProduct()}
+        qty={10}
+      />,
+      withAllBackorderDisplayEnabled,
+    );
+
+    expect(screen.getByText('Bundle option 1:')).toBeVisible();
+    expect(screen.getByText('9 ready to ship')).toBeVisible();
+    expect(screen.getByText('1 will be backordered')).toBeVisible();
+    expect(screen.getByText('Lead time: 2-4 weeks')).toBeVisible();
+  });
+
+  it('renders nothing when the product is missing', () => {
+    renderWithProviders(
+      <PicklistSelectionBackorderMessage selection={bundleOption1} product={undefined} qty={10} />,
+      withAllBackorderDisplayEnabled,
+    );
+
+    expect(screen.queryByText('Bundle option 1:')).toBeNull();
+    expect(screen.queryByText('will be backordered', { exact: false })).toBeNull();
+  });
+
+  it('renders nothing when the product is not backordered', () => {
+    renderWithProviders(
+      <PicklistSelectionBackorderMessage
+        selection={bundleOption1}
+        product={buildPicklistProduct({ totalOnHand: 100, availableToSell: 100 })}
+        qty={10}
+      />,
+      withAllBackorderDisplayEnabled,
+    );
+
+    expect(screen.queryByText('Bundle option 1:')).toBeNull();
+    expect(screen.queryByText('will be backordered', { exact: false })).toBeNull();
+  });
+});

--- a/apps/storefront/src/components/PicklistSelectionBackorderMessage.tsx
+++ b/apps/storefront/src/components/PicklistSelectionBackorderMessage.tsx
@@ -1,0 +1,42 @@
+import { Box, Typography } from '@mui/material';
+
+import BackorderMessage from '@/components/BackorderMessage';
+import type { ProductSearch } from '@/shared/service/b2b/graphql/product';
+import {
+  getCatalogBackorderFieldsForPicklistProduct,
+  type PicklistSelection,
+} from '@/utils/catalogBackorderDisplay';
+
+interface PicklistSelectionBackorderMessageProps {
+  selection: PicklistSelection;
+  product: ProductSearch | undefined;
+  qty: number;
+}
+
+function PicklistSelectionBackorderMessage({
+  selection,
+  product,
+  qty,
+}: PicklistSelectionBackorderMessageProps) {
+  const backorderFields = getCatalogBackorderFieldsForPicklistProduct(qty, product);
+
+  if (!backorderFields) {
+    return null;
+  }
+
+  return (
+    <Box sx={{ mt: 1, width: '100%' }}>
+      <Typography sx={{ color: '#616161', typography: 'body2' }}>
+        {`${selection.displayName}:`}
+      </Typography>
+      <BackorderMessage
+        totalOnHand={backorderFields.totalOnHand}
+        quantityBackordered={backorderFields.quantityBackordered}
+        backorderMessage={backorderFields.backorderMessage}
+        visible
+      />
+    </Box>
+  );
+}
+
+export default PicklistSelectionBackorderMessage;

--- a/apps/storefront/src/pages/QuickOrder/components/QuickOrderB2BTable.tsx
+++ b/apps/storefront/src/pages/QuickOrder/components/QuickOrderB2BTable.tsx
@@ -2,6 +2,7 @@ import { Dispatch, SetStateAction, useCallback, useMemo, useRef, useState } from
 import { Box, FormControlLabel, styled, Switch, TextField, Typography } from '@mui/material';
 
 import BackorderMessage from '@/components/BackorderMessage';
+import PicklistBackorderMessages from '@/components/PicklistBackorderMessages';
 import B3Spin from '@/components/spin/B3Spin';
 import { B3PaginationTable, GetRequestList } from '@/components/table/B3PaginationTable';
 import { TableColumnItem } from '@/components/table/B3Table';
@@ -14,6 +15,7 @@ import { getOrderedProducts, searchProducts } from '@/shared/service/b2b';
 import {
   type CatalogQuickVariantSku,
   getVariantInfoBySkus,
+  type ProductSearch,
 } from '@/shared/service/b2b/graphql/product';
 import { activeCurrencyInfoSelector, useAppSelector } from '@/store';
 import { ProductInfoType } from '@/types/gql/graphql';
@@ -27,7 +29,9 @@ import { conversionProductsList } from '@/utils/b3Product/shared/config';
 import { snackbar } from '@/utils/b3Tip';
 import {
   catalogListHasBackorderedItemsForDisplay,
+  catalogListHasPicklistBackorderedItemsForDisplay,
   getCatalogProductRowDisplayState,
+  getProductDetailsForPicklistSelections,
 } from '@/utils/catalogBackorderDisplay';
 
 import B3FilterMore from '../../../components/filter/B3FilterMore';
@@ -143,6 +147,9 @@ function QuickOrderTable({
 
   const [total, setTotalCount] = useState<number>(0);
   const [variantInfoList, setVariantInfoList] = useState<CatalogQuickVariantSku[]>([]);
+  const [picklistProductsById, setPicklistProductsById] = useState<Record<number, ProductSearch>>(
+    {},
+  );
   const [showBackorderDetails, setShowBackorderDetails] = useState(false);
   const [tableDataVersion, setTableDataVersion] = useState(0);
 
@@ -202,14 +209,57 @@ function QuickOrderTable({
       variantSku: node.variantSku,
     }));
 
-    return catalogListHasBackorderedItemsForDisplay(items, inventoryBySku);
+    if (catalogListHasBackorderedItemsForDisplay(items, inventoryBySku)) {
+      return true;
+    }
+
+    const picklistRows = cacheList.map(({ node }) => ({
+      qty: Number(node.quantity) || 0,
+      selections: getProductDetailsForPicklistSelections(node),
+    }));
+
+    return catalogListHasPicklistBackorderedItemsForDisplay(picklistRows, picklistProductsById);
     // tableDataVersion drives re-evaluation when list or qty changes
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [inventoryBySku, isBackorderMessagingEnabled, tableDataVersion]);
+  }, [inventoryBySku, picklistProductsById, isBackorderMessagingEnabled, tableDataVersion]);
 
   const showBackorderToggle = backorderUiEnabled && hasBackorderedItems;
 
   const { currency_code: currencyCode } = useAppSelector(activeCurrencyInfoSelector);
+
+  const fetchPicklistProducts = useCallback(
+    async (productIds: number[]) => {
+      if (!backorderUiEnabled || productIds.length === 0) {
+        return;
+      }
+
+      const newProductIds = [...new Set(productIds)].filter((id) => !picklistProductsById[id]);
+
+      if (newProductIds.length === 0) {
+        return;
+      }
+
+      try {
+        const { productsSearch = [] } = await searchProducts({
+          productIds: newProductIds,
+          currencyCode,
+          companyId: companyInfoId,
+          customerGroupId,
+        });
+
+        setPicklistProductsById((prev) => {
+          const next = { ...prev };
+          productsSearch.forEach((product: ProductSearch) => {
+            next[Number(product.id)] = product;
+          });
+          return next;
+        });
+      } catch {
+        // Inventory fetch failure should not block the product list
+      }
+    },
+    [backorderUiEnabled, picklistProductsById, currencyCode, companyInfoId, customerGroupId],
+  );
 
   const handleGetProductsById = async (listProducts: ListItemProps[]) => {
     if (listProducts.length > 0) {
@@ -268,6 +318,13 @@ function QuickOrderTable({
         .map((item) => item.node.variantSku)
         .filter((sku): sku is string => Boolean(sku));
       fetchInventoryForSkus(skus).catch(() => {
+        // Inventory fetch failure should not block the product list
+      });
+
+      const picklistProductIds = listProducts.flatMap((item) =>
+        getProductDetailsForPicklistSelections(item.node).map((selection) => selection.productId),
+      );
+      fetchPicklistProducts(picklistProductIds).catch(() => {
         // Inventory fetch failure should not block the product list
       });
     }
@@ -491,6 +548,7 @@ function QuickOrderTable({
           backorderUiEnabled,
           formatOnlyAvailable: () => '',
         });
+        const picklistSelections = getProductDetailsForPicklistSelections(row);
 
         return (
           <Box
@@ -521,6 +579,17 @@ function QuickOrderTable({
                   quantityBackordered={backorderFields.quantityBackordered}
                   backorderMessage={backorderFields.backorderMessage}
                   visible={showBackorderDetails}
+                />
+              </Box>
+            )}
+            {picklistSelections.length > 0 && (
+              <Box sx={{ width: '100%', textAlign: 'right' }}>
+                <PicklistBackorderMessages
+                  selections={picklistSelections}
+                  picklistProductsById={picklistProductsById}
+                  qty={Number(qty) || 0}
+                  visible={showBackorderDetails}
+                  backorderUiEnabled={backorderUiEnabled}
                 />
               </Box>
             )}
@@ -691,6 +760,7 @@ function QuickOrderTable({
               checkBox={checkBox}
               handleUpdateProductQty={handleUpdateProductQty}
               inventoryBySku={inventoryBySku}
+              picklistProductsById={picklistProductsById}
               backorderUiEnabled={backorderUiEnabled}
               showBackorderDetails={showBackorderDetails}
             />

--- a/apps/storefront/src/pages/QuickOrder/components/QuickOrderCard.tsx
+++ b/apps/storefront/src/pages/QuickOrder/components/QuickOrderCard.tsx
@@ -2,19 +2,24 @@ import { ReactElement } from 'react';
 import { Box, CardContent, styled, TextField, Typography } from '@mui/material';
 
 import BackorderMessage from '@/components/BackorderMessage';
+import PicklistBackorderMessages from '@/components/PicklistBackorderMessages';
 import { PRODUCT_DEFAULT_IMAGE } from '@/constants';
 import { useB3Lang } from '@/lib/lang';
-import type { CatalogQuickVariantSku } from '@/shared/service/b2b/graphql/product';
+import type { CatalogQuickVariantSku, ProductSearch } from '@/shared/service/b2b/graphql/product';
 import b2bGetVariantImageByVariantInfo from '@/utils/b2bGetVariantImageByVariantInfo';
 import { currencyFormat } from '@/utils/b3CurrencyFormat';
 import { displayFormat } from '@/utils/b3DateFormat';
-import { getCatalogProductRowDisplayState } from '@/utils/catalogBackorderDisplay';
+import {
+  getCatalogProductRowDisplayState,
+  getProductDetailsForPicklistSelections,
+} from '@/utils/catalogBackorderDisplay';
 
 interface QuickOrderCardProps {
   item: any;
   checkBox?: () => ReactElement;
   handleUpdateProductQty: (id: number, val: string) => void;
   inventoryBySku?: Record<string, CatalogQuickVariantSku>;
+  picklistProductsById?: Record<number, ProductSearch>;
   backorderUiEnabled?: boolean;
   showBackorderDetails?: boolean;
 }
@@ -31,6 +36,7 @@ function QuickOrderCard(props: QuickOrderCardProps) {
     checkBox,
     handleUpdateProductQty,
     inventoryBySku = {},
+    picklistProductsById = {},
     backorderUiEnabled = false,
     showBackorderDetails = false,
   } = props;
@@ -60,6 +66,7 @@ function QuickOrderCard(props: QuickOrderCardProps) {
     backorderUiEnabled,
     formatOnlyAvailable: () => '',
   });
+  const picklistSelections = getProductDetailsForPicklistSelections(shoppingDetail);
 
   return (
     <Box
@@ -164,6 +171,13 @@ function QuickOrderCard(props: QuickOrderCardProps) {
                 />
               </Box>
             )}
+            <PicklistBackorderMessages
+              selections={picklistSelections}
+              picklistProductsById={picklistProductsById}
+              qty={Number(quantity) || 0}
+              visible={showBackorderDetails}
+              backorderUiEnabled={backorderUiEnabled}
+            />
           </Box>
 
           <Typography sx={{ fontSize: '14px' }}>

--- a/apps/storefront/src/pages/QuickOrder/index.main.test.tsx
+++ b/apps/storefront/src/pages/QuickOrder/index.main.test.tsx
@@ -5359,6 +5359,105 @@ describe('when backorder messaging is enabled on purchased products', () => {
     return { orderedProduct };
   };
 
+  const setupPurchasedProductsTableWithPicklist = ({
+    mainTotalOnHand = 100,
+    mainAvailableToSell = 100,
+    picklistTotalOnHand = 9,
+    picklistAvailableToSell = 10,
+  }: {
+    mainTotalOnHand?: number;
+    mainAvailableToSell?: number;
+    picklistTotalOnHand?: number;
+    picklistAvailableToSell?: number;
+  } = {}) => {
+    const modifierId = 100;
+    const optionValueId = 200;
+    const picklistProductId = 999111;
+
+    const orderedProduct = buildRecentlyOrderedProductNodeWith({
+      node: {
+        productName: 'Laugh Canister',
+        variantSku,
+        sku: variantSku,
+        basePrice: '100',
+        optionSelections: [{ option_id: modifierId, value_id: optionValueId }],
+      },
+    });
+
+    const getRecentlyOrderedProducts = vi.fn().mockReturnValue(
+      buildGetRecentlyOrderedProductsWith({
+        data: { orderedProducts: { totalCount: 1, edges: [orderedProduct] } },
+      }),
+    );
+
+    const parentProduct = buildSearchProductWith({
+      id: Number(orderedProduct.node.productId),
+      name: orderedProduct.node.productName,
+      sku: variantSku,
+      modifiers: [
+        {
+          id: modifierId,
+          type: 'product_list',
+          display_name: 'Bundle option 1',
+          required: false,
+          option_values: [{ id: optionValueId, value_data: { product_id: picklistProductId } }],
+        },
+      ],
+      variants: [
+        buildVariantWith({
+          sku: variantSku,
+          variant_id: Number(orderedProduct.node.variantId),
+          product_id: Number(orderedProduct.node.productId),
+          purchasing_disabled: false,
+        }),
+      ],
+    });
+
+    const picklistProduct = buildSearchProductWith({
+      id: picklistProductId,
+      name: 'Picklist Widget',
+      inventoryTracking: 'product',
+      availableToSell: picklistAvailableToSell,
+      unlimitedBackorder: false,
+      totalOnHand: picklistTotalOnHand,
+      backorderMessage: 'Picklist lead time: 6 weeks',
+      variants: [],
+    });
+
+    const searchProducts = vi.fn();
+    when(searchProducts)
+      .calledWith(stringContainingAll(`productIds: [${orderedProduct.node.productId}]`))
+      .thenReturn({ data: { productsSearch: [parentProduct] } });
+    when(searchProducts)
+      .calledWith(stringContainingAll(`productIds: [${picklistProductId}]`))
+      .thenReturn({ data: { productsSearch: [picklistProduct] } });
+
+    const variantInfo = buildVariantInfoWith({
+      variantSku,
+      inventoryTracking: 'variant',
+      availableToSell: mainAvailableToSell,
+      unlimitedBackorder: false,
+      totalOnHand: mainTotalOnHand,
+      backorderMessage: 'Main lead time',
+    });
+
+    const getVariantInfoBySkus = when(vi.fn())
+      .calledWith(expect.stringContaining(`variantSkus: ["${variantSku}"]`))
+      .thenReturn(buildVariantInfoResponseWith({ data: { variantSku: [variantInfo] } }));
+
+    server.use(
+      graphql.query('RecentlyOrderedProducts', ({ query }) =>
+        HttpResponse.json(getRecentlyOrderedProducts(query)),
+      ),
+      graphql.query('SearchProducts', ({ query }) => HttpResponse.json(searchProducts(query))),
+      graphql.query('GetVariantInfoBySkus', ({ query }) =>
+        HttpResponse.json(getVariantInfoBySkus(query)),
+      ),
+    );
+
+    return { orderedProduct };
+  };
+
   it('shows backorder lines when toggle is on and qty exceeds on hand', async () => {
     setupPurchasedProductsTable();
 
@@ -5469,6 +5568,53 @@ describe('when backorder messaging is enabled on purchased products', () => {
       ).not.toBeInTheDocument();
     });
     expect(screen.queryByText('will be backordered', { exact: false })).not.toBeInTheDocument();
+  });
+
+  it('shows a labeled picklist backorder block when toggle is on and qty exceeds picklist on hand', async () => {
+    setupPurchasedProductsTableWithPicklist();
+
+    renderWithProviders(<QuickOrder />, { preloadedState: backorderPreloadedState });
+
+    expect(await screen.findByText('Laugh Canister')).toBeInTheDocument();
+
+    const table = screen.getByRole('table');
+    const quantityInput = within(table).getByRole('spinbutton');
+
+    await userEvent.type(quantityInput, '10', {
+      initialSelectionStart: 0,
+      initialSelectionEnd: Infinity,
+    });
+
+    const backorderToggle = await screen.findByRole('checkbox', { name: /Backorder details/i });
+    await userEvent.click(backorderToggle);
+
+    await waitFor(() => {
+      expect(screen.getByText('Bundle option 1:')).toBeVisible();
+    });
+    expect(screen.getByText('9 ready to ship')).toBeVisible();
+    expect(screen.getByText('1 will be backordered')).toBeVisible();
+    expect(screen.getByText('Picklist lead time: 6 weeks')).toBeVisible();
+  });
+
+  it('hides the picklist backorder block when toggle is off', async () => {
+    setupPurchasedProductsTableWithPicklist();
+
+    renderWithProviders(<QuickOrder />, { preloadedState: backorderPreloadedState });
+
+    expect(await screen.findByText('Laugh Canister')).toBeInTheDocument();
+
+    const table = screen.getByRole('table');
+    const quantityInput = within(table).getByRole('spinbutton');
+
+    await userEvent.type(quantityInput, '10', {
+      initialSelectionStart: 0,
+      initialSelectionEnd: Infinity,
+    });
+
+    await screen.findByRole('checkbox', { name: /Backorder details/i });
+
+    expect(screen.queryByText('Bundle option 1:')).not.toBeInTheDocument();
+    expect(screen.queryByText('Picklist lead time: 6 weeks')).not.toBeInTheDocument();
   });
 
   describe('on mobile', () => {

--- a/apps/storefront/src/utils/catalogBackorderDisplay.test.ts
+++ b/apps/storefront/src/utils/catalogBackorderDisplay.test.ts
@@ -1,17 +1,19 @@
 import { describe, expect, it } from 'vitest';
 
-import type { CatalogQuickVariantSku } from '@/shared/service/b2b/graphql/product';
+import type { CatalogQuickVariantSku, ProductSearch } from '@/shared/service/b2b/graphql/product';
 import type { Variant } from '@/types/products';
 import type { ShoppingListProductItem } from '@/types/shoppingList';
 
 import {
   buildVariantSkuDependencyKey,
   catalogListHasBackorderedItemsForDisplay,
+  catalogListHasPicklistBackorderedItemsForDisplay,
   getCatalogBackorderDisplayFields,
   getCatalogBackorderDisplayQuantity,
   getCatalogBackorderFieldsForVariantSku,
   getCatalogInventoryRowFromSearchProduct,
   getCatalogProductRowDisplayState,
+  getProductDetailsForPicklistSelections,
   quantityExceedsAvailableToSell,
 } from './catalogBackorderDisplay';
 
@@ -374,6 +376,154 @@ describe('catalogBackorderDisplay', () => {
         catalogListHasBackorderedItemsForDisplay(
           [{ qty: 10, variantSku: 'UNKNOWN' }],
           inventoryBySku,
+        ),
+      ).toBe(false);
+    });
+  });
+
+  describe('getProductDetailsForPicklistSelections', () => {
+    const buildRow = (type: string) => ({
+      optionSelections: [{ option_id: 100, value_id: 200 }],
+      productsSearch: {
+        modifiers: [
+          {
+            id: 100,
+            type,
+            display_name: 'Bundle option 1',
+            option_values: [{ id: 200, value_data: { product_id: 555 } }],
+          },
+        ],
+      },
+    });
+
+    it('resolves a product_list selection to its product id', () => {
+      expect(getProductDetailsForPicklistSelections(buildRow('product_list'))).toEqual([
+        { modifierId: 100, displayName: 'Bundle option 1', productId: 555 },
+      ]);
+    });
+
+    it('resolves a product_list_with_images selection to its product id', () => {
+      expect(getProductDetailsForPicklistSelections(buildRow('product_list_with_images'))).toEqual([
+        { modifierId: 100, displayName: 'Bundle option 1', productId: 555 },
+      ]);
+    });
+
+    it('returns an empty array when there are no picklist modifiers', () => {
+      expect(getProductDetailsForPicklistSelections(buildRow('dropdown'))).toEqual([]);
+    });
+
+    it('returns an empty array when optionSelections is missing', () => {
+      expect(
+        getProductDetailsForPicklistSelections({
+          productsSearch: buildRow('product_list').productsSearch,
+        }),
+      ).toEqual([]);
+    });
+
+    it('skips a selected option value that has no product id', () => {
+      expect(
+        getProductDetailsForPicklistSelections({
+          optionSelections: [{ option_id: 100, value_id: 200 }],
+          productsSearch: {
+            modifiers: [
+              {
+                id: 100,
+                type: 'product_list',
+                display_name: 'Bundle option 1',
+                option_values: [{ id: 200, value_data: {} }],
+              },
+            ],
+          },
+        }),
+      ).toEqual([]);
+    });
+
+    it('resolves multiple picklist modifiers into multiple selections', () => {
+      expect(
+        getProductDetailsForPicklistSelections({
+          optionSelections: [
+            { option_id: 100, value_id: 200 },
+            { option_id: 101, value_id: 201 },
+          ],
+          productsSearch: {
+            modifiers: [
+              {
+                id: 100,
+                type: 'product_list',
+                display_name: 'Bundle option 1',
+                option_values: [{ id: 200, value_data: { product_id: 555 } }],
+              },
+              {
+                id: 101,
+                type: 'product_list_with_images',
+                display_name: 'Bundle option 2',
+                option_values: [{ id: 201, value_data: { product_id: 666 } }],
+              },
+            ],
+          },
+        }),
+      ).toEqual([
+        { modifierId: 100, displayName: 'Bundle option 1', productId: 555 },
+        { modifierId: 101, displayName: 'Bundle option 2', productId: 666 },
+      ]);
+    });
+  });
+
+  describe('catalogListHasPicklistBackorderedItemsForDisplay', () => {
+    const productTrackedPicklist = {
+      id: 555,
+      inventoryTracking: 'product',
+      availableToSell: 10,
+      unlimitedBackorder: false,
+      totalOnHand: 9,
+      backorderMessage: 'Lead time: 2-4 weeks',
+    } as ProductSearch;
+
+    const variantTrackedPicklist = {
+      id: 666,
+      inventoryTracking: 'variant',
+      variants: [
+        {
+          available_to_sell: 10,
+          unlimited_backorder: false,
+          total_on_hand: 9,
+          backorder_message: 'Lead time: 2-4 weeks',
+        },
+      ],
+    } as unknown as ProductSearch;
+
+    const selection = { modifierId: 100, displayName: 'Bundle option 1', productId: 555 };
+
+    it('returns true when a product-tracked picklist item is backordered', () => {
+      expect(
+        catalogListHasPicklistBackorderedItemsForDisplay([{ qty: 10, selections: [selection] }], {
+          555: productTrackedPicklist,
+        }),
+      ).toBe(true);
+    });
+
+    it('returns true when a variant-tracked picklist item is backordered', () => {
+      expect(
+        catalogListHasPicklistBackorderedItemsForDisplay(
+          [{ qty: 10, selections: [{ ...selection, productId: 666 }] }],
+          { 666: variantTrackedPicklist },
+        ),
+      ).toBe(true);
+    });
+
+    it('returns false when qty is within on hand', () => {
+      expect(
+        catalogListHasPicklistBackorderedItemsForDisplay([{ qty: 9, selections: [selection] }], {
+          555: productTrackedPicklist,
+        }),
+      ).toBe(false);
+    });
+
+    it('returns false when the picklist product is missing from the map', () => {
+      expect(
+        catalogListHasPicklistBackorderedItemsForDisplay(
+          [{ qty: 10, selections: [selection] }],
+          {},
         ),
       ).toBe(false);
     });

--- a/apps/storefront/src/utils/catalogBackorderDisplay.ts
+++ b/apps/storefront/src/utils/catalogBackorderDisplay.ts
@@ -1,4 +1,4 @@
-import type { CatalogQuickVariantSku } from '@/shared/service/b2b/graphql/product';
+import type { CatalogQuickVariantSku, ProductSearch } from '@/shared/service/b2b/graphql/product';
 import type { Variant } from '@/types/products';
 import type { ShoppingListProductItem } from '@/types/shoppingList';
 import type { BackorderDisplayFields } from '@/utils/backorderDisplayFromInventory';
@@ -158,6 +158,106 @@ export function catalogListHasBackorderedItemsForDisplay(
         variantSku,
         inventoryBySku,
       }),
+    ),
+  );
+}
+
+export interface PicklistSelection {
+  modifierId: number;
+  displayName: string;
+  productId: number;
+}
+
+// Only the modifier fields this resolver reads — keeps the input contract decoupled
+// from the full Modifiers type so loosely-typed row sources can be passed directly.
+interface PicklistModifier {
+  id?: number | string;
+  type?: string;
+  display_name: string;
+  option_values?: Array<{ id: number; value_data?: { product_id?: number } | null }> | null;
+}
+
+interface PicklistSelectionSource {
+  optionSelections?: Array<{ option_id: number; value_id: number }> | null;
+  productsSearch?: { modifiers?: PicklistModifier[] | null } | null;
+}
+
+const isPicklistModifier = (modifier: PicklistModifier): boolean =>
+  typeof modifier.type === 'string' && modifier.type.includes('product_list');
+
+export function getProductDetailsForPicklistSelections(
+  row: PicklistSelectionSource,
+): PicklistSelection[] {
+  const optionSelections = row.optionSelections ?? [];
+  if (optionSelections.length === 0) {
+    return [];
+  }
+
+  const modifiers = row.productsSearch?.modifiers ?? [];
+
+  return modifiers.flatMap((modifier) => {
+    if (!isPicklistModifier(modifier)) {
+      return [];
+    }
+
+    const selection = optionSelections.find(
+      (option) => Number(option.option_id) === Number(modifier.id),
+    );
+    if (!selection) {
+      return [];
+    }
+
+    const optionValue = (modifier.option_values ?? []).find(
+      (value) => Number(value.id) === Number(selection.value_id),
+    );
+    const productId = optionValue?.value_data?.product_id;
+    if (productId == null) {
+      return [];
+    }
+
+    return [
+      {
+        modifierId: Number(modifier.id),
+        displayName: modifier.display_name,
+        productId,
+      },
+    ];
+  });
+}
+
+export function getCatalogBackorderFieldsForPicklistProduct(
+  quantity: number,
+  product: ProductSearch | undefined,
+): BackorderDisplayFields | null {
+  if (!product) {
+    return null;
+  }
+
+  // A picklist (product_list) modifier references a product, not a variant — value_data
+  // carries only product_id, and the row stores no child-variant id. The app resolves a
+  // picklist product to variants[0] wherever it's carted/quoted/listed (ProductListDialog,
+  // ChooseOptionsDialog, B3ProductList), so matching that here reflects the same variant the
+  // item was ordered under.
+  const inventoryRow = getCatalogInventoryRowFromSearchProduct(
+    product,
+    product.variants?.[0] as unknown as Partial<Variant> | undefined,
+  );
+
+  return getCatalogBackorderDisplayFields(
+    getCatalogBackorderDisplayQuantity(quantity, inventoryRow),
+    inventoryRow,
+  );
+}
+
+export function catalogListHasPicklistBackorderedItemsForDisplay(
+  rows: Array<{ qty: number; selections: PicklistSelection[] }>,
+  picklistProductsById: Record<number, ProductSearch>,
+): boolean {
+  return rows.some(({ qty, selections }) =>
+    selections.some((selection) =>
+      Boolean(
+        getCatalogBackorderFieldsForPicklistProduct(qty, picklistProductsById[selection.productId]),
+      ),
     ),
   );
 }


### PR DESCRIPTION
Jira: [BACK-657](https://bigcommercecloud.atlassian.net/browse/BACK-657)

## What/Why?
When a picklist item exists within the purchased product page, show back order information for the picked item as well as the parent.

This informaiton should also be surfaced to the customer.

## Rollout/Rollback
Revert this PR is there are issues.

## Testing
Tests updated

Picklist products work:
Parent with one picklist:
<img width="997" height="842" alt="PicklistWorks" src="https://github.com/user-attachments/assets/42fc5030-dcfc-41aa-8114-6850e46f2040" />
Two of the same parent with individual elements display indepenently:
<img width="1056" height="874" alt="PicklistWorks2" src="https://github.com/user-attachments/assets/7a7fa860-35a5-4f12-a0ad-b0d900e4a788" />

Please note that the parent is displaying incorrectly as the validation currently validates each parent individually, I have raised https://bigcommercecloud.atlassian.net/browse/BACK-705 to cover this.


ping TBA

[BACK-657]: https://bigcommercecloud.atlassian.net/browse/BACK-657?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Customer-facing inventory/backorder text depends on extra `searchProducts` calls and picklist resolution; failures are swallowed so the list still loads, but messaging could be wrong or missing until data arrives.
> 
> **Overview**
> Extends **purchased products / Quick Order** backorder messaging so **bundle picklist (`product_list`) choices** show their own labeled on-hand, backorder qty, and lead-time copy when **Backorder details** is on—not only the parent line SKU.
> 
> `catalogBackorderDisplay` gains helpers to resolve picklist selections from row `optionSelections` + modifier metadata, compute backorder fields from fetched `ProductSearch` inventory (using `variants[0]` for variant-tracked picklist products, consistent with elsewhere in the app), and detect whether any row has picklist backorder so the existing toggle still appears.
> 
> `QuickOrderB2BTable` loads referenced picklist product IDs via `searchProducts`, caches them in `picklistProductsById`, and renders new `PicklistBackorderMessages` / `PicklistSelectionBackorderMessage` in the desktop qty column and mobile `QuickOrderCard`. Unit and Quick Order integration tests cover the new behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9215f91022f30065e0083729fdf6612ef0a03f54. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->