### PR TITLE
fix(common): B2B-4912 fix pending-approval loginFlag dropped on init navigation

### DIFF
--- a/apps/storefront/src/App.tsx
+++ b/apps/storefront/src/App.tsx
@@ -216,9 +216,8 @@ export default function App() {
 
         // background login enter judgment and refresh
         const nativeLinkInterceptionEnabled =
-          store.getState().global.featureFlags[
-            'B2B-4912.buyer_portal_native_link_interception'
-          ] ?? false;
+          store.getState().global.featureFlags['B2B-4912.buyer_portal_native_link_interception'] ??
+          false;
         const shouldOpenAllowedPage = nativeLinkInterceptionEnabled
           ? shouldOpenAllowedPageOnInit({ pathname, hash: window.location.hash, customerId })
           : !pathname.includes('checkout') && !(!!customerId && !window.location.hash);

--- a/apps/storefront/src/App.tsx
+++ b/apps/storefront/src/App.tsx
@@ -216,7 +216,7 @@ export default function App() {
           }
         }
 
-        const resolvedAuthorizedPages = isB2BUser
+        const resolvedAuthorizedPages = isB2BUserSelector(store.getState())
           ? b2bJumpPath(Number(userInfo.role))
           : PATH_ROUTES.ORDERS;
 

--- a/apps/storefront/src/App.tsx
+++ b/apps/storefront/src/App.tsx
@@ -22,6 +22,7 @@ import { handleHideRegisterPage } from '@/utils/b3HideRegister';
 import { hideStorefrontElement } from '@/utils/b3HideStorefrontElement';
 import { getQuoteEnabled } from '@/utils/b3Init';
 
+import { shouldOpenAllowedPageOnInit } from '@/utils/nativeStorefrontLinks';
 import b2bVerifyBcLoginStatus from './utils/b2bVerifyBcLoginStatus';
 import { b2bJumpPath } from './utils/b3CheckPermissions/b2bPermissionPath';
 import clearInvoiceCart from './utils/b3ClearCart';
@@ -213,8 +214,15 @@ export default function App() {
         }
 
         // background login enter judgment and refresh
