### PR TITLE
feat(quotes): BACK-726 Centralise usePicklistInventory hook for re-use.

### DIFF
--- a/apps/storefront/src/hooks/usePicklistInventory.test.ts
+++ b/apps/storefront/src/hooks/usePicklistInventory.test.ts
@@ -1,0 +1,102 @@
+import { act, waitFor } from '@testing-library/react';
+import { buildCompanyStateWith } from 'tests/test-utils';
+import { renderHookWithProviders } from 'tests/utils/hook-test-utils';
+
+import { searchProducts } from '@/shared/service/b2b';
+import { setCompanyInfo } from '@/store/slices/company';
+
+import { usePicklistInventory } from './usePicklistInventory';
+
+vi.mock('@/shared/service/b2b', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/shared/service/b2b')>()),
+  searchProducts: vi.fn(),
+}));
+
+const renderUsePicklistInventory = (ids: number[]) =>
+  renderHookWithProviders(
+    ({ productIds }: { productIds: number[] }) => usePicklistInventory(productIds),
+    {
+      initialProps: { productIds: ids },
+    },
+  );
+
+describe('usePicklistInventory', () => {
+  beforeEach(() => {
+    vi.mocked(searchProducts).mockReset();
+  });
+
+  it('fetches and returns inventory keyed by product id', async () => {
+    vi.mocked(searchProducts).mockResolvedValue({ productsSearch: [{ id: 555 }] });
+
+    const { result } = renderUsePicklistInventory([555]);
+
+    await waitFor(() => expect(result.result.current[555]).toBeDefined());
+    expect(searchProducts).toHaveBeenCalledWith(expect.objectContaining({ productIds: [555] }));
+  });
+
+  it('does not fetch when given no product ids', () => {
+    vi.mocked(searchProducts).mockResolvedValue({ productsSearch: [] });
+
+    const { result } = renderUsePicklistInventory([]);
+
+    expect(result.result.current).toEqual({});
+    expect(searchProducts).not.toHaveBeenCalled();
+  });
+
+  it('does not refetch when the same product ids are requested again', async () => {
+    vi.mocked(searchProducts).mockResolvedValue({ productsSearch: [{ id: 555 }] });
+
+    const { result } = renderUsePicklistInventory([555]);
+    await waitFor(() => expect(result.result.current[555]).toBeDefined());
+
+    result.rerender({ productIds: [555] });
+    await waitFor(() => expect(result.result.current[555]).toBeDefined());
+
+    expect(searchProducts).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns empty inventory after the id list is cleared', async () => {
+    vi.mocked(searchProducts).mockResolvedValue({ productsSearch: [{ id: 555 }] });
+
+    const { result } = renderUsePicklistInventory([555]);
+    await waitFor(() => expect(result.result.current[555]).toBeDefined());
+
+    result.rerender({ productIds: [] });
+
+    expect(result.result.current).toEqual({});
+  });
+
+  it('refetches under a new key when the company context changes', async () => {
+    vi.mocked(searchProducts).mockImplementation(async (data?: { companyId?: string }) => ({
+      productsSearch: [{ id: 555, companyId: data?.companyId }],
+    }));
+
+    const { companyInfo } = buildCompanyStateWith('WHATEVER_VALUES');
+
+    const { store } = renderHookWithProviders(
+      ({ productIds }: { productIds: number[] }) => usePicklistInventory(productIds),
+      {
+        initialProps: { productIds: [555] },
+        preloadedState: {
+          company: buildCompanyStateWith({ companyInfo: { ...companyInfo, id: 'company-a' } }),
+        },
+      },
+    );
+
+    await waitFor(() =>
+      expect(searchProducts).toHaveBeenCalledWith(
+        expect.objectContaining({ companyId: 'company-a' }),
+      ),
+    );
+
+    act(() => {
+      store.dispatch(setCompanyInfo({ ...companyInfo, id: 'company-b' }));
+    });
+
+    await waitFor(() =>
+      expect(searchProducts).toHaveBeenCalledWith(
+        expect.objectContaining({ companyId: 'company-b' }),
+      ),
+    );
+  });
+});

