### PR TITLE
[B2B-4627] Fix partial shipment display on unified order detail

### DIFF
--- a/apps/storefront/src/pages/OrderDetail/index.unified.test.tsx
+++ b/apps/storefront/src/pages/OrderDetail/index.unified.test.tsx
@@ -948,6 +948,192 @@ describe('Order detail path with unified SF GQL flag ON', () => {
       expect(screen.getByText(/123 Main St/)).toBeVisible();
       expect(screen.getByText(/456 Oak Ave/)).toBeVisible();
     });
+
+    it('renders both shipped and not-shipped sections for a partial shipment', async () => {
+      const partialOrder = buildShippedOrder({
+        status: { value: 'PARTIALLY_SHIPPED', label: 'Partially Shipped' },
+        consignments: {
+          shipping: {
+            edges: [
+              {
+                cursor: 'sc1',
+                node: {
+                  entityId: 1001,
+                  shippingAddress: {
+                    firstName: 'Jane',
+                    lastName: 'Doe',
+                    company: 'Acme Corp',
+                    address1: '123 Main St',
+                    address2: null,
+                    city: 'Austin',
+                    stateOrProvince: 'TX',
+                    postalCode: '73301',
+                    country: 'United States',
+                    countryCode: 'US',
+                    phone: null,
+                    email: null,
+                  },
+                  shippingCost: { currencyCode: 'USD', value: 15 },
+                  lineItems: {
+                    edges: [
+                      {
+                        node: {
+                          entityId: 2001,
+                          productEntityId: 3001,
+                          variantEntityId: 4001,
+                          sku: 'WIDGET-A',
+                          brand: 'WidgetCo',
+                          name: 'Partially Shipped Widget',
+                          quantity: 5,
+                          productOptions: [],
+                          subTotalListPrice: { currencyCode: 'USD', value: 125 },
+                          image: null,
+                          baseCatalogProduct: null,
+                        },
+                      },
+                    ],
+                  },
+                  shipments: {
+                    edges: [
+                      {
+                        node: {
+                          entityId: 5001,
+                          shippedAt: { utc: '2026-05-15T10:00:00Z' },
+                          shippingMethodName: 'Standard Shipping',
+                          shippingProviderName: 'FedEx',
+                          tracking: {
+                            number: 'PARTIAL-TRACK-001',
+                            url: 'https://fedex.com/track/PARTIAL-TRACK-001',
+                          },
+                          items: [{ lineItemId: 2001, quantity: 2 }],
+                        },
+                      },
+                    ],
+                  },
+                },
+              },
+            ],
+          },
+          downloads: null,
+        },
+      });
+
+      setupServerWithOrder(partialOrder);
+      await renderAndWait();
+
+      expect(await screen.findByText(/Shipment/)).toBeVisible();
+      expect(screen.getByText('PARTIAL-TRACK-001')).toBeVisible();
+      expect(screen.getByText('Not shipped yet')).toBeVisible();
+      // Product appears in both shipped and not-shipped sections
+      expect(screen.getAllByText('Partially Shipped Widget')).toHaveLength(2);
+    });
+
+    it('renders multiple shipments for different line items in the same consignment', async () => {
+      const multiShipmentOrder = buildShippedOrder({
+        consignments: {
+          shipping: {
+            edges: [
+              {
+                cursor: 'sc1',
+                node: {
+                  entityId: 1001,
+                  shippingAddress: {
+                    firstName: 'Jane',
+                    lastName: 'Doe',
+                    company: 'Acme Corp',
+                    address1: '123 Main St',
+                    address2: null,
+                    city: 'Austin',
+                    stateOrProvince: 'TX',
+                    postalCode: '73301',
+                    country: 'United States',
+                    countryCode: 'US',
+                    phone: null,
+                    email: null,
+                  },
+                  shippingCost: { currencyCode: 'USD', value: 20 },
+                  lineItems: {
+                    edges: [
+                      {
+                        node: {
+                          entityId: 2001,
+                          productEntityId: 3001,
+                          variantEntityId: 4001,
+                          sku: 'W-A',
+                          brand: null,
+                          name: 'Widget Alpha',
+                          quantity: 3,
+                          productOptions: [],
+                          subTotalListPrice: { currencyCode: 'USD', value: 75 },
+                          image: null,
+                          baseCatalogProduct: null,
+                        },
+                      },
+                      {
+                        node: {
+                          entityId: 2002,
+                          productEntityId: 3002,
+                          variantEntityId: 4002,
+                          sku: 'W-B',
+                          brand: null,
+                          name: 'Widget Beta',
+                          quantity: 4,
+                          productOptions: [],
+                          subTotalListPrice: { currencyCode: 'USD', value: 100 },
+                          image: null,
+                          baseCatalogProduct: null,
+                        },
+                      },
+                    ],
+                  },
+                  shipments: {
+                    edges: [
+                      {
+                        node: {
+                          entityId: 5001,
+                          shippedAt: { utc: '2026-05-10T10:00:00Z' },
+                          shippingMethodName: 'Standard Shipping',
+                          shippingProviderName: 'FedEx',
+                          tracking: {
+                            number: 'MULTI-TRACK-001',
+                            url: 'https://fedex.com/track/MULTI-TRACK-001',
+                          },
+                          items: [{ lineItemId: 2001, quantity: 3 }],
+                        },
+                      },
+                      {
+                        node: {
+                          entityId: 5002,
+                          shippedAt: { utc: '2026-05-12T14:00:00Z' },
+                          shippingMethodName: 'Express Shipping',
+                          shippingProviderName: 'UPS',
+                          tracking: {
+                            number: 'MULTI-TRACK-002',
+                            url: 'https://ups.com/track/MULTI-TRACK-002',
+                          },
+                          items: [{ lineItemId: 2002, quantity: 2 }],
+                        },
+                      },
+                    ],
+                  },
+                },
+              },
+            ],
+          },
+          downloads: null,
+        },
+      });
+
+      setupServerWithOrder(multiShipmentOrder);
+      await renderAndWait();
+
+      expect(await screen.findByText('MULTI-TRACK-001')).toBeVisible();
+      expect(screen.getByText('MULTI-TRACK-002')).toBeVisible();
+      expect(screen.getByText('Widget Alpha')).toBeVisible();
+      // Widget Beta appears in both shipped and not-shipped sections (2 of 4 shipped)
+      expect(screen.getAllByText('Widget Beta')).toHaveLength(2);
+      expect(screen.getByText('Not shipped yet')).toBeVisible();
+    });
   });
 
   describe('B2B-4826: payment details', () => {

--- a/apps/storefront/src/pages/OrderDetail/index.unified.test.tsx
+++ b/apps/storefront/src/pages/OrderDetail/index.unified.test.tsx
@@ -702,6 +702,7 @@ describe('Order detail path with unified SF GQL flag ON', () => {
                             number: '1Z999AA10123456784',
                             url: 'https://fedex.com/track/1Z999AA10123456784',
                           },
+                          items: [{ lineItemId: 2001, quantity: 3 }],
                         },
                       },
                     ],

