### PR TITLE
fix(orders): BACK-756 gate reorder ATS behind backorder flags

### DIFF
--- a/apps/storefront/src/pages/OrderDetail/components/OrderCheckboxProduct.tsx
+++ b/apps/storefront/src/pages/OrderDetail/components/OrderCheckboxProduct.tsx
@@ -36,6 +36,7 @@ interface OrderCheckboxProductProps {
   type?: string;
   catalogInventoryBySku?: Record<string, CatalogQuickVariantSku>;
   backorderUiEnabled?: boolean;
+  showReorderAtsHelper?: boolean;
 }
 
 export default function OrderCheckboxProduct(props: OrderCheckboxProductProps) {
@@ -50,6 +51,7 @@ export default function OrderCheckboxProduct(props: OrderCheckboxProductProps) {
     type,
     catalogInventoryBySku,
     backorderUiEnabled = false,
+    showReorderAtsHelper = false,
   } = props;
 
   const b3Lang = useB3Lang();
@@ -204,7 +206,7 @@ export default function OrderCheckboxProduct(props: OrderCheckboxProductProps) {
         const { qtyHelperText, backorderFields } = getCatalogProductRowDisplayState({
           qty,
           productHelperText: product.helperText,
-          showAvailableToSellHelper: type === 'reOrder',
+          showAvailableToSellHelper: showReorderAtsHelper,
           inventoryRow: usesCatalogBackorderInventory
             ? catalogInventoryBySku?.[product.sku.toUpperCase()]
             : undefined,

--- a/apps/storefront/src/pages/OrderDetail/components/OrderDialog.tsx
+++ b/apps/storefront/src/pages/OrderDetail/components/OrderDialog.tsx
@@ -103,7 +103,7 @@ export default function OrderDialog({
   orderId,
 }: OrderDialogProps) {
   const navigate = useNavigate();
-  const { isBackorderEnabled, isBackorderMessagingContextEnabled, hasAnyBackorderDisplay } =
+  const { isBackorderMessagingContextEnabled: isReorderAtsEnabled, hasAnyBackorderDisplay } =
     useBackorderStorefrontMessaging();
   const isB2BUser = useAppSelector(isB2BUserSelector);
   const [isOpenCreateShopping, setOpenCreateShopping] = useState(false);
@@ -386,7 +386,7 @@ export default function OrderDialog({
     try {
       setIsRequestLoading(true);
 
-      if (isBackorderEnabled) {
+      if (isReorderAtsEnabled) {
         await handleReorderBackend();
       } else {
         await handleReorderOnFrontend();
@@ -594,10 +594,11 @@ export default function OrderDialog({
             type={type}
             catalogInventoryBySku={catalogInventoryBySku}
             backorderUiEnabled={
-              isBackorderMessagingContextEnabled &&
+              isReorderAtsEnabled &&
               hasAnyBackorderDisplay &&
               (type === 'reOrder' || type === 'shoppingList')
             }
+            showReorderAtsHelper={type === 'reOrder' && isReorderAtsEnabled}
           />
 
           {type === 'return' && (

--- a/apps/storefront/src/pages/OrderDetail/index.test.tsx
+++ b/apps/storefront/src/pages/OrderDetail/index.test.tsx
@@ -1761,6 +1761,9 @@ describe('when a personal customer visits an order', () => {
       storeInfo: buildStoreInfoStateWith({ timeFormat: { display: 'j F Y' } }),
       global: buildGlobalStateWith({
         backorderEnabled: true,
+        featureFlags: {
+          'BACK-134.backorders_phase_1_1_control_messaging_on_storefront': true,
+        },
       }),
     };
 
@@ -3107,6 +3110,199 @@ describe('when a personal customer visits an order', () => {
 
       await waitFor(() => {
         expect(screen.getByText('Please select at least one item')).toBeVisible();
+      });
+    });
+  });
+
+  describe('when reorder ATS validation is gated behind backorder flags', () => {
+    const variantSku = 'REORDER-ATS-SKU';
+
+    const basePreloadedState = {
+      company: buildCompanyStateWith({
+        customer: {
+          role: CustomerRole.B2C,
+        },
+      }),
+      storeInfo: buildStoreInfoStateWith({ timeFormat: { display: 'j F Y' } }),
+    };
+
+    const buildVisibleReorderProduct = () => ({
+      ...buildProductWith({
+        name: 'Tracked Product',
+        sku: variantSku,
+        quantity: 1,
+        product_options: [],
+      }),
+      isVisible: true,
+    });
+
+    it('does not show ATS helper when backorder is enabled but BACK-134 is off', async () => {
+      const product = buildVisibleReorderProduct();
+
+      const variantInfo = buildVariantInfoWith({
+        variantSku,
+        inventoryTracking: 'variant',
+        isStock: '0',
+        stock: 100,
+        minQuantity: 0,
+        maxQuantity: 0,
+      });
+
+      const createCartSimple = vi.fn();
+      const validateProductHandler = vi.fn();
+
+      server.use(
+        graphql.query('GetCustomerOrderStatuses', () =>
+          HttpResponse.json(buildCustomerOrderStatusesWith('WHATEVER_VALUES')),
+        ),
+        graphql.query('AddressConfig', () =>
+          HttpResponse.json(buildAddressConfigResponseWith('WHATEVER_VALUES')),
+        ),
+        graphql.query('GetCustomerOrder', () =>
+          HttpResponse.json(
+            buildCustomerOrderResponseWith({
+              data: { customerOrder: { products: [product] } },
+            }),
+          ),
+        ),
+        graphql.query('GetVariantInfoBySkus', ({ query }) => {
+          if (query.includes(`"${variantSku}"`)) {
+            return HttpResponse.json(
+              buildVariantInfoResponseWith({ data: { variantSku: [variantInfo] } }),
+            );
+          }
+
+          return HttpResponse.json(buildVariantInfoResponseWith({ data: { variantSku: [] } }));
+        }),
+        graphql.query('getCart', () => HttpResponse.json({ data: { site: { cart: null } } })),
+        graphql.mutation('createCartSimple', ({ variables }) =>
+          HttpResponse.json(createCartSimple(variables)),
+        ),
+        graphql.query('ValidateProduct', () => {
+          validateProductHandler();
+          return HttpResponse.json({
+            data: { validateProduct: { responseType: 'SUCCESS', message: '' } },
+          });
+        }),
+      );
+
+      when(createCartSimple)
+        .calledWith({
+          createCartInput: {
+            lineItems: [
+              {
+                quantity: 5,
+                productEntityId: product.product_id,
+                variantEntityId: product.variant_id,
+                selectedOptions: { multipleChoices: [], textFields: [] },
+              },
+            ],
+          },
+        })
+        .thenReturn({ data: { cart: { createCart: { cart: { entityId: 'cart-1' } } } } });
+
+      renderWithProviders(<OrderDetails />, {
+        preloadedState: {
+          ...basePreloadedState,
+          global: buildGlobalStateWith({
+            backorderEnabled: true,
+            featureFlags: {
+              'BACK-134.backorders_phase_1_1_control_messaging_on_storefront': false,
+            },
+          }),
+        },
+      });
+
+      await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+      await userEvent.click(screen.getByRole('button', { name: 'Re-Order' }));
+
+      const dialog = await screen.findByRole('dialog', { name: 'Re-Order' });
+      const productGroup = within(dialog).getByRole('group', { name: 'Tracked Product' });
+
+      await userEvent.click(within(productGroup).getByRole('checkbox'));
+
+      await userEvent.type(within(productGroup).getByRole('spinbutton'), '5', {
+        initialSelectionStart: 0,
+        initialSelectionEnd: Infinity,
+      });
+
+      expect(within(dialog).queryByText('Only 0 available')).not.toBeInTheDocument();
+
+      await userEvent.click(screen.getByRole('button', { name: 'Add to cart' }));
+
+      await waitFor(() => {
+        expect(screen.getByText('Products are added to cart')).toBeVisible();
+      });
+
+      expect(validateProductHandler).not.toHaveBeenCalled();
+    });
+
+    it('shows ATS helper when backorder and BACK-134 are enabled', async () => {
+      const product = buildVisibleReorderProduct();
+
+      const variantInfo = buildVariantInfoWith({
+        variantSku,
+        inventoryTracking: 'variant',
+        availableToSell: 2,
+        unlimitedBackorder: false,
+        isStock: '1',
+        stock: 2,
+        minQuantity: 0,
+        maxQuantity: 0,
+      });
+
+      server.use(
+        graphql.query('GetCustomerOrderStatuses', () =>
+          HttpResponse.json(buildCustomerOrderStatusesWith('WHATEVER_VALUES')),
+        ),
+        graphql.query('AddressConfig', () =>
+          HttpResponse.json(buildAddressConfigResponseWith('WHATEVER_VALUES')),
+        ),
+        graphql.query('GetCustomerOrder', () =>
+          HttpResponse.json(
+            buildCustomerOrderResponseWith({
+              data: { customerOrder: { products: [product] } },
+            }),
+          ),
+        ),
+        graphql.query('GetVariantInfoBySkus', ({ query }) => {
+          if (query.includes(`"${variantSku}"`)) {
+            return HttpResponse.json(
+              buildVariantInfoResponseWith({ data: { variantSku: [variantInfo] } }),
+            );
+          }
+
+          return HttpResponse.json(buildVariantInfoResponseWith({ data: { variantSku: [] } }));
+        }),
+      );
+
+      renderWithProviders(<OrderDetails />, {
+        preloadedState: {
+          ...basePreloadedState,
+          global: buildGlobalStateWith({
+            backorderEnabled: true,
+            featureFlags: {
+              'BACK-134.backorders_phase_1_1_control_messaging_on_storefront': true,
+            },
+          }),
+        },
+      });
+
+      await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+      await userEvent.click(screen.getByRole('button', { name: 'Re-Order' }));
+
+      const dialog = await screen.findByRole('dialog', { name: 'Re-Order' });
+      const productGroup = within(dialog).getByRole('group', { name: 'Tracked Product' });
+
+      await userEvent.type(within(productGroup).getByRole('spinbutton'), '5', {
+        initialSelectionStart: 0,
+        initialSelectionEnd: Infinity,
+      });
+
+      await waitFor(() => {
+        expect(within(dialog).getByText('Only 2 available')).toBeVisible();
       });
     });
   });

--- a/apps/storefront/src/pages/OrderDetail/index.unified.test.tsx
+++ b/apps/storefront/src/pages/OrderDetail/index.unified.test.tsx
@@ -2081,6 +2081,7 @@ describe('Order detail path with unified SF GQL flag ON', () => {
         backorderEnabled: true,
         featureFlags: {
           'B2B-4613.buyer_portal_unified_sf_gql_orders': true,
+          'BACK-134.backorders_phase_1_1_control_messaging_on_storefront': true,
         },
       }),
       storeInfo: buildStoreInfoStateWith({ timeFormat: { display: 'j F Y' } }),


### PR DESCRIPTION
Jira: [BACK-756](https://bigcommercecloud.atlassian.net/browse/BACK-756)

## What/Why?
Reorder was showing false “Only 0 available” errors when `variantSku` returned null `availableToSell` fields (e.g. when `Feature_Backorder` or the `BACK-134` experiment flag was off), because the UI always ran ATS checks and treated null as zero.

Fixing this to gate the ATS helper text and backend reorder validation behind `isBackorderMessagingContextEnabled` (Feature_Backorder + BACK-134), matching other catalog backorder flows. Legacy min/max stock validation on the frontend reorder path is unchanged.

## Rollout/Rollback
Merge/revert. Validation is now gated by `Feature_Backorder && BACK-134.backorders_phase_1_1_control_messaging_on_storefront`.

## Testing
Store with backorders disabled.

### Before
Validation error “Only 0 available” appears.

https://github.com/user-attachments/assets/7ce13c97-1774-4a82-a69d-88976054b41c

### After
No validation error appears, able to add to cart.

https://github.com/user-attachments/assets/29e1d4dc-599a-4dc3-9bd4-aa677b1d0033

With backorder messaging enabled, expected ATS validation error.

https://github.com/user-attachments/assets/05bdcbf7-670d-409d-bdde-aec1c993f452

Ping @animesh1987 @benpratt77 

[BACK-634]: https://bigcommercecloud.atlassian.net/browse/BACK-634?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes reorder validation and add-to-cart behavior for stores with backorder on but BACK-134 off; incorrect gating could block valid reorders or skip needed ATS checks.
> 
> **Overview**
> Fixes false **“Only 0 available”** reorder errors when catalog `availableToSell` is missing or null because the UI always ran ATS checks for reorder dialogs.
> 
> **Reorder ATS** (inline “Only N available” helper and **backend** `ValidateProduct` path) is now gated on **`isBackorderMessagingContextEnabled`** (`Feature_Backorder` + **`BACK-134`**), aligned with other storefront backorder messaging. When that context is off, reorder uses the **legacy frontend** stock/min/max path and does not show ATS helper text.
> 
> `OrderCheckboxProduct` takes an explicit **`showReorderAtsHelper`** prop instead of inferring ATS from dialog `type === 'reOrder'`. Tests cover BACK-134 on/off and existing backend-validation suites enable the BACK-134 flag where needed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 809b1575339a7fca4272fae3bfbafa032740476e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

[BACK-756]: https://bigcommercecloud.atlassian.net/browse/BACK-756?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