### PR TITLE
feat(quotes): BACK-720 Respect picklist backorders for the quote draft flow.

### DIFF
--- a/apps/storefront/src/pages/quote/components/QuoteSummary.tsx
+++ b/apps/storefront/src/pages/quote/components/QuoteSummary.tsx
@@ -5,21 +5,19 @@ import {
   useEffect,
   useId,
   useImperativeHandle,
-  useMemo,
   useState,
 } from 'react';
 import { Box, Card, CardContent, Grid, Typography } from '@mui/material';
 
 import ShippingExpectationPrompt from '@/components/ShippingExpectationPrompt';
-import { useFeatureFlag } from '@/hooks/useFeatureFlag';
-import { useIsBackorderEnabled } from '@/hooks/useIsBackorderEnabled';
+import { useBackorderStorefrontMessaging } from '@/hooks/useBackorderStorefrontMessaging';
 import { useB3Lang } from '@/lib/lang';
 import { useAppSelector } from '@/store';
 import { currencyFormat } from '@/utils/b3CurrencyFormat';
 import { getBCPrice } from '@/utils/b3Product/b3Product';
 
+import { useDraftQuoteBackorderState } from '../hooks/useDraftQuoteBackorderState';
 import getQuoteDraftShowPriceTBD from '../shared/utils';