--- a/apps/storefront/src/pages/OrderDetail/shared/convertOrderDetail.ts
+++ b/apps/storefront/src/pages/OrderDetail/shared/convertOrderDetail.ts
@@ -332,16 +332,42 @@ function convertShippings(order: Order, decimalPlaces: number): OrderShippingsIt
       convertLineItemToProduct(le.node, decimalPlaces, consignment.entityId),
     );
 
-    const hasShipments = consignment.shipments.edges.length > 0;
+    // Sum shipped quantity per line item across all shipments.
+    // shipment.items[].lineItemId references lineItem.entityId (product.id).
+    const shippedByLineItem = new Map<number, number>();
+    consignment.shipments.edges.forEach((se) => {
+      se.node.items.forEach((item) => {
+        shippedByLineItem.set(
+          item.lineItemId,
+          (shippedByLineItem.get(item.lineItemId) ?? 0) + item.quantity,
+        );
+      });
+    });
 
-    const productsWithShipStatus = products.map((p) => ({
-      ...p,
-      quantity_shipped: hasShipments ? p.quantity : 0,
-      not_shipping_number: hasShipments ? 0 : p.quantity,
-    }));
+    const productsWithShipStatus = products.map((p) => {
+      const shipped = shippedByLineItem.get(p.id) ?? 0;
+      return {
+        ...p,
+        quantity_shipped: shipped,
+        not_shipping_number: p.quantity - shipped,
+      };
+    });
 
     const shipmentItems = consignment.shipments.edges.map((se) => {
       const shipment = se.node;
+
+      // Only include products that were in this specific shipment.
+      const shipmentProductInfo = shipment.items
+        .map((item) => {
+          const product = productsWithShipStatus.find((p) => p.id === item.lineItemId);
+          if (!product) return null;
+          return {
+            ...product,
+            current_quantity_shipped: item.quantity,
+          };
+        })
+        .filter(Boolean);
+
       return {
         id: shipment.entityId,
         order_id: order.entityId,
@@ -356,26 +382,25 @@ function convertShippings(order: Order, decimalPlaces: number): OrderShippingsIt
         billing_address: convertAddress(order.billingAddress),
         comments: '',
         customer_id: 0,
-        items: products.map((p) => ({
-          order_product_id: p.id,
-          product_id: p.product_id,
-          quantity: p.quantity,
+        items: shipment.items.map((item) => ({
+          order_product_id: item.lineItemId,
+          product_id: productsWithShipStatus.find((p) => p.id === item.lineItemId)?.product_id ?? 0,
+          quantity: item.quantity,
         })),
         merchant_shipping_cost: '0',
         shipping_address: address,
-        itemsInfo: productsWithShipStatus.map((p) => ({
-          ...p,
-          current_quantity_shipped: p.quantity,
-        })),
+        itemsInfo: shipmentProductInfo,
       };
     });
 
-    const notShipItems = hasShipments
-      ? []
-      : productsWithShipStatus.map((p) => ({
-          ...p,
-          not_shipping_number: p.quantity,
-        }));
+    const notShipItems = productsWithShipStatus
+      .filter((p) => p.quantity > p.quantity_shipped)
+      .map((p) => ({
+        ...p,
+        not_shipping_number: p.quantity - p.quantity_shipped,
+      }));
+
+    const itemsShippedCount = productsWithShipStatus.filter((p) => p.quantity_shipped > 0).length;
 
     const shippingCost = formatPrice(consignment.shippingCost.value, decimalPlaces);
 
@@ -393,7 +418,7 @@ function convertShippings(order: Order, decimalPlaces: number): OrderShippingsIt
       handling_cost_inc_tax: '0',
       handling_cost_tax: '0',
       handling_cost_tax_class_id: 0,
-      items_shipped: hasShipments ? products.length : 0,
+      items_shipped: itemsShippedCount,
       items_total: products.length,
       shipping_method: shipmentItems[0]?.shipping_method ?? '',
       shipping_quotes: '',

--- a/apps/storefront/src/shared/service/bc/graphql/orders.ts
+++ b/apps/storefront/src/shared/service/bc/graphql/orders.ts
@@ -62,12 +62,18 @@ export interface OrderShipmentTracking {
   url?: string;
 }
 
+export interface OrderShipmentLineItem {
+  lineItemId: number;
+  quantity: number;
+}
+
 export interface OrderShipment {
   entityId: number;
   shippedAt: DateTimeExtended;
   shippingMethodName: string;
   shippingProviderName: string;
   tracking: OrderShipmentTracking | null;
+  items: OrderShipmentLineItem[];
 }
 
 /** Projects OrderShippingConsignment. */
@@ -393,6 +399,10 @@ const orderShipmentFields = `entityId
         ... on OrderShipmentUrlOnlyTracking {
           url
         }
+      }
+      items {
+        lineItemId
+        quantity
       }`;
 
 const orderConsignmentsFields = `consignments {


### PR DESCRIPTION
Jira: [B2B-4627](https://bigcommercecloud.atlassian.net/browse/B2B-4627)

## What/Why?

The unified order detail path (behind `B2B-4613.buyer_portal_unified_sf_gql_orders` feature flag) used a binary check for shipped/unshipped status — if any shipment existed on a consignment, all products were marked as fully shipped and the "Not Shipped Yet" section was hidden entirely.

This broke partial shipments, which are common in B2B. For example, if a customer ordered 10 units and only 5 shipped, the legacy portal correctly shows "Shipment 1" (5 items) and "Not Shipped Yet" (5 items). The unified path showed all 10 as shipped with no "Not Shipped Yet" section.

**Root cause:** The SF GQL `OrderShipment` type exposes `items: [OrderShipmentLineItem!]!` (with `lineItemId` and `quantity` per item), but we weren't querying it. Without per-shipment item data, the converter couldn't know which specific products were in which shipment or how many were shipped.

**Changes:**
- **`orders.ts`**: Added `OrderShipmentLineItem` interface and `items { lineItemId quantity }` to the shipment query fragment
- **`convertOrderDetail.ts`**: Replaced the binary `hasShipments` check with real per-product shipped quantity calculation:
  - Sums `quantity` across all shipment items per `lineItemId`
  - Uses real `quantity_shipped` for the `notShip` calculation (`quantity - quantity_shipped`)
  - Each shipment's `itemsInfo` now only includes products actually in that specific shipment (not all consignment products)
  - `items_shipped` count uses real data
- **`index.unified.test.tsx`**: Updated shipment mock to include `items` field matching the new type


## Rollout/Rollback

Gated behind the existing `B2B-4613.buyer_portal_unified_sf_gql_orders` feature flag. No new flags introduced. Rollback is turning the flag off — legacy path is unchanged and unaffected.

## Testing

- All 36 unified order detail tests pass
- All 39 legacy order detail tests pass (unchanged path, no regression)
- TypeScript compilation clean
- Lint clean (only pre-existing `import/extensions` warning)

<img width="1906" height="1001" alt="image" src="https://github.com/user-attachments/assets/b0b378fd-e655-409c-800e-ef40d640fa41" />

[B2B-4627]: https://bigcommercecloud.atlassian.net/browse/B2B-4627?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ





<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes order-detail shipping conversion behind the unified SF GQL feature flag; wrong aggregation could misstate shipped vs pending quantities, but legacy path is untouched.
> 
> **Overview**
> Fixes unified order detail shipping so **partial and multi-shipment** orders match legacy behavior instead of treating any shipment as “everything shipped.”
> 
> The SF GQL order query now fetches **`items { lineItemId, quantity }`** on each shipment. **`convertOrderDetail`** aggregates shipped qty per line item, drives **“Not shipped yet”** from `quantity - quantity_shipped`, and scopes each shipment’s product list to the lines in that shipment only (with accurate **`items_shipped`** counts). Unified order detail tests cover partial shipments and multiple shipments in one consignment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0a33ff2adb458e9efc40cff1ac68c803dbd0c00. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->