### PR TITLE
fix(login): TRAC-837 Bump Catalyst login redirect fallback to 7s

### DIFF
--- a/apps/storefront/src/pages/Login/CatalystLogin.tsx
+++ b/apps/storefront/src/pages/Login/CatalystLogin.tsx
@@ -51,7 +51,7 @@ export function CatalystLogin() {
   useEffect(() => {
     const timeout = setTimeout(() => {
       window.location.href = '/login';
-    }, 3000);
+    }, 7000);
 
     return () => {
       clearTimeout(timeout);


### PR DESCRIPTION
Jira: [TRAC-837](https://bigcommercecloud.atlassian.net/browse/TRAC-837)

## What/Why?

On Catalyst storefronts, `CatalystLogin` (`apps/storefront/src/pages/Login/CatalystLogin.tsx`) schedules a fallback `window.location.href = '/login'` redirect on mount. The intent is to send the shopper to the storefront login page if buyer-portal auth never resolves.

The window was `3000`ms. On slower sessions that elapsed before the async auth resolution (`B2BToken` hydration plus `getCurrentCustomerInfo`) could `navigate('/orders')` and unmount the component. The premature `/login` redirect is then bounced straight back to `/?section=orders` by Catalyst while the BC session is still valid, which is one engine of the `/?section=orders` <-> `/#/login` loop reported in TRAC-837.

This is a hotfix mitigation only. It widens the fallback to `7000`ms to give auth resolution more headroom before the redirect fires. It does not address the root cause (B2C and unapproved-B2B shoppers have no buyer-portal session yet are still pushed into the portal orders page); that fix is scoped separately.

## Rollout/Rollback

Ships with the next `b2b-buyer-portal` headless bundle deploy. No feature flag, no migration. Rollback is a straight revert of this single-line change; behavior returns to the previous 3s fallback.

## Testing

- CI
- Manual repro on an affected store (e.g. Gem Setra B2B Production, store `1003304730`) recommended before promoting out of draft: log in as a B2C or unapproved-B2B user and confirm slower-resolving sessions land correctly instead of bouncing to `/#/login`.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single constant change in a fallback timer with no auth or API behavior changes; worst case is a slightly longer loading state before redirect.
> 
> **Overview**
> **TRAC-837 hotfix:** In `CatalystLogin`, the mount-time fallback that sends shoppers to `/login` when buyer-portal auth does not resolve in time is extended from **3s to 7s**.
> 
> That gives `B2BToken` hydration and `navigate('/orders')` more time on slow Catalyst sessions, reducing premature redirects that Catalyst bounces back while the BC session is still valid (the `/?section=orders` ↔ `/#/login` loop). This is a timing mitigation only; it does not change logout/masquerade logic or fix the separate root cause for B2C/unapproved-B2B users.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 625d2b692600ecad0de280258fe3b68186c768d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->






[TRAC-837]: https://bigcommercecloud.atlassian.net/browse/TRAC-837?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