-import { draftQuoteListHasBackorderedItemsForDisplay } from '../utils/getQuoteBackorderDisplayFields';
 
 interface Summary {
   subtotal: number;
@@ -45,20 +43,21 @@ const QuoteSummary = forwardRef((_, ref: Ref<unknown>) => {
   const [isHideQuoteDraftPrice, setHideQuoteDraftPrice] = useState<boolean>(false);
   const showInclusiveTaxPrice = useAppSelector(({ global }) => global.showInclusiveTaxPrice);
   const draftQuoteList = useAppSelector(({ quoteInfo }) => quoteInfo.draftQuoteList);
-  const backorderEnabled = useIsBackorderEnabled();
-  const isBackorderMessagingEnabled = useFeatureFlag(
-    'BACK-134.backorders_phase_1_1_control_messaging_on_storefront',
-  );
+  const {
+    isBackorderEnabled,
+    isBackorderMessagingEnabled,
+    isBackorderMessagingContextEnabled,
+    hasAnyBackorderDisplay,
+  } = useBackorderStorefrontMessaging();
   const { showDefaultShippingExpectationPrompt, defaultShippingExpectationPrompt } = useAppSelector(
     ({ global }) => global.backorderDisplaySettings,
   );
 
-  const hasBackorderedItems = useMemo(() => {
-    if (!isBackorderMessagingEnabled) {
-      return false;
-    }
-    return draftQuoteListHasBackorderedItemsForDisplay(draftQuoteList);
-  }, [draftQuoteList, isBackorderMessagingEnabled]);
+  const { hasBackorderedItems } = useDraftQuoteBackorderState({
+    items: draftQuoteList,
+    isBackorderMessagingEnabled,
+    draftQuoteBackorderContextEnabled: isBackorderMessagingContextEnabled && hasAnyBackorderDisplay,
+  });
 
   const priceCalc = (price: number) => parseFloat(String(price));
 
@@ -162,7 +161,7 @@ const QuoteSummary = forwardRef((_, ref: Ref<unknown>) => {
 
             {isBackorderMessagingEnabled && (
               <ShippingExpectationPrompt
-                backorderEnabled={backorderEnabled}
+                backorderEnabled={isBackorderEnabled}
                 hasBackorderedItems={hasBackorderedItems}
                 showDefaultShippingExpectationPrompt={showDefaultShippingExpectationPrompt}
                 defaultShippingExpectationPrompt={defaultShippingExpectationPrompt}

--- a/apps/storefront/src/pages/quote/components/QuoteTable.test.tsx
+++ b/apps/storefront/src/pages/quote/components/QuoteTable.test.tsx
@@ -1,10 +1,22 @@
-import { buildGlobalStateWith, renderWithProviders, screen } from 'tests/test-utils';
+import {
+  buildGlobalStateWith,
+  renderWithProviders,
+  screen,
+  userEvent,
+  waitFor,
+} from 'tests/test-utils';
 import { vi } from 'vitest';
 
+import { searchProducts } from '@/shared/service/b2b';
 import { Product } from '@/types';
 import { QuoteItem } from '@/types/quotes';
 
 import QuoteTable from './QuoteTable';
+
+vi.mock('@/shared/service/b2b', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/shared/service/b2b')>()),
+  searchProducts: vi.fn(),
+}));
 
 const lineItemWithBackorder: QuoteItem = {
   node: {
@@ -23,6 +35,101 @@ const lineItemWithBackorder: QuoteItem = {
       unlimitedBackorder: false,
       backorderMessage: 'Restock soon',
     } as Product,
+  },
+};
+
+const picklistLineItem: QuoteItem = {
+  node: {
+    id: 'item-picklist',
+    optionList: JSON.stringify([{ optionId: 'attribute[100]', optionValue: '200' }]),
+    calculatedValue: {},
+    basePrice: 24,
+    taxPrice: 0,
+    quantity: 10,
+    variantSku: 'PK',
+    productName: 'Pickle Kit',
+    productsSearch: {
+      inventoryTracking: 'none',
+      modifiers: [
+        {
+          id: 100,
+          type: 'product_list',
+          display_name: 'PickleFest',
+          option_values: [{ id: 200, value_data: { product_id: 555 } }],
+        },
+      ],
+    } as unknown as Product,
+  },
+};
+
+const picklistLineWithParentBackorder: QuoteItem = {
+  node: {
+    id: 'item-picklist-parent',
+    optionList: JSON.stringify([{ optionId: 'attribute[100]', optionValue: '200' }]),
+    calculatedValue: {},
+    basePrice: 24,
+    taxPrice: 0,
+    quantity: 10,
+    variantSku: 'PK',
+    productName: 'Pickle Kit',
+    productsSearch: {
+      inventoryTracking: 'product',
+      totalOnHand: 2,
+      availableToSell: 100,
+      unlimitedBackorder: false,
+      backorderMessage: 'Kit restock note',
+      modifiers: [
+        {
+          id: 100,
+          type: 'product_list',
+          display_name: 'PickleFest',
+          option_values: [{ id: 200, value_data: { product_id: 555 } }],
+        },
+      ],
+    } as unknown as Product,
+  },
+};
+
+const picklistLineWithStaleInventory: QuoteItem = {
+  node: {
+    id: 'item-stale',
+    productId: 999,
+    optionList: JSON.stringify([{ optionId: 'attribute[100]', optionValue: '200' }]),
+    calculatedValue: {},
+    basePrice: 24,
+    taxPrice: 0,
+    quantity: 5,
+    variantSku: 'PK',
+    productName: 'Pickle Kit',
+    productsSearch: {
+      inventoryTracking: 'none',
+      modifiers: [
+        {
+          id: 100,
+          type: 'product_list',
+          display_name: 'PickleFest',
+          option_values: [{ id: 200, value_data: { product_id: 555 } }],
+        },
+      ],
+    } as unknown as Product,
+  },
+};
+
+const withPicklistMessagingEnabled = {
+  preloadedState: {
+    global: buildGlobalStateWith({
+      backorderEnabled: true,
+      backorderDisplaySettings: {
+        showQuantityOnBackorder: true,
+        showQuantityOnHand: false,
+        showBackorderMessage: true,
+        showDefaultShippingExpectationPrompt: false,
+        defaultShippingExpectationPrompt: '',
+      },
+      featureFlags: {
+        'BACK-134.backorders_phase_1_1_control_messaging_on_storefront': true,
+      },
+    }),
   },
 };
 
@@ -63,5 +170,119 @@ describe('QuoteTable backorder messaging', () => {
     );
 
     expect(screen.queryByText('Backorder details')).not.toBeInTheDocument();
+  });
+
+  it('fetches picklist child products and shows their backorder message when the toggle is on', async () => {
+    vi.mocked(searchProducts).mockResolvedValue({
+      productsSearch: [
+        {
+          id: 555,
+          inventoryTracking: 'product',
+          totalOnHand: 1,
+          availableToSell: 100,
+          unlimitedBackorder: false,
+          backorderMessage: 'Ice Pick ships in 3 weeks',
+        },
+      ],
+    });
+
+    const updateSummary = vi.fn();
+
+    renderWithProviders(
+      <QuoteTable total={1} items={[picklistLineItem]} updateSummary={updateSummary} />,
+      withPicklistMessagingEnabled,
+    );
+
+    const toggle = await screen.findByText('Backorder details');
+
+    expect(searchProducts).toHaveBeenCalledWith(expect.objectContaining({ productIds: [555] }));
+
+    await userEvent.click(toggle);
+
+    await waitFor(() => {
+      expect(screen.getByText('PickleFest:')).toBeVisible();
+    });
+    expect(screen.getByText('Ice Pick ships in 3 weeks')).toBeVisible();
+  });
+
+  it('shows the line and its picklist child backorder messages independently', async () => {
+    vi.mocked(searchProducts).mockResolvedValue({
+      productsSearch: [
+        {
+          id: 555,
+          inventoryTracking: 'product',
+          totalOnHand: 1,
+          availableToSell: 100,
+          unlimitedBackorder: false,
+          backorderMessage: 'Ice Pick ships in 3 weeks',
+        },
+      ],
+    });
+
+    const updateSummary = vi.fn();
+
+    renderWithProviders(
+      <QuoteTable
+        total={1}
+        items={[picklistLineWithParentBackorder]}
+        updateSummary={updateSummary}
+      />,
+      withPicklistMessagingEnabled,
+    );
+
+    const toggle = await screen.findByText('Backorder details');
+    await userEvent.click(toggle);
+
+    await waitFor(() => {
+      expect(screen.getByText('Ice Pick ships in 3 weeks')).toBeVisible();
+    });
+    expect(screen.getByText('Kit restock note')).toBeVisible();
+  });
+
+  it('shows a line backorder message from live inventory even when the stored snapshot is untracked', async () => {
+    vi.mocked(searchProducts).mockResolvedValue({
+      productsSearch: [
+        {
+          id: 999,
+          inventoryTracking: 'product',
+          totalOnHand: 2,
+          availableToSell: 100,
+          unlimitedBackorder: false,
+          backorderMessage: 'Kit ships next week',
+        },
+        {
+          id: 555,
+          inventoryTracking: 'product',
+          totalOnHand: 1,
+          availableToSell: 100,
+          unlimitedBackorder: false,
+          backorderMessage: 'Ice Pick ships in 3 weeks',
+        },
+      ],
+    });
+
+    const updateSummary = vi.fn();
+
+    renderWithProviders(
+      <QuoteTable
+        total={1}
+        items={[picklistLineWithStaleInventory]}
+        updateSummary={updateSummary}
+      />,
+      withPicklistMessagingEnabled,
+    );
+
+    const toggle = await screen.findByText('Backorder details');
+
+    expect(searchProducts).toHaveBeenCalledWith(
+      expect.objectContaining({ productIds: expect.arrayContaining([999, 555]) }),
+    );
+
+    await userEvent.click(toggle);
+
+    await waitFor(() => {
+      expect(screen.getByText('Kit ships next week')).toBeVisible();
+    });
+    expect(screen.getByText('Ice Pick ships in 3 weeks')).toBeVisible();
   });
 });

--- a/apps/storefront/src/pages/quote/components/QuoteTable.tsx
+++ b/apps/storefront/src/pages/quote/components/QuoteTable.tsx
@@ -1,9 +1,10 @@
-import { useMemo, useState } from 'react';
+import { useState } from 'react';
 import { Delete, Edit, Warning as WarningIcon } from '@mui/icons-material';
 import { Box, FormControlLabel, styled, Switch, TextField, Typography } from '@mui/material';
 import ceil from 'lodash-es/ceil';
 
 import BackorderMessage from '@/components/BackorderMessage';
+import PicklistBackorderMessages from '@/components/PicklistBackorderMessages';
 import { TableColumnItem } from '@/components/table/B3Table';
 import PaginationTable from '@/components/table/PaginationTable';
 import { PRODUCT_DEFAULT_IMAGE } from '@/constants';
@@ -24,10 +25,11 @@ import { getProductOptionsFields } from '@/utils/b3Product/shared/config';
 import { snackbar } from '@/utils/b3Tip';
 
 import ChooseOptionsDialog from '../../ShoppingListDetails/components/ChooseOptionsDialog';
+import { useDraftQuoteBackorderState } from '../hooks/useDraftQuoteBackorderState';
 import {
-  draftQuoteListHasBackorderedItemsForDisplay,
   getDraftBackorderDisplayFields,
   getQuoteItemBackendAvailability,
+  resolveDraftLineProductId,
 } from '../utils/getQuoteBackorderDisplayFields';
 
 import QuoteTableCard from './QuoteTableCard';
@@ -177,12 +179,11 @@ function QuoteTable({ total, items, updateSummary }: QuoteTableProps) {
 
   const showBackorderMessageBase = draftQuoteBackorderContextEnabled && showBackorderDetails;
 
-  const hasBackorderedItems = useMemo(() => {
-    if (!isBackorderMessagingEnabled) {
-      return false;
-    }
-    return draftQuoteListHasBackorderedItemsForDisplay(items);
-  }, [items, isBackorderMessagingEnabled]);
+  const { hasBackorderedItems, inventoryById, selectionsByRowId } = useDraftQuoteBackorderState({
+    items,
+    isBackorderMessagingEnabled,
+    draftQuoteBackorderContextEnabled,
+  });
 
   const showBackorderToggle = draftQuoteBackorderContextEnabled && hasBackorderedItems;
 
@@ -428,8 +429,12 @@ function QuoteTable({ total, items, updateSummary }: QuoteTableProps) {
       key: 'Qty',
       title: b3Lang('quoteDraft.quoteTable.qty'),
       render: (row) => {
-        const backorderFields = getDraftBackorderDisplayFields(row);
+        const backorderFields = getDraftBackorderDisplayFields(
+          row,
+          inventoryById[resolveDraftLineProductId(row)],
+        );
         const shouldShowBackorder = showBackorderMessageBase && Boolean(backorderFields);
+        const picklistSelections = selectionsByRowId[String(row.id)] ?? [];
         return (
           <>
             <TextField
@@ -464,6 +469,15 @@ function QuoteTable({ total, items, updateSummary }: QuoteTableProps) {
                   visible
                 />
               </Box>
+            )}
+            {picklistSelections.length > 0 && (
+              <PicklistBackorderMessages
+                selections={picklistSelections}
+                picklistProductsById={inventoryById}
+                qty={Number(row.quantity) || 0}
+                visible={showBackorderDetails}
+                backorderUiEnabled={draftQuoteBackorderContextEnabled}
+              />
             )}
           </>
         );
@@ -593,6 +607,8 @@ function QuoteTable({ total, items, updateSummary }: QuoteTableProps) {
             handleUpdateProductQty={handleUpdateProductQty}
             draftQuoteBackorderContextEnabled={draftQuoteBackorderContextEnabled}
             showBackorderDetails={showBackorderDetails}
+            picklistProductsById={inventoryById}
+            picklistSelections={selectionsByRowId[String(row.id)] ?? []}
           />
         )}
       />

--- a/apps/storefront/src/pages/quote/components/QuoteTableCard.tsx
+++ b/apps/storefront/src/pages/quote/components/QuoteTableCard.tsx
@@ -2,15 +2,21 @@ import { Delete, Edit } from '@mui/icons-material';
 import { Box, CardContent, styled, TextField, Typography } from '@mui/material';
 
 import BackorderMessage from '@/components/BackorderMessage';
+import PicklistBackorderMessages from '@/components/PicklistBackorderMessages';
 import { PRODUCT_DEFAULT_IMAGE } from '@/constants';
 import { useB3Lang } from '@/lib/lang';
+import { type ProductSearch } from '@/shared/service/b2b/graphql/product';
 import { Product } from '@/types';
 import { QuoteItem } from '@/types/quotes';
 import { currencyFormat } from '@/utils/b3CurrencyFormat';
 import { getBCPrice, getDisplayPrice } from '@/utils/b3Product/b3Product';
 import { getProductOptionsFields } from '@/utils/b3Product/shared/config';
+import { type PicklistSelection } from '@/utils/catalogBackorderDisplay';
 
-import { getDraftBackorderDisplayFields } from '../utils/getQuoteBackorderDisplayFields';
+import {
+  getDraftBackorderDisplayFields,
+  resolveDraftLineProductId,
+} from '../utils/getQuoteBackorderDisplayFields';
 
 interface QuoteTableCardProps {
   item: QuoteItem['node'];
@@ -20,6 +26,8 @@ interface QuoteTableCardProps {
   isLast: boolean;
   draftQuoteBackorderContextEnabled: boolean;
   showBackorderDetails?: boolean;
+  picklistProductsById?: Record<number, ProductSearch>;
+  picklistSelections?: PicklistSelection[];
 }
 
 const StyledImage = styled('img')(() => ({
@@ -36,6 +44,8 @@ function QuoteTableCard({
   isLast,
   draftQuoteBackorderContextEnabled,
   showBackorderDetails = false,
+  picklistProductsById = {},
+  picklistSelections = [],
 }: QuoteTableCardProps) {
   const {
     basePrice,
@@ -49,7 +59,10 @@ function QuoteTableCard({
   } = item;
 
   const b3Lang = useB3Lang();
-  const backorderFields = getDraftBackorderDisplayFields(item);
+  const backorderFields = getDraftBackorderDisplayFields(
+    item,
+    picklistProductsById[resolveDraftLineProductId(item)],
+  );
 
   const showBackorderMessage =
     draftQuoteBackorderContextEnabled && Boolean(backorderFields) && showBackorderDetails;
@@ -187,6 +200,15 @@ function QuoteTableCard({
                   visible
                 />
               </Box>
+            )}
+            {picklistSelections.length > 0 && (
+              <PicklistBackorderMessages
+                selections={picklistSelections}
+                picklistProductsById={picklistProductsById}
+                qty={Number(quantity) || 0}
+                visible={showBackorderDetails}
+                backorderUiEnabled={draftQuoteBackorderContextEnabled}
+              />
             )}
           </>
           <Typography sx={{ fontSize: '14px' }}>Total: {totalPrice}</Typography>

--- a/apps/storefront/src/pages/quote/hooks/useDraftQuoteBackorderState.test.ts
+++ b/apps/storefront/src/pages/quote/hooks/useDraftQuoteBackorderState.test.ts
@@ -1,0 +1,206 @@
+import { waitFor } from '@testing-library/react';
+import { renderHookWithProviders } from 'tests/utils/hook-test-utils';
+
+import { searchProducts } from '@/shared/service/b2b';
+import { Product } from '@/types';
+import { QuoteItem } from '@/types/quotes';
+
+import { useDraftQuoteBackorderState } from './useDraftQuoteBackorderState';
+
+vi.mock('@/shared/service/b2b', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/shared/service/b2b')>()),
+  searchProducts: vi.fn(),
+}));
+
+const picklistModifier = {
+  id: 100,
+  type: 'product_list',
+  display_name: 'PickleFest',
+  option_values: [{ id: 200, value_data: { product_id: 555 } }],
+};
+
+const backorderedLine: QuoteItem = {
+  node: {
+    id: 'line',
+    productId: 999,
+    quantity: 10,
+    variantSku: 'PK',
+    productName: 'Pickle Kit',
+    basePrice: 24,
+    taxPrice: 0,
+    optionList: '[]',
+    calculatedValue: {},
+    productsSearch: {
+      inventoryTracking: 'product',
+      totalOnHand: 2,
+      availableToSell: 100,
+      unlimitedBackorder: false,
+      backorderMessage: 'Stored kit note',
+    } as unknown as Product,
+  },
+};
+
+const untrackedLineWithPicklist: QuoteItem = {
+  node: {
+    id: 'line-picklist',
+    productId: 999,
+    quantity: 5,
+    variantSku: 'PK',
+    productName: 'Pickle Kit',
+    basePrice: 24,
+    taxPrice: 0,
+    optionList: JSON.stringify([{ optionId: 'attribute[100]', optionValue: '200' }]),
+    calculatedValue: {},
+    // Stored data says the line is untracked; live inventory below overrides it.
+    productsSearch: {
+      inventoryTracking: 'none',
+      modifiers: [picklistModifier],
+    } as unknown as Product,
+  },
+};
+
+const lineWithoutProductId: QuoteItem = {
+  node: {
+    id: 'line-no-product-id',
+    quantity: 10,
+    variantSku: 'PK',
+    productName: 'Pickle Kit',
+    basePrice: 24,
+    taxPrice: 0,
+    optionList: '[]',
+    calculatedValue: {},
+    productsSearch: {
+      id: 777,
+      inventoryTracking: 'none',
+    } as unknown as Product,
+  },
+};
+
+const contextEnabled = {
+  items: [] as QuoteItem[],
+  isBackorderMessagingEnabled: true,
+  draftQuoteBackorderContextEnabled: true,
+};
+
+const renderState = (input: Parameters<typeof useDraftQuoteBackorderState>[0]) =>
+  renderHookWithProviders(
+    (props: Parameters<typeof useDraftQuoteBackorderState>[0]) =>
+      useDraftQuoteBackorderState(props),
+    { initialProps: input },
+  );
+
+describe('useDraftQuoteBackorderState', () => {
+  beforeEach(() => {
+    vi.mocked(searchProducts).mockReset();
+    vi.mocked(searchProducts).mockResolvedValue({ productsSearch: [] });
+  });
+
+  it('does not flag backordered items when messaging is disabled', () => {
+    const { result } = renderState({
+      ...contextEnabled,
+      items: [backorderedLine],
+      isBackorderMessagingEnabled: false,
+    });
+
+    expect(result.result.current.hasBackorderedItems).toBe(false);
+  });
+
+  it('does not resolve picklist rows or fetch when the context is disabled', () => {
+    const { result } = renderState({
+      ...contextEnabled,
+      items: [untrackedLineWithPicklist],
+      draftQuoteBackorderContextEnabled: false,
+    });
+
+    expect(result.result.current.picklistRows).toEqual([]);
+    expect(searchProducts).not.toHaveBeenCalled();
+  });
+
+  it('flags the line as backordered from stored data before live inventory arrives', () => {
+    const { result } = renderState({ ...contextEnabled, items: [backorderedLine] });
+
+    expect(result.result.current.hasBackorderedItems).toBe(true);
+  });
+
+  it('flags the line as backordered from live inventory even when the stored snapshot is untracked', async () => {
+    vi.mocked(searchProducts).mockResolvedValue({
+      productsSearch: [
+        {
+          id: 999,
+          inventoryTracking: 'product',
+          totalOnHand: 1,
+          availableToSell: 100,
+          unlimitedBackorder: false,
+          backorderMessage: 'Live kit note',
+        },
+      ],
+    });
+
+    const { result } = renderState({ ...contextEnabled, items: [untrackedLineWithPicklist] });
+
+    await waitFor(() => expect(result.result.current.inventoryById[999]).toBeDefined());
+
+    expect(result.result.current.hasBackorderedItems).toBe(true);
+  });
+
+  it('flags backorders from a picklist child even when the line itself is not backordered', async () => {
+    vi.mocked(searchProducts).mockResolvedValue({
+      productsSearch: [
+        {
+          id: 555,
+          inventoryTracking: 'product',
+          totalOnHand: 1,
+          availableToSell: 100,
+          unlimitedBackorder: false,
+          backorderMessage: 'Child ships late',
+        },
+      ],
+    });
+
+    const { result } = renderState({ ...contextEnabled, items: [untrackedLineWithPicklist] });
+
+    await waitFor(() => expect(result.result.current.inventoryById[555]).toBeDefined());
+    expect(result.result.current.hasBackorderedItems).toBe(true);
+  });
+
+  it('requests both line and picklist-child product ids together', async () => {
+    renderState({ ...contextEnabled, items: [untrackedLineWithPicklist] });
+
+    await waitFor(() =>
+      expect(searchProducts).toHaveBeenCalledWith(
+        expect.objectContaining({ productIds: expect.arrayContaining([999, 555]) }),
+      ),
+    );
+  });
+
+  it('resolves live inventory from the snapshot product id when node.productId is missing', async () => {
+    vi.mocked(searchProducts).mockResolvedValue({
+      productsSearch: [
+        {
+          id: 777,
+          inventoryTracking: 'product',
+          totalOnHand: 1,
+          availableToSell: 100,
+          unlimitedBackorder: false,
+          backorderMessage: 'Ships late',
+        },
+      ],
+    });
+
+    const { result } = renderState({ ...contextEnabled, items: [lineWithoutProductId] });
+
+    await waitFor(() =>
+      expect(searchProducts).toHaveBeenCalledWith(expect.objectContaining({ productIds: [777] })),
+    );
+    await waitFor(() => expect(result.result.current.inventoryById[777]).toBeDefined());
+    expect(result.result.current.hasBackorderedItems).toBe(true);
+  });
+
+  it('exposes resolved picklist selections keyed by row id', () => {
+    const { result } = renderState({ ...contextEnabled, items: [untrackedLineWithPicklist] });
+
+    expect(result.result.current.selectionsByRowId['line-picklist']).toEqual([
+      { modifierId: 100, displayName: 'PickleFest', productId: 555 },
+    ]);
+  });
+});

--- a/apps/storefront/src/pages/quote/hooks/useDraftQuoteBackorderState.ts
+++ b/apps/storefront/src/pages/quote/hooks/useDraftQuoteBackorderState.ts
@@ -1,0 +1,95 @@
+import { useMemo } from 'react';
+
+import { usePicklistInventory } from '@/hooks/usePicklistInventory';
+import { type ProductSearch } from '@/shared/service/b2b/graphql/product';
+import { QuoteItem } from '@/types/quotes';
+import {
+  catalogListHasPicklistBackorderedItemsForDisplay,
+  type PicklistSelection,
+} from '@/utils/catalogBackorderDisplay';
+
+import {
+  getDraftBackorderDisplayFields,
+  getDraftQuotePicklistSelections,
+  resolveDraftLineProductId,
+} from '../utils/getQuoteBackorderDisplayFields';
+
+interface PicklistRow {
+  id: string;
+  qty: number;
+  selections: PicklistSelection[];
+}
+
+interface DraftQuoteBackorderState {
+  hasBackorderedItems: boolean;
+  inventoryById: Record<number, ProductSearch>;
+  picklistRows: PicklistRow[];
+  selectionsByRowId: Record<string, PicklistSelection[]>;
+}
+
+interface DraftQuoteBackorderInput {
+  items: QuoteItem[];
+  isBackorderMessagingEnabled: boolean;
+  draftQuoteBackorderContextEnabled: boolean;
+}
+
+// Single source of truth for the draft quote's backorder state, shared by the table and the
+// summary so they can never disagree about whether an item is backordered.
+export function useDraftQuoteBackorderState({
+  items,
+  isBackorderMessagingEnabled,
+  draftQuoteBackorderContextEnabled,
+}: DraftQuoteBackorderInput): DraftQuoteBackorderState {
+  const { picklistRows, selectionsByRowId } = useMemo(() => {
+    const rows = draftQuoteBackorderContextEnabled
+      ? items.map((item) => ({
+          id: String(item.node.id),
+          qty: Number(item.node.quantity) || 0,
+          selections: getDraftQuotePicklistSelections(item.node),
+        }))
+      : [];
+
+    return {
+      picklistRows: rows,
+      selectionsByRowId: Object.fromEntries(rows.map((row) => [row.id, row.selections])),
+    };
+  }, [items, draftQuoteBackorderContextEnabled]);
+
+  const inventoryProductIds = useMemo(() => {
+    if (!draftQuoteBackorderContextEnabled) {
+      return [];
+    }
+    const lineIds = items.flatMap((item) => {
+      const productId = resolveDraftLineProductId(item.node);
+      return productId > 0 ? [productId] : [];
+    });
+    const childIds = picklistRows.flatMap((row) =>
+      row.selections.map((selection) => selection.productId),
+    );
+    return [...new Set([...lineIds, ...childIds])];
+  }, [items, picklistRows, draftQuoteBackorderContextEnabled]);
+
+  const inventoryById = usePicklistInventory(inventoryProductIds);
+
+  const hasBackorderedItems = useMemo(() => {
+    if (!isBackorderMessagingEnabled) {
+      return false;
+    }
+
+    const lineBackordered = items.some((item) =>
+      Boolean(
+        getDraftBackorderDisplayFields(
+          item.node,
+          inventoryById[resolveDraftLineProductId(item.node)],
+        ),
+      ),
+    );
+
+    return (
+      lineBackordered ||
+      catalogListHasPicklistBackorderedItemsForDisplay(picklistRows, inventoryById)
+    );
+  }, [items, isBackorderMessagingEnabled, picklistRows, inventoryById]);
+
+  return { hasBackorderedItems, inventoryById, picklistRows, selectionsByRowId };
+}

--- a/apps/storefront/src/pages/quote/utils/getQuoteBackorderDisplayFields.test.ts
+++ b/apps/storefront/src/pages/quote/utils/getQuoteBackorderDisplayFields.test.ts
@@ -3,9 +3,9 @@ import { describe, expect, it } from 'vitest';
 import type { QuoteItem } from '@/types/quotes';
 
 import {
-  draftQuoteListHasBackorderedItemsForDisplay,
   draftRowQuantityExceedsAvailableToSell,
   getDraftBackorderDisplayFields,
+  getDraftQuotePicklistSelections,
   getQuoteBackorderDisplayFields,
   getQuoteBackorderDisplayQuantity,
   getQuoteItemBackendAvailability,
@@ -290,57 +290,6 @@ describe('draftRowQuantityExceedsAvailableToSell', () => {
   });
 });
 
-describe('draftQuoteListHasBackorderedItemsForDisplay', () => {
-  it('returns false for an empty list', () => {
-    expect(draftQuoteListHasBackorderedItemsForDisplay([])).toBe(false);
-  });
-
-  it('returns true when an item has backorder fields and quantity is within available-to-sell', () => {
-    const row = {
-      quantity: 10,
-      variantSku: 'V1',
-      productsSearch: {
-        inventoryTracking: 'product',
-        totalOnHand: 3,
-        availableToSell: 10,
-        unlimitedBackorder: false,
-      },
-    } as QuoteLineNode;
-
-    expect(draftQuoteListHasBackorderedItemsForDisplay([{ node: row }] as QuoteItem[])).toBe(true);
-  });
-
-  it('returns false when ordered quantity is within total on hand (no backordered quantity)', () => {
-    const row = {
-      quantity: 2,
-      variantSku: 'V1',
-      productsSearch: {
-        inventoryTracking: 'product',
-        totalOnHand: 5,
-        availableToSell: 10,
-        unlimitedBackorder: false,
-      },
-    } as QuoteLineNode;
-
-    expect(draftQuoteListHasBackorderedItemsForDisplay([{ node: row }] as QuoteItem[])).toBe(false);
-  });
-
-  it('returns true when quantity exceeds available-to-sell but capped backorder fields exist', () => {
-    const row = {
-      quantity: 10,
-      variantSku: 'V1',
-      productsSearch: {
-        inventoryTracking: 'product',
-        totalOnHand: 3,
-        availableToSell: 4,
-        unlimitedBackorder: false,
-      },
-    } as QuoteLineNode;
-
-    expect(draftQuoteListHasBackorderedItemsForDisplay([{ node: row }] as QuoteItem[])).toBe(true);
-  });
-});
-
 describe('getQuoteBackorderDisplayFields for quote detail rows', () => {
   it('caps backorder display using enriched productsSearch ATS and API snapshot on-hand', () => {
     const row = {
@@ -482,6 +431,70 @@ describe('getQuoteBackorderDisplayFields for quote detail rows', () => {
       quantityBackordered: 8,
       backorderMessage: 'Snapshot message',
     });
+  });
+});
+
+describe('getDraftQuotePicklistSelections', () => {
+  const picklistModifier = {
+    id: 100,
+    type: 'product_list',
+    display_name: 'Pick a pickle',
+    option_values: [{ id: 200, value_data: { product_id: 555 } }],
+  };
+
+  const buildRow = (optionList: string) =>
+    ({
+      quantity: 1,
+      optionList,
+      productsSearch: { modifiers: [picklistModifier] },
+    }) as unknown as QuoteItem['node'];
+
+  it('resolves a picklist selection from camelCase attribute-keyed optionList', () => {
+    const optionList = JSON.stringify([{ optionId: 'attribute[100]', optionValue: '200' }]);
+
+    expect(getDraftQuotePicklistSelections(buildRow(optionList))).toEqual([
+      { modifierId: 100, displayName: 'Pick a pickle', productId: 555 },
+    ]);
+  });
+
+  it('resolves a picklist selection from snake_case option_id/option_value entries', () => {
+    const optionList = JSON.stringify([{ option_id: 100, option_value: 200 }]);
+
+    expect(getDraftQuotePicklistSelections(buildRow(optionList))).toEqual([
+      { modifierId: 100, displayName: 'Pick a pickle', productId: 555 },
+    ]);
+  });
+
+  it('returns an empty array when the modifier is not a picklist', () => {
+    const optionList = JSON.stringify([{ optionId: 'attribute[100]', optionValue: '200' }]);
+    const row = {
+      quantity: 1,
+      optionList,
+      productsSearch: { modifiers: [{ ...picklistModifier, type: 'dropdown' }] },
+    } as unknown as QuoteItem['node'];
+
+    expect(getDraftQuotePicklistSelections(row)).toEqual([]);
+  });
+
+  it('returns an empty array when optionList is empty', () => {
+    expect(getDraftQuotePicklistSelections(buildRow('[]'))).toEqual([]);
+  });
+
+  it('returns an empty array when optionList is not valid JSON', () => {
+    expect(getDraftQuotePicklistSelections(buildRow('not json'))).toEqual([]);
+  });
+
+  it('skips null and primitive entries without throwing on malformed optionList', () => {
+    const optionList = JSON.stringify([
+      null,
+      'x',
+      42,
+      { optionId: 'attribute[100]', optionValue: '200' },
+    ]);
+
+    expect(getDraftQuotePicklistSelections(buildRow(optionList))).toEqual([
+      { modifierId: 100, displayName: 'Pick a pickle', productId: 555 },
+    ]);
   });
 });
 

--- a/apps/storefront/src/pages/quote/utils/getQuoteBackorderDisplayFields.ts
+++ b/apps/storefront/src/pages/quote/utils/getQuoteBackorderDisplayFields.ts
@@ -1,7 +1,14 @@
+import { type ProductSearch } from '@/shared/service/b2b/graphql/product';
 import type { Variant } from '@/types/products';
 import { QuoteItem } from '@/types/quotes';
 import type { BackorderDisplayFields } from '@/utils/backorderDisplayFromInventory';
 import { getBackorderDisplayFieldsFromOnHand } from '@/utils/backorderDisplayFromInventory';
+import {
+  getProductDetailsForPicklistSelections,
+  type PicklistSelection,
+  type PicklistSelectionSource,
+} from '@/utils/catalogBackorderDisplay';
+import { parseAttributeOptionId } from '@/utils/parseAttributeOptionId';
 
 export interface QuoteBackorderRow {
   quantity: number | string;
@@ -135,14 +142,82 @@ export function getQuoteBackorderDisplayFields(
   return getBackorderDisplayFieldsFromOnHand(displayQty, totalOnHand, backorderMessage);
 }
 
-export function getDraftBackorderDisplayFields(row: QuoteItem['node']) {
-  return getQuoteBackorderDisplayFields(row);
+// Fall back to the snapshot's id so rows missing node.productId still resolve live
+// inventory rather than stale stored data.
+export function resolveDraftLineProductId(row: QuoteItem['node']): number {
+  return Number(row.productId) || Number(row.productsSearch?.id);
 }
 
-export function draftQuoteListHasBackorderedItemsForDisplay(draftQuoteList: QuoteItem[]): boolean {
-  return draftQuoteList.some((quoteItem) =>
-    Boolean(getQuoteBackorderDisplayFields(quoteItem.node)),
-  );
+export function getDraftBackorderDisplayFields(
+  row: QuoteItem['node'],
+  liveProductsSearch?: ProductSearch,
+) {
+  if (!liveProductsSearch) {
+    return getQuoteBackorderDisplayFields(row);
+  }
+
+  return getQuoteBackorderDisplayFields({
+    ...row,
+    productsSearch: liveProductsSearch as unknown as QuoteBackorderRow['productsSearch'],
+  });
+}
+
+interface DraftQuoteOptionListEntry {
+  option_id?: number | string;
+  optionId?: number | string;
+  option_value?: number | string;
+  optionValue?: number | string;
+}
+
+// Draft `optionList` is a JSON string keyed {option_id|optionId, option_value|optionValue}
+// with ids shaped like "attribute[123]"; translate to the resolver's numeric-pair shape.
+function parseDraftQuoteOptionSelections(
+  optionList: string | undefined,
+): Array<{ option_id: number; value_id: number }> {
+  if (!optionList) {
+    return [];
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(optionList);
+  } catch {
+    return [];
+  }
+
+  if (!Array.isArray(parsed)) {
+    return [];
+  }
+
+  return (parsed as unknown[]).flatMap((item) => {
+    if (item === null || typeof item !== 'object') {
+      return [];
+    }
+
+    const entry = item as DraftQuoteOptionListEntry;
+    const rawId = entry.option_id ?? entry.optionId;
+    const rawValue = entry.option_value ?? entry.optionValue;
+    if (rawId == null || rawValue == null) {
+      return [];
+    }
+
+    const optionId = parseAttributeOptionId(rawId);
+    const valueId = Number(rawValue);
+    if (optionId === null || Number.isNaN(valueId)) {
+      return [];
+    }
+
+    return [{ option_id: optionId, value_id: valueId }];
+  });
+}
+
+export function getDraftQuotePicklistSelections(row: QuoteItem['node']): PicklistSelection[] {
+  const source: PicklistSelectionSource = {
+    optionSelections: parseDraftQuoteOptionSelections(row.optionList),
+    productsSearch: row.productsSearch,
+  };
+
+  return getProductDetailsForPicklistSelections(source);
 }
 
 export function quoteDetailListHasBackorderedItemsForDisplay(

--- a/apps/storefront/src/store/selectors.ts
+++ b/apps/storefront/src/store/selectors.ts
@@ -4,6 +4,7 @@ import type { RootState } from '@/store';
 import { CompanyStatus, Currency, CustomerRole, UserTypes } from '@/types';
 import { getCorrespondsConfigurationPermission } from '@/utils/b3CheckPermissions/base';
 import { B2BPermissionsMapParams } from '@/utils/b3CheckPermissions/config';
+import { parseAttributeOptionId } from '@/utils/parseAttributeOptionId';
 
 import { defaultCurrenciesState } from './slices/storeConfigs';
 
@@ -77,10 +78,8 @@ export const formattedQuoteDraftListSelector = createSelector(quoteInfoSelector,
       const parsedOptionList: OptionList[] = JSON.parse(optionList);
 
       const optionSelections = parsedOptionList.map(({ optionId, optionValue }) => {
-        const optionIdFormatted = optionId.match(/\d+/);
-
         return {
-          optionId: optionIdFormatted?.[0] ? Number(optionIdFormatted[0]) : optionId,
+          optionId: parseAttributeOptionId(optionId) ?? optionId,
           optionValue: Number(optionValue),
         };
       });

--- a/apps/storefront/src/utils/catalogBackorderDisplay.ts
+++ b/apps/storefront/src/utils/catalogBackorderDisplay.ts
@@ -204,7 +204,7 @@ interface PicklistModifier {
   option_values?: Array<{ id: number; value_data?: { product_id?: number } | null }> | null;
 }
 
-interface PicklistSelectionSource {
+export interface PicklistSelectionSource {
   optionSelections?: Array<{ option_id: number; value_id: number }> | null;
   productsSearch?: { modifiers?: PicklistModifier[] | null } | null;
 }

--- a/apps/storefront/src/utils/parseAttributeOptionId.test.ts
+++ b/apps/storefront/src/utils/parseAttributeOptionId.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseAttributeOptionId } from './parseAttributeOptionId';
+
+describe('parseAttributeOptionId', () => {
+  it('extracts the numeric id from an attribute-keyed option id', () => {
+    expect(parseAttributeOptionId('attribute[123]')).toBe(123);
+  });
+
+  it('returns a numeric id unchanged', () => {
+    expect(parseAttributeOptionId(456)).toBe(456);
+  });
+
+  it('parses a bare numeric string', () => {
+    expect(parseAttributeOptionId('789')).toBe(789);
+  });
+
+  it('returns the first digit run for a compound attribute key', () => {
+    expect(parseAttributeOptionId('attribute[12][month]')).toBe(12);
+  });
+
+  it('returns null when the id has no digits', () => {
+    expect(parseAttributeOptionId('none')).toBeNull();
+  });
+
+  it('returns null for an empty string', () => {
+    expect(parseAttributeOptionId('')).toBeNull();
+  });
+});

--- a/apps/storefront/src/utils/parseAttributeOptionId.ts
+++ b/apps/storefront/src/utils/parseAttributeOptionId.ts
@@ -1,0 +1,4 @@
+export function parseAttributeOptionId(rawId: string | number): number | null {
+  const match = `${rawId}`.match(/\d+/);
+  return match ? Number(match[0]) : null;
+}


### PR DESCRIPTION
Jira: [BACK-720](https://bigcommercecloud.atlassian.net/browse/BACK-720)

## What/Why?
Implement backorder information display for Picklisted items.

Additionally has inventory fetched fresh, as previously the on draft creation data can be out of date.
To note on this, there was an existing issue where quotes in draft status were using the data from when the quote was first created. This lead to stale data being used here when ascertaining whether a item needed to be backordered. I did contemplate splitting this into a separate PR, but it made more contextual sense to keep it all in  here together.

## Rollout/Rollback
Revert this Pr is there are issues.

## Testing
Tests continue to pass. Also added additional tests.
Before:

Picklist child is not represented in the backorder information display:
<img width="1475" height="891" alt="beforePicklist" src="https://github.com/user-attachments/assets/f2788085-7bf8-47fc-bb30-8aa4476fcbf4" />

After:
Picklist is now represented properly.
<img width="1440" height="839" alt="picklist5OnhandSEcondShowsbackordred" src="https://github.com/user-attachments/assets/657050b6-5e44-4c6e-ba9b-4a0646be9015" />

_Please note that the items in the above screenshot are all validated separately thus the second parent not recognising that 11 have been ordered (5 from parent 1 and 6 from parent 2) and the second element thinking that 5 are still on hand. A ticket has been raised to resolve this [BACK-705](https://bigcommercecloud.atlassian.net/browse/BACK-705)._

ping @bigcommerce/team-b2b @animesh1987 

[BACK-720]: https://bigcommercecloud.atlassian.net/browse/BACK-720?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BACK-705]: https://bigcommercecloud.atlassian.net/browse/BACK-705?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds async product search on the draft quote UI and changes when backorder messaging appears; impact is limited to storefront quote draft display behind existing backorder feature flags.
> 
> **Overview**
> Draft quote **backorder details** now account for **picklist (product_list) child products**, not just the parent line, and **line-level backorder fields prefer freshly fetched inventory** instead of the snapshot stored when the quote was created.
> 
> A shared **`useDraftQuoteBackorderState`** hook drives the draft table and summary so toggles, shipping expectation prompts, and “has backordered items” stay aligned. It resolves picklist selections from draft `optionList`, batches **`searchProducts`** for parent and child product IDs, and feeds **`PicklistBackorderMessages`** on desktop and mobile row layouts.
> 
> Supporting changes include **`getDraftQuotePicklistSelections`**, optional live override in **`getDraftBackorderDisplayFields`**, **`resolveDraftLineProductId`**, and **`parseAttributeOptionId`** (also used when formatting draft option selections in the store selector).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05c87bbce51e9e1ca8ed472ef735a7f8a770f938. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->