### PR TITLE
fix(login): TRAC-837 Bump Catalyst login redirect fallback to 7s

### DIFF
--- a/apps/storefront/src/pages/Login/CatalystLogin.tsx
+++ b/apps/storefront/src/pages/Login/CatalystLogin.tsx
@@ -49,9 +49,14 @@ export function CatalystLogin() {
   const loginFlag = searchParams.get('loginFlag');
 
   useEffect(() => {
+    // Hotfix (TRAC-837): give the async auth resolution more headroom before the
+    // fallback storefront-login redirect fires. On slower sessions the 3s window
+    // elapsed before the B2BToken/customer info resolved and navigated away,
+    // firing window.location.href='/login' and feeding the Catalyst
+    // /?section=orders <-> /#/login loop. 7s reduces that race.
     const timeout = setTimeout(() => {
       window.location.href = '/login';
-    }, 3000);
+    }, 7000);
 
     return () => {
       clearTimeout(timeout);


### PR DESCRIPTION
Jira: [TRAC-837](https://bigcommercecloud.atlassian.net/browse/TRAC-837)

## What/Why?

On Catalyst storefronts, `CatalystLogin` (`apps/storefront/src/pages/Login/CatalystLogin.tsx`) schedules a fallback `window.location.href = '/login'` redirect on mount. The intent is to send the shopper to the storefront login page if buyer-portal auth never resolves.

The window was `3000`ms. On slower sessions that elapsed before the async auth resolution (`B2BToken` hydration plus `getCurrentCustomerInfo`) could `navigate('/orders')` and unmount the component. The premature `/login` redirect is then bounced straight back to `/?section=orders` by Catalyst while the BC session is still valid, which is one engine of the `/?section=orders` <-> `/#/login` loop reported in TRAC-837.

This is a hotfix mitigation only. It widens the fallback to `7000`ms to give auth resolution more headroom before the redirect fires. It does not address the root cause (B2C and unapproved-B2B shoppers have no buyer-portal session yet are still pushed into the portal orders page); that fix is scoped separately.

## Rollout/Rollback

Ships with the next `b2b-buyer-portal` headless bundle deploy. No feature flag, no migration. Rollback is a straight revert of this single-line change; behavior returns to the previous 3s fallback.

## Testing

- CI
- Manual repro on an affected store (e.g. Gem Setra B2B Production, store `1003304730`) recommended before promoting out of draft: log in as a B2C or unapproved-B2B user and confirm slower-resolving sessions land correctly instead of bouncing to `/#/login`.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single timeout constant change on Catalyst login with no auth or data-model changes; worst case is a slightly longer wait before the existing fallback redirect.
> 
> **Overview**
> **Hotfix for TRAC-837:** In `CatalystLogin`, the mount-time fallback that sends shoppers to `/login` when buyer-portal auth never finishes now waits **7s** instead of **3s**.
> 
> On slower Catalyst sessions the shorter window could fire `window.location.href = '/login'` before `B2BToken` resolution and `navigate('/orders')` completed, which contributed to a redirect loop between `/?section=orders` and `/#/login`. The change only widens that race window; it does not change logout or navigation logic elsewhere.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 329070aa71e0e1f0213876e6c5a8a7bb19e47d47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->




[TRAC-837]: https://bigcommercecloud.atlassian.net/browse/TRAC-837?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