### PR TITLE
feat(quotes): BACK-721 Implement backorders for picklist children in submitted quotes.

### DIFF
--- a/apps/storefront/src/pages/QuoteDetail/index.tsx
+++ b/apps/storefront/src/pages/QuoteDetail/index.tsx
@@ -47,13 +47,13 @@ import QuoteDetailTable from '../quote/components/QuoteDetailTable';
 import QuoteInfo from '../quote/components/QuoteInfo';
 import QuoteNote from '../quote/components/QuoteNote';
 import QuoteTermsAndConditions from '../quote/components/QuoteTermsAndConditions';
+import { useQuoteDetailBackorderState } from '../quote/hooks/useQuoteDetailBackorderState';
 import {
   getQuoteValidationErrorMessage,
   QUOTE_VALIDATION_ERROR_CODES,
   QUOTE_VALIDATION_MESSAGE_CONTEXTS,
 } from '../quote/shared/getQuoteValidationErrorMessage';
 import { buildQuoteStockSnapshot } from '../quote/utils/buildQuoteStockSnapshot';
-import { quoteDetailListHasBackorderedItemsForDisplay } from '../quote/utils/getQuoteBackorderDisplayFields';
 import getB2BQuoteExtraFields from '../quote/utils/getQuoteExtraFields';
 import { handleQuoteCheckout } from '../quote/utils/quoteCheckout';
 
@@ -285,7 +285,7 @@ function QuoteDetail() {
 
   const [quoteDetail, setQuoteDetail] = useState<any>({});
   const [productList, setProductList] = useState<ProductInfoProps[]>([]);
-  const hasBackorderedItems = quoteDetailListHasBackorderedItemsForDisplay(productList);
+  const { hasBackorderedItems } = useQuoteDetailBackorderState(productList, quoteDetail.status);
   const [fileList, setFileList] = useState<FileObjects[]>([]);
   const [isHideQuoteCheckout, setIsHideQuoteCheckout] = useState(true);
   const [quoteValidationErrors, setQuoteValidationErrors] = useState<

--- a/apps/storefront/src/pages/quote/components/QuoteDetailTable.test.tsx
+++ b/apps/storefront/src/pages/quote/components/QuoteDetailTable.test.tsx
@@ -1,0 +1,125 @@
+import {
+  buildGlobalStateWith,
+  renderWithProviders,
+  screen,
+  userEvent,
+  waitFor,
+} from 'tests/test-utils';
+import { vi } from 'vitest';
+
+import { searchProducts } from '@/shared/service/b2b';
+
+import QuoteDetailTable from './QuoteDetailTable';
+
+type QuoteDetailTableProps = Parameters<typeof QuoteDetailTable>[0];
+
+vi.mock('@/shared/service/b2b', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/shared/service/b2b')>()),
+  searchProducts: vi.fn(),
+}));
+
+const picklistRow = {
+  id: 'item-picklist',
+  productId: 112,
+  productName: 'Pickle Kit',
+  sku: 'PK',
+  quantity: 10,
+  basePrice: 24,
+  offeredPrice: 24,
+  tax: 0,
+  optionList: '[]',
+  imageUrl: '',
+  options: [{ optionId: 100, optionName: 'PickleFest', optionLabel: 'Ice Pick', optionValue: 200 }],
+  productsSearch: {
+    inventoryTracking: 'none',
+    variants: [],
+    modifiers: [
+      {
+        id: 100,
+        type: 'product_list',
+        display_name: 'PickleFest',
+        option_values: [{ id: 200, value_data: { product_id: 555 } }],
+      },
+    ],
+  },
+};
+
+const productList = [picklistRow] as unknown as QuoteDetailTableProps['productList'];
+const getQuoteTableDetails = (async () => ({
+  edges: [{ node: picklistRow }],
+  totalCount: 1,
+})) as unknown as QuoteDetailTableProps['getQuoteTableDetails'];
+
+const sharedProps = {
+  total: 1,
+  productList,
+  getQuoteTableDetails,
+  getTaxRate: () => 0,
+  quoteReviewedBySalesRep: false,
+  displayDiscount: false,
+  currency: { token: '$', decimalToken: '.', thousandsToken: ',', decimalPlaces: 2 } as never,
+  status: 1,
+} satisfies QuoteDetailTableProps;
+
+const renderTable = (messagingEnabled: boolean) =>
+  renderWithProviders(<QuoteDetailTable {...sharedProps} />, {
+    preloadedState: {
+      global: buildGlobalStateWith({
+        backorderEnabled: true,
+        backorderDisplaySettings: {
+          showQuantityOnBackorder: true,
+          showQuantityOnHand: true,
+          showBackorderMessage: true,
+          showDefaultShippingExpectationPrompt: false,
+          defaultShippingExpectationPrompt: '',
+        },
+        featureFlags: {
+          'BACK-134.backorders_phase_1_1_control_messaging_on_storefront': messagingEnabled,
+        },
+      }),
+    },
+  });
+
+describe('QuoteDetailTable picklist backorders', () => {
+  beforeEach(() => {
+    vi.mocked(searchProducts).mockReset();
+    vi.mocked(searchProducts).mockResolvedValue({
+      productsSearch: [
+        {
+          id: 555,
+          inventoryTracking: 'product',
+          totalOnHand: 1,
+          availableToSell: 100,
+          unlimitedBackorder: false,
+          backorderMessage: 'Ice Pick ships in 3 weeks',
+        },
+      ] as never,
+    });
+  });
+
+  it('fetches the picklist child product and shows its backorder message when the toggle is on', async () => {
+    renderTable(true);
+
+    const toggle = await screen.findByText('Backorder details');
+
+    expect(searchProducts).toHaveBeenCalledWith(expect.objectContaining({ productIds: [555] }));
+
+    await userEvent.click(toggle);
+
+    await waitFor(() => {
+      expect(screen.getByText('PickleFest:')).toBeVisible();
+    });
+    expect(screen.getByText('Ice Pick ships in 3 weeks')).toBeVisible();
+  });
+
+  it('hides the backorder toggle when storefront messaging is disabled', async () => {
+    vi.mocked(searchProducts).mockResolvedValue({ productsSearch: [] });
+
+    renderTable(false);
+
+    await screen.findByText('Pickle Kit');
+
+    expect(screen.queryByText('Backorder details')).toBeNull();
+    expect(searchProducts).not.toHaveBeenCalled();
+  });
+});

