### PR TITLE
fix(login): TRAC-837 Bump Catalyst login redirect fallback to 7s

### DIFF
--- a/apps/storefront/src/pages/Login/CatalystLogin.tsx
+++ b/apps/storefront/src/pages/Login/CatalystLogin.tsx
@@ -49,9 +49,14 @@ export function CatalystLogin() {
   const loginFlag = searchParams.get('loginFlag');
 
   useEffect(() => {
+    // Hotfix (TRAC-837): give the async auth resolution more headroom before the
+    // fallback storefront-login redirect fires. On slower sessions the 3s window
+    // elapsed before the B2BToken/customer info resolved and navigated away,
+    // firing window.location.href='/login' and feeding the Catalyst
+    // /?section=orders <-> /#/login loop. 7s reduces that race.
     const timeout = setTimeout(() => {
       window.location.href = '/login';
-    }, 3000);
+    }, 7000);
 
     return () => {
       clearTimeout(timeout);


### PR DESCRIPTION
Jira: [TRAC-837](https://bigcommercecloud.atlassian.net/browse/TRAC-837)

## What/Why?

On Catalyst storefronts, `CatalystLogin` (`apps/storefront/src/pages/Login/CatalystLogin.tsx`) schedules a fallback `window.location.href = '/login'` redirect on mount. The intent is to send the shopper to the storefront login page if buyer-portal auth never resolves.

The window was `3000`ms. On slower sessions that elapsed before the async auth resolution (`B2BToken` hydration plus `getCurrentCustomerInfo`) could `navigate('/orders')` and unmount the component. The premature `/login` redirect is then bounced straight back to `/?section=orders` by Catalyst while the BC session is still valid, which is one engine of the `/?section=orders` <-> `/#/login` loop reported in TRAC-837.

This is a hotfix mitigation only. It widens the fallback to `7000`ms to give auth resolution more headroom before the redirect fires. It does not address the root cause (B2C and unapproved-B2B shoppers have no buyer-portal session yet are still pushed into the portal orders page); that fix is scoped separately.

## Rollout/Rollback

Ships with the next `b2b-buyer-portal` headless bundle deploy. No feature flag, no migration. Rollback is a straight revert of this single-line change; behavior returns to the previous 3s fallback.

## Testing

- CI
- Manual repro on an affected store (e.g. Gem Setra B2B Production, store `1003304730`) recommended before promoting out of draft: log in as a B2C or unapproved-B2B user and confirm slower-resolving sessions land correctly instead of bouncing to `/#/login`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single timeout constant and comment in Catalyst-only login flow; no auth logic changes, though users may wait longer before the fallback redirect on genuinely stuck sessions.
> 
> **Overview**
> **TRAC-837 hotfix:** In `CatalystLogin`, the fallback timer that sends users to `/login` when async auth has not finished is increased from **3s to 7s**, with an inline comment documenting the race.
> 
> On slow sessions, B2B token and customer resolution sometimes completed after the old window, so `window.location.href = '/login'` ran anyway and contributed to a redirect loop between Catalyst `/?section=orders` and `/#/login`. The longer delay is a mitigation until a root-cause fix ships; logout/navigation logic is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92f1a19b28437375fd36409e3a7ff28a2d0db563. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


[TRAC-837]: https://bigcommercecloud.atlassian.net/browse/TRAC-837?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