### PR TITLE
feat(quotes): BACK-722 Implement backorders for picklist children in ordered quotes.

### DIFF
--- a/apps/storefront/src/components/PicklistBackorderMessages.test.tsx
+++ b/apps/storefront/src/components/PicklistBackorderMessages.test.tsx
@@ -160,4 +160,68 @@ describe('PicklistBackorderMessages', () => {
     expect(screen.queryByText('Bundle option 1:')).toBeNull();
     expect(screen.queryByText('1 will be backordered')).toBeNull();
   });
+
+  describe('history mode (ordered quotes)', () => {
+    it('renders the order history instead of live inventory', () => {
+      renderWithProviders(
+        <PicklistBackorderMessages
+          selections={[bundleOption1]}
+          picklistProductsById={{ 555: buildPicklistProduct({ totalOnHand: 100 }) }}
+          qty={10}
+          visible
+          backorderUiEnabled
+          historyByProductId={{
+            555: {
+              product_id: 555,
+              quantity_backordered: 4,
+              total_on_hand: 6,
+              backorder_message: 'Ordered lead time: 3 weeks',
+            },
+          }}
+        />,
+        withAllBackorderDisplayEnabled,
+      );
+
+      expect(screen.getByText('Bundle option 1:')).toBeVisible();
+      expect(screen.getByText('6 ready to ship')).toBeVisible();
+      expect(screen.getByText('4 will be backordered')).toBeVisible();
+      expect(screen.getByText('Ordered lead time: 3 weeks')).toBeVisible();
+    });
+
+    it('renders nothing for an item missing from the history', () => {
+      renderWithProviders(
+        <PicklistBackorderMessages
+          selections={[bundleOption1]}
+          picklistProductsById={{ 555: buildPicklistProduct() }}
+          qty={10}
+          visible
+          backorderUiEnabled
+          historyByProductId={{}}
+        />,
+        withAllBackorderDisplayEnabled,
+      );
+
+      expect(screen.queryByText('Bundle option 1:')).toBeNull();
+      expect(screen.queryByText('will be backordered', { exact: false })).toBeNull();
+    });
+
+    it('renders nothing for a history child that is not backordered', () => {
+      renderWithProviders(
+        <PicklistBackorderMessages
+          selections={[bundleOption1]}
+          picklistProductsById={{ 555: buildPicklistProduct() }}
+          qty={10}
+          visible
+          backorderUiEnabled
+          historyByProductId={{
+            555: { product_id: 555, quantity_backordered: 0, total_on_hand: 10 },
+          }}
+        />,
+        withAllBackorderDisplayEnabled,
+      );
+
+      expect(screen.queryByText('Bundle option 1:')).toBeNull();
+      expect(screen.queryByText('will be backordered', { exact: false })).toBeNull();
+    });
+  });
 });

--- a/apps/storefront/src/components/PicklistBackorderMessages.tsx
+++ b/apps/storefront/src/components/PicklistBackorderMessages.tsx
@@ -1,6 +1,10 @@
 import PicklistSelectionBackorderMessage from '@/components/PicklistSelectionBackorderMessage';
 import type { ProductSearch } from '@/shared/service/b2b/graphql/product';
