### PR TITLE
[B2B-4628] Wire productAttributeEntityId and valueEntityId for reorder and shopping list

### DIFF
--- a/apps/storefront/src/pages/OrderDetail/shared/convertOrderDetail.ts
+++ b/apps/storefront/src/pages/OrderDetail/shared/convertOrderDetail.ts
@@ -5,6 +5,7 @@ import type {
   OrderAddress,
   OrderDigitalLineItem,
   OrderLineItem,
+  OrderLineItemProductOption,
 } from '@/shared/service/bc/graphql/orders';
 import { OrderHistoryEventType } from '@/shared/service/bc/graphql/orders';
 import type {
@@ -170,12 +171,7 @@ interface LineItemBase {
   productEntityId: number;
   name: string;
   quantity: number;
-  productOptions: Array<{
-    name: string;
-    value: string;
-    productAttributeEntityId?: number;
-    productAttributeValueEntityId?: number;
-  }>;
+  productOptions: OrderLineItemProductOption[];
   subTotalListPrice: Money;
 }
 

--- a/apps/storefront/src/pages/OrderDetail/shared/convertOrderDetail.ts
+++ b/apps/storefront/src/pages/OrderDetail/shared/convertOrderDetail.ts
@@ -170,7 +170,12 @@ interface LineItemBase {
   productEntityId: number;
   name: string;
   quantity: number;
-  productOptions: Array<{ name: string; value: string }>;
+  productOptions: Array<{
+    name: string;
+    value: string;
+    productAttributeEntityId?: number;
+    productAttributeValueEntityId?: number;
+  }>;
   subTotalListPrice: Money;
 }
 
@@ -217,15 +222,15 @@ function buildOrderProduct(
     refund_amount: '0',
     return_id: 0,
     optionList: item.productOptions.map((o) => ({
-      optionId: 0,
-      optionValue: o.value,
+      optionId: o.productAttributeEntityId ?? 0,
+      optionValue: o.productAttributeValueEntityId?.toString() ?? o.value,
       type: o.name,
     })),
     product_options: item.productOptions.map((o) => ({
-      id: 0,
-      option_id: 0,
+      id: o.productAttributeEntityId ?? 0,
+      option_id: o.productAttributeEntityId ?? 0,
       order_product_id: item.entityId,
-      product_option_id: 0,
+      product_option_id: o.productAttributeEntityId ?? 0,
       name: o.name,
       value: o.value,
       display_name: o.name,

--- a/apps/storefront/src/shared/service/bc/graphql/orders.ts
+++ b/apps/storefront/src/shared/service/bc/graphql/orders.ts
@@ -40,6 +40,10 @@ export interface OrderAddress {
 export interface OrderLineItemProductOption {
   name: string;
   value: string;
+  /** Option ID — maps to product_attribute_id (PROJECT-7288). */
+  productAttributeEntityId?: number;
+  /** Option value ID — maps to validated_value (PROJECT-7288). */
+  productAttributeValueEntityId?: number;
 }
 
 /** Projects OrderPhysicalLineItem. */
@@ -371,6 +375,8 @@ const orderLineItemFields = `entityId
       productOptions {
         name
         value
+        productAttributeEntityId
+        productAttributeValueEntityId
       }
       subTotalListPrice {
         ${moneyFields}

--- a/apps/storefront/src/shared/service/bc/graphql/orders.ts
+++ b/apps/storefront/src/shared/service/bc/graphql/orders.ts
@@ -40,9 +40,9 @@ export interface OrderAddress {
 export interface OrderLineItemProductOption {
   name: string;
   value: string;
-  /** Option ID — maps to product_attribute_id (PROJECT-7288). */
+  /** Option ID — maps to product_attribute_id. */
   productAttributeEntityId?: number;
-  /** Option value ID — maps to validated_value (PROJECT-7288). */
+  /** Option value ID — maps to validated_value. */
   productAttributeValueEntityId?: number;
 }
 


### PR DESCRIPTION
Jira: [B2B-4628](https://bigcommercecloud.atlassian.net/browse/B2B-4628)

## What/Why?

Wires the product option IDs through the unified order detail converter so reorder and shopping list flows send real option IDs once BE exposes them on `OrderLineItemProductOption` (PROJECT-7288).

Field names confirmed by the BC Orders team:
- `productAttributeEntityId` — option ID (maps to `product_attribute_id`)
- `productAttributeValueEntityId` — option value ID (maps to `validated_value`)

Without these, the converter hardcodes `0` for all option IDs, causing reorder to send `optionEntityId: 0` and shopping list to send `attribute[0]` — breaks products with non-variant-defining options (text fields, file uploads).

`variantEntityId` is already wired from B2B-4826 — no changes needed for P5.

All fields are optional with `?? 0` fallback. Behind the `B2B-4613.buyer_portal_unified_sf_gql_orders` feature flag.

## Rollout/Rollback

Behind existing feature flag. No new flags. Rollback is turning the flag off.

## Testing

- 78 tests pass (39 unified + 39 legacy)
- TypeScript clean, lint clean

[B2B-4628]: https://bigcommercecloud.atlassian.net/browse/B2B-4628?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to unified GQL order-detail conversion behind an existing feature flag, with backward-compatible fallbacks when option IDs are missing.
> 
> **Overview**
> **Unified order detail** now passes real product option IDs from Storefront GraphQL into the legacy `OrderProductItem` shape used by **reorder** and **add to shopping list**, instead of hardcoding `0` for every option.
> 
> The orders GraphQL layer extends `OrderLineItemProductOption` with optional `productAttributeEntityId` and `productAttributeValueEntityId`, requests them on physical line items, and `convertOrderDetail` maps them into `optionList` / `product_options` (with `?? 0` and display `value` fallbacks when the API omits IDs). That fixes broken reorders and `attribute[0]` shopping-list payloads for non-variant options like text fields once the backend exposes these fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2739491c9abb0e32b0547bcdea7e924f1b7f4232. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->