--- a/apps/storefront/src/pages/quote/components/QuoteDetailTable.tsx
+++ b/apps/storefront/src/pages/quote/components/QuoteDetailTable.tsx
@@ -2,19 +2,19 @@ import { forwardRef, Ref, useImperativeHandle, useRef, useState } from 'react';
 import { Box, FormControlLabel, styled, Switch, Typography } from '@mui/material';
 
 import BackorderMessage from '@/components/BackorderMessage';
+import PicklistBackorderMessages from '@/components/PicklistBackorderMessages';
 import { B3PaginationTable, GetRequestList } from '@/components/table/B3PaginationTable';
 import { TableColumnItem } from '@/components/table/B3Table';
 import { PRODUCT_DEFAULT_IMAGE } from '@/constants';
-import { useBackorderStorefrontMessaging } from '@/hooks/useBackorderStorefrontMessaging';
-import { useFeatureFlag } from '@/hooks/useFeatureFlag';
 import { useB3Lang } from '@/lib/lang';
 import { useAppSelector } from '@/store';
 import { currencyFormatConvert } from '@/utils/b3CurrencyFormat';
 import { getBCPrice, getDisplayPrice } from '@/utils/b3Product/b3Product';
 
+import { useQuoteDetailBackorderState } from '../hooks/useQuoteDetailBackorderState';
 import {
   getQuoteBackorderDisplayFields,
-  quoteDetailListHasBackorderedItemsForDisplay,
+  getQuotePicklistSelections,
 } from '../utils/getQuoteBackorderDisplayFields';
 
 import QuoteDetailTableCard from './QuoteDetailTableCard';
@@ -122,17 +122,16 @@ function QuoteDetailTable(props: ShoppingDetailTableProps, ref: Ref<unknown>) {
     status,
   } = props;
 
-  const isOrdered = Number(status) === 4;
-  const surfaceOrderedQuoteBackorders = useFeatureFlag(
-    'BACK-593.surface_order_backorder_info_on_quotes',
-  );
-  const shouldDisplayBackorderInformation = !isOrdered || surfaceOrderedQuoteBackorders;
+  const {
+    shouldDisplayBackorderInformation,
+    backorderContextEnabled,
+    picklistProductsById,
+    hasBackorderedItems,
+  } = useQuoteDetailBackorderState(productList, status);
 
   const isEnableProduct = useAppSelector(
     ({ global }) => global.blockPendingQuoteNonPurchasableOOS.isEnableProduct,
   );
-  const { isBackorderMessagingContextEnabled, hasAnyBackorderDisplay } =
-    useBackorderStorefrontMessaging();
   const enteredInclusiveTax = useAppSelector(
     ({ storeConfigs }) => storeConfigs.currencies.enteredInclusiveTax,
   );