--- a/apps/storefront/src/hooks/usePicklistInventory.ts
+++ b/apps/storefront/src/hooks/usePicklistInventory.ts
@@ -1,0 +1,41 @@
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
+
+import { searchProducts } from '@/shared/service/b2b';
+import { type ProductSearch } from '@/shared/service/b2b/graphql/product';
+import { activeCurrencyInfoSelector, useAppSelector } from '@/store';
+
+const EMPTY_INVENTORY: Record<number, ProductSearch> = {};
+
+export function usePicklistInventory(productIds: number[]): Record<number, ProductSearch> {
+  const { currency_code: currencyCode } = useAppSelector(activeCurrencyInfoSelector);
+  const companyInfoId = useAppSelector(({ company }) => company.companyInfo.id);
+  const customerGroupId = useAppSelector(({ company }) => company.customer.customerGroupId);
+
+  const requestedIds = [...new Set(productIds)].sort((a, b) => a - b);
+
+  const { data } = useQuery({
+    queryKey: ['picklistInventory', { requestedIds, currencyCode, companyInfoId, customerGroupId }],
+    enabled: requestedIds.length > 0,
+    placeholderData: keepPreviousData,
+    queryFn: async () => {
+      const { productsSearch: products = [] } = await searchProducts({
+        productIds: requestedIds,
+        currencyCode,
+        companyId: companyInfoId,
+        customerGroupId,
+      });
+
+      const inventory: Record<number, ProductSearch> = {};
+      products.forEach((product: ProductSearch) => {
+        inventory[Number(product.id)] = product;
+      });
+      return inventory;
+    },
+  });
+
+  if (requestedIds.length === 0) {
+    return EMPTY_INVENTORY;
+  }
+
+  return data ?? EMPTY_INVENTORY;
+}

--- a/apps/storefront/src/pages/QuickOrder/components/QuickOrderB2BTable.tsx
+++ b/apps/storefront/src/pages/QuickOrder/components/QuickOrderB2BTable.tsx
@@ -9,13 +9,13 @@ import { TableColumnItem } from '@/components/table/B3Table';
 import { PRODUCT_DEFAULT_IMAGE } from '@/constants';
 import { useBackorderStorefrontMessaging } from '@/hooks/useBackorderStorefrontMessaging';
 import { useMobile } from '@/hooks/useMobile';
+import { usePicklistInventory } from '@/hooks/usePicklistInventory';
 import { useSort } from '@/hooks/useSort';
 import { useB3Lang } from '@/lib/lang';
 import { getOrderedProducts, searchProducts } from '@/shared/service/b2b';
 import {
   type CatalogQuickVariantSku,
   getVariantInfoBySkus,
-  type ProductSearch,
 } from '@/shared/service/b2b/graphql/product';
 import { activeCurrencyInfoSelector, useAppSelector } from '@/store';
 import { ProductInfoType } from '@/types/gql/graphql';
