### PR TITLE
feat(quotes): BACK-718 block over-ATS adds in quote search modal

### DIFF
--- a/apps/storefront/src/pages/QuoteDraft/index.test.tsx
+++ b/apps/storefront/src/pages/QuoteDraft/index.test.tsx
@@ -56,6 +56,11 @@ interface VariantInfo {
   purchasingDisabled: '1' | '0';
   variantSku: string;
   imageUrl: string;
+  inventoryTracking?: string;
+  availableToSell?: number;
+  unlimitedBackorder?: boolean;
+  totalOnHand?: number | null;
+  backorderMessage?: string | null;
 }
 
 const { server } = startMockServer();
@@ -3147,6 +3152,352 @@ describe('when the user is a B2B customer', () => {
 
         expect(validateProduct).toHaveBeenCalled();
         expect(await screen.findByText('Product was added to your quote.')).toBeInTheDocument();
+      });
+
+      describe('when OOS quoting is disabled and backorder messaging is enabled', () => {
+        const backorderMessagingGlobal = buildGlobalStateWith({
+          backorderEnabled: true,
+          blockPendingQuoteNonPurchasableOOS: { isEnableProduct: false },
+          backorderDisplaySettings: {
+            showQuantityOnBackorder: true,
+            showQuantityOnHand: true,
+            showBackorderMessage: true,
+            showDefaultShippingExpectationPrompt: false,
+            defaultShippingExpectationPrompt: '',
+          },
+          featureFlags: {
+            'BACK-134.backorders_phase_1_1_control_messaging_on_storefront': true,
+          },
+        });
+
+        const setupSearchModalWithInventory = ({
+          availableToSell = 7,
+          totalOnHand = 2,
+          unlimitedBackorder = false,
+          isEnableProduct = false,
+          isBackorderMessagingEnabled = true,
+          inventoryFetchFails = false,
+          pendingInventoryFetch,
+        }: {
+          availableToSell?: number;
+          totalOnHand?: number;
+          unlimitedBackorder?: boolean;
+          isEnableProduct?: boolean;
+          isBackorderMessagingEnabled?: boolean;
+          inventoryFetchFails?: boolean;
+          pendingInventoryFetch?: Promise<HttpResponse<VariantInfoResponse>>;
+        } = {}) => {
+          const variant = buildVariantWith({
+            sku: 'LC-123',
+            purchasing_disabled: false,
+            bc_calculated_price: {
+              tax_exclusive: 123,
+            },
+          });
+
+          const searchProducts = vi.fn<(...arg: unknown[]) => SearchProductsResponse>();
+
+          when(searchProducts)
+            .calledWith(stringContainingAll('search: "Laugh Canister"', 'currencyCode: "USD"'))
+            .thenReturn({
+              data: {
+                productsSearch: [
+                  buildSearchProductWith({
+                    id: variant.product_id,
+                    name: 'Laugh Canister',
+                    sku: 'LC-123',
+                    optionsV3: [],
+                    isPriceHidden: false,
+                    orderQuantityMinimum: 0,
+                    orderQuantityMaximum: 0,
+                    inventoryLevel: 100,
+                    variants: [variant],
+                  }),
+                ],
+              },
+            });
+
+          const getPriceProducts = vi.fn<(...arg: unknown[]) => PriceProductsResponse>();
+
+          when(getPriceProducts)
+            .calledWith({
+              storeHash: 'store-hash',
+              channelId: 1,
+              currencyCode: 'USD',
+              items: [
+                { productId: variant.product_id, variantId: variant.variant_id, options: [] },
+              ],
+              customerGroupId: 0,
+            })
+            .thenReturn({
+              data: {
+                priceProducts: [buildProductPriceWith('WHATEVER_VALUES')],
+              },
+            });
+
+          const variantInfo = buildVariantInfoWith({
+            variantSku: 'LC-123',
+            minQuantity: 0,
+            purchasingDisabled: '0',
+            isStock: '1',
+            stock: 50,
+            productId: variant.product_id.toString(),
+            variantId: variant.variant_id.toString(),
+            inventoryTracking: 'variant',
+            availableToSell,
+            unlimitedBackorder,
+            totalOnHand,
+            backorderMessage: 'Lead time: 2-4 weeks',
+          });
+
+          const getVariantInfoBySkus = vi.fn();
+
+          when(getVariantInfoBySkus)
+            .calledWith(expect.stringContaining('variantSkus: ["LC-123"]'))
+            .thenReturn(buildVariantInfoResponseWith({ data: { variantSku: [variantInfo] } }));
+
+          const validateProduct = vi.fn<(...arg: unknown[]) => ValidateProductResponse>();
+
+          when(validateProduct)
+            .calledWith(expect.any(Object))
+            .thenReturn({
+              data: {
+                validateProduct: buildValidateProductWith({ responseType: 'SUCCESS', message: '' }),
+              },
+            });
+
+          server.use(
+            graphql.query('Countries', () =>
+              HttpResponse.json({ data: { countries: [fakeCountry] } }),
+            ),
+            graphql.query('Addresses', () =>
+              HttpResponse.json({ data: { addresses: { totalCount: 0, edges: [] } } }),
+            ),
+            graphql.query('getQuoteExtraFields', () =>
+              HttpResponse.json({ data: { quoteExtraFieldsConfig: [] } }),
+            ),
+            graphql.query('SearchProducts', ({ query }) =>
+              HttpResponse.json(searchProducts(query)),
+            ),
+            graphql.query('priceProducts', ({ variables }) =>
+              HttpResponse.json(getPriceProducts(variables)),
+            ),
+            graphql.query('GetVariantInfoBySkus', ({ query }) => {
+              if (inventoryFetchFails) {
+                return HttpResponse.error();
+              }
+
+              if (pendingInventoryFetch) {
+                return pendingInventoryFetch;
+              }
+
+              return HttpResponse.json(getVariantInfoBySkus(query));
+            }),
+            graphql.query('ValidateProduct', ({ variables }) =>
+              HttpResponse.json(validateProduct(variables)),
+            ),
+          );
+
+          const quoteInfo = buildQuoteInfoStateWith({
+            draftQuoteInfo: {
+              contactInfo: { email: customerEmail },
+              billingAddress: noAddress,
+              shippingAddress: noAddress,
+            },
+            draftQuoteList: [],
+          });
+
+          renderWithProviders(<QuoteDraft setOpenPage={vi.fn()} />, {
+            preloadedState: {
+              ...preloadedState,
+              quoteInfo,
+              global: buildGlobalStateWith({
+                ...backorderMessagingGlobal,
+                blockPendingQuoteNonPurchasableOOS: { isEnableProduct },
+                featureFlags: {
+                  'BACK-134.backorders_phase_1_1_control_messaging_on_storefront':
+                    isBackorderMessagingEnabled,
+                },
+              }),
+            },
+          });
+
+          return { validateProduct, variantInfo };
+        };
+
+        const openSearchModal = async () => {
+          await userEvent.click(screen.getByText('Add to quote'));
+          const searchProduct = screen.getByPlaceholderText('Search products');
+          await userEvent.type(searchProduct, 'Laugh Canister');
+          await userEvent.click(screen.getByRole('button', { name: 'Search product' }));
+
+          const dialog = await screen.findByRole('dialog');
+          await within(dialog).findByRole('spinbutton');
+
+          return dialog;
+        };
+
+        it('shows Only X available, disables Add to quote, and keeps backorder lines when qty exceeds ATS', async () => {
+          const { validateProduct } = setupSearchModalWithInventory();
+
+          const dialog = await openSearchModal();
+          const quantityInput = within(dialog).getByRole('spinbutton');
+
+          await userEvent.type(quantityInput, '10', {
+            initialSelectionStart: 0,
+            initialSelectionEnd: Infinity,
+          });
+
+          await waitFor(() => {
+            expect(within(dialog).getByText('Only 7 available')).toBeVisible();
+          });
+
+          expect(within(dialog).getByText('2 ready to ship')).toBeVisible();
+          expect(within(dialog).getByText('5 will be backordered')).toBeVisible();
+          expect(within(dialog).getByText('Lead time: 2-4 weeks')).toBeVisible();
+
+          const addToQuote = within(dialog).getByRole('button', { name: 'Add to quote' });
+          expect(addToQuote).toBeDisabled();
+
+          expect(validateProduct).not.toHaveBeenCalled();
+          expect(screen.queryByText('Product was added to your quote.')).not.toBeInTheDocument();
+        });
+
+        it('does not show ATS error when quantity is within available to sell', async () => {
+          setupSearchModalWithInventory();
+
+          const dialog = await openSearchModal();
+          const quantityInput = within(dialog).getByRole('spinbutton');
+
+          await userEvent.type(quantityInput, '5', {
+            initialSelectionStart: 0,
+            initialSelectionEnd: Infinity,
+          });
+
+          await waitFor(() => {
+            expect(within(dialog).queryByText('Only 7 available')).not.toBeInTheDocument();
+          });
+
+          expect(within(dialog).getByRole('button', { name: 'Add to quote' })).toBeEnabled();
+        });
+
+        it('does not show ATS error when OOS quoting is enabled', async () => {
+          setupSearchModalWithInventory({ isEnableProduct: true });
+
+          const dialog = await openSearchModal();
+          const quantityInput = within(dialog).getByRole('spinbutton');
+
+          await userEvent.type(quantityInput, '10', {
+            initialSelectionStart: 0,
+            initialSelectionEnd: Infinity,
+          });
+
+          await waitFor(() => {
+            expect(within(dialog).getByText('2 ready to ship')).toBeVisible();
+          });
+
+          expect(within(dialog).getByText('5 will be backordered')).toBeVisible();
+          expect(within(dialog).queryByText('Only 7 available')).not.toBeInTheDocument();
+          expect(within(dialog).getByRole('button', { name: 'Add to quote' })).toBeEnabled();
+        });
+
+        it('does not show ATS error when unlimited backorder is true', async () => {
+          setupSearchModalWithInventory({ unlimitedBackorder: true });
+
+          const dialog = await openSearchModal();
+          const quantityInput = within(dialog).getByRole('spinbutton');
+
+          await userEvent.type(quantityInput, '10', {
+            initialSelectionStart: 0,
+            initialSelectionEnd: Infinity,
+          });
+
+          await waitFor(() => {
+            expect(within(dialog).queryByText('Only 7 available')).not.toBeInTheDocument();
+          });
+
+          expect(within(dialog).getByRole('button', { name: 'Add to quote' })).toBeEnabled();
+        });
+
+        it('does not show ATS error when backorder messaging is disabled', async () => {
+          setupSearchModalWithInventory({ isBackorderMessagingEnabled: false });
+
+          const dialog = await openSearchModal();
+          const quantityInput = within(dialog).getByRole('spinbutton');
+
+          await userEvent.type(quantityInput, '10', {
+            initialSelectionStart: 0,
+            initialSelectionEnd: Infinity,
+          });
+
+          expect(within(dialog).queryByText('Only 7 available')).not.toBeInTheDocument();
+          expect(within(dialog).getByRole('button', { name: 'Add to quote' })).toBeEnabled();
+        });
+
+        it('keeps Add to quote enabled with no ATS helper when inventory lookup fails', async () => {
+          const { validateProduct } = setupSearchModalWithInventory({ inventoryFetchFails: true });
+
+          const dialog = await openSearchModal();
+          const quantityInput = within(dialog).getByRole('spinbutton');
+
+          await userEvent.type(quantityInput, '10', {
+            initialSelectionStart: 0,
+            initialSelectionEnd: Infinity,
+          });
+
+          await waitFor(() => {
+            expect(within(dialog).queryByText('Only 7 available')).not.toBeInTheDocument();
+          });
+
+          expect(
+            within(dialog).queryByText('will be backordered', { exact: false }),
+          ).not.toBeInTheDocument();
+
+          const addToQuote = within(dialog).getByRole('button', { name: 'Add to quote' });
+          expect(addToQuote).toBeEnabled();
+
+          await userEvent.click(addToQuote);
+
+          expect(validateProduct).toHaveBeenCalled();
+          expect(await screen.findByText('Product was added to your quote.')).toBeInTheDocument();
+        });
+
+        it('keeps Add to quote enabled and allows add while inventory lookup is pending', async () => {
+          let resolveInventoryFetch!: (value: HttpResponse<VariantInfoResponse>) => void;
+          const pendingInventoryFetch = new Promise<HttpResponse<VariantInfoResponse>>(
+            (resolve) => {
+              resolveInventoryFetch = resolve;
+            },
+          );
+
+          const { validateProduct, variantInfo } = setupSearchModalWithInventory({
+            pendingInventoryFetch,
+          });
+
+          const dialog = await openSearchModal();
+          const quantityInput = within(dialog).getByRole('spinbutton');
+
+          await userEvent.type(quantityInput, '10', {
+            initialSelectionStart: 0,
+            initialSelectionEnd: Infinity,
+          });
+
+          expect(within(dialog).queryByText('Only 7 available')).not.toBeInTheDocument();
+
+          const addToQuote = within(dialog).getByRole('button', { name: 'Add to quote' });
+          expect(addToQuote).toBeEnabled();
+
+          await userEvent.click(addToQuote);
+
+          expect(validateProduct).toHaveBeenCalled();
+          expect(await screen.findByText('Product was added to your quote.')).toBeInTheDocument();
+
+          resolveInventoryFetch(
+            HttpResponse.json(
+              buildVariantInfoResponseWith({ data: { variantSku: [variantInfo] } }),
+            ),
+          );
+        });
       });
     });
 

