### PR TITLE
fix(register): B2B-5156 Buyer Portal: Clean up Log out issue

### DIFF
--- a/apps/storefront/src/pages/Login/index.test.tsx
+++ b/apps/storefront/src/pages/Login/index.test.tsx
@@ -10,6 +10,8 @@ import {
   waitFor,
 } from 'tests/test-utils';
 
+import { setupStore } from '@/store';
+import { clearCompanySlice } from '@/store/slices/company';
 import { CustomerRole } from '@/types';
 import { snackbar } from '@/utils/b3Tip';
 import { getCurrentCustomerInfo } from '@/utils/loginInfo';
@@ -439,6 +441,32 @@ describe('LoginPage', () => {
 
       // Should not call logout for flags not in shouldLogout array
       expect(logoutMock).not.toHaveBeenCalled();
+    });
+
+    it('should logout only once when loginFlag=loggedOutLogin even after isLoggedIn flips to false', async () => {
+      const store = setupStore({
+        company: buildCompanyStateWith({
+          customer: { role: CustomerRole.ADMIN },
+          tokens: { B2BToken: 'test-token', bcGraphqlToken: '', currentCustomerJWT: '' },
+        }),
+      });
+
+      // Mimic the real logout: clearing the company slice flips the customer
+      // role to GUEST, so isLoggedIn becomes false and the effect re-runs. The
+      // ref guard must stop that re-run from triggering a second logout (which
+      // would wipe the BC storefront token the login flow depends on).
+      const logoutMock = vi.fn(async () => {
+        store.dispatch(clearCompanySlice());
+      });
+      vi.mocked(useLogout).mockReturnValue(logoutMock);
+
+      renderLoginPage({ store, initialEntries: ['/?loginFlag=loggedOutLogin'] });
+
+      await waitFor(() => {
+        expect(logoutMock).toHaveBeenCalledWith({ showLogoutBanner: true });
+      });
+
+      expect(logoutMock).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/apps/storefront/src/pages/Login/index.tsx
+++ b/apps/storefront/src/pages/Login/index.tsx
@@ -56,6 +56,13 @@ function Login(props: PageProps) {
 
   const [isLoading, setLoading] = useState(true);
   const isSubmittingRef = useRef(false);
+  /**
+    * Tracks which loginFlag has already triggered logout so it only runs once.
+    Without this, the first logout flips isLoggedIn to false,
+    the effect fires again, and a second logout clears the freshly fetched bcGraphqlToken,
+    breaking login until refresh.
+   */
+  const handledLogoutFlagRef = useRef<LoginFlagType | null>(null);
   const [isMobile] = useMobile();
 
   const [showTipInfo, setShowTipInfo] = useState<boolean>(true);
@@ -107,11 +114,19 @@ function Login(props: PageProps) {
         if (isLoginFlagType(loginFlag)) {
           setLoginFlag(loginFlag);
 
-          if (isLoggedIn && loginFlag === 'loggedOutLogin') {
-            await logout({ showLogoutBanner: true });
-            // All company-related flags have isLoggedIn set to false.
-          } else if (!isLoggedIn && SHOULD_LOGOUT_FLAGS.includes(loginFlag)) {
-            await logout({ showLogoutBanner: false });
+          const shouldLogout =
+            (isLoggedIn && loginFlag === 'loggedOutLogin') ||
+            (!isLoggedIn && SHOULD_LOGOUT_FLAGS.includes(loginFlag));
+
+          /* 
+            Guard against a second logout: logging out flips isLoggedIn to
+            false and re-runs this effect, which would otherwise re-trigger
+            logout via the !isLoggedIn branch. Only log out once per flag.
+          */
+          if (shouldLogout && handledLogoutFlagRef.current !== loginFlag) {
+            handledLogoutFlagRef.current = loginFlag;
+            // Banner only when an actually-logged-in user is signing out.
+            await logout({ showLogoutBanner: isLoggedIn && loginFlag === 'loggedOutLogin' });
           }
         }
 

--- a/apps/storefront/src/pages/Login/index.tsx
+++ b/apps/storefront/src/pages/Login/index.tsx
@@ -56,6 +56,13 @@ function Login(props: PageProps) {
 
   const [isLoading, setLoading] = useState(true);
   const isSubmittingRef = useRef(false);
+  /**
+   * Tracks which loginFlag has already triggered logout so it only runs once.
+   * Without this, the first logout flips isLoggedIn to false,
+   * the effect fires again, and a second logout clears the freshly fetched bcGraphqlToken,
+   * breaking login until refresh.
+   */
+  const handledLogoutFlagRef = useRef<LoginFlagType | null>(null);
   const [isMobile] = useMobile();
 
   const [showTipInfo, setShowTipInfo] = useState<boolean>(true);
@@ -107,11 +114,19 @@ function Login(props: PageProps) {
         if (isLoginFlagType(loginFlag)) {
           setLoginFlag(loginFlag);
 
-          if (isLoggedIn && loginFlag === 'loggedOutLogin') {
-            await logout({ showLogoutBanner: true });
-            // All company-related flags have isLoggedIn set to false.
-          } else if (!isLoggedIn && SHOULD_LOGOUT_FLAGS.includes(loginFlag)) {
-            await logout({ showLogoutBanner: false });
+          const shouldLogout =
+            (isLoggedIn && loginFlag === 'loggedOutLogin') ||
+            (!isLoggedIn && SHOULD_LOGOUT_FLAGS.includes(loginFlag));
+
+          /*
+           * Guard against a second logout: logging out flips isLoggedIn to
+           * false and re-runs this effect, which would otherwise re-trigger
+           * logout via the !isLoggedIn branch. Only log out once per flag.
+           */
+          if (shouldLogout && handledLogoutFlagRef.current !== loginFlag) {
+            handledLogoutFlagRef.current = loginFlag;
+            // Banner only when an actually-logged-in user is signing out.
+            await logout({ showLogoutBanner: isLoggedIn && loginFlag === 'loggedOutLogin' });
           }
         }
 


### PR DESCRIPTION
Jira: [B2B-5156](https://bigcommercecloud.atlassian.net/browse/B2B-5156)

## What/Why?
<!--
  A description about what this pull request implements and its purpose.
  Try to be detailed and describe any technical details to simplify the job
  of the reviewer and the individual on production support.
-->
Fixes a bug on the Login page where the logout effect could fire multiple times, the second run wiping a freshly-fetched storefront token and breaking login until a manual page refresh.

In `Login/index.tsx`

A useEffect handles the loginFlag query param and decides whether to log the user out:

If `isLoggedIn && loginFlag === 'loggedOutLogin' `→ logout with banner.
If `!isLoggedIn && SHOULD_LOGOUT_FLAGS.includes(loginFlag)` → logout without banner.
The problem: calling `logout()` clears the company slice, which flips the customer role to GUEST. 

That makes `isLoggedIn` become false, the effect re-runs, and the `!isLoggedIn` branch fires a second logout. 
This second logout clears the `bcGraphqlToken` that the login flow had just fetched, leaving login broken until refresh.

### **Fix**
`Login/index.tsx`

Added a `handledLogoutFlagRef` ref that records which loginFlag has already triggered a logout, so logout runs once per flag.
Merged the two logout conditions into a single shouldLogout expression, then gated the actual `logout()` call on `handledLogoutFlagRef.current !== loginFlag`.
Preserved the original banner behavior: the logout banner only shows when an actually-logged-in user signs out `(showLogoutBanner: isLoggedIn && loginFlag === 'loggedOutLogin')`.

## Rollout/Rollback
<!--
Detail how this change will be rolled out. Include reference to any
experiments and how the success will be measured as the experiment is
ramped.

Document rollback procedures. Is rolling back the change as simple as
rolling back an experiment or does it require reverting code? Are there
database migrations that may change our decision to roll forward instead of
back?
-->

Revert

## Testing
<!--
Provide as much information as you can about how you tested and how another
Engineer can test your change. Include screenshots, or test run output
where appropriate.
-->
After Fix


https://github.com/user-attachments/assets/be772bcb-51dd-4ea9-aff8-df949884d2f1


Before Fix

https://github.com/user-attachments/assets/1d69059f-a6f1-4304-a484-c1f1f97a86a1


[B2B-5156]: https://bigcommercecloud.atlassian.net/browse/B2B-5156?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches login/logout and token lifecycle on a critical path, but the change is a narrow guard with preserved behavior and test coverage.
> 
> **Overview**
> Fixes a **double-logout** on the Login page when `loginFlag` (e.g. `loggedOutLogin`) triggers `logout()` in a `useEffect` that depends on `isLoggedIn`.
> 
> The first logout clears auth state and sets `isLoggedIn` to false, which **re-runs the effect** and could hit the guest `SHOULD_LOGOUT_FLAGS` path a second time, clearing a freshly set `bcGraphqlToken` and breaking sign-in until refresh.
> 
> **`Login/index.tsx`** adds `handledLogoutFlagRef` so logout runs **once per flag**, unifies the two logout branches into `shouldLogout`, and keeps **banner behavior** (`showLogoutBanner` only when a logged-in user hits `loggedOutLogin`).
> 
> **`index.test.tsx`** adds a regression test that simulates logout clearing the company slice and asserts `logout` is called exactly once.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit efed0cfa8701da9a61f8b91c3790a23a13c054c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->