### PR TITLE
[B2B-4628] Fix product selection identity in reorder and shopping list

### DIFF
--- a/apps/storefront/src/pages/OrderDetail/components/OrderCheckboxProduct.tsx
+++ b/apps/storefront/src/pages/OrderDetail/components/OrderCheckboxProduct.tsx
@@ -77,7 +77,7 @@ export default function OrderCheckboxProduct(props: OrderCheckboxProductProps) {
       setCheckedArr([]);
       setReturnList([]);
     } else {
-      const variantIds = products.map((item) => item.variant_id);
+      const productIds = products.map((item) => item.id);
       const returnIds: ReturnListProps[] = [];
       products.forEach((item, index) => {
         returnIds[index] = {
@@ -86,21 +86,21 @@ export default function OrderCheckboxProduct(props: OrderCheckboxProductProps) {
         };
       });
 
-      setCheckedArr(variantIds);
+      setCheckedArr(productIds);
       setReturnList(returnIds);
     }
   };
 
-  const handleSelectChange = (variantId: number, returnId: number, returnQty: number) => {
+  const handleSelectChange = (productId: number, returnId: number, returnQty: number) => {
     const newList = [...checkedArr];
     const newReturnList = [...returnList];
-    const index = newList.findIndex((item) => item === variantId);
+    const index = newList.findIndex((item) => item === productId);
     const returnIndex = newReturnList.findIndex((item) => item.returnId === returnId);
     if (index !== -1) {
       newList.splice(index, 1);
       newReturnList.splice(returnIndex, 1);
     } else {
-      newList.push(variantId);
+      newList.push(productId);
       newReturnList.push({
         returnId,
         returnQty,
@@ -110,7 +110,7 @@ export default function OrderCheckboxProduct(props: OrderCheckboxProductProps) {
     setReturnList(newReturnList);
   };
 
-  const isChecked = (variantId: number) => checkedArr.includes(variantId);
+  const isChecked = (productId: number) => checkedArr.includes(productId);
 
   const handleProductQuantityChange =
     (product: EditableProductItem) => (e: ChangeEvent<HTMLInputElement>) => {
@@ -220,9 +220,9 @@ export default function OrderCheckboxProduct(props: OrderCheckboxProductProps) {
             aria-labelledby={`group-label-${product.id}`}
           >
             <Checkbox
-              checked={isChecked(product.variant_id)}
+              checked={isChecked(product.id)}
               onChange={() =>
-                handleSelectChange(product.variant_id, product.id, Number(product.editQuantity))
+                handleSelectChange(product.id, product.id, Number(product.editQuantity))
               }
             />
             <FlexItem>

--- a/apps/storefront/src/pages/OrderDetail/components/OrderDialog.tsx
+++ b/apps/storefront/src/pages/OrderDetail/components/OrderDialog.tsx
@@ -246,7 +246,7 @@ export default function OrderDialog({
     const items: CustomFieldItems[] = [];
     const skus: string[] = [];
     editableProducts.forEach((product) => {
-      if (checkedArr.includes(product.variant_id)) {
+      if (checkedArr.includes(product.id)) {
         items.push({
           quantity: parseInt(`${product.editQuantity}`, 10) || 1,
           productId: product.product_id,
@@ -288,7 +288,7 @@ export default function OrderDialog({
   };
 
   const handleReorderBackend = async () => {
-    const items = editableProducts.filter((product) => checkedArr.includes(product.variant_id));
+    const items = editableProducts.filter((product) => checkedArr.includes(product.id));
 
     if (items.length <= 0) {
       return;
@@ -366,9 +366,11 @@ export default function OrderDialog({
     // This will throw if there are errors, no need to check the response
     await createOrUpdateExistingCart(validItems);
 
-    const successfulVariantIds = validItems.map((item) => item.variantId);
+    const successfulLineItemIds = validItems
+      .map((item) => editableProducts.find((p) => p.product_id === item.productId)?.id)
+      .filter((id): id is number => id != null);
 
-    if (successfulVariantIds.length === checkedArr.length) {
+    if (validItems.length === checkedArr.length) {
       setOpen(false);
       setReorderValidationBanner(false);
       showSuccessSnackbarWithCartLink(b3Lang('orderDetail.reorder.productsAdded'));
@@ -376,9 +378,7 @@ export default function OrderDialog({
       showSuccessSnackbarWithCartLink(
         b3Lang('orderDetail.reorder.partialSuccess', { count: validItems.length }),
       );
-      setCheckedArr((prev) =>
-        prev.filter((variantId) => !successfulVariantIds.includes(variantId)),
-      );
+      setCheckedArr((prev) => prev.filter((id) => !successfulLineItemIds.includes(id)));
     }
   };
 
@@ -440,6 +440,7 @@ export default function OrderDialog({
     try {
       const items = editableProducts.map((product) => {
         const {
+          id: lineItemId,
           product_id: productId,
           variant_id: variantId,
           editQuantity,
@@ -447,6 +448,7 @@ export default function OrderDialog({
         } = product;
 
         return {
+          lineItemId,
           productId: Number(productId),
           variantId,
           quantity: Number(editQuantity),
@@ -460,7 +462,7 @@ export default function OrderDialog({
           }),
         };
       });
-      const params = items.filter((item) => checkedArr.includes(Number(item.variantId)));
+      const params = items.filter((item) => checkedArr.includes(item.lineItemId));
 
       const addToShoppingList = isB2BUser ? addProductToShoppingList : addProductToBcShoppingList;
 

--- a/apps/storefront/src/pages/OrderDetail/index.unified.test.tsx
+++ b/apps/storefront/src/pages/OrderDetail/index.unified.test.tsx
@@ -1773,6 +1773,58 @@ describe('Order detail path with unified SF GQL flag ON', () => {
       });
     });
 
+    it('can independently select products that share variant_id 0', async () => {
+      const simpleProductA = {
+        entityId: 2001,
+        productEntityId: 3001,
+        variantEntityId: null,
+        name: 'Gift Card $50',
+        quantity: 1,
+        productOptions: [] as Array<{ name: string; value: string }>,
+      };
+      const simpleProductB = {
+        entityId: 2002,
+        productEntityId: 3002,
+        variantEntityId: null,
+        name: 'Gift Card $100',
+        quantity: 1,
+        productOptions: [] as Array<{ name: string; value: string }>,
+      };
+
+      const order = buildUnifiedOrderWithProducts([simpleProductA, simpleProductB]);
+
+      server.use(
+        graphql.query('GetOrderDetail', () =>
+          HttpResponse.json(buildOrderDetailResponseWith({ data: { site: { order } } })),
+        ),
+        graphql.query('GetCustomerOrderStatuses', () =>
+          HttpResponse.json(buildCustomerOrderStatusesWith('WHATEVER_VALUES')),
+        ),
+        graphql.query('AddressConfig', () =>
+          HttpResponse.json(buildAddressConfigResponseWith('WHATEVER_VALUES')),
+        ),
+      );
+
+      renderWithProviders(<OrderDetails />, {
+        preloadedState,
+        initialEntries: [{ state: { isCompanyOrder: false } }],
+      });
+
+      await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+      await userEvent.click(screen.getByRole('button', { name: 'Re-Order' }));
+
+      const dialog = await screen.findByRole('dialog', { name: 'Re-Order' });
+
+      const giftCard50 = within(dialog).getByRole('group', { name: 'Gift Card $50' });
+      const giftCard100 = within(dialog).getByRole('group', { name: 'Gift Card $100' });
+
+      await userEvent.click(within(giftCard50).getByRole('checkbox'));
+
+      expect(within(giftCard50).getByRole('checkbox')).toBeChecked();
+      expect(within(giftCard100).getByRole('checkbox')).not.toBeChecked();
+    });
+
     it('shows a warning if no product is selected', async () => {
       const screamProduct = {
         entityId: 2001,


### PR DESCRIPTION
Jira: [B2B-4628](https://bigcommercecloud.atlassian.net/browse/B2B-4628)

## What/Why?

Fixes GAP from the like-for-like parity audit — product selection in the reorder and shopping list dialogs used `variant_id` as the identity key in `checkedArr`. On the unified SF GQL path, products with null `variantEntityId` (simple products, gift certificates) all share `variant_id: 0`, so selecting one product would select all of them.

Changed the selection identity to use `product.id` (the line item `entityId`) which is unique per product regardless of variant status.

**Changes:**
- **`OrderCheckboxProduct.tsx`** — `handleSelectAllChange`, `handleSelectChange`, and `isChecked` all use `product.id` instead of `product.variant_id`
- **`OrderDialog.tsx`** — reorder frontend validation, backend validation, and shopping list confirm all filter `checkedArr` by `product.id`. Partial reorder success flow tracks successful line item IDs directly instead of catalog product IDs (fixes a secondary bug where two lines sharing the same `product_id` but differing by options would both get unchecked when only one succeeded).

**No BE dependency.** This is a pure FE fix behind the existing feature flag.

**Note:** `productOptionId` and `variantEntityId` wiring have been intentionally excluded from this PR — approach is pending discussion with the BC Orders team (Sylvia meeting).

## Rollout/Rollback

Gated behind the existing `B2B-4613.buyer_portal_unified_sf_gql_orders` feature flag. No new flags. Rollback is turning the flag off — legacy path unchanged.

## Testing

- All 36 unified order detail tests pass
- All 39 legacy order detail tests pass (no regression)
- TypeScript compilation clean
- Lint clean (only pre-existing `import/extensions` warnings)

Screenshots/videos to be attached.

[B2B-4628]: https://bigcommercecloud.atlassian.net/browse/B2B-4628?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches cart reorder and shopping-list submission on the unified orders flag path; behavior change is intentional but could affect edge cases with duplicate catalog products on one order.
> 
> **Overview**
> Fixes **linked checkbox selection** in Re-Order and Add to Shopping List when the unified storefront GQL path maps simple products (null `variantEntityId`) to **`variant_id: 0`**. Selection state in `checkedArr` now keys off **`product.id`** (order line `entityId`) instead of `variant_id`, so each row can be toggled independently.
> 
> **`OrderCheckboxProduct`** — select-all, per-row toggle, and `isChecked` all read/write `product.id`.
> 
> **`OrderDialog`** — frontend reorder, backend reorder filtering, and shopping-list confirm all honor `checkedArr` by line item id. After a **partial** backend reorder, successful rows are cleared from selection using resolved **line item ids** (not variant/catalog ids), avoiding cases where two lines share a `product_id` but differ by options.
> 
> Adds a unified order detail test that two gift-card lines with null variants stay independently selectable in the Re-Order dialog.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b6bc31d64445d5e291fb75a74b10126470be8bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->