### PR TITLE
feat(quotes): BACK-593 Allow quotes in order status to show backorder information.

### DIFF
--- a/apps/storefront/src/pages/QuoteDetail/index.test.tsx
+++ b/apps/storefront/src/pages/QuoteDetail/index.test.tsx
@@ -1509,6 +1509,59 @@ describe('when the user is a B2B customer', () => {
 
       expect(screen.queryByText(/backorder details/i)).not.toBeInTheDocument();
     });
+
+    it('hides the toggle on an ordered quote with backordered items when the BACK-593 experiment is off', async () => {
+      const quote = buildQuoteWith({
+        data: {
+          quote: {
+            id: '272989',
+            status: 4,
+            productsList: [buildQuoteProductWith({ quantityBackordered: 3 })],
+          },
+        },
+      });
+
+      server.use(graphql.query('GetQuoteInfoB2B', () => HttpResponse.json(quote)));
+      vitest.mocked(useParams).mockReturnValue({ id: '272989' });
+
+      renderWithProviders(<QuoteDetail />, { preloadedState: backorderPreloadedState });
+
+      await waitForElementToBeRemoved(() => screen.queryByText(/loading/i));
+
+      expect(screen.queryByText(/backorder details/i)).not.toBeInTheDocument();
+    });
+
+    it('shows the toggle on an ordered quote with backordered items', async () => {
+      const quote = buildQuoteWith({
+        data: {
+          quote: {
+            id: '272989',
+            status: 4,
+            productsList: [buildQuoteProductWith({ quantityBackordered: 3 })],
+          },
+        },
+      });
+
+      server.use(graphql.query('GetQuoteInfoB2B', () => HttpResponse.json(quote)));
+      vitest.mocked(useParams).mockReturnValue({ id: '272989' });
+
+      renderWithProviders(<QuoteDetail />, {
+        preloadedState: {
+          ...backorderPreloadedState,
+          global: {
+            ...backorderPreloadedState.global,
+            featureFlags: {
+              ...backorderPreloadedState.global.featureFlags,
+              'BACK-593.surface_order_backorder_info_on_quotes': true,
+            },
+          },
+        },
+      });
+
+      await waitForElementToBeRemoved(() => screen.queryByText(/loading/i));
+
+      expect(await screen.findByText(/backorder details/i)).toBeInTheDocument();
+    });
   });
 
   describe('fix_quote_currency_symbol_placement feature flag', () => {

--- a/apps/storefront/src/pages/quote/components/QuoteDetailTable.tsx
+++ b/apps/storefront/src/pages/quote/components/QuoteDetailTable.tsx
@@ -6,6 +6,7 @@ import { B3PaginationTable, GetRequestList } from '@/components/table/B3Paginati
 import { TableColumnItem } from '@/components/table/B3Table';
 import { PRODUCT_DEFAULT_IMAGE } from '@/constants';
 import { useBackorderStorefrontMessaging } from '@/hooks/useBackorderStorefrontMessaging';
+import { useFeatureFlag } from '@/hooks/useFeatureFlag';
 import { useB3Lang } from '@/lib/lang';
 import { useAppSelector } from '@/store';
 import { currencyFormatConvert } from '@/utils/b3CurrencyFormat';
@@ -120,7 +121,12 @@ function QuoteDetailTable(props: ShoppingDetailTableProps, ref: Ref<unknown>) {
     currency,
     status,
   } = props;
+
   const isOrdered = Number(status) === 4;
+  const surfaceOrderedQuoteBackorders = useFeatureFlag(
+    'BACK-593.surface_order_backorder_info_on_quotes',
+  );
+  const shouldDisplayBackorderInformation = !isOrdered || surfaceOrderedQuoteBackorders;
 
   const isEnableProduct = useAppSelector(
     ({ global }) => global.blockPendingQuoteNonPurchasableOOS.isEnableProduct,
@@ -318,7 +324,7 @@ function QuoteDetailTable(props: ShoppingDetailTableProps, ref: Ref<unknown>) {
             <Typography sx={{ padding: '12px 0' }}>{row.quantity}</Typography>
             {isBackorderMessagingContextEnabled &&
               hasAnyBackorderDisplay &&
-              !isOrdered &&
+              shouldDisplayBackorderInformation &&
               backorderFields && (
                 <BackorderMessage
                   totalOnHand={backorderFields.totalOnHand}
@@ -425,7 +431,7 @@ function QuoteDetailTable(props: ShoppingDetailTableProps, ref: Ref<unknown>) {
         </Typography>
         {isBackorderMessagingContextEnabled &&
           hasAnyBackorderDisplay &&
-          !isOrdered &&
+          shouldDisplayBackorderInformation &&
           hasBackorderedItems && (
             <FormControlLabel
               control={
@@ -463,7 +469,7 @@ function QuoteDetailTable(props: ShoppingDetailTableProps, ref: Ref<unknown>) {
             displayDiscount={displayDiscount}
             getTaxRate={getTaxRate}
             showBackorderDetails={showBackorderDetails}
-            status={status}
+            shouldDisplayBackorderInformation={shouldDisplayBackorderInformation}
           />
         )}
       />

--- a/apps/storefront/src/pages/quote/components/QuoteDetailTableCard.tsx
+++ b/apps/storefront/src/pages/quote/components/QuoteDetailTableCard.tsx
@@ -21,7 +21,7 @@ interface QuoteTableCardProps {
   displayDiscount: boolean;
   currency: CurrencyProps | DisplayCurrency;
   showBackorderDetails?: boolean;
-  status?: string | number;
+  shouldDisplayBackorderInformation?: boolean;
 }
 
 const StyledImage = styled('img')(() => ({
@@ -40,9 +40,8 @@ function QuoteDetailTableCard(props: QuoteTableCardProps) {
     currency,
     displayDiscount,
     showBackorderDetails = false,
-    status,
+    shouldDisplayBackorderInformation = true,
   } = props;
-  const isOrdered = Number(status) === 4;
   const b3Lang = useB3Lang();
   const isCurrencySymbolPlacementFixEnabled = useFeatureFlag(
     'B2B-3876.fix_quote_currency_symbol_placement',
@@ -155,7 +154,7 @@ function QuoteDetailTableCard(props: QuoteTableCardProps) {
           </Typography>
           {isBackorderMessagingContextEnabled &&
             hasAnyBackorderDisplay &&
-            !isOrdered &&
+            shouldDisplayBackorderInformation &&
             backorderFields && (
               <BackorderMessage
                 totalOnHand={backorderFields.totalOnHand}

--- a/apps/storefront/src/utils/featureFlags.ts
+++ b/apps/storefront/src/utils/featureFlags.ts
@@ -51,6 +51,10 @@ export const featureFlags = [
     key: 'B2B-4870.default_buyer_portal_styling_on_login_page',
     name: 'defaultBuyerPortalStylingOnLoginPage',
   },
+  {
+    key: 'BACK-593.surface_order_backorder_info_on_quotes',
+    name: 'surfaceOrderBackorderInfoOnQuotes',
+  },
 ] as const;
 
 export type FeatureFlagKey = (typeof featureFlags)[number]['key'];


### PR DESCRIPTION
Jira: [BACK-593](https://bigcommercecloud.atlassian.net/browse/BACK-593)

## What/Why?
Lift the restriction for quotes in order status to show backorder information.

Note, requires https://github.com/bigcommerce/b2b-edition-api/pull/6832 to be deployed.
Releasing before this will lead to live inventory data being served instead of the historical order data.

## Rollout/Rollback
Revert this PR if there are any issues.

## Testing
Given an order of two items with 1 in stock and unlimited backorders at time of order creation:
Before:
Since this quote is in order status it does not show any backorder information. 
<img width="1490" height="893" alt="before" src="https://github.com/user-attachments/assets/f21c1d79-abdf-42be-96ae-86c0866ada5a" />

After:
The ordered quote now shows backorder information. 
<img width="1480" height="893" alt="Screenshot 2026-06-23 at 11 37 24 am" src="https://github.com/user-attachments/assets/7e627dc1-7dd5-4b9e-8cff-e686939f2fc8" />

ping @bigcommerce/team-b2b 

[BACK-593]: https://bigcommercecloud.atlassian.net/browse/BACK-593?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes quote detail inventory/backorder presentation for ordered quotes when the flag is on, with a documented ordering dependency on the API for correct historical data.
> 
> **Overview**
> **Ordered quotes** (status 4) no longer unconditionally hide backorder messaging. Display is gated by the new feature flag `BACK-593.surface_order_backorder_info_on_quotes`: when the flag is off, behavior matches today (no backorder details toggle or per-line `BackorderMessage` on ordered quotes); when on, ordered quotes with backordered lines show the same UI as non-ordered quotes.
> 
> `QuoteDetailTable` centralizes the rule as `shouldDisplayBackorderInformation` and passes it to `QuoteDetailTableCard` instead of raw `status`, so mobile cards follow the same gate. The flag is registered in `featureFlags.ts`. Tests cover ordered quotes with backordered items for flag off vs on.
> 
> **Deploy note:** This storefront change expects the related API work so quote lines serve historical order backorder fields; shipping before that API can show live inventory instead of order-time data.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 772eb19942772c9a17cbcfe079382117e2dc2db0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->