### PR TITLE
fix(quotes): BACK-711 hide backorder display for complex products

### DIFF
--- a/apps/storefront/src/components/B3ProductList.tsx
+++ b/apps/storefront/src/components/B3ProductList.tsx
@@ -11,7 +11,10 @@ import type { CatalogQuickVariantSku } from '@/shared/service/b2b/graphql/produc
 import { useAppSelector } from '@/store';
 import { currencyFormat, ordersCurrencyFormat } from '@/utils/b3CurrencyFormat';
 import { getDisplayPrice, judgmentBuyerProduct } from '@/utils/b3Product/b3Product';
-import { getCatalogProductRowDisplayState } from '@/utils/catalogBackorderDisplay';
+import {
+  getCatalogProductRowDisplayState,
+  productRequiresChooseOptionsBeforeAdd,
+} from '@/utils/catalogBackorderDisplay';
 
 import { MoneyFormat, ProductItem } from '../types';
 
@@ -143,7 +146,7 @@ function getBackorderLayoutStyles(
   };
 }
 
-interface ProductProps<T> {
+interface ProductProps<T extends ProductItem = ProductItem> {
   products: Array<T & ProductItem>;
   money?: MoneyFormat;
   renderAction?: (item: T & ProductItem) => ReactElement;
@@ -170,7 +173,7 @@ function getProductVariantSku(product: ProductItem): string {
   return product.variants?.[0]?.sku ?? product.sku;
 }
 
-export function B3ProductList<T>(props: ProductProps<T>) {
+export function B3ProductList<T extends ProductItem>(props: ProductProps<T>) {
   const {
     products,
     renderAction,
@@ -372,7 +375,9 @@ export function B3ProductList<T>(props: ProductProps<T>) {
         const discountedTotalPrice = getProductTotals(quantity, discountedPrice);
 
         const variantSku = getProductVariantSku(product);
-        const inventoryRow = catalogInventoryBySku?.[variantSku.toUpperCase()];
+        const inventoryRow = productRequiresChooseOptionsBeforeAdd(product)
+          ? undefined
+          : catalogInventoryBySku?.[variantSku.toUpperCase()];
         const { qtyHelperText, backorderFields } = getCatalogProductRowDisplayState({
           qty: Number(quantity) || 0,
           productHelperText: product.helperText,

--- a/apps/storefront/src/pages/QuickOrder/components/ProductListDialog.tsx
+++ b/apps/storefront/src/pages/QuickOrder/components/ProductListDialog.tsx
@@ -14,7 +14,10 @@ import { ShoppingListDetailsContext } from '@/pages/ShoppingListDetails/context/
 import { useAppSelector } from '@/store';
 import { ShoppingListProductItem } from '@/types';
 import { snackbar } from '@/utils/b3Tip';
-import { buildVariantSkuDependencyKey } from '@/utils/catalogBackorderDisplay';
+import {
+  buildVariantSkuDependencyKey,
+  productRequiresChooseOptionsBeforeAdd,
+} from '@/utils/catalogBackorderDisplay';
 
 interface ProductTableActionProps {
   product: ShoppingListProductItem;
@@ -107,7 +110,9 @@ export default function ProductListDialog(props: ProductListDialogProps) {
   const variantSkuDependencyKey = useMemo(
     () =>
       buildVariantSkuDependencyKey(
-        productList.map((product) => product.variants?.[0]?.sku ?? product.sku),
+        productList
+          .filter((product) => !productRequiresChooseOptionsBeforeAdd(product))
+          .map((product) => product.variants?.[0]?.sku ?? product.sku),
       ),
     [productList],
   );

--- a/apps/storefront/src/pages/QuoteDraft/index.test.tsx
+++ b/apps/storefront/src/pages/QuoteDraft/index.test.tsx
@@ -3498,6 +3498,189 @@ describe('when the user is a B2B customer', () => {
             ),
           );
         });
+
+        it('does not show backorder lines for complex products before choosing options', async () => {
+          const productId = 9101;
+          const optionId = 60;
+          const sizeM = 202;
+          const variantSku = 'TEE-M';
+          const variantId = 5101;
+
+          const variantM = buildVariantWith({
+            variant_id: variantId,
+            product_id: productId,
+            sku: variantSku,
+            purchasing_disabled: false,
+            option_values: [
+              {
+                id: sizeM,
+                label: 'M',
+                option_id: optionId,
+                option_display_name: 'Size',
+              },
+            ],
+            bc_calculated_price: { tax_exclusive: 50 },
+          });
+
+          const variantS = buildVariantWith({
+            product_id: productId,
+            sku: 'TEE-S',
+            purchasing_disabled: false,
+            option_values: [
+              {
+                id: 201,
+                label: 'S',
+                option_id: optionId,
+                option_display_name: 'Size',
+              },
+            ],
+            bc_calculated_price: { tax_exclusive: 45 },
+          });
+
+          const sizeOption = buildSearchProductV3OptionWith({
+            id: optionId,
+            product_id: productId,
+            type: 'rectangles',
+            display_name: 'Size',
+            option_values: [
+              buildSearchProductV3OptionValueWith({ id: 201, label: 'S', is_default: false }),
+              buildSearchProductV3OptionValueWith({ id: sizeM, label: 'M', is_default: true }),
+            ],
+          });
+
+          const searchProducts = vi.fn<(...arg: unknown[]) => SearchProductsResponse>();
+
+          when(searchProducts)
+            .calledWith(stringContainingAll('search: "Size Tee"', 'currencyCode: "USD"'))
+            .thenReturn({
+              data: {
+                productsSearch: [
+                  buildSearchProductWith({
+                    id: productId,
+                    name: 'Size Tee',
+                    sku: 'TEE-BASE',
+                    inventoryTracking: 'product',
+                    availableToSell: 10,
+                    unlimitedBackorder: false,
+                    totalOnHand: 2,
+                    backorderMessage: 'Lead time: 2-4 weeks',
+                    optionsV3: [sizeOption],
+                    isPriceHidden: false,
+                    orderQuantityMinimum: 0,
+                    orderQuantityMaximum: 0,
+                    variants: [variantS, variantM],
+                  }),
+                ],
+              },
+            });
+
+          const getPriceProducts = vi.fn<(...arg: unknown[]) => PriceProductsResponse>();
+
+          when(getPriceProducts)
+            .calledWith({
+              storeHash: 'store-hash',
+              channelId: 1,
+              currencyCode: 'USD',
+              items: [{ productId, variantId, options: [] }],
+              customerGroupId: 0,
+            })
+            .thenReturn({
+              data: {
+                priceProducts: [
+                  buildProductPriceWith({
+                    productId,
+                    variantId,
+                  }),
+                ],
+              },
+            });
+
+          server.use(
+            graphql.query('Countries', () =>
+              HttpResponse.json({ data: { countries: [fakeCountry] } }),
+            ),
+            graphql.query('Addresses', () =>
+              HttpResponse.json({ data: { addresses: { totalCount: 0, edges: [] } } }),
+            ),
+            graphql.query('getQuoteExtraFields', () =>
+              HttpResponse.json({ data: { quoteExtraFieldsConfig: [] } }),
+            ),
+            graphql.query('SearchProducts', ({ query }) =>
+              HttpResponse.json(searchProducts(query)),
+            ),
+            graphql.query('priceProducts', ({ variables }) =>
+              HttpResponse.json(getPriceProducts(variables)),
+            ),
+          );
+
+          const quoteInfo = buildQuoteInfoStateWith({
+            draftQuoteInfo: {
+              contactInfo: { email: customerEmail },
+              billingAddress: noAddress,
+              shippingAddress: noAddress,
+            },
+            draftQuoteList: [],
+          });
+
+          renderWithProviders(<QuoteDraft setOpenPage={vi.fn()} />, {
+            preloadedState: {
+              ...preloadedState,
+              quoteInfo,
+              global: buildGlobalStateWith({
+                ...backorderMessagingGlobal,
+                blockPendingQuoteNonPurchasableOOS: { isEnableProduct: false },
+              }),
+            },
+          });
+
+          await userEvent.click(screen.getByText('Add to quote'));
+          const searchProduct = screen.getByPlaceholderText('Search products');
+          await userEvent.type(searchProduct, 'Size Tee');
+          await userEvent.click(screen.getByRole('button', { name: 'Search product' }));
+
+          const dialog = await screen.findByRole('dialog');
+          const quantityInput = within(dialog).getByRole('spinbutton');
+
+          expect(within(dialog).getByRole('button', { name: 'Choose options' })).toBeVisible();
+
+          await userEvent.type(quantityInput, '10', {
+            initialSelectionStart: 0,
+            initialSelectionEnd: Infinity,
+          });
+
+          await waitFor(() => {
+            expect(within(dialog).getByText('Size Tee')).toBeVisible();
+          });
+          expect(
+            within(dialog).queryByText('will be backordered', { exact: false }),
+          ).not.toBeInTheDocument();
+          expect(
+            within(dialog).queryByText('ready to ship', { exact: false }),
+          ).not.toBeInTheDocument();
+          expect(within(dialog).queryByText('Lead time: 2-4 weeks')).not.toBeInTheDocument();
+          expect(within(dialog).queryByText('Only 7 available')).not.toBeInTheDocument();
+
+          await userEvent.click(within(dialog).getByRole('button', { name: 'Choose options' }));
+
+          const chooseOptionsDialog = await screen.findByRole('dialog', { name: 'Choose options' });
+
+          await waitFor(() => {
+            expect(within(chooseOptionsDialog).getByText(variantSku)).toBeInTheDocument();
+          });
+
+          const chooseOptionsQuantityInput = within(chooseOptionsDialog).getByRole('spinbutton');
+
+          await userEvent.type(chooseOptionsQuantityInput, '10', {
+            initialSelectionStart: 0,
+            initialSelectionEnd: Infinity,
+          });
+
+          await waitFor(() => {
+            expect(within(chooseOptionsDialog).getByText('2 ready to ship')).toBeVisible();
+          });
+          expect(within(chooseOptionsDialog).getByText('8 will be backordered')).toBeVisible();
+          expect(within(chooseOptionsDialog).getByText('Lead time: 2-4 weeks')).toBeVisible();
+        });
       });
     });
 

--- a/apps/storefront/src/pages/ShoppingListDetails/components/ProductListDialog.tsx
+++ b/apps/storefront/src/pages/ShoppingListDetails/components/ProductListDialog.tsx
@@ -14,6 +14,7 @@ import { useAppSelector } from '@/store';
 import { snackbar } from '@/utils/b3Tip';
 import {
   buildVariantSkuDependencyKey,
+  productRequiresChooseOptionsBeforeAdd,
   shouldBlockQuoteAtsAdd,
 } from '@/utils/catalogBackorderDisplay';
 
@@ -119,7 +120,9 @@ export default function ProductListDialog(props: ProductListDialogProps) {
   const variantSkuDependencyKey = useMemo(
     () =>
       buildVariantSkuDependencyKey(
-        productList.map((product) => product.variants?.[0]?.sku ?? product.sku),
+        productList
+          .filter((product) => !productRequiresChooseOptionsBeforeAdd(product))
+          .map((product) => product.variants?.[0]?.sku ?? product.sku),
       ),
     [productList],
   );
@@ -137,7 +140,7 @@ export default function ProductListDialog(props: ProductListDialogProps) {
 
   const productExceedsAvailableToSell = useCallback(
     (product: ShoppingListProductItem) => {
-      if (!showQuoteAtsHelper) {
+      if (!showQuoteAtsHelper || productRequiresChooseOptionsBeforeAdd(product)) {
         return false;
       }
 

--- a/apps/storefront/src/pages/ShoppingListDetails/index.test.tsx
+++ b/apps/storefront/src/pages/ShoppingListDetails/index.test.tsx
@@ -4113,6 +4113,157 @@ describe('when backorder messaging is enabled in add to list search modal', () =
       ).not.toBeInTheDocument();
     });
   });
+
+  it('does not show backorder lines for complex products before choosing options', async () => {
+    const complexSearchTerm = 'Fog Towel';
+    const productId = 9001;
+    const optionId = 50;
+    const sizeM = 102;
+
+    vitest.mocked(useParams).mockReturnValue({ id: '272989' });
+
+    const listProductEdge = buildShoppingListProductEdgeWith({
+      node: {
+        productName: 'Existing list item',
+        productId: 8000,
+        variantSku: 'LIST-SKU-001',
+        quantity: 1,
+        basePrice: '10.00',
+      },
+    });
+
+    const variantM = buildSearchB2BProductVariantWith({
+      product_id: productId,
+      sku: 'TOWEL-M',
+      purchasing_disabled: false,
+      available_to_sell: 10,
+      unlimited_backorder: false,
+      total_on_hand: 2,
+      backorder_message: 'Lead time: 2-4 weeks',
+      option_values: [
+        {
+          id: sizeM,
+          label: 'M',
+          option_id: optionId,
+          option_display_name: 'Size',
+        },
+      ],
+      bc_calculated_price: {
+        tax_exclusive: 50,
+        tax_inclusive: 55,
+        as_entered: 50,
+        entered_inclusive: false,
+      },
+    });
+
+    const variantS = buildSearchB2BProductVariantWith({
+      product_id: productId,
+      sku: 'TOWEL-S',
+      purchasing_disabled: false,
+      option_values: [
+        {
+          id: 101,
+          label: 'S',
+          option_id: optionId,
+          option_display_name: 'Size',
+        },
+      ],
+      bc_calculated_price: {
+        tax_exclusive: 45,
+        tax_inclusive: 50,
+        as_entered: 45,
+        entered_inclusive: false,
+      },
+    });
+
+    const sizeOption = buildSearchB2BProductV3OptionWith({
+      id: optionId,
+      product_id: productId,
+      type: 'rectangles',
+      display_name: 'Size',
+      option_values: [
+        buildSearchB2BProductV3OptionValueWith({
+          id: 101,
+          label: 'S',
+          is_default: false,
+        }),
+        buildSearchB2BProductV3OptionValueWith({
+          id: sizeM,
+          label: 'M',
+          is_default: true,
+        }),
+      ],
+    });
+
+    const searchProduct = buildSearchB2BProductWith({
+      id: productId,
+      name: 'Fog Towel',
+      sku: 'TOWEL-BASE',
+      inventoryTracking: 'variant',
+      optionsV3: [sizeOption],
+      isPriceHidden: false,
+      orderQuantityMinimum: 0,
+      orderQuantityMaximum: 0,
+      variants: [variantS, variantM],
+    });
+
+    const shoppingListResponse = buildShoppingListGraphQLResponseWith({
+      data: {
+        shoppingList: {
+          products: { totalCount: 1, edges: [listProductEdge] },
+          status: 0,
+          grandTotal: '10.00',
+          totalTax: '0',
+        },
+      },
+    });
+
+    server.use(
+      graphql.query('B2BShoppingListDetails', () => HttpResponse.json(shoppingListResponse)),
+      graphql.query('SearchProducts', ({ query }) => {
+        if (/productIds: \[\d/.test(query)) {
+          return HttpResponse.json(
+            buildSearchProductsResponseWith({ data: { productsSearch: [] } }),
+          );
+        }
+
+        return HttpResponse.json(
+          buildSearchProductsResponseWith({ data: { productsSearch: [searchProduct] } }),
+        );
+      }),
+    );
+
+    renderWithProviders(<ShoppingListDetailsContent setOpenPage={() => {}} />, {
+      preloadedState: backorderPreloadedState,
+    });
+
+    await waitForElementToBeRemoved(() => screen.queryByText(/loading/i));
+
+    await screen.findByRole('heading', { name: /add to list/i });
+
+    const searchBox = screen.getByPlaceholderText('Search products');
+    await userEvent.type(searchBox, complexSearchTerm);
+    await userEvent.click(screen.getByRole('button', { name: /Search product/i }));
+
+    const dialog = await screen.findByRole('dialog', { name: 'Add to list' });
+    const quantityInput = within(dialog).getByRole('spinbutton');
+
+    expect(within(dialog).getByRole('button', { name: 'Choose options' })).toBeVisible();
+
+    await userEvent.type(quantityInput, '10', {
+      initialSelectionStart: 0,
+      initialSelectionEnd: Infinity,
+    });
+
+    await waitFor(() => {
+      expect(within(dialog).getByText('Fog Towel')).toBeVisible();
+    });
+    expect(
+      within(dialog).queryByText('will be backordered', { exact: false }),
+    ).not.toBeInTheDocument();
+    expect(within(dialog).queryByText('ready to ship', { exact: false })).not.toBeInTheDocument();
+    expect(within(dialog).queryByText('Lead time: 2-4 weeks')).not.toBeInTheDocument();
+  });
 });
 
 describe('when backorder messaging is enabled in choose options dialog', () => {

--- a/apps/storefront/src/types/products.ts
+++ b/apps/storefront/src/types/products.ts
@@ -59,6 +59,7 @@ export interface ProductItem {
   type?: string;
   product_id?: number;
   downloadFileUrls?: string[];
+  allOptions?: Partial<AllOptionProps>[];
 }
 
 interface OptionValue {

--- a/apps/storefront/src/types/shoppingList.ts
+++ b/apps/storefront/src/types/shoppingList.ts
@@ -1,5 +1,5 @@
 import { Modifiers, ProductItemOption } from './common';
-import { AllOptionProps, ProductItem, Variant } from './products';
+import { ProductItem, Variant } from './products';
 
 export interface ShoppingListItem {
   customerInfo: {
@@ -33,7 +33,6 @@ export interface ShoppingListProductItem extends ProductItem {
   modifiers?: Modifiers[];
   costPrice?: string;
   variants?: Variant[];
-  allOptions?: Partial<AllOptionProps>[];
   selectOptions?: string;
   orderQuantityMaximum?: number;
   orderQuantityMinimum?: number;

--- a/apps/storefront/src/utils/catalogBackorderDisplay.test.ts
+++ b/apps/storefront/src/utils/catalogBackorderDisplay.test.ts
@@ -14,6 +14,7 @@ import {
   getCatalogInventoryRowFromSearchProduct,
   getCatalogProductRowDisplayState,
   getProductDetailsForPicklistSelections,
+  productRequiresChooseOptionsBeforeAdd,
   quantityExceedsAvailableToSell,
   shouldBlockQuoteAtsAdd,
 } from './catalogBackorderDisplay';
@@ -23,6 +24,22 @@ describe('catalogBackorderDisplay', () => {
     expect(buildVariantSkuDependencyKey(['B-SKU', 'A-SKU', 'B-SKU', '', null, undefined])).toBe(
       'A-SKU|B-SKU',
     );
+  });
+
+  describe('productRequiresChooseOptionsBeforeAdd', () => {
+    it('returns true when allOptions has entries', () => {
+      expect(productRequiresChooseOptionsBeforeAdd({ allOptions: [{ id: 1 }] })).toBe(true);
+    });
+
+    it('returns false when allOptions is empty or missing', () => {
+      expect(productRequiresChooseOptionsBeforeAdd({ allOptions: [] })).toBe(false);
+      expect(productRequiresChooseOptionsBeforeAdd({})).toBe(false);
+      expect(productRequiresChooseOptionsBeforeAdd({ allOptions: null })).toBe(false);
+    });
+
+    it('returns false when allOptions is not an array', () => {
+      expect(productRequiresChooseOptionsBeforeAdd({ allOptions: 'Size' })).toBe(false);
+    });
   });
 
   it('quantityExceedsAvailableToSell is false when unlimited backorder', () => {

--- a/apps/storefront/src/utils/catalogBackorderDisplay.ts
+++ b/apps/storefront/src/utils/catalogBackorderDisplay.ts
@@ -8,6 +8,10 @@ export function buildVariantSkuDependencyKey(skus: readonly (string | undefined 
   return [...new Set(skus.filter((sku): sku is string => Boolean(sku)))].sort().join('|');
 }
 
+export function productRequiresChooseOptionsBeforeAdd(product: { allOptions?: unknown }): boolean {
+  return Array.isArray(product.allOptions) && product.allOptions.length > 0;
+}
+
 type SearchProductInventorySource = Pick<
   ShoppingListProductItem,
   | 'inventoryTracking'


### PR DESCRIPTION
Jira: [BACK-711](https://bigcommercecloud.atlassian.net/browse/BACK-711)

## What/Why?
Hiding backorder display for complex products (i.e. before options are selected), in various flows:
- Shopping List -> Add to list
- Quote Draft -> Add to quote
- Quick Order-> Quick Order Pad

## Rollout/Rollback
Merge/revert. Backorder display is gated by `Feature_Backorder && BACK-134.backorders_phase_1_1_control_messaging_on_storefront`.

## Testing
### Shopping List
#### Before
<img width="912" height="373" alt="Screenshot 2026-07-01 at 9 42 14 am" src="https://github.com/user-attachments/assets/d8721315-fb6c-4faf-a805-2f2f9ead166c" />

#### After
<img width="913" height="343" alt="Screenshot 2026-07-01 at 9 36 37 am" src="https://github.com/user-attachments/assets/0b15f759-9351-46ef-a062-ccb9f974cb70" />

### Quote Draft
#### Before
<img width="914" height="417" alt="Screenshot 2026-07-01 at 9 41 16 am" src="https://github.com/user-attachments/assets/8efa6dfe-284a-4e7a-a881-a31397a3bd5e" />

#### After
<img width="913" height="344" alt="Screenshot 2026-07-01 at 9 40 04 am" src="https://github.com/user-attachments/assets/899ef93d-917f-4625-b932-ae71ce6e8436" />

### Quick Order
#### Before
<img width="913" height="397" alt="Screenshot 2026-07-01 at 9 42 55 am" src="https://github.com/user-attachments/assets/90bd2f60-62cc-42e0-949a-04503fe895cf" />

#### After
<img width="913" height="345" alt="Screenshot 2026-07-01 at 9 37 24 am" src="https://github.com/user-attachments/assets/dd72f02b-3f23-4ce3-abf3-2fe479eaf19c" />

Ping @animesh1987 @benpratt77 

[BACK-711]: https://bigcommercecloud.atlassian.net/browse/BACK-711?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only gating behind existing backorder feature flags; behavior for simple products is unchanged and coverage is added via tests.
> 
> **Overview**
> **Hides backorder and ATS messaging** for products that still require **Choose options** in catalog search/add dialogs (shopping list, quote draft, quick order pad).
> 
> Adds `productRequiresChooseOptionsBeforeAdd` (non-empty `allOptions`) and uses it to **skip inventory lookup and row display state** in `B3ProductList`, **narrow SKU dependency keys** for `useCatalogInventoryBySku`, and **bypass quote “exceeds ATS” checks** until a variant is chosen. `ProductItem` now includes optional `allOptions` so list rows can be classified.
> 
> Integration tests assert complex products show no backorder/lead-time copy in the add dialog until **Choose options** is used; unit tests cover the helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e34f9a135e719afaafbcf96b735b0a40bb8288a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->