@@ -145,8 +144,6 @@ function QuoteDetailTable(props: ShoppingDetailTableProps, ref: Ref<unknown>) {
   });
 
   const [showBackorderDetails, setShowBackorderDetails] = useState(false);
-
-  const hasBackorderedItems = quoteDetailListHasBackorderedItemsForDisplay(productList);
 
   useImperativeHandle(ref, () => ({
     getList: () => paginationTableRef.current?.getList(),
@@ -318,21 +315,28 @@ function QuoteDetailTable(props: ShoppingDetailTableProps, ref: Ref<unknown>) {
       title: b3Lang('quoteDetail.table.qty'),
       render: (row) => {
         const backorderFields = getQuoteBackorderDisplayFields(row);
+        const picklistSelections = backorderContextEnabled ? getQuotePicklistSelections(row) : [];
 
         return (
           <Box>
             <Typography sx={{ padding: '12px 0' }}>{row.quantity}</Typography>
-            {isBackorderMessagingContextEnabled &&
-              hasAnyBackorderDisplay &&
-              shouldDisplayBackorderInformation &&
-              backorderFields && (
-                <BackorderMessage
-                  totalOnHand={backorderFields.totalOnHand}
-                  quantityBackordered={backorderFields.quantityBackordered}
-                  backorderMessage={backorderFields.backorderMessage}
-                  visible={showBackorderDetails}
-                />
-              )}
+            {backorderContextEnabled && backorderFields && (
+              <BackorderMessage
+                totalOnHand={backorderFields.totalOnHand}
+                quantityBackordered={backorderFields.quantityBackordered}
+                backorderMessage={backorderFields.backorderMessage}
+                visible={showBackorderDetails}
+              />
+            )}
+            {picklistSelections.length > 0 && (
+              <PicklistBackorderMessages
+                selections={picklistSelections}
+                picklistProductsById={picklistProductsById}
+                qty={Number(row.quantity) || 0}
+                visible={showBackorderDetails}
+                backorderUiEnabled={backorderContextEnabled}
+              />
+            )}
           </Box>
         );
       },
@@ -429,22 +433,19 @@ function QuoteDetailTable(props: ShoppingDetailTableProps, ref: Ref<unknown>) {
         >
           {b3Lang('quoteDetail.table.totalProducts', { total: total || 0 })}
         </Typography>
-        {isBackorderMessagingContextEnabled &&
-          hasAnyBackorderDisplay &&
-          shouldDisplayBackorderInformation &&
-          hasBackorderedItems && (
-            <FormControlLabel
-              control={
-                <Switch
-                  checked={showBackorderDetails}
-                  onChange={(e) => setShowBackorderDetails(e.target.checked)}
-                />
-              }
-              label={b3Lang('quoteDetail.table.backorderDetails')}
-              labelPlacement="start"
-              sx={{ mr: 0, gap: '0.5rem' }}
-            />
-          )}
+        {backorderContextEnabled && hasBackorderedItems && (
+          <FormControlLabel
+            control={
+              <Switch
+                checked={showBackorderDetails}
+                onChange={(e) => setShowBackorderDetails(e.target.checked)}
+              />
+            }
+            label={b3Lang('quoteDetail.table.backorderDetails')}
+            labelPlacement="start"
+            sx={{ mr: 0, gap: '0.5rem' }}
+          />
+        )}
       </Box>
       <B3PaginationTable
         ref={paginationTableRef}
@@ -470,6 +471,7 @@ function QuoteDetailTable(props: ShoppingDetailTableProps, ref: Ref<unknown>) {
             getTaxRate={getTaxRate}
             showBackorderDetails={showBackorderDetails}
             shouldDisplayBackorderInformation={shouldDisplayBackorderInformation}
+            picklistProductsById={picklistProductsById}
           />
         )}
       />

--- a/apps/storefront/src/pages/quote/components/QuoteDetailTableCard.tsx
+++ b/apps/storefront/src/pages/quote/components/QuoteDetailTableCard.tsx
@@ -1,16 +1,21 @@
 import { Box, CardContent, styled, Typography } from '@mui/material';
 
 import BackorderMessage from '@/components/BackorderMessage';
+import PicklistBackorderMessages from '@/components/PicklistBackorderMessages';
 import { PRODUCT_DEFAULT_IMAGE } from '@/constants';
 import { useBackorderStorefrontMessaging } from '@/hooks/useBackorderStorefrontMessaging';
 import { useFeatureFlag } from '@/hooks/useFeatureFlag';
 import { useB3Lang } from '@/lib/lang';
+import { type ProductSearch } from '@/shared/service/b2b/graphql/product';
 import { useAppSelector } from '@/store';
 import { DisplayCurrency } from '@/types/currency';
 import { currencyFormatConvert } from '@/utils/b3CurrencyFormat';
 import { getBCPrice } from '@/utils/b3Product/b3Product';
 
-import { getQuoteBackorderDisplayFields } from '../utils/getQuoteBackorderDisplayFields';
+import {
+  getQuoteBackorderDisplayFields,
+  getQuotePicklistSelections,
+} from '../utils/getQuoteBackorderDisplayFields';
 
 interface QuoteTableCardProps {
   item: any;
@@ -22,6 +27,7 @@ interface QuoteTableCardProps {
   currency: CurrencyProps | DisplayCurrency;
   showBackorderDetails?: boolean;
   shouldDisplayBackorderInformation?: boolean;
+  picklistProductsById?: Record<number, ProductSearch>;
 }
 
 const StyledImage = styled('img')(() => ({
@@ -41,6 +47,7 @@ function QuoteDetailTableCard(props: QuoteTableCardProps) {
     displayDiscount,
     showBackorderDetails = false,
     shouldDisplayBackorderInformation = true,
+    picklistProductsById = {},
   } = props;
   const b3Lang = useB3Lang();
   const isCurrencySymbolPlacementFixEnabled = useFeatureFlag(
@@ -65,6 +72,13 @@ function QuoteDetailTableCard(props: QuoteTableCardProps) {
   } = quoteTableItem;
 
   const backorderFields = getQuoteBackorderDisplayFields(quoteTableItem);
+  const backorderContextEnabled =
+    isBackorderMessagingContextEnabled &&
+    hasAnyBackorderDisplay &&
+    shouldDisplayBackorderInformation;
+  const picklistSelections = backorderContextEnabled
+    ? getQuotePicklistSelections(quoteTableItem)
+    : [];
 
   const taxRate = getTaxRate(variants);
   const taxPrice = enteredInclusiveTax
@@ -163,6 +177,15 @@ function QuoteDetailTableCard(props: QuoteTableCardProps) {
                 visible={showBackorderDetails}
               />
             )}
+          {picklistSelections.length > 0 && (
+            <PicklistBackorderMessages
+              selections={picklistSelections}
+              picklistProductsById={picklistProductsById}
+              qty={Number(quantity) || 0}
+              visible={showBackorderDetails}
+              backorderUiEnabled={backorderContextEnabled}
+            />
+          )}
           <Typography
             sx={{
               fontSize: '14px',

--- a/apps/storefront/src/pages/quote/hooks/useDraftQuoteBackorderState.ts
+++ b/apps/storefront/src/pages/quote/hooks/useDraftQuoteBackorderState.ts
@@ -10,7 +10,7 @@ import {
 
 import {
   getDraftBackorderDisplayFields,
-  getDraftQuotePicklistSelections,
+  getQuotePicklistSelections,
   resolveDraftLineProductId,
 } from '../utils/getQuoteBackorderDisplayFields';
 
@@ -45,7 +45,7 @@ export function useDraftQuoteBackorderState({
       ? items.map((item) => ({
           id: String(item.node.id),
           qty: Number(item.node.quantity) || 0,
-          selections: getDraftQuotePicklistSelections(item.node),
+          selections: getQuotePicklistSelections(item.node),
         }))
       : [];
 

--- a/apps/storefront/src/pages/quote/hooks/useQuoteDetailBackorderState.test.ts
+++ b/apps/storefront/src/pages/quote/hooks/useQuoteDetailBackorderState.test.ts
@@ -1,0 +1,103 @@
+import { waitFor } from '@testing-library/react';
+import { renderHookWithProviders } from 'tests/utils/hook-test-utils';
+
+import * as b2bService from '@/shared/service/b2b';
+
+import { useQuoteDetailBackorderState } from './useQuoteDetailBackorderState';
+
+const messaging = {
+  isBackorderMessagingContextEnabled: true,
+  hasAnyBackorderDisplay: true,
+};
+
+vi.mock('@/hooks/useBackorderStorefrontMessaging', () => ({
+  useBackorderStorefrontMessaging: () => messaging,
+}));
+
+vi.mock('@/hooks/useFeatureFlag', () => ({
+  useFeatureFlag: () => false,
+}));
+
+const picklistModifier = {
+  id: 100,
+  type: 'product_list',
+  display_name: 'PickleFest',
+  option_values: [{ id: 200, value_data: { product_id: 555 } }],
+};
+
+const backorderedLine = {
+  quantity: 10,
+  optionList: '[]',
+  productsSearch: {
+    inventoryTracking: 'product',
+    totalOnHand: 2,
+    availableToSell: 100,
+    unlimitedBackorder: false,
+    backorderMessage: 'Ships late',
+  },
+} as never;
+
+// The line itself is untracked (never backordered), so any backorder must come from the picklist child.
+const lineWithBackorderedPicklistChild = {
+  quantity: 5,
+  optionList: JSON.stringify([{ optionId: 'attribute[100]', optionValue: '200' }]),
+  productsSearch: {
+    inventoryTracking: 'none',
+    modifiers: [picklistModifier],
+  },
+} as never;
+
+const renderState = (...args: Parameters<typeof useQuoteDetailBackorderState>) =>
+  renderHookWithProviders(
+    (props: { productList: (typeof args)[0]; status: (typeof args)[1] }) =>
+      useQuoteDetailBackorderState(props.productList, props.status),
+    { initialProps: { productList: args[0], status: args[1] } },
+  );
+
+describe('useQuoteDetailBackorderState', () => {
+  beforeEach(() => {
+    vi.spyOn(b2bService, 'searchProducts').mockResolvedValue({ productsSearch: [] });
+    messaging.isBackorderMessagingContextEnabled = true;
+    messaging.hasAnyBackorderDisplay = true;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('flags the line as backordered from its stored snapshot', () => {
+    const { result } = renderState([backorderedLine], 1);
+
+    expect(result.result.current.hasBackorderedItems).toBe(true);
+  });
+
+  it('flags backorders from a picklist child even when the line itself is not backordered', async () => {
+    vi.spyOn(b2bService, 'searchProducts').mockResolvedValue({
+      productsSearch: [
+        {
+          id: 555,
+          inventoryTracking: 'product',
+          totalOnHand: 1,
+          availableToSell: 100,
+          unlimitedBackorder: false,
+          backorderMessage: 'Child ships late',
+        },
+      ],
+    });
+
+    const { result } = renderState([lineWithBackorderedPicklistChild], 1);
+
+    await waitFor(() => expect(result.result.current.picklistProductsById[555]).toBeDefined());
+    expect(result.result.current.hasBackorderedItems).toBe(true);
+  });
+
+  it('does not flag backorders or fetch inventory when the messaging context is disabled', () => {
+    messaging.isBackorderMessagingContextEnabled = false;
+
+    const { result } = renderState([lineWithBackorderedPicklistChild], 1);
+
+    expect(result.result.current.backorderContextEnabled).toBe(false);
+    expect(result.result.current.hasBackorderedItems).toBe(false);
+    expect(b2bService.searchProducts).not.toHaveBeenCalled();
+  });
+});

--- a/apps/storefront/src/pages/quote/hooks/useQuoteDetailBackorderState.ts
+++ b/apps/storefront/src/pages/quote/hooks/useQuoteDetailBackorderState.ts
@@ -1,0 +1,72 @@
+import { useMemo } from 'react';
+
+import { useBackorderStorefrontMessaging } from '@/hooks/useBackorderStorefrontMessaging';
+import { useFeatureFlag } from '@/hooks/useFeatureFlag';
+import { usePicklistInventory } from '@/hooks/usePicklistInventory';
+import { type ProductSearch } from '@/shared/service/b2b/graphql/product';
+import { QuoteStatus } from '@/shared/service/b2b/graphql/quote';
+import { catalogListHasPicklistBackorderedItemsForDisplay } from '@/utils/catalogBackorderDisplay';
+
+import {
+  getQuotePicklistSelections,
+  type QuoteBackorderRow,
+  quoteDetailListHasBackorderedItemsForDisplay,
+} from '../utils/getQuoteBackorderDisplayFields';
+
+type QuoteDetailBackorderRow = QuoteBackorderRow & Parameters<typeof getQuotePicklistSelections>[0];
+
+interface QuoteDetailBackorderState {
+  shouldDisplayBackorderInformation: boolean;
+  backorderContextEnabled: boolean;
+  picklistProductsById: Record<number, ProductSearch>;
+  hasBackorderedItems: boolean;
+}
+
+export function useQuoteDetailBackorderState(
+  productList: QuoteDetailBackorderRow[],
+  status: string | number,
+): QuoteDetailBackorderState {
+  const isOrdered = Number(status) === QuoteStatus.ORDERED;
+  const surfaceOrderedQuoteBackorders = useFeatureFlag(
+    'BACK-593.surface_order_backorder_info_on_quotes',
+  );
+  const shouldDisplayBackorderInformation = !isOrdered || surfaceOrderedQuoteBackorders;
+
+  const { isBackorderMessagingContextEnabled, hasAnyBackorderDisplay } =
+    useBackorderStorefrontMessaging();
+  const backorderContextEnabled =
+    isBackorderMessagingContextEnabled &&
+    hasAnyBackorderDisplay &&
+    shouldDisplayBackorderInformation;
+
+  const picklistProductIds = useMemo(
+    () =>
+      backorderContextEnabled
+        ? productList.flatMap((row) =>
+            getQuotePicklistSelections(row).map((selection) => selection.productId),
+          )
+        : [],
+    [productList, backorderContextEnabled],
+  );
+  const picklistProductsById = usePicklistInventory(picklistProductIds);
+
+  const hasBackorderedItems = useMemo(
+    () =>
+      quoteDetailListHasBackorderedItemsForDisplay(productList) ||
+      catalogListHasPicklistBackorderedItemsForDisplay(
+        productList.map((row) => ({
+          qty: Number(row.quantity) || 0,
+          selections: getQuotePicklistSelections(row),
+        })),
+        picklistProductsById,
+      ),
+    [productList, picklistProductsById],
+  );
+
+  return {
+    shouldDisplayBackorderInformation,
+    backorderContextEnabled,
+    picklistProductsById,
+    hasBackorderedItems,
+  };
+}

--- a/apps/storefront/src/pages/quote/utils/getQuoteBackorderDisplayFields.test.ts
+++ b/apps/storefront/src/pages/quote/utils/getQuoteBackorderDisplayFields.test.ts
@@ -5,10 +5,10 @@ import type { QuoteItem } from '@/types/quotes';
 import {
   draftRowQuantityExceedsAvailableToSell,
   getDraftBackorderDisplayFields,
-  getDraftQuotePicklistSelections,
   getQuoteBackorderDisplayFields,
   getQuoteBackorderDisplayQuantity,
   getQuoteItemBackendAvailability,
+  getQuotePicklistSelections,
   type QuoteBackorderRow,
   quoteDetailListHasBackorderedItemsForDisplay,
 } from './getQuoteBackorderDisplayFields';
@@ -434,7 +434,7 @@ describe('getQuoteBackorderDisplayFields for quote detail rows', () => {
   });
 });
 
-describe('getDraftQuotePicklistSelections', () => {
+describe('getQuotePicklistSelections', () => {
   const picklistModifier = {
     id: 100,
     type: 'product_list',
@@ -452,7 +452,7 @@ describe('getDraftQuotePicklistSelections', () => {
   it('resolves a picklist selection from camelCase attribute-keyed optionList', () => {
     const optionList = JSON.stringify([{ optionId: 'attribute[100]', optionValue: '200' }]);
 
-    expect(getDraftQuotePicklistSelections(buildRow(optionList))).toEqual([
+    expect(getQuotePicklistSelections(buildRow(optionList))).toEqual([
       { modifierId: 100, displayName: 'Pick a pickle', productId: 555 },
     ]);
   });
@@ -460,7 +460,46 @@ describe('getDraftQuotePicklistSelections', () => {
   it('resolves a picklist selection from snake_case option_id/option_value entries', () => {
     const optionList = JSON.stringify([{ option_id: 100, option_value: 200 }]);
 
-    expect(getDraftQuotePicklistSelections(buildRow(optionList))).toEqual([
+    expect(getQuotePicklistSelections(buildRow(optionList))).toEqual([
+      { modifierId: 100, displayName: 'Pick a pickle', productId: 555 },
+    ]);
+  });
+
+  it('resolves a submitted quote selection from its options', () => {
+    const row = {
+      quantity: 1,
+      options: [
+        { optionId: 100, optionValue: 200, optionName: 'PickleFest', optionLabel: 'Ice Pick' },
+      ],
+      productsSearch: { modifiers: [picklistModifier] },
+    } as unknown as QuoteItem['node'];
+
+    expect(getQuotePicklistSelections(row)).toEqual([
+      { modifierId: 100, displayName: 'Pick a pickle', productId: 555 },
+    ]);
+  });
+
+  it('resolves a submitted quote selection from snake_case option_id/option_value options', () => {
+    const row = {
+      quantity: 1,
+      options: [{ option_id: 100, option_value: 200 }],
+      productsSearch: { modifiers: [picklistModifier] },
+    } as unknown as QuoteItem['node'];
+
+    expect(getQuotePicklistSelections(row)).toEqual([
+      { modifierId: 100, displayName: 'Pick a pickle', productId: 555 },
+    ]);
+  });
+
+  it('resolves a submitted quote selection even when a leftover draft optionList is present', () => {
+    const row = {
+      quantity: 1,
+      options: [{ optionId: 100, optionValue: 200 }],
+      optionList: '[]',
+      productsSearch: { modifiers: [picklistModifier] },
+    } as unknown as QuoteItem['node'];
+
+    expect(getQuotePicklistSelections(row)).toEqual([
       { modifierId: 100, displayName: 'Pick a pickle', productId: 555 },
     ]);
   });
@@ -473,15 +512,15 @@ describe('getDraftQuotePicklistSelections', () => {
       productsSearch: { modifiers: [{ ...picklistModifier, type: 'dropdown' }] },
     } as unknown as QuoteItem['node'];
 
-    expect(getDraftQuotePicklistSelections(row)).toEqual([]);
+    expect(getQuotePicklistSelections(row)).toEqual([]);
   });
 
   it('returns an empty array when optionList is empty', () => {
-    expect(getDraftQuotePicklistSelections(buildRow('[]'))).toEqual([]);
+    expect(getQuotePicklistSelections(buildRow('[]'))).toEqual([]);
   });
 
   it('returns an empty array when optionList is not valid JSON', () => {
-    expect(getDraftQuotePicklistSelections(buildRow('not json'))).toEqual([]);
+    expect(getQuotePicklistSelections(buildRow('not json'))).toEqual([]);
   });
 
   it('skips null and primitive entries without throwing on malformed optionList', () => {
@@ -492,7 +531,7 @@ describe('getDraftQuotePicklistSelections', () => {
       { optionId: 'attribute[100]', optionValue: '200' },
     ]);
 
-    expect(getDraftQuotePicklistSelections(buildRow(optionList))).toEqual([
+    expect(getQuotePicklistSelections(buildRow(optionList))).toEqual([
       { modifierId: 100, displayName: 'Pick a pickle', productId: 555 },
     ]);
   });

--- a/apps/storefront/src/pages/quote/utils/getQuoteBackorderDisplayFields.ts
+++ b/apps/storefront/src/pages/quote/utils/getQuoteBackorderDisplayFields.ts
@@ -162,17 +162,46 @@ export function getDraftBackorderDisplayFields(
   });
 }
 
-interface DraftQuoteOptionListEntry {
+interface QuoteOptionEntry {
   option_id?: number | string;
   optionId?: number | string;
   option_value?: number | string;
   optionValue?: number | string;
 }
 
-// Draft `optionList` is a JSON string keyed {option_id|optionId, option_value|optionValue}
-// with ids shaped like "attribute[123]"; translate to the resolver's numeric-pair shape.
-function parseDraftQuoteOptionSelections(
-  optionList: string | undefined,
+// Option ids arrive either as a bare number or shaped like "attribute[123]"; normalise the id and
+// its value into a numeric { option_id, value_id } pair, or null if either can't be parsed.
+function toQuoteOptionSelection(
+  rawId: number | string | undefined,
+  rawValue: number | string | undefined,
+): { option_id: number; value_id: number } | null {
+  if (rawId == null || rawValue == null) {
+    return null;
+  }
+
+  const optionId = parseAttributeOptionId(rawId);
+  const valueId = Number(rawValue);
+  if (optionId === null || Number.isNaN(valueId)) {
+    return null;
+  }
+
+  return { option_id: optionId, value_id: valueId };
+}
+
+function quoteOptionEntriesToSelections(
+  entries: QuoteOptionEntry[],
+): Array<{ option_id: number; value_id: number }> {
+  return entries.flatMap((entry) => {
+    const selection = toQuoteOptionSelection(
+      entry.option_id ?? entry.optionId,
+      entry.option_value ?? entry.optionValue,
+    );
+    return selection ? [selection] : [];
+  });
+}
+
+function parseQuoteOptionListSelections(
+  optionList: string | null | undefined,
 ): Array<{ option_id: number; value_id: number }> {
   if (!optionList) {
     return [];
@@ -189,35 +218,28 @@ function parseDraftQuoteOptionSelections(
     return [];
   }
 
-  return (parsed as unknown[]).flatMap((item) => {
-    if (item === null || typeof item !== 'object') {
-      return [];
-    }
-
-    const entry = item as DraftQuoteOptionListEntry;
-    const rawId = entry.option_id ?? entry.optionId;
-    const rawValue = entry.option_value ?? entry.optionValue;
-    if (rawId == null || rawValue == null) {
-      return [];
-    }
-
-    const optionId = parseAttributeOptionId(rawId);
-    const valueId = Number(rawValue);
-    if (optionId === null || Number.isNaN(valueId)) {
-      return [];
-    }
-
-    return [{ option_id: optionId, value_id: valueId }];
-  });
+  const entries = parsed.filter(
+    (item): item is QuoteOptionEntry => item !== null && typeof item === 'object',
+  );
+  return quoteOptionEntriesToSelections(entries);
 }
 
-export function getDraftQuotePicklistSelections(row: QuoteItem['node']): PicklistSelection[] {
-  const source: PicklistSelectionSource = {
-    optionSelections: parseDraftQuoteOptionSelections(row.optionList),
-    productsSearch: row.productsSearch,
-  };
+// Draft rows carry selections as `optionList` (a JSON string); saved/detail rows carry them as a
+// structured `options` array. Both shapes key entries as either option_id/option_value or
+// optionId/optionValue, and both translate to the resolver's {option_id, value_id} shape.
+export function getQuotePicklistSelections(row: {
+  optionList?: string | null;
+  options?: QuoteOptionEntry[] | null;
+  productsSearch?: PicklistSelectionSource['productsSearch'];
+}): PicklistSelection[] {
+  const optionSelections = row.options?.length
+    ? quoteOptionEntriesToSelections(row.options)
+    : parseQuoteOptionListSelections(row.optionList);
 
-  return getProductDetailsForPicklistSelections(source);
+  return getProductDetailsForPicklistSelections({
+    optionSelections,
+    productsSearch: row.productsSearch,
+  });
 }
 
 export function quoteDetailListHasBackorderedItemsForDisplay(


### PR DESCRIPTION
Jira: [BACK-721](https://bigcommercecloud.atlassian.net/browse/BACK-721)

## What/Why?
Implement backorder information display for Picklisted items.

~~Please note this PR is built on https://github.com/bigcommerce/b2b-buyer-portal/pull/934~~

## Rollout/Rollback
Revert this PR if there are issues.

## Testing
Added tests:
Before:
Picklisted item for submitted quote is not showing backorder information:
<img width="1823" height="1011" alt="Screenshot 2026-06-30 at 2 45 24 pm" src="https://github.com/user-attachments/assets/484108ce-e785-46f7-87c1-9cc7a0c5958d" />

After:
Picklisted product is now showing backorder as expected.
<img width="1796" height="1000" alt="Screenshot 2026-06-30 at 2 42 28 pm" src="https://github.com/user-attachments/assets/a7bab2ef-8256-4183-b87e-ef4ab61935e1" />
Still works for non-picklist items
<img width="1857" height="987" alt="QuoteWithAndWithoutPicklist" src="https://github.com/user-attachments/assets/317082ae-44d1-4a8a-9598-05e071833775" />

Displays correctly when only parent has backorder
<img width="1796" height="998" alt="Screenshot 2026-07-15 at 10 04 45 am" src="https://github.com/user-attachments/assets/d930396c-0f33-4912-a11e-c165c4ef7042" />

Displays correctly when only child has backorder
<img width="1862" height="1003" alt="Screenshot 2026-07-15 at 9 57 47 am" src="https://github.com/user-attachments/assets/28ba7958-846d-4a45-af31-3cb2a2dd24e7" />

Still displays correctly when no backorders are required:
<img width="1806" height="980" alt="Screenshot 2026-07-15 at 10 11 10 am" src="https://github.com/user-attachments/assets/850dd255-c715-4c64-8296-4df2f1b3bb1b" />

Quote Draft:
<img width="1801" height="1001" alt="QuoteDraftWithAndWithoutPicklist" src="https://github.com/user-attachments/assets/44e4604f-0897-4267-9e2c-225121820287" />


ping @bigcommerce/team-b2b @animesh1987 @declankirk 

[BACK-721]: https://bigcommercecloud.atlassian.net/browse/BACK-721?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds live product search for picklist children and changes when backorder UI appears on quote detail; incorrect inventory or selection parsing could mislead buyers, but scope is storefront display behind existing feature flags.
> 
> **Overview**
> Submitted **quote detail** now surfaces backorder messaging for **picklist (product_list) child products**, not only the parent line’s snapshot.
> 
> A new **`useQuoteDetailBackorderState`** hook centralizes quote-detail backorder behavior: feature flags and storefront messaging gates, live inventory for picklist child IDs via **`usePicklistInventory`**, and **`hasBackorderedItems`** that includes both parent-line backorders and picklist children. **Quote detail** and the product table/card use this hook instead of duplicating checks.
> 
> **`getDraftQuotePicklistSelections`** is generalized to **`getQuotePicklistSelections`**, preferring submitted rows’ **`options`** (with draft **`optionList`** JSON as fallback). **`QuoteDetailTable`** / **`QuoteDetailTableCard`** render **`PicklistBackorderMessages`** when the backorder-details toggle is on. Draft quote backorder state reuses the renamed helper.
> 
> Tests cover the hook, table picklist fetch/display, and expanded picklist selection parsing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e517a7ccce46afb5dc45258ebed78a0c3e74aa5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->