-        if (!pathname.includes('checkout') && !(customerId && !window.location.hash)) {
-          await gotoAllowedAppPage(Number(userInfo.role), gotoPage);
+        const shouldOpenAllowedPage = shouldOpenAllowedPageOnInit({
+          pathname,
+          hash: window.location.hash,
+          customerId,
+        });
+        const isAccountPageWithoutHash = pathname.includes('account.php') && !window.location.hash;
+
+        if (shouldOpenAllowedPage) {
+          await gotoAllowedAppPage(Number(userInfo.role), gotoPage, isAccountPageWithoutHash);
         } else {
           showPageMask(false);
         }

--- a/apps/storefront/src/App.tsx
+++ b/apps/storefront/src/App.tsx
@@ -22,6 +22,7 @@ import { handleHideRegisterPage } from '@/utils/b3HideRegister';
 import { hideStorefrontElement } from '@/utils/b3HideStorefrontElement';
 import { getQuoteEnabled } from '@/utils/b3Init';
 import { shouldOpenAllowedPageOnInit } from '@/utils/nativeStorefrontLinks';
+import { resolveInitNavigation } from '@/utils/resolveInitNavigation';
 
 import b2bVerifyBcLoginStatus from './utils/b2bVerifyBcLoginStatus';
 import { b2bJumpPath } from './utils/b3CheckPermissions/b2bPermissionPath';
@@ -203,16 +204,21 @@ export default function App() {
           role: Number(role),
           isAgenting,
         };
+        let companyLoginFlag: string | null = null;
         if (!customerId) {
           const info = await getCurrentCustomerInfo().catch((error) => {
             if (isCompanyError(error)) {
-              gotoPage(`/login?loginFlag=${error.reason}`);
+              companyLoginFlag = error.reason;
             }
           });
           if (info) {
             userInfo.role = info?.role;
           }
         }
+
+        const resolvedAuthorizedPages = isB2BUser
+          ? b2bJumpPath(Number(userInfo.role))
+          : PATH_ROUTES.ORDERS;
 
         // background login enter judgment and refresh
         const nativeLinkInterceptionEnabled =
@@ -223,23 +229,21 @@ export default function App() {
           : !pathname.includes('checkout') && !(!!customerId && !window.location.hash);
         const isAccountPageWithoutHash = pathname.includes('account.php') && !window.location.hash;
 
-        if (shouldOpenAllowedPage) {
-          if (isAccountPageWithoutHash && search) {
-            // Map native action (e.g. ?action=address_book) to the correct portal route
-            // using the same logic as runtime click interception, so direct navigation
-            // and link clicks land on the same page.
-            gotoPage(
-              openPageByClick({
-                href: `${pathname}${search}`,
-                role: Number(userInfo.role),
-                isRegisterAndLogin: false,
-                isAgenting,
-                authorizedPages,
-              }),
-            );
-          } else {
-            await gotoAllowedAppPage(Number(userInfo.role), gotoPage, isAccountPageWithoutHash);
-          }
+        const initNavigation = resolveInitNavigation({
+          companyLoginFlag,
+          shouldOpenAllowedPage,
+          isAccountPageWithoutHash,
+          pathname,
+          search,
+          role: Number(userInfo.role),
+          isAgenting,
+          authorizedPages: resolvedAuthorizedPages,
+        });
+
+        if (initNavigation.type === 'goto') {
+          gotoPage(initNavigation.url);
+        } else if (initNavigation.type === 'allowedAppPage') {
+          await gotoAllowedAppPage(Number(userInfo.role), gotoPage, isAccountPageWithoutHash);
         } else {
           showPageMask(false);
         }

--- a/apps/storefront/src/App.tsx
+++ b/apps/storefront/src/App.tsx
@@ -41,6 +41,7 @@ import {
   rolePermissionSelector,
   setGlobalCommonState,
   setOpenPageReducer,
+  store,
   useAppDispatch,
   useAppSelector,
 } from './store';
@@ -214,11 +215,13 @@ export default function App() {
         }
 
         // background login enter judgment and refresh
-        const shouldOpenAllowedPage = shouldOpenAllowedPageOnInit({
-          pathname,
-          hash: window.location.hash,
-          customerId,
-        });
+        const nativeLinkInterceptionEnabled =
+          store.getState().global.featureFlags[
+            'B2B-4912.buyer_portal_native_link_interception'
+          ] ?? false;
+        const shouldOpenAllowedPage = nativeLinkInterceptionEnabled
+          ? shouldOpenAllowedPageOnInit({ pathname, hash: window.location.hash, customerId })
+          : !pathname.includes('checkout') && !(!!customerId && !window.location.hash);
         const isAccountPageWithoutHash = pathname.includes('account.php') && !window.location.hash;
 
         if (shouldOpenAllowedPage) {

--- a/apps/storefront/src/App.tsx
+++ b/apps/storefront/src/App.tsx
@@ -21,8 +21,8 @@ import { openPageByClick, removeBCMenus } from '@/utils/b3AccountItem';
 import { handleHideRegisterPage } from '@/utils/b3HideRegister';
 import { hideStorefrontElement } from '@/utils/b3HideStorefrontElement';
 import { getQuoteEnabled } from '@/utils/b3Init';
-
 import { shouldOpenAllowedPageOnInit } from '@/utils/nativeStorefrontLinks';
+
 import b2bVerifyBcLoginStatus from './utils/b2bVerifyBcLoginStatus';
 import { b2bJumpPath } from './utils/b3CheckPermissions/b2bPermissionPath';
 import clearInvoiceCart from './utils/b3ClearCart';

--- a/apps/storefront/src/App.tsx
+++ b/apps/storefront/src/App.tsx
@@ -222,7 +222,22 @@ export default function App() {
         const isAccountPageWithoutHash = pathname.includes('account.php') && !window.location.hash;
 
         if (shouldOpenAllowedPage) {
-          await gotoAllowedAppPage(Number(userInfo.role), gotoPage, isAccountPageWithoutHash);
+          if (isAccountPageWithoutHash && search) {
+            // Map native action (e.g. ?action=address_book) to the correct portal route
+            // using the same logic as runtime click interception, so direct navigation
+            // and link clicks land on the same page.
+            gotoPage(
+              openPageByClick({
+                href: `${pathname}${search}`,
+                role: Number(userInfo.role),
+                isRegisterAndLogin: false,
+                isAgenting,
+                authorizedPages,
+              }),
+            );
+          } else {
+            await gotoAllowedAppPage(Number(userInfo.role), gotoPage, isAccountPageWithoutHash);
+          }
         } else {
           showPageMask(false);
         }

--- a/apps/storefront/src/hooks/useB3AppOpen.test.tsx
+++ b/apps/storefront/src/hooks/useB3AppOpen.test.tsx
@@ -99,6 +99,33 @@ describe('useB3AppOpen native storefront link interception', () => {
     });
   });
 
+  it('keeps the full href for a configured account.php link when the native flag is off', async () => {
+    // #checkout-customer-login is matched by id (dom.registerElement), independent of
+    // its href, so isConfiguredTarget is true regardless of the flag. Its href still
+    // looks like a native account.php link, which is what triggered the bug: without
+    // the fix, isNativeBuyerPortalLink ignored the flag and rewrote the href anyway.
+    document.body.innerHTML = `
+      <a id="checkout-customer-login" href="${window.location.origin}/account.php">Account</a>
+    `;
+    const handleEnterClick = vi.fn();
+
+    renderHookWithProviders(
+      () =>
+        useB3AppOpen({
+          isOpen: false,
+          handleEnterClick,
+          authorizedPages: '/orders',
+        }),
+      { preloadedState: { company: loggedInCompanyState } },
+    );
+
+    await userEvent.click(screen.getByRole('link'));
+
+    await waitFor(() => {
+      expect(handleEnterClick).toHaveBeenCalledWith(`${window.location.origin}/account.php`, true);
+    });
+  });
+
   it('does not intercept checkout placeholder links', async () => {
     window.history.pushState({}, '', '/checkout');
     document.body.innerHTML = '<a href="#">Continue</a>';

--- a/apps/storefront/src/hooks/useB3AppOpen.test.tsx
+++ b/apps/storefront/src/hooks/useB3AppOpen.test.tsx
@@ -1,0 +1,94 @@
+import { waitFor } from '@testing-library/react';
+import { buildCompanyStateWith, userEvent } from 'tests/test-utils';
+import { renderHookWithProviders } from 'tests/utils/hook-test-utils';
+
+import { CustomerRole } from '@/types';
+
+import { useB3AppOpen } from './useB3AppOpen';
+
+const loggedInCompanyState = buildCompanyStateWith({
+  customer: {
+    id: 123,
+    role: CustomerRole.ADMIN,
+  },
+});
+
+describe('useB3AppOpen native storefront link interception', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    window.history.pushState({}, '', '/');
+  });
+
+  it('intercepts child clicks inside account anchors', async () => {
+    document.body.innerHTML = `
+      <a class="navUser-action" href="${window.location.origin}/account.php?action=order_status">
+        <span class="navUser-item-accountLabel">Account</span>
+      </a>
+    `;
+    const handleEnterClick = vi.fn();
+
+    renderHookWithProviders(
+      () =>
+        useB3AppOpen({
+          isOpen: false,
+          handleEnterClick,
+          authorizedPages: '/orders',
+        }),
+      { preloadedState: { company: loggedInCompanyState } },
+    );
+
+    await userEvent.click(document.querySelector('.navUser-item-accountLabel') as HTMLElement);
+
+    await waitFor(() => {
+      expect(handleEnterClick).toHaveBeenCalledWith('/account.php?action=order_status', false);
+    });
+  });
+
+  it('intercepts same-origin absolute account links without navUser classes', async () => {
+    document.body.innerHTML = `
+      <li class="menu-item">
+        <a href="${window.location.origin}/account.php">Account</a>
+      </li>
+    `;
+    const handleEnterClick = vi.fn();
+
+    renderHookWithProviders(
+      () =>
+        useB3AppOpen({
+          isOpen: false,
+          handleEnterClick,
+          authorizedPages: '/orders',
+        }),
+      { preloadedState: { company: loggedInCompanyState } },
+    );
+
+    await userEvent.click(document.querySelector('a[href]') as HTMLElement);
+
+    await waitFor(() => {
+      expect(handleEnterClick).toHaveBeenCalledWith('/account.php', false);
+    });
+  });
+
+  it('does not intercept checkout placeholder links', async () => {
+    window.history.pushState({}, '', '/checkout');
+    document.body.innerHTML = '<a href="#">Continue</a>';
+    const handleEnterClick = vi.fn();
+
+    renderHookWithProviders(
+      () =>
+        useB3AppOpen({
+          isOpen: false,
+          handleEnterClick,
+          authorizedPages: '/orders',
+        }),
+      { preloadedState: { company: loggedInCompanyState } },
+    );
+
+    await userEvent.click(document.querySelector('a[href]') as HTMLElement);
+
+    // Drain microtasks before asserting absence
+    await Promise.resolve();
+
+    expect(handleEnterClick).not.toHaveBeenCalled();
+  });
+});

--- a/apps/storefront/src/hooks/useB3AppOpen.test.tsx
+++ b/apps/storefront/src/hooks/useB3AppOpen.test.tsx
@@ -1,4 +1,4 @@
-import { waitFor } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import { buildCompanyStateWith, userEvent } from 'tests/test-utils';
 import { renderHookWithProviders } from 'tests/utils/hook-test-utils';
 
@@ -37,7 +37,7 @@ describe('useB3AppOpen native storefront link interception', () => {
       { preloadedState: { company: loggedInCompanyState } },
     );
 
-    await userEvent.click(document.querySelector('.navUser-item-accountLabel') as HTMLElement);
+    await userEvent.click(screen.getByText('Account'));
 
     await waitFor(() => {
       expect(handleEnterClick).toHaveBeenCalledWith('/account.php?action=order_status', false);
@@ -62,7 +62,7 @@ describe('useB3AppOpen native storefront link interception', () => {
       { preloadedState: { company: loggedInCompanyState } },
     );
 
-    await userEvent.click(document.querySelector('a[href]') as HTMLElement);
+    await userEvent.click(screen.getByRole('link'));
 
     await waitFor(() => {
       expect(handleEnterClick).toHaveBeenCalledWith('/account.php', false);
@@ -84,7 +84,7 @@ describe('useB3AppOpen native storefront link interception', () => {
       { preloadedState: { company: loggedInCompanyState } },
     );
 
-    await userEvent.click(document.querySelector('a[href]') as HTMLElement);
+    await userEvent.click(screen.getByRole('link'));
 
     // Drain microtasks before asserting absence
     await Promise.resolve();

--- a/apps/storefront/src/hooks/useB3AppOpen.test.tsx
+++ b/apps/storefront/src/hooks/useB3AppOpen.test.tsx
@@ -1,5 +1,5 @@
 import { screen, waitFor } from '@testing-library/react';
-import { buildCompanyStateWith, userEvent } from 'tests/test-utils';
+import { buildCompanyStateWith, buildGlobalStateWith, userEvent } from 'tests/test-utils';
 import { renderHookWithProviders } from 'tests/utils/hook-test-utils';
 
 import { CustomerRole } from '@/types';
@@ -15,7 +15,9 @@ const loggedInCompanyState = buildCompanyStateWith({
 
 const withNativeLinkInterception = {
   company: loggedInCompanyState,
-  global: { featureFlags: { 'B2B-4912.buyer_portal_native_link_interception': true } },
+  global: buildGlobalStateWith({
+    featureFlags: { 'B2B-4912.buyer_portal_native_link_interception': true },
+  }),
 };
 
 describe('useB3AppOpen native storefront link interception', () => {

--- a/apps/storefront/src/hooks/useB3AppOpen.test.tsx
+++ b/apps/storefront/src/hooks/useB3AppOpen.test.tsx
@@ -76,6 +76,29 @@ describe('useB3AppOpen native storefront link interception', () => {
     });
   });
 
+  it('keeps the full href for configured elements that are not native buyer-portal links', async () => {
+    document.body.innerHTML = `
+      <a id="checkout-customer-login" href="${window.location.origin}/#/orders">Login</a>
+    `;
+    const handleEnterClick = vi.fn();
+
+    renderHookWithProviders(
+      () =>
+        useB3AppOpen({
+          isOpen: false,
+          handleEnterClick,
+          authorizedPages: '/orders',
+        }),
+      { preloadedState: { company: loggedInCompanyState } },
+    );
+
+    await userEvent.click(screen.getByRole('link'));
+
+    await waitFor(() => {
+      expect(handleEnterClick).toHaveBeenCalledWith(`${window.location.origin}/#/orders`, true);
+    });
+  });
+
   it('does not intercept checkout placeholder links', async () => {
     window.history.pushState({}, '', '/checkout');
     document.body.innerHTML = '<a href="#">Continue</a>';

--- a/apps/storefront/src/hooks/useB3AppOpen.test.tsx
+++ b/apps/storefront/src/hooks/useB3AppOpen.test.tsx
@@ -13,6 +13,11 @@ const loggedInCompanyState = buildCompanyStateWith({
   },
 });
 
+const withNativeLinkInterception = {
+  company: loggedInCompanyState,
+  global: { featureFlags: { 'B2B-4912.buyer_portal_native_link_interception': true } },
+};
+
 describe('useB3AppOpen native storefront link interception', () => {
   beforeEach(() => {
     document.body.innerHTML = '';
@@ -34,7 +39,7 @@ describe('useB3AppOpen native storefront link interception', () => {
           handleEnterClick,
           authorizedPages: '/orders',
         }),
-      { preloadedState: { company: loggedInCompanyState } },
+      { preloadedState: withNativeLinkInterception },
     );
 
     await userEvent.click(screen.getByText('Account'));
@@ -59,7 +64,7 @@ describe('useB3AppOpen native storefront link interception', () => {
           handleEnterClick,
           authorizedPages: '/orders',
         }),
-      { preloadedState: { company: loggedInCompanyState } },
+      { preloadedState: withNativeLinkInterception },
     );
 
     await userEvent.click(screen.getByRole('link'));

--- a/apps/storefront/src/hooks/useB3AppOpen.ts
+++ b/apps/storefront/src/hooks/useB3AppOpen.ts
@@ -25,6 +25,10 @@ const useB3AppOpen = (initOpenState: OpenPageState) => {
     setCheckoutRegisterNumber(() => checkoutRegisterNumber + 1);
   }, [checkoutRegisterNumber]);
   const role = useAppSelector((state) => state.company.customer.role);
+  const isNativeLinkInterceptionEnabled = useAppSelector(
+    ({ global }) =>
+      global.featureFlags['B2B-4912.buyer_portal_native_link_interception'] ?? false,
+  );
   const authorizedPages = initOpenState?.authorizedPages || '/orders';
 
   const [openPage, setOpenPage] = useState<OpenPageState>({
@@ -101,7 +105,7 @@ const useB3AppOpen = (initOpenState: OpenPageState) => {
       const nativePath = anchor ? getNativeStorefrontPath(anchor.href) : null;
       const isNativeBuyerPortalLink = anchor ? isBuyerPortalNativeHref(anchor.href) : false;
 
-      if (isConfiguredTarget || isNativeBuyerPortalLink) {
+      if (isConfiguredTarget || (isNativeLinkInterceptionEnabled && isNativeBuyerPortalLink)) {
         const isSearchNode = handleJudgeSearchNode(e);
         const isCheckoutNormalHref = handleJudgeCheckoutNormalHref(e, anchor);
 
@@ -172,7 +176,7 @@ const useB3AppOpen = (initOpenState: OpenPageState) => {
       });
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [checkoutRegisterNumber, initOpenState, role]);
+  }, [checkoutRegisterNumber, initOpenState, isNativeLinkInterceptionEnabled, role]);
 
   useMutationObservable(config['dom.checkoutRegisterParentElement'], callback);
 

--- a/apps/storefront/src/hooks/useB3AppOpen.ts
+++ b/apps/storefront/src/hooks/useB3AppOpen.ts
@@ -5,7 +5,6 @@ import config from '@/lib/config';
 import { useAppSelector } from '@/store';
 import { CustomerRole } from '@/types';
 import { OpenPageState } from '@/types/hooks';
-
 import {
   getClosestAnchorFromTarget,
   getNativeStorefrontPath,
@@ -109,7 +108,8 @@ const useB3AppOpen = (initOpenState: OpenPageState) => {
         if (isSearchNode || isCheckoutNormalHref) return false;
         e.preventDefault();
         e.stopPropagation();
-        const isRegisterArrInclude = registerArr.includes(target) || (anchor ? registerArr.includes(anchor) : false);
+        const isRegisterArrInclude =
+          registerArr.includes(target) || (anchor ? registerArr.includes(anchor) : false);
         const tagHref = nativePath || anchor?.href || (e.target as HTMLAnchorElement)?.href;
         let href = tagHref || authorizedPages;
         if (!tagHref || typeof tagHref !== 'string') {

--- a/apps/storefront/src/hooks/useB3AppOpen.ts
+++ b/apps/storefront/src/hooks/useB3AppOpen.ts
@@ -69,12 +69,15 @@ const useB3AppOpen = (initOpenState: OpenPageState) => {
     return isSearchNode;
   };
 
-  const handleJudgeCheckoutNormalHref = (element: MouseEvent) => {
+  const handleJudgeCheckoutNormalHref = (
+    element: MouseEvent,
+    anchor: HTMLAnchorElement | null,
+  ) => {
     if (window?.location?.pathname !== CHECKOUT_URL) return false;
 
     const target = element.target as HTMLAnchorElement;
 
-    if (target.getAttribute('href') && target.getAttribute('href') === '#') return true;
+    if (target.getAttribute('href') === '#' || anchor?.getAttribute('href') === '#') return true;
 
     return false;
   };
@@ -103,7 +106,7 @@ const useB3AppOpen = (initOpenState: OpenPageState) => {
 
       if (isConfiguredTarget || isNativeBuyerPortalLink) {
         const isSearchNode = handleJudgeSearchNode(e);
-        const isCheckoutNormalHref = handleJudgeCheckoutNormalHref(e);
+        const isCheckoutNormalHref = handleJudgeCheckoutNormalHref(e, anchor);
 
         if (isSearchNode || isCheckoutNormalHref) return false;
         e.preventDefault();

--- a/apps/storefront/src/hooks/useB3AppOpen.ts
+++ b/apps/storefront/src/hooks/useB3AppOpen.ts
@@ -6,6 +6,12 @@ import { useAppSelector } from '@/store';
 import { CustomerRole } from '@/types';
 import { OpenPageState } from '@/types/hooks';
 
+import {
+  getClosestAnchorFromTarget,
+  getNativeStorefrontPath,
+  isBuyerPortalNativeHref,
+} from '@/utils/nativeStorefrontLinks';
+
 import useMutationObservable from './useMutationObservable';
 
 interface ChildNodeListProps extends ChildNode {
@@ -86,80 +92,85 @@ const useB3AppOpen = (initOpenState: OpenPageState) => {
         : [],
     );
 
-    if (registerArr.length || allOtherArr.length) {
-      const handleTriggerClick = (e: MouseEvent) => {
-        if (
-          registerArr.includes(e.target as Element) ||
-          allOtherArr.includes(e.target as Element)
-        ) {
-          const isSearchNode = handleJudgeSearchNode(e);
-          const isCheckoutNormalHref = handleJudgeCheckoutNormalHref(e);
+    const handleTriggerClick = (e: MouseEvent) => {
+      const anchor = getClosestAnchorFromTarget(e.target);
+      const target = e.target as Element;
+      const isConfiguredTarget =
+        registerArr.includes(target) ||
+        allOtherArr.includes(target) ||
+        (anchor ? registerArr.includes(anchor) || allOtherArr.includes(anchor) : false);
+      const nativePath = anchor ? getNativeStorefrontPath(anchor.href) : null;
+      const isNativeBuyerPortalLink = anchor ? isBuyerPortalNativeHref(anchor.href) : false;
 
-          if (isSearchNode || isCheckoutNormalHref) return false;
-          e.preventDefault();
-          e.stopPropagation();
-          const isRegisterArrInclude = registerArr.includes(e.target as Element);
-          const tagHref = (e.target as HTMLAnchorElement)?.href;
-          let href = tagHref || authorizedPages;
-          if (!tagHref || typeof tagHref !== 'string') {
-            let parentNode = (e.target as HTMLAnchorElement)?.parentNode;
-            let parentHref = (parentNode as HTMLAnchorElement)?.href;
-            let number = 0;
-            while (number < 3 && !parentHref) {
-              parentNode = (parentNode as HTMLAnchorElement)?.parentNode;
-              const newUrl = (parentNode as HTMLAnchorElement)?.href;
-              if (newUrl && typeof newUrl === 'string') {
-                parentHref = newUrl;
-                number += 3;
-              } else {
-                number += 1;
-              }
-            }
-            if (parentHref) {
-              href = parentHref || authorizedPages;
+      if (isConfiguredTarget || isNativeBuyerPortalLink) {
+        const isSearchNode = handleJudgeSearchNode(e);
+        const isCheckoutNormalHref = handleJudgeCheckoutNormalHref(e);
+
+        if (isSearchNode || isCheckoutNormalHref) return false;
+        e.preventDefault();
+        e.stopPropagation();
+        const isRegisterArrInclude = registerArr.includes(target) || (anchor ? registerArr.includes(anchor) : false);
+        const tagHref = nativePath || anchor?.href || (e.target as HTMLAnchorElement)?.href;
+        let href = tagHref || authorizedPages;
+        if (!tagHref || typeof tagHref !== 'string') {
+          let parentNode = (e.target as HTMLAnchorElement)?.parentNode;
+          let parentHref = (parentNode as HTMLAnchorElement)?.href;
+          let number = 0;
+          while (number < 3 && !parentHref) {
+            parentNode = (parentNode as HTMLAnchorElement)?.parentNode;
+            const newUrl = (parentNode as HTMLAnchorElement)?.href;
+            if (newUrl && typeof newUrl === 'string') {
+              parentHref = newUrl;
+              number += 3;
             } else {
-              const childNodeList = (e.target as HTMLAnchorElement)?.childNodes;
-              if (childNodeList.length > 0) {
-                childNodeList.forEach((node: ChildNodeListProps) => {
-                  const nodeHref = node?.href;
-                  if (nodeHref && node.localName === 'a') {
-                    href = nodeHref || authorizedPages;
-                  }
-                });
-              }
+              number += 1;
             }
           }
-
-          const isLogin = role !== CustomerRole.GUEST;
-          const hrefArr = href.split('/#');
-          if (hrefArr[1] === '') {
-            href = isLogin ? authorizedPages : '/login';
-          }
-
-          if (
-            isLogin &&
-            href.includes('/login') &&
-            !href.includes('action=create_account') &&
-            !href.includes('action=logout')
-          ) {
-            href = authorizedPages;
-          }
-
-          if (initOpenState?.handleEnterClick) {
-            initOpenState.handleEnterClick(href, isRegisterArrInclude);
+          if (parentHref) {
+            href = parentHref || authorizedPages;
+          } else {
+            const childNodeList = (e.target as HTMLAnchorElement)?.childNodes;
+            if (childNodeList.length > 0) {
+              childNodeList.forEach((node: ChildNodeListProps) => {
+                const nodeHref = node?.href;
+                if (nodeHref && node.localName === 'a') {
+                  href = nodeHref || authorizedPages;
+                }
+              });
+            }
           }
         }
-        return false;
-      };
 
-      window.addEventListener('click', handleTriggerClick, {
+        const isLogin = role !== CustomerRole.GUEST;
+        const hrefArr = href.split('/#');
+        if (hrefArr[1] === '') {
+          href = isLogin ? authorizedPages : '/login';
+        }
+
+        if (
+          isLogin &&
+          href.includes('/login') &&
+          !href.includes('action=create_account') &&
+          !href.includes('action=logout')
+        ) {
+          href = authorizedPages;
+        }
+
+        if (initOpenState?.handleEnterClick) {
+          initOpenState.handleEnterClick(href, isRegisterArrInclude);
+        }
+      }
+      return false;
+    };
+
+    window.addEventListener('click', handleTriggerClick, {
+      capture: true,
+    });
+    return () => {
+      window.removeEventListener('click', handleTriggerClick, {
         capture: true,
       });
-      return () => {
-        window.removeEventListener('click', handleTriggerClick);
-      };
-    }
-    return () => {};
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [checkoutRegisterNumber, initOpenState, role]);
 

--- a/apps/storefront/src/hooks/useB3AppOpen.ts
+++ b/apps/storefront/src/hooks/useB3AppOpen.ts
@@ -26,8 +26,7 @@ const useB3AppOpen = (initOpenState: OpenPageState) => {
   }, [checkoutRegisterNumber]);
   const role = useAppSelector((state) => state.company.customer.role);
   const isNativeLinkInterceptionEnabled = useAppSelector(
-    ({ global }) =>
-      global.featureFlags['B2B-4912.buyer_portal_native_link_interception'] ?? false,
+    ({ global }) => global.featureFlags['B2B-4912.buyer_portal_native_link_interception'] ?? false,
   );
   const authorizedPages = initOpenState?.authorizedPages || '/orders';
 

--- a/apps/storefront/src/hooks/useB3AppOpen.ts
+++ b/apps/storefront/src/hooks/useB3AppOpen.ts
@@ -101,10 +101,12 @@ const useB3AppOpen = (initOpenState: OpenPageState) => {
         registerArr.includes(target) ||
         allOtherArr.includes(target) ||
         (anchor ? registerArr.includes(anchor) || allOtherArr.includes(anchor) : false);
-      const nativePath = anchor ? getNativeStorefrontPath(anchor.href) : null;
-      const isNativeBuyerPortalLink = anchor ? isBuyerPortalNativeHref(anchor.href) : false;
+      const isNativeBuyerPortalLink =
+        isNativeLinkInterceptionEnabled && anchor ? isBuyerPortalNativeHref(anchor.href) : false;
+      const nativePath =
+        isNativeBuyerPortalLink && anchor ? getNativeStorefrontPath(anchor.href) : null;
 
-      if (isConfiguredTarget || (isNativeLinkInterceptionEnabled && isNativeBuyerPortalLink)) {
+      if (isConfiguredTarget || isNativeBuyerPortalLink) {
         const isSearchNode = handleJudgeSearchNode(e);
         const isCheckoutNormalHref = handleJudgeCheckoutNormalHref(e, anchor);
 

--- a/apps/storefront/src/hooks/useB3AppOpen.ts
+++ b/apps/storefront/src/hooks/useB3AppOpen.ts
@@ -69,10 +69,7 @@ const useB3AppOpen = (initOpenState: OpenPageState) => {
     return isSearchNode;
   };
 
-  const handleJudgeCheckoutNormalHref = (
-    element: MouseEvent,
-    anchor: HTMLAnchorElement | null,
-  ) => {
+  const handleJudgeCheckoutNormalHref = (element: MouseEvent, anchor: HTMLAnchorElement | null) => {
     if (window?.location?.pathname !== CHECKOUT_URL) return false;
 
     const target = element.target as HTMLAnchorElement;

--- a/apps/storefront/src/hooks/useB3AppOpen.ts
+++ b/apps/storefront/src/hooks/useB3AppOpen.ts
@@ -113,7 +113,10 @@ const useB3AppOpen = (initOpenState: OpenPageState) => {
         e.stopPropagation();
         const isRegisterArrInclude =
           registerArr.includes(target) || (anchor ? registerArr.includes(anchor) : false);
-        const tagHref = nativePath || anchor?.href || (e.target as HTMLAnchorElement)?.href;
+        const tagHref =
+          (isNativeBuyerPortalLink ? nativePath : null) ||
+          anchor?.href ||
+          (e.target as HTMLAnchorElement)?.href;
         let href = tagHref || authorizedPages;
         if (!tagHref || typeof tagHref !== 'string') {
           let parentNode = (e.target as HTMLAnchorElement)?.parentNode;

--- a/apps/storefront/src/load-functions.test.ts
+++ b/apps/storefront/src/load-functions.test.ts
@@ -14,7 +14,7 @@ describe('bindLinks', () => {
     unbindLinks();
   });
 
-  it('intercepts account link child clicks and replays the anchor after init', async () => {
+  it('intercepts account link child clicks and stores the resolved anchor element', async () => {
     document.body.innerHTML = `
       <a class="navUser-action" href="/account.php">
         <span class="navUser-item-accountLabel">Account</span>

--- a/apps/storefront/src/load-functions.test.ts
+++ b/apps/storefront/src/load-functions.test.ts
@@ -1,0 +1,51 @@
+vi.mock('./react-setup', () => ({}));
+
+const importLoadFunctions = async () => import('./load-functions');
+
+describe('bindLinks', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    document.body.innerHTML = '';
+    window.history.pushState({}, '', '/');
+  });
+
+  afterEach(async () => {
+    const { unbindLinks } = await importLoadFunctions();
+    unbindLinks();
+  });
+
+  it('intercepts account link child clicks and replays the anchor after init', async () => {
+    document.body.innerHTML = `
+      <a class="navUser-action" href="/account.php">
+        <span class="navUser-item-accountLabel">Account</span>
+      </a>
+    `;
+    const { bindLinks } = await importLoadFunctions();
+    const span = document.querySelector('.navUser-item-accountLabel');
+    const anchor = document.querySelector('.navUser-action');
+    const click = new MouseEvent('click', { bubbles: true, cancelable: true });
+
+    bindLinks();
+    span?.dispatchEvent(click);
+
+    expect(click.defaultPrevented).toBe(true);
+    expect(window.b2b.initializationEnvironment.clickedLinkElement).toBe(anchor);
+  });
+
+  it('intercepts same-origin absolute account links even without navUser classes', async () => {
+    document.body.innerHTML = `
+      <li class="menu-item">
+        <a href="${window.location.origin}/account.php">Account</a>
+      </li>
+    `;
+    const { bindLinks } = await importLoadFunctions();
+    const anchor = document.querySelector('a[href]');
+    const click = new MouseEvent('click', { bubbles: true, cancelable: true });
+
+    bindLinks();
+    anchor?.dispatchEvent(click);
+
+    expect(click.defaultPrevented).toBe(true);
+    expect(window.b2b.initializationEnvironment.clickedLinkElement).toBe(anchor);
+  });
+});

--- a/apps/storefront/src/load-functions.test.ts
+++ b/apps/storefront/src/load-functions.test.ts
@@ -11,7 +11,7 @@ describe('bindLinks', () => {
 
   afterEach(async () => {
     const { unbindLinks } = await importLoadFunctions();
-    unbindLinks();
+    unbindLinks(true);
   });
 
   it('intercepts account link child clicks and stores the resolved anchor element', async () => {
@@ -42,7 +42,7 @@ describe('bindLinks', () => {
     const anchor = document.querySelector('a[href]');
     const click = new MouseEvent('click', { bubbles: true, cancelable: true });
 
-    bindLinks();
+    bindLinks(true);
     anchor?.dispatchEvent(click);
 
     expect(click.defaultPrevented).toBe(true);

--- a/apps/storefront/src/load-functions.ts
+++ b/apps/storefront/src/load-functions.ts
@@ -62,19 +62,23 @@ const clickNativeBuyerPortalLink = async (e: MouseEvent) => {
   await clickLink(e);
 };
 
-export const bindLinks = () => {
+export const bindLinks = (nativeLinkInterceptionEnabled = false) => {
   const links: NodeListOf<HTMLAnchorElement> = document.querySelectorAll(
     `${config['dom.registerElement']}, ${config['dom.allOtherElement']}`,
   );
 
-  document.addEventListener('click', clickNativeBuyerPortalLink, { capture: true });
+  if (nativeLinkInterceptionEnabled) {
+    document.addEventListener('click', clickNativeBuyerPortalLink, { capture: true });
+  }
   links.forEach((accessLink) => accessLink.addEventListener('click', clickLink));
 };
-export const unbindLinks = () => {
+export const unbindLinks = (nativeLinkInterceptionEnabled = false) => {
   const links: NodeListOf<HTMLAnchorElement> = document.querySelectorAll(
     `${config['dom.registerElement']}, ${config['dom.allOtherElement']}`,
   );
 
-  document.removeEventListener('click', clickNativeBuyerPortalLink, { capture: true });
+  if (nativeLinkInterceptionEnabled) {
+    document.removeEventListener('click', clickNativeBuyerPortalLink, { capture: true });
+  }
   links.forEach((accessLink) => accessLink.removeEventListener('click', clickLink));
 };

--- a/apps/storefront/src/load-functions.ts
+++ b/apps/storefront/src/load-functions.ts
@@ -1,4 +1,5 @@
 import config from '@/lib/config';
+import { getClosestAnchorFromTarget, isBuyerPortalNativeHref } from '@/utils/nativeStorefrontLinks';
 
 export const requestIdleCallbackFunction: typeof window.requestIdleCallback =
   window.requestIdleCallback
@@ -44,10 +45,21 @@ export const initApp = async () => {
 };
 
 const clickLink = async (e: MouseEvent) => {
-  window.b2b.initializationEnvironment.clickedLinkElement = e.target as HTMLElement;
+  const anchor = getClosestAnchorFromTarget(e.target);
+  window.b2b.initializationEnvironment.clickedLinkElement = anchor || (e.target as HTMLElement);
   e.preventDefault();
   e.stopPropagation();
   await initApp();
+};
+
+const clickNativeBuyerPortalLink = async (e: MouseEvent) => {
+  const anchor = getClosestAnchorFromTarget(e.target);
+
+  if (!anchor || !isBuyerPortalNativeHref(anchor.href)) {
+    return;
+  }
+
+  await clickLink(e);
 };
 
 export const bindLinks = () => {
@@ -55,6 +67,7 @@ export const bindLinks = () => {
     `${config['dom.registerElement']}, ${config['dom.allOtherElement']}`,
   );
 
+  document.addEventListener('click', clickNativeBuyerPortalLink, { capture: true });
   links.forEach((accessLink) => accessLink.addEventListener('click', clickLink));
 };
 export const unbindLinks = () => {
@@ -62,5 +75,6 @@ export const unbindLinks = () => {
     `${config['dom.registerElement']}, ${config['dom.allOtherElement']}`,
   );
 
+  document.removeEventListener('click', clickNativeBuyerPortalLink, { capture: true });
   links.forEach((accessLink) => accessLink.removeEventListener('click', clickLink));
 };

--- a/apps/storefront/src/main.ts
+++ b/apps/storefront/src/main.ts
@@ -53,6 +53,10 @@ window.b2b = {
     // load the app when the browser is free
     requestIdleCallbackFunction(initApp);
     // and bind links to load the app
+    // TODO(B2B-4912): once buyer_portal_native_link_interception is fully rolled
+    // out and the flag is removed, drop isNativeLinkInterceptionCached() and the
+    // nativeLinkInterceptionEnabled param from bindLinks/unbindLinks (see
+    // nativeStorefrontLinks.ts for the matching cache-write side to remove too).
     const nativeLinkInterceptionEnabled = isNativeLinkInterceptionCached();
     bindLinks(nativeLinkInterceptionEnabled);
     window.addEventListener('beforeunload', () => unbindLinks(nativeLinkInterceptionEnabled));

--- a/apps/storefront/src/main.ts
+++ b/apps/storefront/src/main.ts
@@ -1,3 +1,4 @@
+import { isNativeLinkInterceptionCached } from './utils/nativeStorefrontLinks';
 import { injectPreMountLoginMask, shouldUseDefaultLoginStyling } from './utils/preMountLoginMask';
 import { bindLinks, initApp, requestIdleCallbackFunction, unbindLinks } from './load-functions';
 
@@ -52,11 +53,12 @@ window.b2b = {
     // load the app when the browser is free
     requestIdleCallbackFunction(initApp);
     // and bind links to load the app
-    bindLinks();
-    window.addEventListener('beforeunload', () => unbindLinks());
+    const nativeLinkInterceptionEnabled = isNativeLinkInterceptionCached();
+    bindLinks(nativeLinkInterceptionEnabled);
+    window.addEventListener('beforeunload', () => unbindLinks(nativeLinkInterceptionEnabled));
     // and observe global flag to simulate click
     window.b2b.initializationEnvironment.isInitListener = () => {
-      unbindLinks();
+      unbindLinks(nativeLinkInterceptionEnabled);
       setTimeout(() => window.b2b.initializationEnvironment.clickedLinkElement?.click(), 0);
     };
   }

--- a/apps/storefront/src/main.ts
+++ b/apps/storefront/src/main.ts
@@ -53,7 +53,7 @@ window.b2b = {
     requestIdleCallbackFunction(initApp);
     // and bind links to load the app
     bindLinks();
-    window.addEventListener('beforeunload', unbindLinks);
+    window.addEventListener('beforeunload', () => unbindLinks());
     // and observe global flag to simulate click
     window.b2b.initializationEnvironment.isInitListener = () => {
       unbindLinks();

--- a/apps/storefront/src/utils/featureFlags.ts
+++ b/apps/storefront/src/utils/featureFlags.ts
@@ -55,6 +55,10 @@ export const featureFlags = [
     key: 'BACK-593.surface_order_backorder_info_on_quotes',
     name: 'surfaceOrderBackorderInfoOnQuotes',
   },
+  {
+    key: 'B2B-4912.buyer_portal_native_link_interception',
+    name: 'buyerPortalNativeLinkInterception',
+  },
 ] as const;
 
 export type FeatureFlagKey = (typeof featureFlags)[number]['key'];

--- a/apps/storefront/src/utils/nativeStorefrontLinks.test.ts
+++ b/apps/storefront/src/utils/nativeStorefrontLinks.test.ts
@@ -49,6 +49,12 @@ describe('getNativeStorefrontPath', () => {
       getNativeStorefrontPath('https://other.example.com/account.php', 'https://store.example.com'),
     ).toBeNull();
   });
+
+  it('preserves hash fragment so runtime clicks do not lose fragment targets', () => {
+    expect(getNativeStorefrontPath('/account.php#invoice123', 'https://store.example.com')).toBe(
+      '/account.php#invoice123',
+    );
+  });
 });
 
 describe('isBuyerPortalNativeHref', () => {
@@ -74,6 +80,10 @@ describe('isBuyerPortalNativeHref', () => {
     expect(
       isBuyerPortalNativeHref('https://other.example.com/account.php', 'https://store.example.com'),
     ).toBe(false);
+  });
+
+  it('matches account.php URLs that include a hash fragment', () => {
+    expect(isBuyerPortalNativeHref('/account.php#section', 'https://store.example.com')).toBe(true);
   });
 });
 
@@ -118,7 +128,7 @@ describe('shouldOpenAllowedPageOnInit', () => {
     ).toBe(true);
   });
 
-  it('opens on account.php even when the URL has a native query string', () => {
+  it('opens on account.php without a hash regardless of native query string (pathname strips search)', () => {
     expect(
       shouldOpenAllowedPageOnInit({
         pathname: '/account.php',

--- a/apps/storefront/src/utils/nativeStorefrontLinks.test.ts
+++ b/apps/storefront/src/utils/nativeStorefrontLinks.test.ts
@@ -163,4 +163,10 @@ describe('shouldOpenAllowedPageOnInit', () => {
       }),
     ).toBe(true);
   });
+
+  it('does not force-open on login.php for a logged-in user without a hash', () => {
+    expect(shouldOpenAllowedPageOnInit({ pathname: '/login.php', hash: '', customerId: 123 })).toBe(
+      false,
+    );
+  });
 });

--- a/apps/storefront/src/utils/nativeStorefrontLinks.test.ts
+++ b/apps/storefront/src/utils/nativeStorefrontLinks.test.ts
@@ -1,0 +1,97 @@
+import {
+  getClosestAnchorFromTarget,
+  getNativeStorefrontPath,
+  isBuyerPortalNativeHref,
+  shouldOpenAllowedPageOnInit,
+} from './nativeStorefrontLinks';
+
+describe('getClosestAnchorFromTarget', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('returns the parent anchor when the clicked target is a child span', () => {
+    document.body.innerHTML = `
+      <a class="navUser-action" href="/account.php">
+        <span class="navUser-item-accountLabel">Account</span>
+      </a>
+    `;
+
+    const span = document.querySelector('.navUser-item-accountLabel');
+    const anchor = document.querySelector('.navUser-action');
+
+    expect(getClosestAnchorFromTarget(span)).toBe(anchor);
+  });
+
+  it('returns null when the event target is not an element', () => {
+    expect(getClosestAnchorFromTarget(window)).toBeNull();
+  });
+});
+
+describe('getNativeStorefrontPath', () => {
+  it('normalizes same-origin absolute account URLs to path and search', () => {
+    expect(getNativeStorefrontPath('https://store.example.com/account.php?action=order_status', 'https://store.example.com')).toBe(
+      '/account.php?action=order_status',
+    );
+  });
+
+  it('keeps relative account URLs as path and search', () => {
+    expect(getNativeStorefrontPath('/account.php?action=address_book', 'https://store.example.com')).toBe(
+      '/account.php?action=address_book',
+    );
+  });
+
+  it('returns null for cross-origin URLs', () => {
+    expect(getNativeStorefrontPath('https://other.example.com/account.php', 'https://store.example.com')).toBeNull();
+  });
+});
+
+describe('isBuyerPortalNativeHref', () => {
+  it('matches account.php and login.php URLs', () => {
+    expect(isBuyerPortalNativeHref('/account.php', 'https://store.example.com')).toBe(true);
+    expect(isBuyerPortalNativeHref('/account.php?action=order_status', 'https://store.example.com')).toBe(true);
+    expect(isBuyerPortalNativeHref('/login.php', 'https://store.example.com')).toBe(true);
+    expect(isBuyerPortalNativeHref('/login.php?action=create_account', 'https://store.example.com')).toBe(true);
+  });
+
+  it('does not match unrelated storefront URLs', () => {
+    expect(isBuyerPortalNativeHref('/cart.php', 'https://store.example.com')).toBe(false);
+    expect(isBuyerPortalNativeHref('/search.php?search_query=account.php', 'https://store.example.com')).toBe(false);
+  });
+
+  it('does not match cross-origin account URLs', () => {
+    expect(isBuyerPortalNativeHref('https://other.example.com/account.php', 'https://store.example.com')).toBe(false);
+  });
+});
+
+describe('shouldOpenAllowedPageOnInit', () => {
+  it('opens on logged-in account.php without a hash', () => {
+    expect(
+      shouldOpenAllowedPageOnInit({
+        pathname: '/account.php',
+        hash: '',
+        customerId: 123,
+      }),
+    ).toBe(true);
+  });
+
+  it('keeps the existing skip for other logged-in no-hash pages', () => {
+    expect(
+      shouldOpenAllowedPageOnInit({
+        pathname: '/',
+        hash: '',
+        customerId: 123,
+      }),
+    ).toBe(false);
+  });
+
+  it('does not open on checkout pages', () => {
+    expect(
+      shouldOpenAllowedPageOnInit({
+        pathname: '/checkout',
+        hash: '',
+        customerId: 123,
+      }),
+    ).toBe(false);
+  });
+});

--- a/apps/storefront/src/utils/nativeStorefrontLinks.test.ts
+++ b/apps/storefront/src/utils/nativeStorefrontLinks.test.ts
@@ -127,5 +127,4 @@ describe('shouldOpenAllowedPageOnInit', () => {
       }),
     ).toBe(true);
   });
-
 });

--- a/apps/storefront/src/utils/nativeStorefrontLinks.test.ts
+++ b/apps/storefront/src/utils/nativeStorefrontLinks.test.ts
@@ -128,13 +128,4 @@ describe('shouldOpenAllowedPageOnInit', () => {
     ).toBe(true);
   });
 
-  it('opens on account.php without a hash regardless of native query string (pathname strips search)', () => {
-    expect(
-      shouldOpenAllowedPageOnInit({
-        pathname: '/account.php',
-        hash: '',
-        customerId: 456,
-      }),
-    ).toBe(true);
-  });
 });

--- a/apps/storefront/src/utils/nativeStorefrontLinks.test.ts
+++ b/apps/storefront/src/utils/nativeStorefrontLinks.test.ts
@@ -30,37 +30,50 @@ describe('getClosestAnchorFromTarget', () => {
 
 describe('getNativeStorefrontPath', () => {
   it('normalizes same-origin absolute account URLs to path and search', () => {
-    expect(getNativeStorefrontPath('https://store.example.com/account.php?action=order_status', 'https://store.example.com')).toBe(
-      '/account.php?action=order_status',
-    );
+    expect(
+      getNativeStorefrontPath(
+        'https://store.example.com/account.php?action=order_status',
+        'https://store.example.com',
+      ),
+    ).toBe('/account.php?action=order_status');
   });
 
   it('keeps relative account URLs as path and search', () => {
-    expect(getNativeStorefrontPath('/account.php?action=address_book', 'https://store.example.com')).toBe(
-      '/account.php?action=address_book',
-    );
+    expect(
+      getNativeStorefrontPath('/account.php?action=address_book', 'https://store.example.com'),
+    ).toBe('/account.php?action=address_book');
   });
 
   it('returns null for cross-origin URLs', () => {
-    expect(getNativeStorefrontPath('https://other.example.com/account.php', 'https://store.example.com')).toBeNull();
+    expect(
+      getNativeStorefrontPath('https://other.example.com/account.php', 'https://store.example.com'),
+    ).toBeNull();
   });
 });
 
 describe('isBuyerPortalNativeHref', () => {
   it('matches account.php and login.php URLs', () => {
     expect(isBuyerPortalNativeHref('/account.php', 'https://store.example.com')).toBe(true);
-    expect(isBuyerPortalNativeHref('/account.php?action=order_status', 'https://store.example.com')).toBe(true);
+    expect(
+      isBuyerPortalNativeHref('/account.php?action=order_status', 'https://store.example.com'),
+    ).toBe(true);
     expect(isBuyerPortalNativeHref('/login.php', 'https://store.example.com')).toBe(true);
-    expect(isBuyerPortalNativeHref('/login.php?action=create_account', 'https://store.example.com')).toBe(true);
+    expect(
+      isBuyerPortalNativeHref('/login.php?action=create_account', 'https://store.example.com'),
+    ).toBe(true);
   });
 
   it('does not match unrelated storefront URLs', () => {
     expect(isBuyerPortalNativeHref('/cart.php', 'https://store.example.com')).toBe(false);
-    expect(isBuyerPortalNativeHref('/search.php?search_query=account.php', 'https://store.example.com')).toBe(false);
+    expect(
+      isBuyerPortalNativeHref('/search.php?search_query=account.php', 'https://store.example.com'),
+    ).toBe(false);
   });
 
   it('does not match cross-origin account URLs', () => {
-    expect(isBuyerPortalNativeHref('https://other.example.com/account.php', 'https://store.example.com')).toBe(false);
+    expect(
+      isBuyerPortalNativeHref('https://other.example.com/account.php', 'https://store.example.com'),
+    ).toBe(false);
   });
 });
 

--- a/apps/storefront/src/utils/nativeStorefrontLinks.test.ts
+++ b/apps/storefront/src/utils/nativeStorefrontLinks.test.ts
@@ -2,6 +2,8 @@ import {
   getClosestAnchorFromTarget,
   getNativeStorefrontPath,
   isBuyerPortalNativeHref,
+  isNativeLinkInterceptionCached,
+  setNativeLinkInterceptionEnabled,
   shouldOpenAllowedPageOnInit,
 } from './nativeStorefrontLinks';
 
@@ -84,6 +86,40 @@ describe('isBuyerPortalNativeHref', () => {
 
   it('matches account.php URLs that include a hash fragment', () => {
     expect(isBuyerPortalNativeHref('/account.php#section', 'https://store.example.com')).toBe(true);
+  });
+
+  it('matches locale-prefixed account.php and login.php URLs', () => {
+    expect(isBuyerPortalNativeHref('/en/account.php', 'https://store.example.com')).toBe(true);
+    expect(
+      isBuyerPortalNativeHref('/en/account.php?action=order_status', 'https://store.example.com'),
+    ).toBe(true);
+    expect(isBuyerPortalNativeHref('/fr-ca/login.php', 'https://store.example.com')).toBe(true);
+  });
+
+  it('does not match a query string that merely contains account.php', () => {
+    expect(
+      isBuyerPortalNativeHref('/search.php?search_query=account.php', 'https://store.example.com'),
+    ).toBe(false);
+  });
+});
+
+describe('native link interception caching', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('defaults to false when nothing has been cached', () => {
+    expect(isNativeLinkInterceptionCached()).toBe(false);
+  });
+
+  it('reads back the last value set', () => {
+    setNativeLinkInterceptionEnabled(true);
+
+    expect(isNativeLinkInterceptionCached()).toBe(true);
+
+    setNativeLinkInterceptionEnabled(false);
+
+    expect(isNativeLinkInterceptionCached()).toBe(false);
   });
 });
 

--- a/apps/storefront/src/utils/nativeStorefrontLinks.test.ts
+++ b/apps/storefront/src/utils/nativeStorefrontLinks.test.ts
@@ -94,4 +94,24 @@ describe('shouldOpenAllowedPageOnInit', () => {
       }),
     ).toBe(false);
   });
+
+  it('opens on account.php order status without a hash for a logged-in customer', () => {
+    expect(
+      shouldOpenAllowedPageOnInit({
+        pathname: '/account.php',
+        hash: '',
+        customerId: 456,
+      }),
+    ).toBe(true);
+  });
+
+  it('opens on account.php even when the URL has a native query string', () => {
+    expect(
+      shouldOpenAllowedPageOnInit({
+        pathname: '/account.php',
+        hash: '',
+        customerId: 456,
+      }),
+    ).toBe(true);
+  });
 });

--- a/apps/storefront/src/utils/nativeStorefrontLinks.ts
+++ b/apps/storefront/src/utils/nativeStorefrontLinks.ts
@@ -4,7 +4,7 @@ interface InitOpenDecisionInput {
   customerId?: number | string;
 }
 
-const NATIVE_BUYER_PORTAL_PATHS = ['/account.php', '/login.php'];
+const NATIVE_STOREFRONT_PATH_SUFFIXES = ['/account.php', '/login.php'];
 
 export function getClosestAnchorFromTarget(target: EventTarget | null): HTMLAnchorElement | null {
   if (!(target instanceof Element)) {
@@ -43,7 +43,7 @@ export function isBuyerPortalNativeHref(href: string, origin = window.location.o
   // contain "account.php" (e.g. /search.php?search_query=account.php) can't.
   const pathname = path.split(/[?#]/)[0];
 
-  return NATIVE_BUYER_PORTAL_PATHS.some((nativePath) => pathname.endsWith(nativePath));
+  return NATIVE_STOREFRONT_PATH_SUFFIXES.some((nativePath) => pathname.endsWith(nativePath));
 }
 
 const NATIVE_LINK_INTERCEPTION_STORAGE_KEY = 'b2b-native-link-interception-enabled';

--- a/apps/storefront/src/utils/nativeStorefrontLinks.ts
+++ b/apps/storefront/src/utils/nativeStorefrontLinks.ts
@@ -25,7 +25,7 @@ export function getNativeStorefrontPath(
       return null;
     }
 
-    return `${url.pathname}${url.search}`;
+    return `${url.pathname}${url.search}${url.hash}`;
   } catch (_error: unknown) {
     return null;
   }
@@ -38,8 +38,11 @@ export function isBuyerPortalNativeHref(href: string, origin = window.location.o
     return false;
   }
 
+  // Strip hash before matching so /account.php#section still matches /account.php
+  const pathWithoutHash = path.split('#')[0];
+
   return NATIVE_BUYER_PORTAL_PATHS.some(
-    (nativePath) => path === nativePath || path.startsWith(`${nativePath}?`),
+    (nativePath) => pathWithoutHash === nativePath || pathWithoutHash.startsWith(`${nativePath}?`),
   );
 }
 

--- a/apps/storefront/src/utils/nativeStorefrontLinks.ts
+++ b/apps/storefront/src/utils/nativeStorefrontLinks.ts
@@ -1,0 +1,55 @@
+interface InitOpenDecisionInput {
+  pathname: string;
+  hash: string;
+  customerId?: number | string;
+}
+
+const NATIVE_BUYER_PORTAL_PATHS = ['/account.php', '/login.php'];
+
+export function getClosestAnchorFromTarget(target: EventTarget | null): HTMLAnchorElement | null {
+  if (!(target instanceof Element)) {
+    return null;
+  }
+
+  return target.closest<HTMLAnchorElement>('a[href]');
+}
+
+export function getNativeStorefrontPath(href: string, origin = window.location.origin): string | null {
+  try {
+    const url = new URL(href, origin);
+
+    if (url.origin !== origin) {
+      return null;
+    }
+
+    return `${url.pathname}${url.search}`;
+  } catch (_error: unknown) {
+    return null;
+  }
+}
+
+export function isBuyerPortalNativeHref(href: string, origin = window.location.origin): boolean {
+  const path = getNativeStorefrontPath(href, origin);
+
+  if (!path) {
+    return false;
+  }
+
+  return NATIVE_BUYER_PORTAL_PATHS.some((nativePath) => path === nativePath || path.startsWith(`${nativePath}?`));
+}
+
+export function shouldOpenAllowedPageOnInit({
+  pathname,
+  hash,
+  customerId,
+}: InitOpenDecisionInput): boolean {
+  if (pathname.includes('checkout')) {
+    return false;
+  }
+
+  if (pathname.includes('account.php') && !hash) {
+    return true;
+  }
+
+  return !(customerId && !hash);
+}

--- a/apps/storefront/src/utils/nativeStorefrontLinks.ts
+++ b/apps/storefront/src/utils/nativeStorefrontLinks.ts
@@ -14,7 +14,10 @@ export function getClosestAnchorFromTarget(target: EventTarget | null): HTMLAnch
   return target.closest<HTMLAnchorElement>('a[href]');
 }
 
-export function getNativeStorefrontPath(href: string, origin = window.location.origin): string | null {
+export function getNativeStorefrontPath(
+  href: string,
+  origin = window.location.origin,
+): string | null {
   try {
     const url = new URL(href, origin);
 
@@ -35,7 +38,9 @@ export function isBuyerPortalNativeHref(href: string, origin = window.location.o
     return false;
   }
 
-  return NATIVE_BUYER_PORTAL_PATHS.some((nativePath) => path === nativePath || path.startsWith(`${nativePath}?`));
+  return NATIVE_BUYER_PORTAL_PATHS.some(
+    (nativePath) => path === nativePath || path.startsWith(`${nativePath}?`),
+  );
 }
 
 export function shouldOpenAllowedPageOnInit({

--- a/apps/storefront/src/utils/nativeStorefrontLinks.ts
+++ b/apps/storefront/src/utils/nativeStorefrontLinks.ts
@@ -38,13 +38,38 @@ export function isBuyerPortalNativeHref(href: string, origin = window.location.o
     return false;
   }
 
-  // Strip hash before matching so /account.php#section still matches /account.php
-  const pathWithoutHash = path.split('#')[0];
+  // Match on the pathname only (strip search/hash) so a locale prefix like
+  // /en/account.php still matches, while a query string that happens to
+  // contain "account.php" (e.g. /search.php?search_query=account.php) can't.
+  const pathname = path.split(/[?#]/)[0];
 
-  return NATIVE_BUYER_PORTAL_PATHS.some(
-    (nativePath) => pathWithoutHash === nativePath || pathWithoutHash.startsWith(`${nativePath}?`),
-  );
+  return NATIVE_BUYER_PORTAL_PATHS.some((nativePath) => pathname.endsWith(nativePath));
 }
+
+const NATIVE_LINK_INTERCEPTION_STORAGE_KEY = 'b2b-native-link-interception-enabled';
+
+/*
+  main.ts binds native-link interception before React mounts, when the
+  LaunchDarkly-backed flag hasn't been fetched into Redux yet. We cache the
+  last-known value here (set from storefrontConfig once configs load) so the
+  next page load can read it back synchronously, mirroring the pattern used
+  for the default-login-styling flag in preMountLoginMask.ts.
+*/
+export const setNativeLinkInterceptionEnabled = (enabled: boolean) => {
+  try {
+    localStorage.setItem(NATIVE_LINK_INTERCEPTION_STORAGE_KEY, String(enabled));
+  } catch {
+    // ignore: persistence is best-effort
+  }
+};
+
+export const isNativeLinkInterceptionCached = (): boolean => {
+  try {
+    return localStorage.getItem(NATIVE_LINK_INTERCEPTION_STORAGE_KEY) === 'true';
+  } catch {
+    return false;
+  }
+};
 
 export function shouldOpenAllowedPageOnInit({
   pathname,

--- a/apps/storefront/src/utils/nativeStorefrontLinks.ts
+++ b/apps/storefront/src/utils/nativeStorefrontLinks.ts
@@ -54,6 +54,11 @@ const NATIVE_LINK_INTERCEPTION_STORAGE_KEY = 'b2b-native-link-interception-enabl
   last-known value here (set from storefrontConfig once configs load) so the
   next page load can read it back synchronously, mirroring the pattern used
   for the default-login-styling flag in preMountLoginMask.ts.
+
+  TODO(B2B-4912): once buyer_portal_native_link_interception is fully rolled out
+  and the flag is deleted, remove this caching bridge entirely, along with the
+  setNativeLinkInterceptionEnabled call in storefrontConfig.ts and the
+  isNativeLinkInterceptionCached read in main.ts.
 */
 export const setNativeLinkInterceptionEnabled = (enabled: boolean) => {
   try {

--- a/apps/storefront/src/utils/resolveInitNavigation.test.ts
+++ b/apps/storefront/src/utils/resolveInitNavigation.test.ts
@@ -1,0 +1,83 @@
+import { CustomerRole } from '@/types';
+
+import { resolveInitNavigation } from './resolveInitNavigation';
+
+const baseInput = {
+  companyLoginFlag: null as string | null,
+  shouldOpenAllowedPage: true,
+  isAccountPageWithoutHash: true,
+  pathname: '/account.php',
+  search: '?action=order_status',
+  role: CustomerRole.B2C,
+  isAgenting: false,
+  authorizedPages: '/orders',
+};
+
+describe('resolveInitNavigation', () => {
+  it('navigates to the login flag and ignores the account-page mapping when there is a company error', () => {
+    const decision = resolveInitNavigation({
+      ...baseInput,
+      companyLoginFlag: 'pendingApprovalToOrder',
+    });
+
+    expect(decision).toEqual({ type: 'goto', url: '/login?loginFlag=pendingApprovalToOrder' });
+  });
+
+  it('navigates to the login flag even when the allowed-page guard is false', () => {
+    const decision = resolveInitNavigation({
+      ...baseInput,
+      companyLoginFlag: 'accountInactive',
+      shouldOpenAllowedPage: false,
+      isAccountPageWithoutHash: false,
+      pathname: '/checkout',
+      search: '',
+    });
+
+    expect(decision).toEqual({ type: 'goto', url: '/login?loginFlag=accountInactive' });
+  });
+
+  it('maps a native account action to the portal route when there is no company error', () => {
+    const decision = resolveInitNavigation({
+      ...baseInput,
+      search: '?action=address_book',
+    });
+
+    expect(decision).toEqual({ type: 'goto', url: '/addresses' });
+  });
+
+  it('uses authorizedPages as-is for SUPER_ADMIN — caller must recompute it from updated role', () => {
+    // openPageByClick returns authorizedPages directly for SUPER_ADMIN. If the
+    // caller passes the render-time value ('/orders') instead of the post-login
+    // recomputed value ('/dashboard'), the user lands on the wrong page.
+    const decision = resolveInitNavigation({
+      ...baseInput,
+      role: CustomerRole.SUPER_ADMIN,
+      authorizedPages: '/dashboard',
+    });
+
+    expect(decision).toEqual({ type: 'goto', url: '/dashboard' });
+  });
+
+  it('defers to gotoAllowedAppPage when the path is not an account page with search', () => {
+    const decision = resolveInitNavigation({
+      ...baseInput,
+      isAccountPageWithoutHash: false,
+      pathname: '/',
+      search: '',
+    });
+
+    expect(decision).toEqual({ type: 'allowedAppPage' });
+  });
+
+  it('shows the page mask when no allowed page should open', () => {
+    const decision = resolveInitNavigation({
+      ...baseInput,
+      shouldOpenAllowedPage: false,
+      isAccountPageWithoutHash: false,
+      pathname: '/checkout',
+      search: '',
+    });
+
+    expect(decision).toEqual({ type: 'mask' });
+  });
+});

--- a/apps/storefront/src/utils/resolveInitNavigation.ts
+++ b/apps/storefront/src/utils/resolveInitNavigation.ts
@@ -11,10 +11,7 @@ interface ResolveInitNavigationInput {
   authorizedPages: string;
 }
 
-type InitNavigation =
-  | { type: 'goto'; url: string }
-  | { type: 'allowedAppPage' }
-  | { type: 'mask' };
+type InitNavigation = { type: 'goto'; url: string } | { type: 'allowedAppPage' } | { type: 'mask' };
 
 export const resolveInitNavigation = ({
   companyLoginFlag,

--- a/apps/storefront/src/utils/resolveInitNavigation.ts
+++ b/apps/storefront/src/utils/resolveInitNavigation.ts
@@ -11,7 +11,7 @@ interface ResolveInitNavigationInput {
   authorizedPages: string;
 }
 
-export type InitNavigation =
+type InitNavigation =
   | { type: 'goto'; url: string }
   | { type: 'allowedAppPage' }
   | { type: 'mask' };

--- a/apps/storefront/src/utils/resolveInitNavigation.ts
+++ b/apps/storefront/src/utils/resolveInitNavigation.ts
@@ -1,0 +1,51 @@
+import { openPageByClick } from '@/utils/b3AccountItem';
+
+interface ResolveInitNavigationInput {
+  companyLoginFlag: string | null;
+  shouldOpenAllowedPage: boolean;
+  isAccountPageWithoutHash: boolean;
+  pathname: string;
+  search: string;
+  role: number;
+  isAgenting: boolean;
+  authorizedPages: string;
+}
+
+export type InitNavigation =
+  | { type: 'goto'; url: string }
+  | { type: 'allowedAppPage' }
+  | { type: 'mask' };
+
+export const resolveInitNavigation = ({
+  companyLoginFlag,
+  shouldOpenAllowedPage,
+  isAccountPageWithoutHash,
+  pathname,
+  search,
+  role,
+  isAgenting,
+  authorizedPages,
+}: ResolveInitNavigationInput): InitNavigation => {
+  if (companyLoginFlag) {
+    return { type: 'goto', url: `/login?loginFlag=${companyLoginFlag}` };
+  }
+
+  if (!shouldOpenAllowedPage) {
+    return { type: 'mask' };
+  }
+
+  if (isAccountPageWithoutHash && search) {
+    return {
+      type: 'goto',
+      url: openPageByClick({
+        href: `${pathname}${search}`,
+        role,
+        isRegisterAndLogin: false,
+        isAgenting,
+        authorizedPages,
+      }),
+    };
+  }
+
+  return { type: 'allowedAppPage' };
+};

--- a/apps/storefront/src/utils/storefrontConfig.ts
+++ b/apps/storefront/src/utils/storefrontConfig.ts
@@ -30,6 +30,7 @@ import { setActiveCurrency, setCurrencies } from '@/store/slices/storeConfigs';
 import { B3SStorage } from '@/utils/b3Storage';
 import { channelId } from '@/utils/basicConfig';
 import { FeatureFlagKey, featureFlags } from '@/utils/featureFlags';
+import { setNativeLinkInterceptionEnabled } from '@/utils/nativeStorefrontLinks';
 import { setDefaultLoginStylingEnabled } from '@/utils/preMountLoginMask';
 
 import { checkEveryPermissionsCode } from './b3CheckPermissions/check';
@@ -303,6 +304,11 @@ const getStoreConfigs = async (dispatch: any, dispatchGlobal: any) => {
   setDefaultLoginStylingEnabled(
     store.getState().global.featureFlags['B2B-4870.default_buyer_portal_styling_on_login_page'] ??
       false,
+  );
+
+  // Same rationale as above, for the native-link-interception flag read in main.ts.
+  setNativeLinkInterceptionEnabled(
+    store.getState().global.featureFlags['B2B-4912.buyer_portal_native_link_interception'] ?? false,
   );
 
   dispatchGlobal({

--- a/apps/storefront/src/utils/storefrontConfig.ts
+++ b/apps/storefront/src/utils/storefrontConfig.ts
@@ -307,6 +307,8 @@ const getStoreConfigs = async (dispatch: any, dispatchGlobal: any) => {
   );
 
   // Same rationale as above, for the native-link-interception flag read in main.ts.
+  // TODO(B2B-4912): remove this call once the flag is fully rolled out and deleted
+  // (see nativeStorefrontLinks.ts for the rest of the caching bridge to remove).
   setNativeLinkInterceptionEnabled(
     store.getState().global.featureFlags['B2B-4912.buyer_portal_native_link_interception'] ?? false,
   );


### PR DESCRIPTION
Jira: [B2B-4912](https://bigcommercecloud.atlassian.net/browse/B2B-4912)

## What/Why?

PR #924 introduced a double-navigation bug in `App.tsx` `init()`: when a pending/inactive-company buyer visited the storefront, the `CompanyError` catch called `gotoPage('/login?loginFlag=…')`, but execution continued into the open-allowed-page block which called `gotoPage(...)` again, overwriting the loginFlag (last-write-wins). The pending-approval alert never showed.

**Fix:** Instead of navigating inside the catch, capture the error reason as `companyLoginFlag`. Then make a single navigation decision via a new pure function `resolveInitNavigation`, which returns a typed `InitNavigation` value. Company errors take priority (returned before any other branch), so the loginFlag can never be overwritten by a subsequent navigation.

**Also fixed:** `authorizedPages` was computed at render time from the Redux `role`, but `getCurrentCustomerInfo()` can update `userInfo.role` (e.g. B2C → SUPER_ADMIN) before `resolveInitNavigation` is called. `openPageByClick` returns `authorizedPages` verbatim for `SUPER_ADMIN`/`JUNIOR_BUYER`, so a stale value would land them on `/orders` instead of `/dashboard` or `/shoppingLists`. Fixed by recomputing `authorizedPages` from `userInfo.role` after `getCurrentCustomerInfo()` completes.


## Rollout/Rollback

No new feature flags introduced. The fix is a refactor of the existing `init()` navigation logic — same observable behavior for healthy users, corrected behavior for pending/inactive-company buyers.

Rollback: revert the two commits on this branch (`619baf18`, `0db5f209`).

## Testing

**Functional Test** Has been tested on integration with 2 previous failed testcase:
-  `tests/ui/domain/b2b/buyer-portal/auth/UnapprovedCompanyLogin.spec.ts`
- `tests/ui/domain/b2b/checkout/InvoicePayment/InvoicePaymentWithCompanyAdmin.spec.ts`

**Unit:** `yarn test run src/utils/resolveInitNavigation.test.ts` — 6/6 passing. Full suite (`yarn test run`) — 1163/1163 passing.

**E2E (manual / CI gate):** `functional-tests` repo — `tests/ui/domain/b2b/buyer-portal/auth/UnapprovedCompanyLogin.spec.ts`, Step 1 ("login-as-customer redirect is blocked"). Run against a store with a **pending** company, with flag `B2B-4912.buyer_portal_native_link_interception` **ON** and **OFF**.

Expected: final URL contains `#/login?loginFlag=<reason>` and the pending-approval alert renders in both flag states.

[B2B-4912]: https://bigcommercecloud.atlassian.net/browse/B2B-4912?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes startup routing and global click handling for login/account flows; wrong ordering could still mis-route pending buyers or break theme-specific account links, though behavior is flag-gated and covered by new unit tests.
> 
> **Overview**
> Fixes **init navigation** so pending/inactive company buyers are not sent to `#/login?loginFlag=…` and then immediately overwritten by a second `gotoPage`. `App.tsx` now stores `companyLoginFlag` from `getCurrentCustomerInfo` errors and routes through **`resolveInitNavigation`**, which prioritizes that login URL over account-page mapping or `gotoAllowedAppPage`. **`authorizedPages`** is recomputed from the post-fetch `userInfo.role` so roles like SUPER_ADMIN land on the right default route.
> 
> Adds **native storefront link interception** behind `B2B-4912.buyer_portal_native_link_interception`: shared helpers in `nativeStorefrontLinks` (anchor resolution, `account.php`/`login.php` detection, init open rules, localStorage cache for pre-React `main.ts`). **`bindLinks`/`useB3AppOpen`** intercept same-origin account/login links (including child-of-anchor clicks) while leaving configured DOM targets on their full href when the flag is off.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79497e2e86767e4a95b18492b1a07c5e89b436f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->