--- a/apps/storefront/src/pages/ShoppingListDetails/components/ProductListDialog.tsx
+++ b/apps/storefront/src/pages/ShoppingListDetails/components/ProductListDialog.tsx
@@ -12,7 +12,10 @@ import { useMobile } from '@/hooks/useMobile';
 import { useB3Lang } from '@/lib/lang';
 import { useAppSelector } from '@/store';
 import { snackbar } from '@/utils/b3Tip';
-import { buildVariantSkuDependencyKey } from '@/utils/catalogBackorderDisplay';
+import {
+  buildVariantSkuDependencyKey,
+  shouldBlockQuoteAtsAdd,
+} from '@/utils/catalogBackorderDisplay';
 
 import { ShoppingListProductItem } from '../../../types';
 import { ShoppingListDetailsContext } from '../context/ShoppingListDetailsContext';
@@ -22,6 +25,7 @@ interface ProductTableActionProps {
   onAddToListClick: (id: number) => void;
   onChooseOptionsClick: (id: number) => void;
   addButtonText: string;
+  addDisabled?: boolean;
 }
 
 function ProductTableAction(props: ProductTableActionProps) {
@@ -30,6 +34,7 @@ function ProductTableAction(props: ProductTableActionProps) {
     onAddToListClick,
     onChooseOptionsClick,
     addButtonText,
+    addDisabled = false,
   } = props;
 
   const {
@@ -57,7 +62,7 @@ function ProductTableAction(props: ProductTableActionProps) {
       onClick={() => {
         onAddToListClick(id);
       }}
-      disabled={isLoading}
+      disabled={isLoading || addDisabled}
       fullWidth={isMobile}
     >
       {addButtonText}
@@ -109,6 +114,7 @@ export default function ProductListDialog(props: ProductListDialogProps) {
   const { isBackorderMessagingContextEnabled, hasAnyBackorderDisplay } =
     useBackorderStorefrontMessaging();
   const backorderUiEnabled = isBackorderMessagingContextEnabled && hasAnyBackorderDisplay;
+  const showQuoteAtsHelper = type === 'quote' && backorderUiEnabled && !isEnableProduct;
 
   const variantSkuDependencyKey = useMemo(
     () =>
@@ -123,6 +129,30 @@ export default function ProductListDialog(props: ProductListDialogProps) {
     enabled: backorderUiEnabled,
     skuDependencyKey: variantSkuDependencyKey,
   });
+
+  const formatOnlyAvailable = useCallback(
+    (count: number) => b3Lang('orderDetail.reorder.onlyAvailable', { count }),
+    [b3Lang],
+  );
+
+  const productExceedsAvailableToSell = useCallback(
+    (product: ShoppingListProductItem) => {
+      if (!showQuoteAtsHelper) {
+        return false;
+      }
+
+      const variantSku = product.variants?.[0]?.sku ?? product.sku;
+      if (!variantSku) {
+        return false;
+      }
+
+      const inventoryRow = inventoryBySku[variantSku.toUpperCase()];
+      const qty = parseInt(product.quantity?.toString() || '', 10) || 1;
+
+      return shouldBlockQuoteAtsAdd(qty, inventoryRow);
+    },
+    [inventoryBySku, showQuoteAtsHelper],
+  );
 
   const handleCancelClicked = () => {
     onCancel();
@@ -153,6 +183,10 @@ export default function ProductListDialog(props: ProductListDialogProps) {
 
   const handleAddToList = (id: number) => {
     const product = productList.find((product) => product.id === id);
+
+    if (!product || productExceedsAvailableToSell(product)) {
+      return;
+    }
 
     if (product && validateQuantityNumber(product || {})) {
       let variantId: number | string = product.variantId || 0;
@@ -223,6 +257,8 @@ export default function ProductListDialog(props: ProductListDialogProps) {
               canToProduct
               catalogBackorderUiEnabled={backorderUiEnabled}
               catalogInventoryBySku={inventoryBySku}
+              showAvailableToSellHelper={showQuoteAtsHelper}
+              formatOnlyAvailable={formatOnlyAvailable}
               onProductQuantityChange={onProductQuantityChange}
               renderAction={(product) => (
                 <ProductTableAction
@@ -230,6 +266,7 @@ export default function ProductListDialog(props: ProductListDialogProps) {
                   onAddToListClick={handleAddToList}
                   onChooseOptionsClick={onChooseOptionsClick}
                   addButtonText={addButtonText}
+                  addDisabled={productExceedsAvailableToSell(product)}
                 />
               )}
               actionWidth="180px"

--- a/apps/storefront/src/utils/catalogBackorderDisplay.test.ts
+++ b/apps/storefront/src/utils/catalogBackorderDisplay.test.ts
@@ -15,6 +15,7 @@ import {
   getCatalogProductRowDisplayState,
   getProductDetailsForPicklistSelections,
   quantityExceedsAvailableToSell,
+  shouldBlockQuoteAtsAdd,
 } from './catalogBackorderDisplay';
 
 describe('catalogBackorderDisplay', () => {
@@ -56,6 +57,44 @@ describe('catalogBackorderDisplay', () => {
 
   it('quantityExceedsAvailableToSell is false when row is undefined', () => {
     expect(quantityExceedsAvailableToSell(10, undefined)).toBe(false);
+  });
+
+  describe('shouldBlockQuoteAtsAdd', () => {
+    const trackedRow = {
+      inventoryTracking: 'variant',
+      unlimitedBackorder: false,
+      availableToSell: 5,
+    } as CatalogQuickVariantSku;
+
+    it('allows add when catalog inventory row is missing', () => {
+      expect(shouldBlockQuoteAtsAdd(1, undefined)).toBe(false);
+    });
+
+    it('blocks add when quantity exceeds available to sell', () => {
+      expect(shouldBlockQuoteAtsAdd(6, trackedRow)).toBe(true);
+    });
+
+    it('allows add when quantity is within available to sell', () => {
+      expect(shouldBlockQuoteAtsAdd(5, trackedRow)).toBe(false);
+    });
+
+    it('allows add when unlimited backorder is true', () => {
+      expect(
+        shouldBlockQuoteAtsAdd(100, {
+          ...trackedRow,
+          unlimitedBackorder: true,
+        }),
+      ).toBe(false);
+    });
+
+    it('allows add when inventory tracking is none', () => {
+      expect(
+        shouldBlockQuoteAtsAdd(100, {
+          inventoryTracking: 'none',
+          availableToSell: 0,
+        } as CatalogQuickVariantSku),
+      ).toBe(false);
+    });
   });
 
   it('getCatalogBackorderDisplayQuantity caps at available to sell when qty exceeds it', () => {

--- a/apps/storefront/src/utils/catalogBackorderDisplay.ts
+++ b/apps/storefront/src/utils/catalogBackorderDisplay.ts
@@ -58,6 +58,13 @@ export function quantityExceedsAvailableToSell(
   return quantity > availableToSell;
 }
 
+export function shouldBlockQuoteAtsAdd(
+  quantity: number,
+  inventoryRow: CatalogQuickVariantSku | undefined,
+): boolean {
+  return quantityExceedsAvailableToSell(quantity, inventoryRow);
+}
+
 export function getCatalogBackorderDisplayQuantity(
   quantity: number,
   row: CatalogQuickVariantSku | undefined,

--- a/apps/storefront/src/utils/validateProducts.test.ts
+++ b/apps/storefront/src/utils/validateProducts.test.ts
@@ -311,4 +311,40 @@ describe('convertStockAndThresholdValidationErrorToWarning', () => {
       error: [],
     });
   });
+
+  it('keeps OOS errors when convertOosErrorsToWarning is false', () => {
+    const { validatedProducts, products } = buildValidatedProductsFixture();
+
+    const result = convertStockAndThresholdValidationErrorToWarning(validatedProducts, {
+      convertOosErrorsToWarning: false,
+    });
+
+    expect(result.warning).toEqual([
+      { status: 'warning', message: 'Existing warning', product: products.warning },
+      {
+        status: 'warning',
+        message: `You need to purchase a minimum of 5 of the ${products.minimumThreshold.name} per order.`,
+        product: products.minimumThreshold,
+      },
+      {
+        status: 'warning',
+        message: `You can only purchase a maximum of 10 of the ${products.maximumThreshold.name} per order.`,
+        product: products.maximumThreshold,
+      },
+    ]);
+    expect(result.error).toEqual(
+      expect.arrayContaining([
+        {
+          status: 'error',
+          error: {
+            type: VALIDATED_PRODUCT_ERROR_TYPES.VALIDATION,
+            message: 'Out of stock.',
+            errorCode: 'OOS',
+            availableToSell: 0,
+          },
+          product: products.stock,
+        },
+      ]),
+    );
+  });
 });

--- a/apps/storefront/src/utils/validateProducts.ts
+++ b/apps/storefront/src/utils/validateProducts.ts
@@ -287,19 +287,29 @@ export const validateProducts = async <T extends ValidateProductsInput>(
   };
 };
 
-/* 
-  Required in case of adding to the quote, because min, max threshold error
-  products should still be added to the quote
+/*
+  For quote add flows: min/max threshold validation errors are always converted to
+  warnings so those products can still be added. OOS validation errors are converted
+  to warnings only when convertOosErrorsToWarning is true (the default).
 */
+interface ConvertStockAndThresholdValidationErrorOptions {
+  convertOosErrorsToWarning?: boolean;
+}
+
 export function convertStockAndThresholdValidationErrorToWarning<T extends ValidateProductsInput>(
   validatedProducts: ValidateProductsResult<T>,
+  options?: ConvertStockAndThresholdValidationErrorOptions,
 ): ValidateProductsResult<T>;
 export function convertStockAndThresholdValidationErrorToWarning<T extends ValidateProductsInput>(
   validatedProducts: ValidateProductsLegacyResult<T>,
+  options?: ConvertStockAndThresholdValidationErrorOptions,
 ): ValidateProductsLegacyResult<T>;
 export function convertStockAndThresholdValidationErrorToWarning<T extends ValidateProductsInput>(
   validatedProducts: ValidateProductsLegacyResult<T> | ValidateProductsResult<T>,
+  options?: ConvertStockAndThresholdValidationErrorOptions,
 ): ValidateProductsLegacyResult<T> | ValidateProductsResult<T> {
+  const convertOosErrorsToWarning = options?.convertOosErrorsToWarning ?? true;
+
   const isThresholdError = (error: ValidatedProductError<T>['error']) =>
     error.type === VALIDATED_PRODUCT_ERROR_TYPES.VALIDATION &&
     error.errorCode === QUOTE_VALIDATION_ERROR_CODES.OTHER &&
@@ -309,13 +319,25 @@ export function convertStockAndThresholdValidationErrorToWarning<T extends Valid
   const isStockError = (error: ValidatedProductError<T>['error']) =>
     error.errorCode === QUOTE_VALIDATION_ERROR_CODES.OOS;
 
-  const stockAndThresholdErrors = validatedProducts.error.filter(
-    ({ error }) => isThresholdError(error) || isStockError(error),
-  ) as Array<ValidatedProductServerError<T>>;
+  const stockAndThresholdErrors = validatedProducts.error.filter(({ error }) => {
+    if (isThresholdError(error)) {
+      return true;
+    }
 
-  const nonStockAndThresholdErrors = validatedProducts.error.filter(
-    ({ error }) => !(isThresholdError(error) || isStockError(error)),
-  );
+    return convertOosErrorsToWarning && isStockError(error);
+  }) as Array<ValidatedProductServerError<T>>;
+
+  const nonStockAndThresholdErrors = validatedProducts.error.filter(({ error }) => {
+    if (isThresholdError(error)) {
+      return false;
+    }
+
+    if (isStockError(error) && convertOosErrorsToWarning) {
+      return false;
+    }
+
+    return true;
+  });
 
   const stockAndThresholdWarnings = stockAndThresholdErrors.map(({ product, error }) => ({
     status: 'warning',


### PR DESCRIPTION
Jira: [BACK-718](https://bigcommercecloud.atlassian.net/browse/BACK-718)

## What/Why?
When the merchant has not allowed adding out-of-stock items to quotes, the draft quote `Add to quote` search modal now validates quantity against ATS before add, displaying an inline error and disabling the button. This behaviour will only occur for stores that have opted into backorders (i.e. `Feature_Backorder && BACK-134.backorders_phase_1_1_control_messaging_on_storefront`).

>[!NOTE]
>This PR only covers **simple products** - a future PR will cover the "choose options" flow for complex products.

## Rollout/Rollback
Merge/revert. Change is gated by `Feature_Backorder && BACK-134.backorders_phase_1_1_control_messaging_on_storefront`.

## Testing
With OOS quoting disabled, inline error and button disabled.

https://github.com/user-attachments/assets/0977707e-3337-4d88-81b7-306ee0e0e160

With OOS quoting enabled, no errors.

https://github.com/user-attachments/assets/2b83e377-07e8-42d0-ba66-d2057cd35b22

With `Feature_Backorder && BACK-134.backorders_phase_1_1_control_messaging_on_storefront` disabled, no errors (until the quote is submitted, as before).

https://github.com/user-attachments/assets/873f56c4-30fc-4c31-8dd1-e6f9696cd662

Ping @benpratt77 @animesh1987 

[BACK-718]: https://bigcommercecloud.atlassian.net/browse/BACK-718?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes quote add UX and inventory gating on the storefront; behavior is feature-flagged but affects when lines can enter a draft quote.
> 
> **Overview**
> When **OOS quoting is off** but **backorder storefront messaging** is on (`Feature_Backorder` + `BACK-134`), the draft quote **Add to quote** product search dialog now blocks simple-product adds whose quantity exceeds **available to sell (ATS)**.
> 
> `ProductListDialog` (quote `type`) turns on the ATS helper via `B3ProductList`, shows **“Only X available”**, keeps backorder copy, **disables Add to quote**, and no-ops the add handler when `shouldBlockQuoteAtsAdd` is true. Adds stay allowed when OOS quoting is enabled, unlimited backorder applies, messaging is off, or inventory lookup fails or is still pending.
> 
> `shouldBlockQuoteAtsAdd` is added in `catalogBackorderDisplay` (delegates to existing ATS exceed logic). `convertStockAndThresholdValidationErrorToWarning` gains optional `convertOosErrorsToWarning` (default `true`) so OOS validation can remain errors when callers opt out.
> 
> Coverage is expanded in `QuoteDraft` integration tests and unit tests for the new helper and validation option.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f3e14a100c0a395232f9472077b5d1c596d0875. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->