@@ -147,9 +147,6 @@ function QuickOrderTable({
 
   const [total, setTotalCount] = useState<number>(0);
   const [variantInfoList, setVariantInfoList] = useState<CatalogQuickVariantSku[]>([]);
-  const [picklistProductsById, setPicklistProductsById] = useState<Record<number, ProductSearch>>(
-    {},
-  );
   const [showBackorderDetails, setShowBackorderDetails] = useState(false);
   const [tableDataVersion, setTableDataVersion] = useState(0);
 
@@ -163,6 +160,9 @@ function QuickOrderTable({
     hasAnyBackorderDisplay,
   } = useBackorderStorefrontMessaging();
   const backorderUiEnabled = isBackorderMessagingContextEnabled && hasAnyBackorderDisplay;
+
+  const [picklistProductIds, setPicklistProductIds] = useState<number[]>([]);
+  const picklistProductsById = usePicklistInventory(picklistProductIds);
 
   const inventoryBySku = useMemo(() => {
     const map: Record<string, CatalogQuickVariantSku> = {};
@@ -227,40 +227,6 @@ function QuickOrderTable({
 
   const { currency_code: currencyCode } = useAppSelector(activeCurrencyInfoSelector);
 
-  const fetchPicklistProducts = useCallback(
-    async (productIds: number[]) => {
-      if (!backorderUiEnabled || productIds.length === 0) {
-        return;
-      }
-
-      const newProductIds = [...new Set(productIds)].filter((id) => !picklistProductsById[id]);
-
-      if (newProductIds.length === 0) {
-        return;
-      }
-
-      try {
-        const { productsSearch = [] } = await searchProducts({
-          productIds: newProductIds,
-          currencyCode,
-          companyId: companyInfoId,
-          customerGroupId,
-        });
-
-        setPicklistProductsById((prev) => {
-          const next = { ...prev };
-          productsSearch.forEach((product: ProductSearch) => {
-            next[Number(product.id)] = product;
-          });
-          return next;
-        });
-      } catch {
-        // Inventory fetch failure should not block the product list
-      }
-    },
-    [backorderUiEnabled, picklistProductsById, currencyCode, companyInfoId, customerGroupId],
-  );
-
   const handleGetProductsById = async (listProducts: ListItemProps[]) => {
     if (listProducts.length > 0) {
       const productIds: number[] = [];
@@ -313,7 +279,9 @@ function QuickOrderTable({
 
     setTotalCount(totalCount);
 
-    if (backorderUiEnabled && listProducts?.length) {
+    if (!backorderUiEnabled) {
+      setPicklistProductIds([]);
+    } else if (listProducts?.length) {
       const skus = listProducts
         .map((item) => item.node.variantSku)
         .filter((sku): sku is string => Boolean(sku));
@@ -321,12 +289,10 @@ function QuickOrderTable({
         // Inventory fetch failure should not block the product list
       });
 
-      const picklistProductIds = listProducts.flatMap((item) =>
+      const pagePicklistProductIds = listProducts.flatMap((item) =>
         getProductDetailsForPicklistSelections(item.node).map((selection) => selection.productId),
       );
-      fetchPicklistProducts(picklistProductIds).catch(() => {
-        // Inventory fetch failure should not block the product list
-      });
+      setPicklistProductIds((prev) => [...new Set([...prev, ...pagePicklistProductIds])]);
     }
 
     setTableDataVersion((version) => version + 1);

--- a/apps/storefront/tests/utils/hook-test-utils.tsx
+++ b/apps/storefront/tests/utils/hook-test-utils.tsx
@@ -1,6 +1,7 @@
 import { ComponentProps, PropsWithChildren, Suspense, useContext, useEffect } from 'react';
 import { Provider } from 'react-redux';
 import { MemoryRouter, useLocation } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, RenderHookOptions } from '@testing-library/react';
 import { Mock } from 'vitest';
 
@@ -51,24 +52,29 @@ export const renderHookWithProviders = <Result, Props>(
   } = options;
 
   vi.spyOn(storeModule, 'store', 'get').mockReturnValue(store);
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: Infinity, staleTime: 0 } },
+  });
   const navigation = vi.fn();
 
   function Wrapper({ children }: PropsWithChildren) {
     return (
       <Suspense fallback="test-loading">
-        <GlobalProvider>
-          <MockGlobalProvider payload={initialGlobalContext} />
-          <Provider store={store}>
-            <LangProvider>
-              <DynamicallyVariableProvider>
-                <B3LayoutTip />
-                <MemoryRouter initialEntries={initialEntries}>
-                  <NavigationSpy spy={navigation}>{children}</NavigationSpy>
-                </MemoryRouter>
-              </DynamicallyVariableProvider>
-            </LangProvider>
-          </Provider>
-        </GlobalProvider>
+        <QueryClientProvider client={queryClient}>
+          <GlobalProvider>
+            <MockGlobalProvider payload={initialGlobalContext} />
+            <Provider store={store}>
+              <LangProvider>
+                <DynamicallyVariableProvider>
+                  <B3LayoutTip />
+                  <MemoryRouter initialEntries={initialEntries}>
+                    <NavigationSpy spy={navigation}>{children}</NavigationSpy>
+                  </MemoryRouter>
+                </DynamicallyVariableProvider>
+              </LangProvider>
+            </Provider>
+          </GlobalProvider>
+        </QueryClientProvider>
       </Suspense>
     );
   }


### PR DESCRIPTION
Jira: [BACK-726](https://bigcommercecloud.atlassian.net/browse/BACK-726)

## What/Why?
Centralise usePicklistInventory hook for re-use.
In a previous PR we added functionality for fetching Picklist inventory information.
This information should be accessible across several places so lets move this out so we can re-use this.

## Rollout/Rollback
Revert this PR if there are issues.

## Testing
Picklist inventory checks still work:
<img width="1494" height="769" alt="Screenshot 2026-06-26 at 1 21 54 pm" src="https://github.com/user-attachments/assets/48c102a6-066b-4fb5-b883-5e04a2cd438f" />

On page load discovers child from picklist needs backordering as expected:
<img width="1465" height="887" alt="childOnlyPicklistWorks" src="https://github.com/user-attachments/assets/5091eff7-3e2f-4062-8083-100ca6f1850c" />

ping @bigcommerce/team-b2b 

[BACK-726]: https://bigcommercecloud.atlassian.net/browse/BACK-726?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how picklist inventory is fetched and cached for Quick Order backorder UI; behavior is covered by new hook tests but incorrect caching could show stale backorder messages.
> 
> **Overview**
> Extracts picklist product inventory loading into a shared **`usePicklistInventory`** hook backed by React Query, so other storefront surfaces can reuse the same **`searchProducts`** lookup and caching.
> 
> **Quick Order B2B table** drops its local `fetchPicklistProducts` state/callback and instead maintains a **`picklistProductIds`** list (merged per page when backorder UI is on, cleared when off), feeding it into the hook for **`picklistProductsById`** used by backorder messaging.
> 
> Adds hook unit tests (empty IDs, deduped refetch, company context invalidation) and wraps **`renderHookWithProviders`** with **`QueryClientProvider`** for React Query in tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82cc2c0c7e6072b7294b4d012609ace3d60e9a5c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->