-import type { PicklistSelection } from '@/utils/catalogBackorderDisplay';
+import {
+  getPicklistBackorderHistoryFields,
+  type PicklistBackorderHistoryChild,
+  type PicklistSelection,
+} from '@/utils/catalogBackorderDisplay';
 
 interface PicklistBackorderMessagesProps {
   selections: PicklistSelection[];
@@ -8,6 +12,7 @@ interface PicklistBackorderMessagesProps {
   qty: number;
   visible: boolean;
   backorderUiEnabled: boolean;
+  historyByProductId?: Record<number, PicklistBackorderHistoryChild>;
 }
 
 function PicklistBackorderMessages({
@@ -16,6 +21,7 @@ function PicklistBackorderMessages({
   qty,
   visible,
   backorderUiEnabled,
+  historyByProductId,
 }: PicklistBackorderMessagesProps) {
   if (!backorderUiEnabled || selections.length === 0 || !visible) {
     return null;
@@ -29,6 +35,11 @@ function PicklistBackorderMessages({
           selection={selection}
           product={picklistProductsById[selection.productId]}
           qty={qty}
+          backorderFields={
+            historyByProductId
+              ? getPicklistBackorderHistoryFields(historyByProductId[selection.productId])
+              : undefined
+          }
         />
       ))}
     </>

--- a/apps/storefront/src/components/PicklistSelectionBackorderMessage.tsx
+++ b/apps/storefront/src/components/PicklistSelectionBackorderMessage.tsx
@@ -2,6 +2,7 @@ import { Box, Typography } from '@mui/material';
 
 import BackorderMessage from '@/components/BackorderMessage';
 import type { ProductSearch } from '@/shared/service/b2b/graphql/product';
+import type { BackorderDisplayFields } from '@/utils/backorderDisplayFromInventory';
 import {
   getCatalogBackorderFieldsForPicklistProduct,
   type PicklistSelection,
@@ -11,16 +12,21 @@ interface PicklistSelectionBackorderMessageProps {
   selection: PicklistSelection;
   product: ProductSearch | undefined;
   qty: number;
+  backorderFields?: BackorderDisplayFields | null;
 }
 
 function PicklistSelectionBackorderMessage({
   selection,
   product,
   qty,
+  backorderFields,
 }: PicklistSelectionBackorderMessageProps) {
-  const backorderFields = getCatalogBackorderFieldsForPicklistProduct(qty, product);
+  const resolvedFields =
+    backorderFields === undefined
+      ? getCatalogBackorderFieldsForPicklistProduct(qty, product)
+      : backorderFields;
 
-  if (!backorderFields) {
+  if (!resolvedFields) {
     return null;
   }
 
@@ -30,9 +36,9 @@ function PicklistSelectionBackorderMessage({
         {`${selection.displayName}:`}
       </Typography>
       <BackorderMessage
-        totalOnHand={backorderFields.totalOnHand}
-        quantityBackordered={backorderFields.quantityBackordered}
-        backorderMessage={backorderFields.backorderMessage}
+        totalOnHand={resolvedFields.totalOnHand}
+        quantityBackordered={resolvedFields.quantityBackordered}
+        backorderMessage={resolvedFields.backorderMessage}
         visible
       />
     </Box>

--- a/apps/storefront/src/pages/quote/components/QuoteDetailTable.tsx
+++ b/apps/storefront/src/pages/quote/components/QuoteDetailTable.tsx
@@ -10,11 +10,13 @@ import { useB3Lang } from '@/lib/lang';
 import { useAppSelector } from '@/store';
 import { currencyFormatConvert } from '@/utils/b3CurrencyFormat';
 import { getBCPrice, getDisplayPrice } from '@/utils/b3Product/b3Product';
+import { type PicklistBackorderHistoryChild } from '@/utils/catalogBackorderDisplay';
 
 import { useQuoteDetailBackorderState } from '../hooks/useQuoteDetailBackorderState';
 import {
   getQuoteBackorderDisplayFields,
   getQuotePicklistSelections,
+  getRowPicklistBackorderHistory,
 } from '../utils/getQuoteBackorderDisplayFields';
 
 import QuoteDetailTableCard from './QuoteDetailTableCard';
@@ -42,6 +44,7 @@ interface ProductInfoProps {
   backorderMessage?: string;
   totalOnHand?: number;
   quantityBackordered?: number;
+  picklistBackorder?: PicklistBackorderHistoryChild[];
 }
 
 interface ListItemProps {
@@ -123,6 +126,7 @@ function QuoteDetailTable(props: ShoppingDetailTableProps, ref: Ref<unknown>) {
   } = props;
 
   const {
+    isOrdered,
     shouldDisplayBackorderInformation,
     backorderContextEnabled,
     picklistProductsById,
@@ -316,6 +320,7 @@ function QuoteDetailTable(props: ShoppingDetailTableProps, ref: Ref<unknown>) {
       render: (row) => {
         const backorderFields = getQuoteBackorderDisplayFields(row);
         const picklistSelections = backorderContextEnabled ? getQuotePicklistSelections(row) : [];
+        const historyByProductId = isOrdered ? getRowPicklistBackorderHistory(row) : undefined;
 
         return (
           <Box>
@@ -335,6 +340,7 @@ function QuoteDetailTable(props: ShoppingDetailTableProps, ref: Ref<unknown>) {
                 qty={Number(row.quantity) || 0}
                 visible={showBackorderDetails}
                 backorderUiEnabled={backorderContextEnabled}
+                historyByProductId={historyByProductId}
               />
             )}
           </Box>
@@ -472,6 +478,7 @@ function QuoteDetailTable(props: ShoppingDetailTableProps, ref: Ref<unknown>) {
             showBackorderDetails={showBackorderDetails}
             shouldDisplayBackorderInformation={shouldDisplayBackorderInformation}
             picklistProductsById={picklistProductsById}
+            historyByProductId={isOrdered ? getRowPicklistBackorderHistory(row) : undefined}
           />
         )}
       />

--- a/apps/storefront/src/pages/quote/components/QuoteDetailTableCard.tsx
+++ b/apps/storefront/src/pages/quote/components/QuoteDetailTableCard.tsx
@@ -11,6 +11,7 @@ import { useAppSelector } from '@/store';
 import { DisplayCurrency } from '@/types/currency';
 import { currencyFormatConvert } from '@/utils/b3CurrencyFormat';
 import { getBCPrice } from '@/utils/b3Product/b3Product';
+import type { PicklistBackorderHistoryChild } from '@/utils/catalogBackorderDisplay';
 
 import {
   getQuoteBackorderDisplayFields,
@@ -28,6 +29,7 @@ interface QuoteTableCardProps {
   showBackorderDetails?: boolean;
   shouldDisplayBackorderInformation?: boolean;
   picklistProductsById?: Record<number, ProductSearch>;
+  historyByProductId?: Record<number, PicklistBackorderHistoryChild>;
 }
 
 const StyledImage = styled('img')(() => ({
@@ -48,6 +50,7 @@ function QuoteDetailTableCard(props: QuoteTableCardProps) {
     showBackorderDetails = false,
     shouldDisplayBackorderInformation = true,
     picklistProductsById = {},
+    historyByProductId,
   } = props;
   const b3Lang = useB3Lang();
   const isCurrencySymbolPlacementFixEnabled = useFeatureFlag(
@@ -184,6 +187,7 @@ function QuoteDetailTableCard(props: QuoteTableCardProps) {
               qty={Number(quantity) || 0}
               visible={showBackorderDetails}
               backorderUiEnabled={backorderContextEnabled}
+              historyByProductId={historyByProductId}
             />
           )}
           <Typography

--- a/apps/storefront/src/pages/quote/hooks/useQuoteDetailBackorderState.test.ts
+++ b/apps/storefront/src/pages/quote/hooks/useQuoteDetailBackorderState.test.ts
@@ -2,6 +2,7 @@ import { waitFor } from '@testing-library/react';
 import { renderHookWithProviders } from 'tests/utils/hook-test-utils';
 
 import * as b2bService from '@/shared/service/b2b';
+import { QuoteStatus } from '@/shared/service/b2b/graphql/quote';
 
 import { useQuoteDetailBackorderState } from './useQuoteDetailBackorderState';
 
@@ -98,6 +99,28 @@ describe('useQuoteDetailBackorderState', () => {
 
     expect(result.result.current.backorderContextEnabled).toBe(false);
     expect(result.result.current.hasBackorderedItems).toBe(false);
+    expect(b2bService.searchProducts).not.toHaveBeenCalled();
+  });
+
+  it('flags backorders from the picklist snapshot on an ordered quote without fetching live inventory', () => {
+    const orderedRowWithSnapshotChild = {
+      quantity: 5,
+      optionList: JSON.stringify([{ optionId: 'attribute[100]', optionValue: '200' }]),
+      productsSearch: { inventoryTracking: 'none', modifiers: [picklistModifier] },
+      picklistBackorder: [
+        {
+          product_id: 555,
+          quantity_backordered: 3,
+          total_on_hand: 1,
+          backorder_message: 'Ships later',
+        },
+      ],
+    } as never;
+
+    const { result } = renderState([orderedRowWithSnapshotChild], QuoteStatus.ORDERED);
+
+    expect(result.result.current.isOrdered).toBe(true);
+    expect(result.result.current.hasBackorderedItems).toBe(true);
     expect(b2bService.searchProducts).not.toHaveBeenCalled();
   });
 });

--- a/apps/storefront/src/pages/quote/hooks/useQuoteDetailBackorderState.ts
+++ b/apps/storefront/src/pages/quote/hooks/useQuoteDetailBackorderState.ts
@@ -11,11 +11,13 @@ import {
   getQuotePicklistSelections,
   type QuoteBackorderRow,
   quoteDetailListHasBackorderedItemsForDisplay,
+  quoteDetailListHasPicklistBackorderHistory,
 } from '../utils/getQuoteBackorderDisplayFields';
 
 type QuoteDetailBackorderRow = QuoteBackorderRow & Parameters<typeof getQuotePicklistSelections>[0];
 
 interface QuoteDetailBackorderState {
+  isOrdered: boolean;
   shouldDisplayBackorderInformation: boolean;
   backorderContextEnabled: boolean;
   picklistProductsById: Record<number, ProductSearch>;
@@ -39,31 +41,36 @@ export function useQuoteDetailBackorderState(
     hasAnyBackorderDisplay &&
     shouldDisplayBackorderInformation;
 
+  // Ordered quotes read picklist-child backorders from the frozen history on each row, so they
+  // never fetch live inventory; only submitted quotes resolve children against current stock.
   const picklistProductIds = useMemo(
     () =>
-      backorderContextEnabled
+      backorderContextEnabled && !isOrdered
         ? productList.flatMap((row) =>
             getQuotePicklistSelections(row).map((selection) => selection.productId),
           )
         : [],
-    [productList, backorderContextEnabled],
+    [productList, backorderContextEnabled, isOrdered],
   );
   const picklistProductsById = usePicklistInventory(picklistProductIds);
 
   const hasBackorderedItems = useMemo(
     () =>
       quoteDetailListHasBackorderedItemsForDisplay(productList) ||
-      catalogListHasPicklistBackorderedItemsForDisplay(
-        productList.map((row) => ({
-          qty: Number(row.quantity) || 0,
-          selections: getQuotePicklistSelections(row),
-        })),
-        picklistProductsById,
-      ),
-    [productList, picklistProductsById],
+      (isOrdered
+        ? quoteDetailListHasPicklistBackorderHistory(productList)
+        : catalogListHasPicklistBackorderedItemsForDisplay(
+            productList.map((row) => ({
+              qty: Number(row.quantity) || 0,
+              selections: getQuotePicklistSelections(row),
+            })),
+            picklistProductsById,
+          )),
+    [productList, picklistProductsById, isOrdered],
   );
 
   return {
+    isOrdered,
     shouldDisplayBackorderInformation,
     backorderContextEnabled,
     picklistProductsById,

--- a/apps/storefront/src/pages/quote/utils/getQuoteBackorderDisplayFields.test.ts
+++ b/apps/storefront/src/pages/quote/utils/getQuoteBackorderDisplayFields.test.ts
@@ -9,8 +9,10 @@ import {
   getQuoteBackorderDisplayQuantity,
   getQuoteItemBackendAvailability,
   getQuotePicklistSelections,
+  getRowPicklistBackorderHistory,
   type QuoteBackorderRow,
   quoteDetailListHasBackorderedItemsForDisplay,
+  quoteDetailListHasPicklistBackorderHistory,
 } from './getQuoteBackorderDisplayFields';
 
 type QuoteLineNode = QuoteItem['node'];
@@ -291,7 +293,7 @@ describe('draftRowQuantityExceedsAvailableToSell', () => {
 });
 
 describe('getQuoteBackorderDisplayFields for quote detail rows', () => {
-  it('caps backorder display using enriched productsSearch ATS and API snapshot on-hand', () => {
+  it('caps backorder display using enriched productsSearch ATS and API history on-hand', () => {
     const row = {
       quantity: 100,
       variantSku: 'V1',
@@ -314,12 +316,12 @@ describe('getQuoteBackorderDisplayFields for quote detail rows', () => {
     });
   });
 
-  it('prefers API snapshot totalOnHand and backorderMessage over productsSearch values', () => {
+  it('prefers API history totalOnHand and backorderMessage over productsSearch values', () => {
     const row = {
       quantity: 10,
       variantSku: 'V1',
       totalOnHand: 3,
-      backorderMessage: 'Snapshot message',
+      backorderMessage: 'History message',
       productsSearch: {
         inventoryTracking: 'product',
         totalOnHand: 99,
@@ -332,7 +334,7 @@ describe('getQuoteBackorderDisplayFields for quote detail rows', () => {
     expect(getQuoteBackorderDisplayFields(row)).toEqual({
       totalOnHand: 3,
       quantityBackordered: 7,
-      backorderMessage: 'Snapshot message',
+      backorderMessage: 'History message',
     });
   });
 
@@ -396,7 +398,7 @@ describe('getQuoteBackorderDisplayFields for quote detail rows', () => {
       quantity: 10,
       variantSku: 'V1',
       quantityBackordered: 3,
-      backorderMessage: 'Snapshot message',
+      backorderMessage: 'History message',
       productsSearch: {
         inventoryTracking: 'product',
         availableToSell: 10,
@@ -407,7 +409,7 @@ describe('getQuoteBackorderDisplayFields for quote detail rows', () => {
     expect(getQuoteBackorderDisplayFields(row)).toEqual({
       totalOnHand: 0,
       quantityBackordered: 3,
-      backorderMessage: 'Snapshot message',
+      backorderMessage: 'History message',
     });
   });
 
@@ -417,7 +419,7 @@ describe('getQuoteBackorderDisplayFields for quote detail rows', () => {
       variantSku: 'SKU-B',
       totalOnHand: 2,
       quantityBackordered: 8,
-      backorderMessage: 'Snapshot message',
+      backorderMessage: 'History message',
       productsSearch: {
         inventoryTracking: 'variant',
         availableToSell: 10,
@@ -429,7 +431,7 @@ describe('getQuoteBackorderDisplayFields for quote detail rows', () => {
     expect(getQuoteBackorderDisplayFields(row)).toEqual({
       totalOnHand: 2,
       quantityBackordered: 8,
-      backorderMessage: 'Snapshot message',
+      backorderMessage: 'History message',
     });
   });
 });
@@ -552,5 +554,72 @@ describe('quoteDetailListHasBackorderedItemsForDisplay', () => {
     };
 
     expect(quoteDetailListHasBackorderedItemsForDisplay([row])).toBe(true);
+  });
+});
+
+describe('getRowPicklistBackorderHistory', () => {
+  it('indexes the history children by product id', () => {
+    expect(
+      getRowPicklistBackorderHistory({
+        picklistBackorder: [
+          { product_id: 555, quantity_backordered: 2, total_on_hand: 3 },
+          { product_id: 666, quantity_backordered: 0, total_on_hand: 9 },
+        ],
+      }),
+    ).toEqual({
+      555: { product_id: 555, quantity_backordered: 2, total_on_hand: 3 },
+      666: { product_id: 666, quantity_backordered: 0, total_on_hand: 9 },
+    });
+  });
+
+  it('returns undefined when there is no history (non-ordered quotes)', () => {
+    expect(getRowPicklistBackorderHistory({})).toBeUndefined();
+    expect(getRowPicklistBackorderHistory({ picklistBackorder: [] })).toBeUndefined();
+  });
+});
+
+describe('quoteDetailListHasPicklistBackorderHistory', () => {
+  const picklistModifier = {
+    id: 100,
+    type: 'product_list',
+    display_name: 'Pick a pickle',
+    option_values: [{ id: 200, value_data: { product_id: 555 } }],
+  };
+
+  const buildRow = (
+    picklistBackorder: Array<{
+      product_id: number;
+      quantity_backordered: number;
+      total_on_hand: number;
+    }>,
+  ) => ({
+    optionList: JSON.stringify([{ option_id: 100, option_value: 200 }]),
+    productsSearch: { modifiers: [picklistModifier] },
+    picklistBackorder,
+  });
+
+  it('returns true when a resolved selection maps to a backordered history child', () => {
+    expect(
+      quoteDetailListHasPicklistBackorderHistory([
+        buildRow([{ product_id: 555, quantity_backordered: 1, total_on_hand: 0 }]),
+      ]),
+    ).toBe(true);
+  });
+
+  it('returns false when the matched history child is not backordered', () => {
+    expect(
+      quoteDetailListHasPicklistBackorderHistory([
+        buildRow([{ product_id: 555, quantity_backordered: 0, total_on_hand: 9 }]),
+        {},
+      ]),
+    ).toBe(false);
+  });
+
+  it('returns false when a backordered history child matches no picklist selection', () => {
+    expect(
+      quoteDetailListHasPicklistBackorderHistory([
+        buildRow([{ product_id: 999, quantity_backordered: 3, total_on_hand: 0 }]),
+      ]),
+    ).toBe(false);
   });
 });

--- a/apps/storefront/src/pages/quote/utils/getQuoteBackorderDisplayFields.ts
+++ b/apps/storefront/src/pages/quote/utils/getQuoteBackorderDisplayFields.ts
@@ -4,7 +4,9 @@ import { QuoteItem } from '@/types/quotes';
 import type { BackorderDisplayFields } from '@/utils/backorderDisplayFromInventory';
 import { getBackorderDisplayFieldsFromOnHand } from '@/utils/backorderDisplayFromInventory';
 import {
+  getPicklistBackorderHistoryFields,
   getProductDetailsForPicklistSelections,
+  type PicklistBackorderHistoryChild,
   type PicklistSelection,
   type PicklistSelectionSource,
 } from '@/utils/catalogBackorderDisplay';
@@ -246,4 +248,42 @@ export function quoteDetailListHasBackorderedItemsForDisplay(
   productList: QuoteBackorderRow[],
 ): boolean {
   return productList.some((item) => Boolean(getQuoteBackorderDisplayFields(item)));
+}
+
+interface PicklistBackorderHistoryRow {
+  picklistBackorder?: PicklistBackorderHistoryChild[] | null;
+}
+
+export function getRowPicklistBackorderHistory(
+  row: PicklistBackorderHistoryRow,
+): Record<number, PicklistBackorderHistoryChild> | undefined {
+  const children = row.picklistBackorder;
+  if (!children?.length) {
+    return undefined;
+  }
+
+  const byProductId: Record<number, PicklistBackorderHistoryChild> = {};
+  children.forEach((child) => {
+    if (child?.product_id != null) {
+      byProductId[child.product_id] = child;
+    }
+  });
+  return byProductId;
+}
+
+export function quoteDetailListHasPicklistBackorderHistory(
+  productList: Array<
+    Parameters<typeof getQuotePicklistSelections>[0] & PicklistBackorderHistoryRow
+  >,
+): boolean {
+  return productList.some((row) => {
+    const historyByProductId = getRowPicklistBackorderHistory(row);
+    if (!historyByProductId) {
+      return false;
+    }
+    return getQuotePicklistSelections(row).some(
+      (selection) =>
+        getPicklistBackorderHistoryFields(historyByProductId[selection.productId]) !== null,
+    );
+  });
 }

--- a/apps/storefront/src/shared/service/b2b/graphql/quote.ts
+++ b/apps/storefront/src/shared/service/b2b/graphql/quote.ts
@@ -1,5 +1,6 @@
 import { QuoteExtraFieldsType } from '@/types/quotes';
 import { channelId, storeHash } from '@/utils/basicConfig';
+import type { PicklistBackorderHistoryChild } from '@/utils/catalogBackorderDisplay';
 import { convertArrayToGraphql, convertObjectToGraphql } from '@/utils/graphqlDataConvert';
 
 import B3Request from '../../request/b3Fetch';
@@ -233,6 +234,7 @@ const getQuoteInfo = `
         backorderMessage,
         totalOnHand,
         quantityBackordered,
+        picklistBackorder,
       },
       storefrontAttachFiles {
         id,
@@ -625,6 +627,7 @@ export interface B2BQuoteDetail {
         backorderMessage?: string;
         totalOnHand?: number;
         quantityBackordered?: number;
+        picklistBackorder?: PicklistBackorderHistoryChild[];
       }[];
       storefrontAttachFiles: unknown[];
       backendAttachFiles: unknown[];

--- a/apps/storefront/src/utils/catalogBackorderDisplay.test.ts
+++ b/apps/storefront/src/utils/catalogBackorderDisplay.test.ts
@@ -14,6 +14,7 @@ import {
   getCatalogInventoryRowFromSearchProduct,
   getCatalogInventorySku,
   getCatalogProductRowDisplayState,
+  getPicklistBackorderHistoryFields,
   getProductDetailsForPicklistSelections,
   productRequiresChooseOptionsBeforeAdd,
   quantityExceedsAvailableToSell,
@@ -604,6 +605,48 @@ describe('catalogBackorderDisplay', () => {
           {},
         ),
       ).toBe(false);
+    });
+  });
+
+  describe('getPicklistBackorderHistoryFields', () => {
+    it('maps a backordered history child to display fields', () => {
+      expect(
+        getPicklistBackorderHistoryFields({
+          product_id: 555,
+          sku: 'CHILD-SKU',
+          backorder_message: 'Lead time: 2-4 weeks',
+          quantity_backordered: 3,
+          total_on_hand: 7,
+        }),
+      ).toEqual({
+        totalOnHand: 7,
+        quantityBackordered: 3,
+        backorderMessage: 'Lead time: 2-4 weeks',
+      });
+    });
+
+    it('returns null when nothing is backordered', () => {
+      expect(
+        getPicklistBackorderHistoryFields({
+          product_id: 555,
+          quantity_backordered: 0,
+          total_on_hand: 10,
+        }),
+      ).toBeNull();
+    });
+
+    it('returns null for an undefined child', () => {
+      expect(getPicklistBackorderHistoryFields(undefined)).toBeNull();
+    });
+
+    it('defaults missing totals and message', () => {
+      expect(
+        getPicklistBackorderHistoryFields({ product_id: 555, quantity_backordered: 2 }),
+      ).toEqual({
+        totalOnHand: 0,
+        quantityBackordered: 2,
+        backorderMessage: undefined,
+      });
     });
   });
 });

--- a/apps/storefront/src/utils/catalogBackorderDisplay.ts
+++ b/apps/storefront/src/utils/catalogBackorderDisplay.ts
@@ -276,6 +276,31 @@ export function getCatalogBackorderFieldsForPicklistProduct(
   );
 }
 
+export interface PicklistBackorderHistoryChild {
+  product_id: number;
+  sku?: string | null;
+  backorder_message?: string | null;
+  quantity_backordered?: number | null;
+  total_on_hand?: number | null;
+}
+
+export function getPicklistBackorderHistoryFields(
+  child: PicklistBackorderHistoryChild | undefined,
+): BackorderDisplayFields | null {
+  if (!child) {
+    return null;
+  }
+  if ((child.quantity_backordered ?? 0) <= 0) {
+    return null;
+  }
+
+  return {
+    totalOnHand: child.total_on_hand ?? 0,
+    quantityBackordered: child.quantity_backordered ?? 0,
+    backorderMessage: child.backorder_message ?? undefined,
+  };
+}
+
 export function catalogListHasPicklistBackorderedItemsForDisplay(
   rows: Array<{ qty: number; selections: PicklistSelection[] }>,
   picklistProductsById: Record<number, ProductSearch>,


### PR DESCRIPTION
Jira: [BACK-722](https://bigcommercecloud.atlassian.net/browse/BACK-722)

## What/Why?
~~**Note** This PR relies on the backend change in https://github.com/bigcommerce/b2b-edition-api/pull/6897 and also relies on https://github.com/bigcommerce/b2b-buyer-portal/pull/946 and the PR's before that. This should be the last Pr merged in this queue.~~

Implement backorders for picklist children in ordered quotes.
For Quotes in ordered status, when an item is a picklist, that picklist is not currently displaying backorder information.
We now display this information on the quote page.

## Rollout/Rollback
Revert this PR if there are issues.

## Testing
Quote shows parent has 1 on hand and 2 backordered and child has 2 on hand and 1 backordered.
<img width="1488" height="881" alt="quote" src="https://github.com/user-attachments/assets/b7cad144-19e8-406d-8562-b4e682d42241" />

Updating the products inventory to show zero in stock for both:
<img width="1209" height="276" alt="stock" src="https://github.com/user-attachments/assets/2505a606-0700-4bd2-90c9-ace84564d1f3" />

Ordered quote still shows parent has 1 on hand and 2 backordered and child has 2 on hand and 1 backordered as per the historical order placement.
<img width="1490" height="878" alt="ordered" src="https://github.com/user-attachments/assets/6821d3f5-caa4-426b-b355-a982b1522ba0" />

ping @animesh1987 @bigcommerce/team-b2b

[BACK-722]: https://bigcommercecloud.atlassian.net/browse/BACK-722?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes quote backorder display and inventory-fetch branching by quote status; behavior depends on backend `picklistBackorder` but is covered by tests and limited to storefront quote detail.
> 
> **Overview**
> **Ordered quotes** with picklist (bundle) options now show **per-child backorder messaging** (on hand, backordered qty, lead-time text) on the quote detail table and mobile cards, matching parent-line behavior for frozen order history.
> 
> For **ordered** status, picklist children use the line item’s **`picklistBackorder`** snapshot from GraphQL instead of live product search. **Open/submitted** quotes still resolve picklist inventory via **`usePicklistInventory`**. The backorder-details toggle and **`hasBackorderedItems`** account for picklist history on ordered quotes so child backorders surface the UI even when the parent line isn’t backordered.
> 
> Shared picklist UI accepts optional **`historyByProductId`**; when present, **`getPicklistBackorderHistoryFields`** drives display instead of catalog inventory math.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8bc9914899ff23ecb06ca659862d25db0634260. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->