### PR TITLE
fix(common): B2B-4912 fix account page takeover failures

### DIFF
--- a/apps/storefront/src/App.tsx
+++ b/apps/storefront/src/App.tsx
@@ -216,9 +216,8 @@ export default function App() {
 
         // background login enter judgment and refresh
         const nativeLinkInterceptionEnabled =
-          store.getState().global.featureFlags[
-            'B2B-4912.buyer_portal_native_link_interception'
-          ] ?? false;
+          store.getState().global.featureFlags['B2B-4912.buyer_portal_native_link_interception'] ??
+          false;
         const shouldOpenAllowedPage = nativeLinkInterceptionEnabled
           ? shouldOpenAllowedPageOnInit({ pathname, hash: window.location.hash, customerId })
           : !pathname.includes('checkout') && !(!!customerId && !window.location.hash);

--- a/apps/storefront/src/App.tsx
+++ b/apps/storefront/src/App.tsx
@@ -22,6 +22,7 @@ import { handleHideRegisterPage } from '@/utils/b3HideRegister';
 import { hideStorefrontElement } from '@/utils/b3HideStorefrontElement';
 import { getQuoteEnabled } from '@/utils/b3Init';
 
+import { shouldOpenAllowedPageOnInit } from '@/utils/nativeStorefrontLinks';
 import b2bVerifyBcLoginStatus from './utils/b2bVerifyBcLoginStatus';
 import { b2bJumpPath } from './utils/b3CheckPermissions/b2bPermissionPath';
 import clearInvoiceCart from './utils/b3ClearCart';
@@ -213,8 +214,15 @@ export default function App() {
         }
 
         // background login enter judgment and refresh
-        if (!pathname.includes('checkout') && !(customerId && !window.location.hash)) {
-          await gotoAllowedAppPage(Number(userInfo.role), gotoPage);
+        const shouldOpenAllowedPage = shouldOpenAllowedPageOnInit({
+          pathname,
+          hash: window.location.hash,
+          customerId,
+        });
+        const isAccountPageWithoutHash = pathname.includes('account.php') && !window.location.hash;
+
+        if (shouldOpenAllowedPage) {
+          await gotoAllowedAppPage(Number(userInfo.role), gotoPage, isAccountPageWithoutHash);
         } else {
           showPageMask(false);
         }

--- a/apps/storefront/src/App.tsx
+++ b/apps/storefront/src/App.tsx
@@ -41,6 +41,7 @@ import {
   rolePermissionSelector,
   setGlobalCommonState,
   setOpenPageReducer,
+  store,
   useAppDispatch,
   useAppSelector,
 } from './store';
@@ -214,11 +215,13 @@ export default function App() {
         }
 
         // background login enter judgment and refresh
-        const shouldOpenAllowedPage = shouldOpenAllowedPageOnInit({
-          pathname,
-          hash: window.location.hash,
-          customerId,
-        });
+        const nativeLinkInterceptionEnabled =
+          store.getState().global.featureFlags[
+            'B2B-4912.buyer_portal_native_link_interception'
+          ] ?? false;
+        const shouldOpenAllowedPage = nativeLinkInterceptionEnabled
+          ? shouldOpenAllowedPageOnInit({ pathname, hash: window.location.hash, customerId })
+          : !pathname.includes('checkout') && !(!!customerId && !window.location.hash);
         const isAccountPageWithoutHash = pathname.includes('account.php') && !window.location.hash;
 
         if (shouldOpenAllowedPage) {

--- a/apps/storefront/src/App.tsx
+++ b/apps/storefront/src/App.tsx
@@ -21,8 +21,8 @@ import { openPageByClick, removeBCMenus } from '@/utils/b3AccountItem';
 import { handleHideRegisterPage } from '@/utils/b3HideRegister';
 import { hideStorefrontElement } from '@/utils/b3HideStorefrontElement';
 import { getQuoteEnabled } from '@/utils/b3Init';
-
 import { shouldOpenAllowedPageOnInit } from '@/utils/nativeStorefrontLinks';
+
 import b2bVerifyBcLoginStatus from './utils/b2bVerifyBcLoginStatus';
 import { b2bJumpPath } from './utils/b3CheckPermissions/b2bPermissionPath';
 import clearInvoiceCart from './utils/b3ClearCart';

--- a/apps/storefront/src/App.tsx
+++ b/apps/storefront/src/App.tsx
@@ -222,7 +222,22 @@ export default function App() {
         const isAccountPageWithoutHash = pathname.includes('account.php') && !window.location.hash;
 
         if (shouldOpenAllowedPage) {
-          await gotoAllowedAppPage(Number(userInfo.role), gotoPage, isAccountPageWithoutHash);
+          if (isAccountPageWithoutHash && search) {
+            // Map native action (e.g. ?action=address_book) to the correct portal route
+            // using the same logic as runtime click interception, so direct navigation
+            // and link clicks land on the same page.
+            gotoPage(
+              openPageByClick({
+                href: `${pathname}${search}`,
+                role: Number(userInfo.role),
+                isRegisterAndLogin: false,
+                isAgenting,
+                authorizedPages,
+              }),
+            );
+          } else {
+            await gotoAllowedAppPage(Number(userInfo.role), gotoPage, isAccountPageWithoutHash);
+          }
         } else {
           showPageMask(false);
         }

--- a/apps/storefront/src/hooks/useB3AppOpen.test.tsx
+++ b/apps/storefront/src/hooks/useB3AppOpen.test.tsx
@@ -1,0 +1,94 @@
+import { waitFor } from '@testing-library/react';
+import { buildCompanyStateWith, userEvent } from 'tests/test-utils';
+import { renderHookWithProviders } from 'tests/utils/hook-test-utils';
+
+import { CustomerRole } from '@/types';
+
+import { useB3AppOpen } from './useB3AppOpen';
+
+const loggedInCompanyState = buildCompanyStateWith({
+  customer: {
+    id: 123,
+    role: CustomerRole.ADMIN,
+  },
+});
+
+describe('useB3AppOpen native storefront link interception', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    window.history.pushState({}, '', '/');
+  });
+
+  it('intercepts child clicks inside account anchors', async () => {
+    document.body.innerHTML = `
+      <a class="navUser-action" href="${window.location.origin}/account.php?action=order_status">
+        <span class="navUser-item-accountLabel">Account</span>
+      </a>
+    `;
+    const handleEnterClick = vi.fn();
+
+    renderHookWithProviders(
+      () =>
+        useB3AppOpen({
+          isOpen: false,
+          handleEnterClick,
+          authorizedPages: '/orders',
+        }),
+      { preloadedState: { company: loggedInCompanyState } },
+    );
+
+    await userEvent.click(document.querySelector('.navUser-item-accountLabel') as HTMLElement);
+
+    await waitFor(() => {
+      expect(handleEnterClick).toHaveBeenCalledWith('/account.php?action=order_status', false);
+    });
+  });
+
+  it('intercepts same-origin absolute account links without navUser classes', async () => {
+    document.body.innerHTML = `
+      <li class="menu-item">
+        <a href="${window.location.origin}/account.php">Account</a>
+      </li>
+    `;
+    const handleEnterClick = vi.fn();
+
+    renderHookWithProviders(
+      () =>
+        useB3AppOpen({
+          isOpen: false,
+          handleEnterClick,
+          authorizedPages: '/orders',
+        }),
+      { preloadedState: { company: loggedInCompanyState } },
+    );
+
+    await userEvent.click(document.querySelector('a[href]') as HTMLElement);
+
+    await waitFor(() => {
+      expect(handleEnterClick).toHaveBeenCalledWith('/account.php', false);
+    });
+  });
+
+  it('does not intercept checkout placeholder links', async () => {
+    window.history.pushState({}, '', '/checkout');
+    document.body.innerHTML = '<a href="#">Continue</a>';
+    const handleEnterClick = vi.fn();
+
+    renderHookWithProviders(
+      () =>
+        useB3AppOpen({
+          isOpen: false,
+          handleEnterClick,
+          authorizedPages: '/orders',
+        }),
+      { preloadedState: { company: loggedInCompanyState } },
+    );
+
+    await userEvent.click(document.querySelector('a[href]') as HTMLElement);
+
+    // Drain microtasks before asserting absence
+    await Promise.resolve();
+
+    expect(handleEnterClick).not.toHaveBeenCalled();
+  });
+});

--- a/apps/storefront/src/hooks/useB3AppOpen.test.tsx
+++ b/apps/storefront/src/hooks/useB3AppOpen.test.tsx
@@ -1,4 +1,4 @@
-import { waitFor } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import { buildCompanyStateWith, userEvent } from 'tests/test-utils';
 import { renderHookWithProviders } from 'tests/utils/hook-test-utils';
 
@@ -37,7 +37,7 @@ describe('useB3AppOpen native storefront link interception', () => {
       { preloadedState: { company: loggedInCompanyState } },
     );
 
-    await userEvent.click(document.querySelector('.navUser-item-accountLabel') as HTMLElement);
+    await userEvent.click(screen.getByText('Account'));
 
     await waitFor(() => {
       expect(handleEnterClick).toHaveBeenCalledWith('/account.php?action=order_status', false);
@@ -62,7 +62,7 @@ describe('useB3AppOpen native storefront link interception', () => {
       { preloadedState: { company: loggedInCompanyState } },
     );
 
-    await userEvent.click(document.querySelector('a[href]') as HTMLElement);
+    await userEvent.click(screen.getByRole('link'));
 
     await waitFor(() => {
       expect(handleEnterClick).toHaveBeenCalledWith('/account.php', false);
@@ -84,7 +84,7 @@ describe('useB3AppOpen native storefront link interception', () => {
       { preloadedState: { company: loggedInCompanyState } },
     );
 
-    await userEvent.click(document.querySelector('a[href]') as HTMLElement);
+    await userEvent.click(screen.getByRole('link'));
 
     // Drain microtasks before asserting absence
     await Promise.resolve();

--- a/apps/storefront/src/hooks/useB3AppOpen.test.tsx
+++ b/apps/storefront/src/hooks/useB3AppOpen.test.tsx
@@ -1,5 +1,5 @@
 import { screen, waitFor } from '@testing-library/react';
-import { buildCompanyStateWith, userEvent } from 'tests/test-utils';
+import { buildCompanyStateWith, buildGlobalStateWith, userEvent } from 'tests/test-utils';
 import { renderHookWithProviders } from 'tests/utils/hook-test-utils';
 
 import { CustomerRole } from '@/types';
@@ -15,7 +15,9 @@ const loggedInCompanyState = buildCompanyStateWith({
 
 const withNativeLinkInterception = {
   company: loggedInCompanyState,
-  global: { featureFlags: { 'B2B-4912.buyer_portal_native_link_interception': true } },
+  global: buildGlobalStateWith({
+    featureFlags: { 'B2B-4912.buyer_portal_native_link_interception': true },
+  }),
 };
 
 describe('useB3AppOpen native storefront link interception', () => {

--- a/apps/storefront/src/hooks/useB3AppOpen.test.tsx
+++ b/apps/storefront/src/hooks/useB3AppOpen.test.tsx
@@ -13,6 +13,11 @@ const loggedInCompanyState = buildCompanyStateWith({
   },
 });
 
+const withNativeLinkInterception = {
+  company: loggedInCompanyState,
+  global: { featureFlags: { 'B2B-4912.buyer_portal_native_link_interception': true } },
+};
+
 describe('useB3AppOpen native storefront link interception', () => {
   beforeEach(() => {
     document.body.innerHTML = '';
@@ -34,7 +39,7 @@ describe('useB3AppOpen native storefront link interception', () => {
           handleEnterClick,
           authorizedPages: '/orders',
         }),
-      { preloadedState: { company: loggedInCompanyState } },
+      { preloadedState: withNativeLinkInterception },
     );
 
     await userEvent.click(screen.getByText('Account'));
@@ -59,7 +64,7 @@ describe('useB3AppOpen native storefront link interception', () => {
           handleEnterClick,
           authorizedPages: '/orders',
         }),
-      { preloadedState: { company: loggedInCompanyState } },
+      { preloadedState: withNativeLinkInterception },
     );
 
     await userEvent.click(screen.getByRole('link'));

--- a/apps/storefront/src/hooks/useB3AppOpen.ts
+++ b/apps/storefront/src/hooks/useB3AppOpen.ts
@@ -25,6 +25,10 @@ const useB3AppOpen = (initOpenState: OpenPageState) => {
     setCheckoutRegisterNumber(() => checkoutRegisterNumber + 1);
   }, [checkoutRegisterNumber]);
   const role = useAppSelector((state) => state.company.customer.role);
+  const isNativeLinkInterceptionEnabled = useAppSelector(
+    ({ global }) =>
+      global.featureFlags['B2B-4912.buyer_portal_native_link_interception'] ?? false,
+  );
   const authorizedPages = initOpenState?.authorizedPages || '/orders';
 
   const [openPage, setOpenPage] = useState<OpenPageState>({
@@ -101,7 +105,7 @@ const useB3AppOpen = (initOpenState: OpenPageState) => {
       const nativePath = anchor ? getNativeStorefrontPath(anchor.href) : null;
       const isNativeBuyerPortalLink = anchor ? isBuyerPortalNativeHref(anchor.href) : false;
 
-      if (isConfiguredTarget || isNativeBuyerPortalLink) {
+      if (isConfiguredTarget || (isNativeLinkInterceptionEnabled && isNativeBuyerPortalLink)) {
         const isSearchNode = handleJudgeSearchNode(e);
         const isCheckoutNormalHref = handleJudgeCheckoutNormalHref(e, anchor);
 
@@ -172,7 +176,7 @@ const useB3AppOpen = (initOpenState: OpenPageState) => {
       });
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [checkoutRegisterNumber, initOpenState, role]);
+  }, [checkoutRegisterNumber, initOpenState, isNativeLinkInterceptionEnabled, role]);
 
   useMutationObservable(config['dom.checkoutRegisterParentElement'], callback);
 

--- a/apps/storefront/src/hooks/useB3AppOpen.ts
+++ b/apps/storefront/src/hooks/useB3AppOpen.ts
@@ -5,7 +5,6 @@ import config from '@/lib/config';
 import { useAppSelector } from '@/store';
 import { CustomerRole } from '@/types';
 import { OpenPageState } from '@/types/hooks';
-
 import {
   getClosestAnchorFromTarget,
   getNativeStorefrontPath,
@@ -109,7 +108,8 @@ const useB3AppOpen = (initOpenState: OpenPageState) => {
         if (isSearchNode || isCheckoutNormalHref) return false;
         e.preventDefault();
         e.stopPropagation();
-        const isRegisterArrInclude = registerArr.includes(target) || (anchor ? registerArr.includes(anchor) : false);
+        const isRegisterArrInclude =
+          registerArr.includes(target) || (anchor ? registerArr.includes(anchor) : false);
         const tagHref = nativePath || anchor?.href || (e.target as HTMLAnchorElement)?.href;
         let href = tagHref || authorizedPages;
         if (!tagHref || typeof tagHref !== 'string') {

--- a/apps/storefront/src/hooks/useB3AppOpen.ts
+++ b/apps/storefront/src/hooks/useB3AppOpen.ts
@@ -69,12 +69,15 @@ const useB3AppOpen = (initOpenState: OpenPageState) => {
     return isSearchNode;
   };
 
-  const handleJudgeCheckoutNormalHref = (element: MouseEvent) => {
+  const handleJudgeCheckoutNormalHref = (
+    element: MouseEvent,
+    anchor: HTMLAnchorElement | null,
+  ) => {
     if (window?.location?.pathname !== CHECKOUT_URL) return false;
 
     const target = element.target as HTMLAnchorElement;
 
-    if (target.getAttribute('href') && target.getAttribute('href') === '#') return true;
+    if (target.getAttribute('href') === '#' || anchor?.getAttribute('href') === '#') return true;
 
     return false;
   };
@@ -103,7 +106,7 @@ const useB3AppOpen = (initOpenState: OpenPageState) => {
 
       if (isConfiguredTarget || isNativeBuyerPortalLink) {
         const isSearchNode = handleJudgeSearchNode(e);
-        const isCheckoutNormalHref = handleJudgeCheckoutNormalHref(e);
+        const isCheckoutNormalHref = handleJudgeCheckoutNormalHref(e, anchor);
 
         if (isSearchNode || isCheckoutNormalHref) return false;
         e.preventDefault();

--- a/apps/storefront/src/hooks/useB3AppOpen.ts
+++ b/apps/storefront/src/hooks/useB3AppOpen.ts
@@ -6,6 +6,12 @@ import { useAppSelector } from '@/store';
 import { CustomerRole } from '@/types';
 import { OpenPageState } from '@/types/hooks';
 
+import {
+  getClosestAnchorFromTarget,
+  getNativeStorefrontPath,
+  isBuyerPortalNativeHref,
+} from '@/utils/nativeStorefrontLinks';
+
 import useMutationObservable from './useMutationObservable';
 
 interface ChildNodeListProps extends ChildNode {
@@ -86,80 +92,85 @@ const useB3AppOpen = (initOpenState: OpenPageState) => {
         : [],
     );
 
-    if (registerArr.length || allOtherArr.length) {
-      const handleTriggerClick = (e: MouseEvent) => {
-        if (
-          registerArr.includes(e.target as Element) ||
-          allOtherArr.includes(e.target as Element)
-        ) {
-          const isSearchNode = handleJudgeSearchNode(e);
-          const isCheckoutNormalHref = handleJudgeCheckoutNormalHref(e);
+    const handleTriggerClick = (e: MouseEvent) => {
+      const anchor = getClosestAnchorFromTarget(e.target);
+      const target = e.target as Element;
+      const isConfiguredTarget =
+        registerArr.includes(target) ||
+        allOtherArr.includes(target) ||
+        (anchor ? registerArr.includes(anchor) || allOtherArr.includes(anchor) : false);
+      const nativePath = anchor ? getNativeStorefrontPath(anchor.href) : null;
+      const isNativeBuyerPortalLink = anchor ? isBuyerPortalNativeHref(anchor.href) : false;
 
-          if (isSearchNode || isCheckoutNormalHref) return false;
-          e.preventDefault();
-          e.stopPropagation();
-          const isRegisterArrInclude = registerArr.includes(e.target as Element);
-          const tagHref = (e.target as HTMLAnchorElement)?.href;
-          let href = tagHref || authorizedPages;
-          if (!tagHref || typeof tagHref !== 'string') {
-            let parentNode = (e.target as HTMLAnchorElement)?.parentNode;
-            let parentHref = (parentNode as HTMLAnchorElement)?.href;
-            let number = 0;
-            while (number < 3 && !parentHref) {
-              parentNode = (parentNode as HTMLAnchorElement)?.parentNode;
-              const newUrl = (parentNode as HTMLAnchorElement)?.href;
-              if (newUrl && typeof newUrl === 'string') {
-                parentHref = newUrl;
-                number += 3;
-              } else {
-                number += 1;
-              }
-            }
-            if (parentHref) {
-              href = parentHref || authorizedPages;
+      if (isConfiguredTarget || isNativeBuyerPortalLink) {
+        const isSearchNode = handleJudgeSearchNode(e);
+        const isCheckoutNormalHref = handleJudgeCheckoutNormalHref(e);
+
+        if (isSearchNode || isCheckoutNormalHref) return false;
+        e.preventDefault();
+        e.stopPropagation();
+        const isRegisterArrInclude = registerArr.includes(target) || (anchor ? registerArr.includes(anchor) : false);
+        const tagHref = nativePath || anchor?.href || (e.target as HTMLAnchorElement)?.href;
+        let href = tagHref || authorizedPages;
+        if (!tagHref || typeof tagHref !== 'string') {
+          let parentNode = (e.target as HTMLAnchorElement)?.parentNode;
+          let parentHref = (parentNode as HTMLAnchorElement)?.href;
+          let number = 0;
+          while (number < 3 && !parentHref) {
+            parentNode = (parentNode as HTMLAnchorElement)?.parentNode;
+            const newUrl = (parentNode as HTMLAnchorElement)?.href;
+            if (newUrl && typeof newUrl === 'string') {
+              parentHref = newUrl;
+              number += 3;
             } else {
-              const childNodeList = (e.target as HTMLAnchorElement)?.childNodes;
-              if (childNodeList.length > 0) {
-                childNodeList.forEach((node: ChildNodeListProps) => {
-                  const nodeHref = node?.href;
-                  if (nodeHref && node.localName === 'a') {
-                    href = nodeHref || authorizedPages;
-                  }
-                });
-              }
+              number += 1;
             }
           }
-
-          const isLogin = role !== CustomerRole.GUEST;
-          const hrefArr = href.split('/#');
-          if (hrefArr[1] === '') {
-            href = isLogin ? authorizedPages : '/login';
-          }
-
-          if (
-            isLogin &&
-            href.includes('/login') &&
-            !href.includes('action=create_account') &&
-            !href.includes('action=logout')
-          ) {
-            href = authorizedPages;
-          }
-
-          if (initOpenState?.handleEnterClick) {
-            initOpenState.handleEnterClick(href, isRegisterArrInclude);
+          if (parentHref) {
+            href = parentHref || authorizedPages;
+          } else {
+            const childNodeList = (e.target as HTMLAnchorElement)?.childNodes;
+            if (childNodeList.length > 0) {
+              childNodeList.forEach((node: ChildNodeListProps) => {
+                const nodeHref = node?.href;
+                if (nodeHref && node.localName === 'a') {
+                  href = nodeHref || authorizedPages;
+                }
+              });
+            }
           }
         }
-        return false;
-      };
 
-      window.addEventListener('click', handleTriggerClick, {
+        const isLogin = role !== CustomerRole.GUEST;
+        const hrefArr = href.split('/#');
+        if (hrefArr[1] === '') {
+          href = isLogin ? authorizedPages : '/login';
+        }
+
+        if (
+          isLogin &&
+          href.includes('/login') &&
+          !href.includes('action=create_account') &&
+          !href.includes('action=logout')
+        ) {
+          href = authorizedPages;
+        }
+
+        if (initOpenState?.handleEnterClick) {
+          initOpenState.handleEnterClick(href, isRegisterArrInclude);
+        }
+      }
+      return false;
+    };
+
+    window.addEventListener('click', handleTriggerClick, {
+      capture: true,
+    });
+    return () => {
+      window.removeEventListener('click', handleTriggerClick, {
         capture: true,
       });
-      return () => {
-        window.removeEventListener('click', handleTriggerClick);
-      };
-    }
-    return () => {};
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [checkoutRegisterNumber, initOpenState, role]);
 

--- a/apps/storefront/src/hooks/useB3AppOpen.ts
+++ b/apps/storefront/src/hooks/useB3AppOpen.ts
@@ -26,8 +26,7 @@ const useB3AppOpen = (initOpenState: OpenPageState) => {
   }, [checkoutRegisterNumber]);
   const role = useAppSelector((state) => state.company.customer.role);
   const isNativeLinkInterceptionEnabled = useAppSelector(
-    ({ global }) =>
-      global.featureFlags['B2B-4912.buyer_portal_native_link_interception'] ?? false,
+    ({ global }) => global.featureFlags['B2B-4912.buyer_portal_native_link_interception'] ?? false,
   );
   const authorizedPages = initOpenState?.authorizedPages || '/orders';
 

--- a/apps/storefront/src/hooks/useB3AppOpen.ts
+++ b/apps/storefront/src/hooks/useB3AppOpen.ts
@@ -69,10 +69,7 @@ const useB3AppOpen = (initOpenState: OpenPageState) => {
     return isSearchNode;
   };
 
-  const handleJudgeCheckoutNormalHref = (
-    element: MouseEvent,
-    anchor: HTMLAnchorElement | null,
-  ) => {
+  const handleJudgeCheckoutNormalHref = (element: MouseEvent, anchor: HTMLAnchorElement | null) => {
     if (window?.location?.pathname !== CHECKOUT_URL) return false;
 
     const target = element.target as HTMLAnchorElement;

--- a/apps/storefront/src/load-functions.test.ts
+++ b/apps/storefront/src/load-functions.test.ts
@@ -14,7 +14,7 @@ describe('bindLinks', () => {
     unbindLinks();
   });
 
-  it('intercepts account link child clicks and replays the anchor after init', async () => {
+  it('intercepts account link child clicks and stores the resolved anchor element', async () => {
     document.body.innerHTML = `
       <a class="navUser-action" href="/account.php">
         <span class="navUser-item-accountLabel">Account</span>

--- a/apps/storefront/src/load-functions.test.ts
+++ b/apps/storefront/src/load-functions.test.ts
@@ -1,0 +1,51 @@
+vi.mock('./react-setup', () => ({}));
+
+const importLoadFunctions = async () => import('./load-functions');
+
+describe('bindLinks', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    document.body.innerHTML = '';
+    window.history.pushState({}, '', '/');
+  });
+
+  afterEach(async () => {
+    const { unbindLinks } = await importLoadFunctions();
+    unbindLinks();
+  });
+
+  it('intercepts account link child clicks and replays the anchor after init', async () => {
+    document.body.innerHTML = `
+      <a class="navUser-action" href="/account.php">
+        <span class="navUser-item-accountLabel">Account</span>
+      </a>
+    `;
+    const { bindLinks } = await importLoadFunctions();
+    const span = document.querySelector('.navUser-item-accountLabel');
+    const anchor = document.querySelector('.navUser-action');
+    const click = new MouseEvent('click', { bubbles: true, cancelable: true });
+
+    bindLinks();
+    span?.dispatchEvent(click);
+
+    expect(click.defaultPrevented).toBe(true);
+    expect(window.b2b.initializationEnvironment.clickedLinkElement).toBe(anchor);
+  });
+
+  it('intercepts same-origin absolute account links even without navUser classes', async () => {
+    document.body.innerHTML = `
+      <li class="menu-item">
+        <a href="${window.location.origin}/account.php">Account</a>
+      </li>
+    `;
+    const { bindLinks } = await importLoadFunctions();
+    const anchor = document.querySelector('a[href]');
+    const click = new MouseEvent('click', { bubbles: true, cancelable: true });
+
+    bindLinks();
+    anchor?.dispatchEvent(click);
+
+    expect(click.defaultPrevented).toBe(true);
+    expect(window.b2b.initializationEnvironment.clickedLinkElement).toBe(anchor);
+  });
+});

--- a/apps/storefront/src/load-functions.ts
+++ b/apps/storefront/src/load-functions.ts
@@ -1,4 +1,5 @@
 import config from '@/lib/config';
+import { getClosestAnchorFromTarget, isBuyerPortalNativeHref } from '@/utils/nativeStorefrontLinks';
 
 export const requestIdleCallbackFunction: typeof window.requestIdleCallback =
   window.requestIdleCallback
@@ -44,10 +45,21 @@ export const initApp = async () => {
 };
 
 const clickLink = async (e: MouseEvent) => {
-  window.b2b.initializationEnvironment.clickedLinkElement = e.target as HTMLElement;
+  const anchor = getClosestAnchorFromTarget(e.target);
+  window.b2b.initializationEnvironment.clickedLinkElement = anchor || (e.target as HTMLElement);
   e.preventDefault();
   e.stopPropagation();
   await initApp();
+};
+
+const clickNativeBuyerPortalLink = async (e: MouseEvent) => {
+  const anchor = getClosestAnchorFromTarget(e.target);
+
+  if (!anchor || !isBuyerPortalNativeHref(anchor.href)) {
+    return;
+  }
+
+  await clickLink(e);
 };
 
 export const bindLinks = () => {
@@ -55,6 +67,7 @@ export const bindLinks = () => {
     `${config['dom.registerElement']}, ${config['dom.allOtherElement']}`,
   );
 
+  document.addEventListener('click', clickNativeBuyerPortalLink, { capture: true });
   links.forEach((accessLink) => accessLink.addEventListener('click', clickLink));
 };
 export const unbindLinks = () => {
@@ -62,5 +75,6 @@ export const unbindLinks = () => {
     `${config['dom.registerElement']}, ${config['dom.allOtherElement']}`,
   );
 
+  document.removeEventListener('click', clickNativeBuyerPortalLink, { capture: true });
   links.forEach((accessLink) => accessLink.removeEventListener('click', clickLink));
 };

--- a/apps/storefront/src/utils/featureFlags.ts
+++ b/apps/storefront/src/utils/featureFlags.ts
@@ -51,6 +51,10 @@ export const featureFlags = [
     key: 'B2B-4870.default_buyer_portal_styling_on_login_page',
     name: 'defaultBuyerPortalStylingOnLoginPage',
   },
+  {
+    key: 'B2B-4912.buyer_portal_native_link_interception',
+    name: 'buyerPortalNativeLinkInterception',
+  },
 ] as const;
 
 export type FeatureFlagKey = (typeof featureFlags)[number]['key'];

--- a/apps/storefront/src/utils/nativeStorefrontLinks.test.ts
+++ b/apps/storefront/src/utils/nativeStorefrontLinks.test.ts
@@ -49,6 +49,12 @@ describe('getNativeStorefrontPath', () => {
       getNativeStorefrontPath('https://other.example.com/account.php', 'https://store.example.com'),
     ).toBeNull();
   });
+
+  it('preserves hash fragment so runtime clicks do not lose fragment targets', () => {
+    expect(getNativeStorefrontPath('/account.php#invoice123', 'https://store.example.com')).toBe(
+      '/account.php#invoice123',
+    );
+  });
 });
 
 describe('isBuyerPortalNativeHref', () => {
@@ -74,6 +80,10 @@ describe('isBuyerPortalNativeHref', () => {
     expect(
       isBuyerPortalNativeHref('https://other.example.com/account.php', 'https://store.example.com'),
     ).toBe(false);
+  });
+
+  it('matches account.php URLs that include a hash fragment', () => {
+    expect(isBuyerPortalNativeHref('/account.php#section', 'https://store.example.com')).toBe(true);
   });
 });
 
@@ -118,7 +128,7 @@ describe('shouldOpenAllowedPageOnInit', () => {
     ).toBe(true);
   });
 
-  it('opens on account.php even when the URL has a native query string', () => {
+  it('opens on account.php without a hash regardless of native query string (pathname strips search)', () => {
     expect(
       shouldOpenAllowedPageOnInit({
         pathname: '/account.php',

--- a/apps/storefront/src/utils/nativeStorefrontLinks.test.ts
+++ b/apps/storefront/src/utils/nativeStorefrontLinks.test.ts
@@ -1,0 +1,97 @@
+import {
+  getClosestAnchorFromTarget,
+  getNativeStorefrontPath,
+  isBuyerPortalNativeHref,
+  shouldOpenAllowedPageOnInit,
+} from './nativeStorefrontLinks';
+
+describe('getClosestAnchorFromTarget', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('returns the parent anchor when the clicked target is a child span', () => {
+    document.body.innerHTML = `
+      <a class="navUser-action" href="/account.php">
+        <span class="navUser-item-accountLabel">Account</span>
+      </a>
+    `;
+
+    const span = document.querySelector('.navUser-item-accountLabel');
+    const anchor = document.querySelector('.navUser-action');
+
+    expect(getClosestAnchorFromTarget(span)).toBe(anchor);
+  });
+
+  it('returns null when the event target is not an element', () => {
+    expect(getClosestAnchorFromTarget(window)).toBeNull();
+  });
+});
+
+describe('getNativeStorefrontPath', () => {
+  it('normalizes same-origin absolute account URLs to path and search', () => {
+    expect(getNativeStorefrontPath('https://store.example.com/account.php?action=order_status', 'https://store.example.com')).toBe(
+      '/account.php?action=order_status',
+    );
+  });
+
+  it('keeps relative account URLs as path and search', () => {
+    expect(getNativeStorefrontPath('/account.php?action=address_book', 'https://store.example.com')).toBe(
+      '/account.php?action=address_book',
+    );
+  });
+
+  it('returns null for cross-origin URLs', () => {
+    expect(getNativeStorefrontPath('https://other.example.com/account.php', 'https://store.example.com')).toBeNull();
+  });
+});
+
+describe('isBuyerPortalNativeHref', () => {
+  it('matches account.php and login.php URLs', () => {
+    expect(isBuyerPortalNativeHref('/account.php', 'https://store.example.com')).toBe(true);
+    expect(isBuyerPortalNativeHref('/account.php?action=order_status', 'https://store.example.com')).toBe(true);
+    expect(isBuyerPortalNativeHref('/login.php', 'https://store.example.com')).toBe(true);
+    expect(isBuyerPortalNativeHref('/login.php?action=create_account', 'https://store.example.com')).toBe(true);
+  });
+
+  it('does not match unrelated storefront URLs', () => {
+    expect(isBuyerPortalNativeHref('/cart.php', 'https://store.example.com')).toBe(false);
+    expect(isBuyerPortalNativeHref('/search.php?search_query=account.php', 'https://store.example.com')).toBe(false);
+  });
+
+  it('does not match cross-origin account URLs', () => {
+    expect(isBuyerPortalNativeHref('https://other.example.com/account.php', 'https://store.example.com')).toBe(false);
+  });
+});
+
+describe('shouldOpenAllowedPageOnInit', () => {
+  it('opens on logged-in account.php without a hash', () => {
+    expect(
+      shouldOpenAllowedPageOnInit({
+        pathname: '/account.php',
+        hash: '',
+        customerId: 123,
+      }),
+    ).toBe(true);
+  });
+
+  it('keeps the existing skip for other logged-in no-hash pages', () => {
+    expect(
+      shouldOpenAllowedPageOnInit({
+        pathname: '/',
+        hash: '',
+        customerId: 123,
+      }),
+    ).toBe(false);
+  });
+
+  it('does not open on checkout pages', () => {
+    expect(
+      shouldOpenAllowedPageOnInit({
+        pathname: '/checkout',
+        hash: '',
+        customerId: 123,
+      }),
+    ).toBe(false);
+  });
+});

--- a/apps/storefront/src/utils/nativeStorefrontLinks.test.ts
+++ b/apps/storefront/src/utils/nativeStorefrontLinks.test.ts
@@ -127,5 +127,4 @@ describe('shouldOpenAllowedPageOnInit', () => {
       }),
     ).toBe(true);
   });
-
 });

--- a/apps/storefront/src/utils/nativeStorefrontLinks.test.ts
+++ b/apps/storefront/src/utils/nativeStorefrontLinks.test.ts
@@ -128,13 +128,4 @@ describe('shouldOpenAllowedPageOnInit', () => {
     ).toBe(true);
   });
 
-  it('opens on account.php without a hash regardless of native query string (pathname strips search)', () => {
-    expect(
-      shouldOpenAllowedPageOnInit({
-        pathname: '/account.php',
-        hash: '',
-        customerId: 456,
-      }),
-    ).toBe(true);
-  });
 });

--- a/apps/storefront/src/utils/nativeStorefrontLinks.test.ts
+++ b/apps/storefront/src/utils/nativeStorefrontLinks.test.ts
@@ -30,37 +30,50 @@ describe('getClosestAnchorFromTarget', () => {
 
 describe('getNativeStorefrontPath', () => {
   it('normalizes same-origin absolute account URLs to path and search', () => {
-    expect(getNativeStorefrontPath('https://store.example.com/account.php?action=order_status', 'https://store.example.com')).toBe(
-      '/account.php?action=order_status',
-    );
+    expect(
+      getNativeStorefrontPath(
+        'https://store.example.com/account.php?action=order_status',
+        'https://store.example.com',
+      ),
+    ).toBe('/account.php?action=order_status');
   });
 
   it('keeps relative account URLs as path and search', () => {
-    expect(getNativeStorefrontPath('/account.php?action=address_book', 'https://store.example.com')).toBe(
-      '/account.php?action=address_book',
-    );
+    expect(
+      getNativeStorefrontPath('/account.php?action=address_book', 'https://store.example.com'),
+    ).toBe('/account.php?action=address_book');
   });
 
   it('returns null for cross-origin URLs', () => {
-    expect(getNativeStorefrontPath('https://other.example.com/account.php', 'https://store.example.com')).toBeNull();
+    expect(
+      getNativeStorefrontPath('https://other.example.com/account.php', 'https://store.example.com'),
+    ).toBeNull();
   });
 });
 
 describe('isBuyerPortalNativeHref', () => {
   it('matches account.php and login.php URLs', () => {
     expect(isBuyerPortalNativeHref('/account.php', 'https://store.example.com')).toBe(true);
-    expect(isBuyerPortalNativeHref('/account.php?action=order_status', 'https://store.example.com')).toBe(true);
+    expect(
+      isBuyerPortalNativeHref('/account.php?action=order_status', 'https://store.example.com'),
+    ).toBe(true);
     expect(isBuyerPortalNativeHref('/login.php', 'https://store.example.com')).toBe(true);
-    expect(isBuyerPortalNativeHref('/login.php?action=create_account', 'https://store.example.com')).toBe(true);
+    expect(
+      isBuyerPortalNativeHref('/login.php?action=create_account', 'https://store.example.com'),
+    ).toBe(true);
   });
 
   it('does not match unrelated storefront URLs', () => {
     expect(isBuyerPortalNativeHref('/cart.php', 'https://store.example.com')).toBe(false);
-    expect(isBuyerPortalNativeHref('/search.php?search_query=account.php', 'https://store.example.com')).toBe(false);
+    expect(
+      isBuyerPortalNativeHref('/search.php?search_query=account.php', 'https://store.example.com'),
+    ).toBe(false);
   });
 
   it('does not match cross-origin account URLs', () => {
-    expect(isBuyerPortalNativeHref('https://other.example.com/account.php', 'https://store.example.com')).toBe(false);
+    expect(
+      isBuyerPortalNativeHref('https://other.example.com/account.php', 'https://store.example.com'),
+    ).toBe(false);
   });
 });
 

--- a/apps/storefront/src/utils/nativeStorefrontLinks.test.ts
+++ b/apps/storefront/src/utils/nativeStorefrontLinks.test.ts
@@ -94,4 +94,24 @@ describe('shouldOpenAllowedPageOnInit', () => {
       }),
     ).toBe(false);
   });
+
+  it('opens on account.php order status without a hash for a logged-in customer', () => {
+    expect(
+      shouldOpenAllowedPageOnInit({
+        pathname: '/account.php',
+        hash: '',
+        customerId: 456,
+      }),
+    ).toBe(true);
+  });
+
+  it('opens on account.php even when the URL has a native query string', () => {
+    expect(
+      shouldOpenAllowedPageOnInit({
+        pathname: '/account.php',
+        hash: '',
+        customerId: 456,
+      }),
+    ).toBe(true);
+  });
 });

--- a/apps/storefront/src/utils/nativeStorefrontLinks.ts
+++ b/apps/storefront/src/utils/nativeStorefrontLinks.ts
@@ -25,7 +25,7 @@ export function getNativeStorefrontPath(
       return null;
     }
 
-    return `${url.pathname}${url.search}`;
+    return `${url.pathname}${url.search}${url.hash}`;
   } catch (_error: unknown) {
     return null;
   }
@@ -38,8 +38,11 @@ export function isBuyerPortalNativeHref(href: string, origin = window.location.o
     return false;
   }
 
+  // Strip hash before matching so /account.php#section still matches /account.php
+  const pathWithoutHash = path.split('#')[0];
+
   return NATIVE_BUYER_PORTAL_PATHS.some(
-    (nativePath) => path === nativePath || path.startsWith(`${nativePath}?`),
+    (nativePath) => pathWithoutHash === nativePath || pathWithoutHash.startsWith(`${nativePath}?`),
   );
 }
 

--- a/apps/storefront/src/utils/nativeStorefrontLinks.ts
+++ b/apps/storefront/src/utils/nativeStorefrontLinks.ts
@@ -1,0 +1,55 @@
+interface InitOpenDecisionInput {
+  pathname: string;
+  hash: string;
+  customerId?: number | string;
+}
+
+const NATIVE_BUYER_PORTAL_PATHS = ['/account.php', '/login.php'];
+
+export function getClosestAnchorFromTarget(target: EventTarget | null): HTMLAnchorElement | null {
+  if (!(target instanceof Element)) {
+    return null;
+  }
+
+  return target.closest<HTMLAnchorElement>('a[href]');
+}
+
+export function getNativeStorefrontPath(href: string, origin = window.location.origin): string | null {
+  try {
+    const url = new URL(href, origin);
+
+    if (url.origin !== origin) {
+      return null;
+    }
+
+    return `${url.pathname}${url.search}`;
+  } catch (_error: unknown) {
+    return null;
+  }
+}
+
+export function isBuyerPortalNativeHref(href: string, origin = window.location.origin): boolean {
+  const path = getNativeStorefrontPath(href, origin);
+
+  if (!path) {
+    return false;
+  }
+
+  return NATIVE_BUYER_PORTAL_PATHS.some((nativePath) => path === nativePath || path.startsWith(`${nativePath}?`));
+}
+
+export function shouldOpenAllowedPageOnInit({
+  pathname,
+  hash,
+  customerId,
+}: InitOpenDecisionInput): boolean {
+  if (pathname.includes('checkout')) {
+    return false;
+  }
+
+  if (pathname.includes('account.php') && !hash) {
+    return true;
+  }
+
+  return !(customerId && !hash);
+}

--- a/apps/storefront/src/utils/nativeStorefrontLinks.ts
+++ b/apps/storefront/src/utils/nativeStorefrontLinks.ts
@@ -14,7 +14,10 @@ export function getClosestAnchorFromTarget(target: EventTarget | null): HTMLAnch
   return target.closest<HTMLAnchorElement>('a[href]');
 }
 
-export function getNativeStorefrontPath(href: string, origin = window.location.origin): string | null {
+export function getNativeStorefrontPath(
+  href: string,
+  origin = window.location.origin,
+): string | null {
   try {
     const url = new URL(href, origin);
 
@@ -35,7 +38,9 @@ export function isBuyerPortalNativeHref(href: string, origin = window.location.o
     return false;
   }
 
-  return NATIVE_BUYER_PORTAL_PATHS.some((nativePath) => path === nativePath || path.startsWith(`${nativePath}?`));
+  return NATIVE_BUYER_PORTAL_PATHS.some(
+    (nativePath) => path === nativePath || path.startsWith(`${nativePath}?`),
+  );
 }
 
 export function shouldOpenAllowedPageOnInit({


### PR DESCRIPTION
Jira: [B2B-4912](https://bigcommercecloud.atlassian.net/browse/B2B-4912)

## What/Why?

There were three cases where the Buyer Portal failed to take over native BC account pages:

1. **Child element clicks** — some themes wrap account link text in a `<span>` inside the `<a>`. Clicking the span meant `e.target` was the span, not the anchor, so the portal never caught it.
2. **Absolute-URL account links** — some themes render account hrefs as full URLs (`https://store.example.com/account.php`). The portal only watched elements matched by configured CSS selectors, so these fell through.
3. **Direct URL navigation** — navigating straight to `/account.php?action=address_book` in the browser was skipped by the portal's startup logic. Even in cases where the portal did open, it ignored the `?action=` param and always landed on the default page instead of the right one.

I added a shared utility that resolves the nearest anchor from any click target, normalises URLs to same-origin paths, and decides whether a link belongs to the portal. That utility is now used in all three interception points: the pre-init capture listener, the runtime click handler, and the startup logic in `App.tsx`. The startup logic also now maps the native `?action=` param to the correct portal route so direct loads and link clicks land in the same place.

## Rollout/Rollback

No feature flag — this is a bug fix on existing behaviour. Rolling back is a revert of this PR.

## Testing
| Before | After |
| --- | --- |
| https://github.com/user-attachments/assets/0c474acc-9575-4363-838c-73d51f20923a | https://github.com/user-attachments/assets/0c0788c4-32cd-463e-b4c7-c43e70d930f9 |


All changes are covered by the unit tests (34 pass, 0 skipped).

[B2B-4912]: https://bigcommercecloud.atlassian.net/browse/B2B-4912?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes global click capture and app bootstrap routing for account/login entry points; behavior is gated by a feature flag but still affects how users reach the portal across themes and direct URLs.
> 
> **Overview**
> Fixes cases where the Buyer Portal failed to take over native BigCommerce **account/login** navigation: clicks on nested elements inside `<a>`, same-origin absolute `account.php`/`login.php` URLs outside configured selectors, and direct loads of `/account.php` with query params.
> 
> Adds **`nativeStorefrontLinks`** helpers (`getClosestAnchorFromTarget`, `getNativeStorefrontPath`, `isBuyerPortalNativeHref`, `shouldOpenAllowedPageOnInit`) and wires them into **pre-init** (`bindLinks` document capture), **runtime** (`useB3AppOpen` window capture, always registered), and **`App.tsx` init** when feature flag **`B2B-4912.buyer_portal_native_link_interception`** is on.
> 
> On startup with the flag enabled, **`shouldOpenAllowedPageOnInit`** replaces the old checkout/logged-in-no-hash heuristic so logged-in **`/account.php`** without a hash still opens the portal; when `?action=` is present, **`openPageByClick`** maps the native URL to the correct portal route (aligned with click interception). Checkout `#` placeholder links remain excluded.
> 
> Unit tests cover the utility, `bindLinks`, and `useB3AppOpen` interception behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 637e80981b6192bbdd6408a2cb1201f07d93e22c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->