### PR TITLE
fix(companies): B2B-5056 Fix register company flow for Catalyst companies

### DIFF
--- a/apps/storefront/src/HeadlessController/getSku.tsx
+++ b/apps/storefront/src/HeadlessController/getSku.tsx
@@ -2,7 +2,7 @@ import { z } from 'zod';
 
 import B3Request from '@/shared/service/request/b3Fetch';
 import { LineItem } from '@/utils/b3Product/b3Product';
-import { platform } from '@/utils/basicConfig';
+import { platform, PLATFORM_BIGCOMMERCE } from '@/utils/basicConfig';
 
 const Options = z.array(
   z.object({
@@ -25,7 +25,7 @@ const graphqlRequest: typeof B3Request.graphqlBC | typeof B3Request.graphqlBCPro
   query,
   variables,
 }) => {
-  return platform === 'bigcommerce'
+  return platform === PLATFORM_BIGCOMMERCE
     ? B3Request.graphqlBC({ query, variables })
     : B3Request.graphqlBCProxy({ query, variables });
 };

--- a/apps/storefront/src/HeadlessController/index.test.tsx
+++ b/apps/storefront/src/HeadlessController/index.test.tsx
@@ -12,6 +12,7 @@ import { when } from 'vitest-when';
 
 import { ShoppingListsItemsProps } from '@/pages/ShoppingLists/config';
 import { CustomerRole } from '@/types';
+import { BigCommerceStorefrontAPIBaseURL } from '@/utils/basicConfig';
 
 import HeadlessController from '.';
 
@@ -50,6 +51,53 @@ const buildShoppingListsNodeWith = builder<{ node: ShoppingListsItemsProps }>(()
     },
   },
 }));
+
+describe('HeadlessController user.logout', () => {
+  const bcGraphql = graphql.link(`${BigCommerceStorefrontAPIBaseURL}/graphql`);
+  const b2bGraphql = graphql.link('https://api-b2b.bigcommerce.com/graphql');
+
+  it('calls the BC logout mutation to clear the storefront session cookie', async () => {
+    const logoutMutation = vi.fn().mockReturnValue({ data: { logout: { result: 'success' } } });
+
+    server.use(
+      bcGraphql.mutation('Logout', () => HttpResponse.json(logoutMutation())),
+      b2bGraphql.mutation('storeFrontToken', () =>
+        HttpResponse.json({ data: { storeFrontToken: { token: faker.string.uuid() } } }),
+      ),
+    );
+
+    const mockSetOpenPage = vi.fn();
+    renderWithProviders(<HeadlessController setOpenPage={mockSetOpenPage} />);
+
+    await window.b2b.utils.user.logout();
+
+    expect(logoutMutation).toHaveBeenCalled();
+  });
+
+  it('prefetches a bcGraphqlToken before calling the BC logout mutation when none is cached', async () => {
+    const freshToken = faker.string.uuid();
+    const logoutAuthHeaders: (string | null)[] = [];
+
+    server.use(
+      bcGraphql.mutation('Logout', ({ request }) => {
+        logoutAuthHeaders.push(request.headers.get('Authorization'));
+        return HttpResponse.json({ data: { logout: { result: 'success' } } });
+      }),
+      b2bGraphql.mutation('storeFrontToken', () =>
+        HttpResponse.json({ data: { storeFrontToken: { token: freshToken } } }),
+      ),
+    );
+
+    const mockSetOpenPage = vi.fn();
+    // Default preloaded state has an empty bcGraphqlToken, simulating a cleared/expired
+    // token before logout runs.
+    renderWithProviders(<HeadlessController setOpenPage={mockSetOpenPage} />);
+
+    await window.b2b.utils.user.logout();
+
+    expect(logoutAuthHeaders).toEqual([`Bearer  ${freshToken}`]);
+  });
+});
 
 describe('HeadlessController shopping lists utils', () => {
   it('getLists retrieves B2B shopping lists', async () => {

--- a/apps/storefront/src/HeadlessController/index.tsx
+++ b/apps/storefront/src/HeadlessController/index.tsx
@@ -15,6 +15,7 @@ import { CustomStyleContext } from '@/shared/customStyleButton';
 import { GlobalContext } from '@/shared/global';
 import { getAllowedRoutesWithoutComponent } from '@/shared/routeList';
 import { getB2BShoppingList, getBcShoppingList, superAdminCompanies } from '@/shared/service/b2b';
+import { bcLogoutLogin } from '@/shared/service/bc';
 import B3Request from '@/shared/service/request/b3Fetch';
 import {
   formattedQuoteDraftListSelector,
@@ -233,6 +234,20 @@ export default function HeadlessController({ setOpenPage }: HeadlessControllerPr
           },
           logout: async () => {
             try {
+              // Invalidate the BC storefront session cookie set via credentials:include,
+              // mirroring CatalystLogin/useLogout, otherwise it stays active for later
+              // credentialed GraphQL calls even after buyer-portal state is cleared.
+              // bcLogoutLogin goes through graphqlBC on Catalyst, which needs a
+              // bcGraphqlToken bearer, so ensure one is present before calling it —
+              // otherwise a cleared/expired token makes the mutation fail while local
+              // state still gets cleared below.
+              await ensureBcGraphqlToken();
+              const { result } = (await bcLogoutLogin()).data.logout;
+
+              if (result !== 'success') {
+                throw new Error('Failed to logout');
+              }
+
               if (isAgenting) {
                 await endMasquerade(store);
               }

--- a/apps/storefront/src/constants/index.ts
+++ b/apps/storefront/src/constants/index.ts
@@ -1,3 +1,5 @@
+import { PLATFORM_BIGCOMMERCE } from '@/utils/basicConfig';
+
 export const SUPPORT_LANGUAGE = ['en', 'zh', 'fr', 'nl', 'de', 'it', 'es'];
 
 // cspell:disable
@@ -68,7 +70,7 @@ export const BROWSER_LANG = navigator.language.substring(0, 2);
 const {
   setting: { platform, cart_url: cartUrl },
 } = window.B3;
-const CART_FALLBACK_VALUE = platform === 'bigcommerce' ? '/cart.php' : '/cart';
+const CART_FALLBACK_VALUE = platform === PLATFORM_BIGCOMMERCE ? '/cart.php' : '/cart';
 export const CART_URL = cartUrl ?? CART_FALLBACK_VALUE;
 export const CHECKOUT_URL = '/checkout';
 

--- a/apps/storefront/src/index.d.ts
+++ b/apps/storefront/src/index.d.ts
@@ -64,6 +64,7 @@ declare global {
         environment: string;
         disable_logout_button?: boolean;
         cart_url?: string;
+        bc_graphql_domain?: string;
       };
     };
     catalyst?: {

--- a/apps/storefront/src/pages/AccountSetting/index.tsx
+++ b/apps/storefront/src/pages/AccountSetting/index.tsx
@@ -28,7 +28,7 @@ import { CustomerRole, UserTypes } from '@/types';
 import { Fields, ParamProps } from '@/types/accountSetting';
 import { B3SStorage } from '@/utils/b3Storage';
 import { snackbar } from '@/utils/b3Tip';
-import { channelId, platform } from '@/utils/basicConfig';
+import { channelId, platform, PLATFORM_CATALYST } from '@/utils/basicConfig';
 import { deCodeField, getAccountFormFields } from '@/utils/registerUtils';
 
 import { getAccountSettingsFields, getPasswordModifiedFields } from './config';
@@ -53,7 +53,7 @@ function useData() {
   const isDisplayUpgradeBanner =
     CustomerRole.B2C === customer.role &&
     [UserTypes.B2C, UserTypes.MULTIPLE_B2C].includes(customer.userType) &&
-    platform === 'catalyst';
+    platform === PLATFORM_CATALYST;
 
   const validateEmailValue = async (emailValue: string) => {
     if (customer.emailAddress === trim(emailValue)) return true;

--- a/apps/storefront/src/pages/Invoice/utils/payment.ts
+++ b/apps/storefront/src/pages/Invoice/utils/payment.ts
@@ -4,6 +4,7 @@ import { getInvoiceCheckoutUrl } from '@/shared/service/b2b';
 import { BcCartData } from '@/types/invoice';
 import { attemptCheckoutLoginAndRedirect } from '@/utils/b3checkout';
 import b2bLogger from '@/utils/b3Logger';
+import { PLATFORM_BIGCOMMERCE, PLATFORM_CATALYST } from '@/utils/basicConfig';
 
 const getCheckoutUrlAndCart = async (params: BcCartData) => {
   const {
@@ -32,12 +33,12 @@ export const gotoInvoiceCheckoutUrl = async (
     }
   };
 
-  if (platform === 'bigcommerce') {
+  if (platform === PLATFORM_BIGCOMMERCE) {
     handleStencil();
     return;
   }
 
-  if (platform === 'catalyst') {
+  if (platform === PLATFORM_CATALYST) {
     window.location.assign(`/checkout?cartId=${cartId}`);
     return;
   }

--- a/apps/storefront/src/pages/Login/CatalystLogin.tsx
+++ b/apps/storefront/src/pages/Login/CatalystLogin.tsx
@@ -6,13 +6,19 @@ import { endUserMasqueradingCompany, superAdminEndMasquerade } from '@/shared/se
 import { bcLogoutLogin } from '@/shared/service/bc';
 import { isLoggedInSelector, store, useAppSelector } from '@/store';
 import { clearCompanySlice } from '@/store/slices/company';
+import { ensureBcGraphqlToken } from '@/utils/loginInfo';
 
+// bcLogoutLogin always goes through graphqlBC on Catalyst, which needs a bcGraphqlToken
+// bearer. B2B auth expiry (and any prior logoutSession()) clears that token before this
+// component mounts, so it must be re-fetched here or the storefront logout mutation fails.
 const logout = () => {
-  return bcLogoutLogin().then((res) => {
-    if (res.data.logout.result !== 'success') {
-      throw new Error('Failed to logout');
-    }
-  });
+  return ensureBcGraphqlToken().then(() =>
+    bcLogoutLogin().then((res) => {
+      if (res.data.logout.result !== 'success') {
+        throw new Error('Failed to logout');
+      }
+    }),
+  );
 };
 
 const useEndMasquerade = () => {

--- a/apps/storefront/src/pages/Login/index.tsx
+++ b/apps/storefront/src/pages/Login/index.tsx
@@ -19,7 +19,7 @@ import { setB2BToken, setCurrentCustomerJWT } from '@/store/slices/company';
 import { LoginFlagType } from '@/types/login';
 import b2bLogger from '@/utils/b3Logger';
 import { snackbar } from '@/utils/b3Tip';
-import { channelId, platform } from '@/utils/basicConfig';
+import { channelId, platform, PLATFORM_CATALYST } from '@/utils/basicConfig';
 import { isCompanyError } from '@/utils/companyUtils';
 import { getCurrentCustomerInfo } from '@/utils/loginInfo';
 import { isDefaultLoginStylingActive } from '@/utils/preMountLoginMask';
@@ -429,7 +429,7 @@ function Login(props: PageProps) {
 }
 
 export default function LoginPage(props: PageProps) {
-  if (platform === 'catalyst') {
+  if (platform === PLATFORM_CATALYST) {
     return <CatalystLogin />;
   }
 

--- a/apps/storefront/src/pages/Login/useLogout.test.tsx
+++ b/apps/storefront/src/pages/Login/useLogout.test.tsx
@@ -23,6 +23,45 @@ const bcGraphql = graphql.link(`${window.location.origin}/graphql`);
 const b2bGraphql = graphql.link('https://api-b2b.bigcommerce.com/graphql');
 
 describe('useLogout', () => {
+  it('prefetches a bcGraphqlToken before calling the BC logout mutation when none is cached', async () => {
+    const freshToken = faker.string.uuid();
+    const logoutAuthHeaders: (string | null)[] = [];
+
+    server.use(
+      bcGraphql.mutation('Logout', ({ request }) => {
+        logoutAuthHeaders.push(request.headers.get('Authorization'));
+        return HttpResponse.json({ data: { logout: { result: 'success' } } });
+      }),
+      b2bGraphql.mutation('storeFrontToken', () =>
+        HttpResponse.json({ data: { storeFrontToken: { token: freshToken } } }),
+      ),
+    );
+
+    const { result } = renderHookWithProviders(() => useLogout(), {
+      preloadedState: {
+        company: buildCompanyStateWith({
+          customer: { role: CustomerRole.ADMIN },
+          tokens: {
+            B2BToken: faker.string.uuid(),
+            // Token already cleared/expired before logout runs, e.g. after a prior
+            // logoutSession() call or natural expiry.
+            bcGraphqlToken: '',
+            currentCustomerJWT: faker.string.uuid(),
+          },
+        }),
+        b2bFeatures: buildB2BFeaturesStateWith({
+          masqueradeCompany: { isAgenting: false },
+        }),
+      },
+    });
+
+    result.result.current({ showLogoutBanner: false });
+
+    await waitFor(() => {
+      expect(logoutAuthHeaders).toEqual([`Bearer  ${freshToken}`]);
+    });
+  });
+
   it('fetches a fresh anonymous storefront token after clearing the session', async () => {
     const freshToken = faker.string.uuid();
 

--- a/apps/storefront/src/pages/Login/useLogout.tsx
+++ b/apps/storefront/src/pages/Login/useLogout.tsx
@@ -46,6 +46,11 @@ export const useLogout = () => {
   const logout = useCallback(
     async ({ showLogoutBanner = true }: LogoutOptions) => {
       try {
+        // bcLogoutLogin goes through graphqlBC on Catalyst, which needs a bcGraphqlToken
+        // bearer. Prefetch it before logging out, otherwise a cleared/expired token makes
+        // the BC logout mutation fail while local state still gets cleared below, leaving
+        // the BC session cookie (set via credentials: 'include') alive.
+        await ensureBcGraphqlToken();
         const { result } = (await bcLogoutLogin()).data.logout;
 
         if (result !== 'success') {

--- a/apps/storefront/src/pages/PDP/index.tsx
+++ b/apps/storefront/src/pages/PDP/index.tsx
@@ -6,6 +6,7 @@ import { useB3Lang } from '@/lib/lang';
 import { GlobalContext } from '@/shared/global';
 import { isB2BUserSelector, useAppSelector } from '@/store';
 import { serialize } from '@/utils/b3Serialize';
+import { PLATFORM_BIGCOMMERCE } from '@/utils/basicConfig';
 
 import CreateShoppingList from '../OrderDetail/components/CreateShoppingList';
 import OrderShoppingList from '../OrderDetail/components/OrderShoppingList';
@@ -24,7 +25,7 @@ function useData() {
   const isB2BUser = useAppSelector(isB2BUserSelector);
 
   const getShoppingListItem = () => {
-    if (platform !== 'bigcommerce') {
+    if (platform !== PLATFORM_BIGCOMMERCE) {
       return window.b2b.utils.shoppingList.itemFromCurrentPage[0];
     }
 

--- a/apps/storefront/src/pages/Registered/index.tsx
+++ b/apps/storefront/src/pages/Registered/index.tsx
@@ -15,7 +15,7 @@ import { useAppSelector } from '@/store';
 import b2bLogger from '@/utils/b3Logger';
 import { loginJump } from '@/utils/b3Login';
 import { B3SStorage } from '@/utils/b3Storage';
-import { platform } from '@/utils/basicConfig';
+import { platform, PLATFORM_CATALYST } from '@/utils/basicConfig';
 import { getCurrentCustomerInfo } from '@/utils/loginInfo';
 
 import { loginCheckout, LoginConfig } from '../Login/helper';
@@ -112,7 +112,7 @@ function Registered(props: PageProps) {
 
         clearRegisterInfo();
 
-        if (platform === 'catalyst') {
+        if (platform === PLATFORM_CATALYST) {
           const landingLoginLocation =
             params.get('redirectTo') === 'check-out'
               ? LOGIN_LANDING_LOCATIONS.CHECKOUT

--- a/apps/storefront/src/pages/quote/utils/quoteCheckout.test.ts
+++ b/apps/storefront/src/pages/quote/utils/quoteCheckout.test.ts
@@ -38,6 +38,8 @@ vi.mock('@/utils/b3Tip', () => ({
 
 vi.mock('@/utils/basicConfig', () => ({
   platform: 'bigcommerce',
+  PLATFORM_BIGCOMMERCE: 'bigcommerce',
+  PLATFORM_CATALYST: 'catalyst',
   storeHash: 'test-store',
   channelId: 1,
   disableLogoutButton: false,

--- a/apps/storefront/src/pages/quote/utils/quoteCheckout.ts
+++ b/apps/storefront/src/pages/quote/utils/quoteCheckout.ts
@@ -8,7 +8,7 @@ import { isLoggedInSelector } from '@/store/selectors';
 import { attemptCheckoutLoginAndRedirect, setQuoteToStorage } from '@/utils/b3checkout';
 import b2bLogger from '@/utils/b3Logger';
 import { snackbar } from '@/utils/b3Tip';
-import { platform } from '@/utils/basicConfig';
+import { platform, PLATFORM_BIGCOMMERCE, PLATFORM_CATALYST } from '@/utils/basicConfig';
 import { getSearchVal } from '@/utils/loginInfo';
 
 import { detectQuoteStockChange, QuoteStockSnapshotItem } from './detectQuoteStockChange';
@@ -121,12 +121,12 @@ export const handleQuoteCheckout = async ({
       }
     }
 
-    if (platform === 'bigcommerce') {
+    if (platform === PLATFORM_BIGCOMMERCE) {
       window.location.href = checkoutUrl;
       return;
     }
 
-    if (platform === 'catalyst') {
+    if (platform === PLATFORM_CATALYST) {
       window.location.href = `/checkout?cartId=${cartId}`;
       return;
     }

--- a/apps/storefront/src/shared/service/b2b/graphql/login.ts
+++ b/apps/storefront/src/shared/service/b2b/graphql/login.ts
@@ -1,4 +1,4 @@
-import { platform } from '@/utils/basicConfig';
+import { isBcStorefrontPlatform } from '@/utils/basicConfig';
 import { convertObjectOrArrayKeysToCamel } from '@/utils/graphqlDataConvert';
 
 import B3Request from '../../request/b3Fetch';
@@ -17,7 +17,10 @@ const storeFrontToken = `mutation storeFrontToken($storeFrontTokenData: Customer
 }
 `;
 export const getBCGraphqlToken = (data: Partial<ApiTokenConfig>): Promise<string> | undefined => {
-  if (platform !== 'bigcommerce') {
+  // Allow both Stencil ('bigcommerce') and Catalyst ('catalyst') to fetch the store-level
+  // BC Storefront bearer token. The storeFrontToken B2B mutation does not require a B2B token,
+  // so this works in the registration flow before the user is logged in.
+  if (!isBcStorefrontPlatform) {
     return undefined;
   }
   return B3Request.graphqlB2B({

--- a/apps/storefront/src/shared/service/bc/api/login.ts
+++ b/apps/storefront/src/shared/service/bc/api/login.ts
@@ -1,11 +1,15 @@
-import { BigCommerceStorefrontAPIBaseURL, platform } from '../../../../utils/basicConfig';
+import {
+  BigCommerceStorefrontAPIBaseURL,
+  platform,
+  PLATFORM_BIGCOMMERCE,
+} from '../../../../utils/basicConfig';
 
 /**
  * This function it's still present due the merchant can logs in as a client and stencil channels trade the current customer jwt to recognize
  * which user log in on the channel
  */
 export const getCurrentCustomerJWT = async (app_client_id: string) => {
-  if (platform !== 'bigcommerce') {
+  if (platform !== PLATFORM_BIGCOMMERCE) {
     return undefined;
   }
   const response = await fetch(
@@ -26,7 +30,7 @@ export const getCurrentCustomerJWT = async (app_client_id: string) => {
  * it makes the stencil channel recognize the user who log in the channel
  */
 export const customerLoginAPI = (storefrontLoginToken: string) => {
-  if (platform !== 'bigcommerce') {
+  if (platform !== PLATFORM_BIGCOMMERCE) {
     return;
   }
   fetch(`${BigCommerceStorefrontAPIBaseURL}/login/token/${storefrontLoginToken}`, {

--- a/apps/storefront/src/shared/service/bc/graphql/cart.ts
+++ b/apps/storefront/src/shared/service/bc/graphql/cart.ts
@@ -2,7 +2,7 @@ import Cookies from 'js-cookie';
 
 import { CreateCartInput, DeleteCartInput } from '@/types/cart';
 import { LineItem } from '@/utils/b3Product/b3Product';
-import { platform } from '@/utils/basicConfig';
+import { platform, PLATFORM_BIGCOMMERCE } from '@/utils/basicConfig';
 
 import B3Request from '../../request/b3Fetch';
 
@@ -326,7 +326,7 @@ export interface GetCart {
 }
 
 export const getCart = async (cartId?: string): Promise<GetCart> => {
-  if (platform === 'bigcommerce') {
+  if (platform === PLATFORM_BIGCOMMERCE) {
     const cartInfo = await B3Request.graphqlBC({
       query: getCartInfo,
     });

--- a/apps/storefront/src/shared/service/bc/graphql/client.ts
+++ b/apps/storefront/src/shared/service/bc/graphql/client.ts
@@ -1,4 +1,4 @@
-import { platform } from '@/utils/basicConfig';
+import { platform, PLATFORM_BIGCOMMERCE } from '@/utils/basicConfig';
 
 import B3Request from '../../request/b3Fetch';
 
@@ -6,7 +6,7 @@ export function storefrontGQLRequest<T = any>(data: {
   query: string;
   variables?: object;
 }): Promise<T> {
-  return platform === 'bigcommerce'
+  return platform === PLATFORM_BIGCOMMERCE
     ? B3Request.graphqlBC<T>(data)
     : B3Request.graphqlBCProxy<T>(data);
 }

--- a/apps/storefront/src/shared/service/bc/graphql/company.ts
+++ b/apps/storefront/src/shared/service/bc/graphql/company.ts
@@ -1,3 +1,7 @@
+import { isBcStorefrontPlatform } from '@/utils/basicConfig';
+
+import B3Request from '../../request/b3Fetch';
+
 import { storefrontGQLRequest } from './client';
 
 /**
@@ -96,8 +100,17 @@ export async function registerCompany(
   input: RegisterCompanyInput,
 ): Promise<RegisterCompanyMutationResponse> {
   const variables = { input };
-  return storefrontGQLRequest<RegisterCompanyMutationResponse>({
-    query: REGISTER_COMPANY_MUTATION,
-    variables,
-  });
+  // Must use graphqlBC (direct + credentials:include) on bigcommerce/catalyst so the
+  // BC session cookie set by bcLogin is sent with the request. The proxy never forwards
+  // cookies, so registerCompany would return "Customer not authenticated" via that path.
+  const request = isBcStorefrontPlatform
+    ? B3Request.graphqlBC<RegisterCompanyMutationResponse>({
+        query: REGISTER_COMPANY_MUTATION,
+        variables,
+      })
+    : storefrontGQLRequest<RegisterCompanyMutationResponse>({
+        query: REGISTER_COMPANY_MUTATION,
+        variables,
+      });
+  return request;
 }

--- a/apps/storefront/src/shared/service/bc/graphql/login.ts
+++ b/apps/storefront/src/shared/service/bc/graphql/login.ts
@@ -1,3 +1,4 @@
+import { isBcStorefrontPlatform } from '@/utils/basicConfig';
 import { mapToCompanyError } from '@/utils/companyUtils';
 
 import B3Request from '../../request/b3Fetch';
@@ -76,13 +77,16 @@ interface LoginVariables {
   password: string;
 }
 
+// bcLogin and bcLogoutLogin must go through graphqlBC (direct to BC Storefront with
+// credentials:include) on platforms where the session cookie matters (bigcommerce, catalyst).
+// Using storefrontGQLRequest would route Catalyst through the proxy, which never sets
+// or sends the BC session cookie that registerCompany requires.
 export const bcLogin = (variables: LoginVariables) =>
-  storefrontGQLRequest({
-    query: getBcLogin(),
-    variables,
-  });
+  isBcStorefrontPlatform
+    ? B3Request.graphqlBC({ query: getBcLogin(), variables })
+    : storefrontGQLRequest({ query: getBcLogin(), variables });
 
 export const bcLogoutLogin = () =>
-  storefrontGQLRequest({
-    query: logoutLogin(),
-  });
+  isBcStorefrontPlatform
+    ? B3Request.graphqlBC({ query: logoutLogin() })
+    : storefrontGQLRequest({ query: logoutLogin() });

--- a/apps/storefront/src/shared/service/request/b3Fetch.ts
+++ b/apps/storefront/src/shared/service/request/b3Fetch.ts
@@ -46,14 +46,23 @@ function request(path: string, config?: RequestInit, type?: RequestTypeKeys) {
   return b3Fetch(url, init);
 }
 
-function graphqlRequest<T, Y>(type: RequestTypeKeys, data: T, config?: Y) {
-  const init = {
+function graphqlRequest<T, Y>(
+  type: RequestTypeKeys,
+  data: T,
+  config?: Y,
+  extraInit?: Partial<RequestInit>,
+) {
+  const init: RequestInit = {
     method: 'POST',
     headers: {
       'content-type': 'application/json',
       ...config,
     },
     body: JSON.stringify(data),
+    // extraInit is spread last so callers can set non-header RequestInit options (e.g.
+    // credentials, signal). Do not pass `headers` here — it would replace the auth headers
+    // above instead of merging with them.
+    ...extraInit,
   };
 
   const url = GraphqlEndpointsFn(type);
@@ -141,14 +150,18 @@ const B3Request = {
     });
   },
   /**
-   * Request used in stencil store to call bigcommerce graphql storefront api
+   * Request used in stencil store to call bigcommerce graphql storefront api.
+   * Uses `credentials: 'include'` so the browser stores and sends the BC session
+   * cookie set by `bcLogin` — required for cross-origin headless (Catalyst) flows.
+   * The BC Storefront respects this because `storeFrontToken` sets allowedCorsOrigins,
+   * causing BC to respond with Access-Control-Allow-Credentials: true.
    */
   graphqlBC: function post<T = any>(data: GQLRequest): Promise<T> {
     const { bcGraphqlToken } = store.getState().company.tokens;
     const config = {
       Authorization: `Bearer  ${bcGraphqlToken}`,
     };
-    return graphqlRequest(RequestType.BCGraphql, data, config);
+    return graphqlRequest(RequestType.BCGraphql, data, config, { credentials: 'include' });
   },
   /**
    * Request used in headless context to talk to the bigcommerce graphql storefront api via proxy

--- a/apps/storefront/src/utils/b2bVerifyBcLoginStatus.ts
+++ b/apps/storefront/src/utils/b2bVerifyBcLoginStatus.ts
@@ -4,14 +4,14 @@ import { store } from '@/store';
 import { CustomerRole } from '@/types';
 import b2bLogger from '@/utils/b3Logger';
 
-import { platform } from './basicConfig';
+import { platform, PLATFORM_BIGCOMMERCE } from './basicConfig';
 
 const b2bVerifyBcLoginStatus = async () => {
   let isBcLogin = false;
   const { role } = store.getState().company.customer;
   const { B2BToken } = store.getState().company.tokens;
 
-  if (B2BToken && platform !== 'bigcommerce') return true;
+  if (B2BToken && platform !== PLATFORM_BIGCOMMERCE) return true;
 
   try {
     if (Number(role) !== CustomerRole.GUEST) {

--- a/apps/storefront/src/utils/b3Login.ts
+++ b/apps/storefront/src/utils/b3Login.ts
@@ -3,14 +3,14 @@ import { NavigateFunction } from 'react-router-dom';
 import { LOGIN_LANDING_LOCATIONS } from '@/constants';
 import { store } from '@/store';
 
-import { platform } from './basicConfig';
+import { platform, PLATFORM_CATALYST } from './basicConfig';
 
 export const loginJump = (navigate: NavigateFunction, isClearSession = false) => {
   const {
     global: { loginLandingLocation, recordOpenHash, setOpenPageFn },
   } = store.getState();
   if (loginLandingLocation === LOGIN_LANDING_LOCATIONS.HOME && !recordOpenHash) {
-    if (platform === 'catalyst') {
+    if (platform === PLATFORM_CATALYST) {
       return false;
     }
 
@@ -30,7 +30,7 @@ export const loginJump = (navigate: NavigateFunction, isClearSession = false) =>
     return false;
   }
   if (loginLandingLocation === LOGIN_LANDING_LOCATIONS.HOME && recordOpenHash) {
-    if (platform === 'catalyst') {
+    if (platform === PLATFORM_CATALYST) {
       return false;
     }
 

--- a/apps/storefront/src/utils/b3PrintInvoice.test.tsx
+++ b/apps/storefront/src/utils/b3PrintInvoice.test.tsx
@@ -10,6 +10,8 @@ const STOREFRONT_URL = 'https://my-custom-storefront.com';
 
 vi.mock('./basicConfig', () => ({
   platform: 'bigcommerce',
+  PLATFORM_BIGCOMMERCE: 'bigcommerce',
+  PLATFORM_CATALYST: 'catalyst',
   BigCommerceStorefrontAPIBaseURL: 'https://store-abc.mybigcommerce.com',
 }));
 

--- a/apps/storefront/src/utils/b3PrintInvoice.tsx
+++ b/apps/storefront/src/utils/b3PrintInvoice.tsx
@@ -1,7 +1,7 @@
 import { store } from '@/store';
 
 import b2bLogger from './b3Logger';
-import { BigCommerceStorefrontAPIBaseURL, platform } from './basicConfig';
+import { BigCommerceStorefrontAPIBaseURL, platform, PLATFORM_BIGCOMMERCE } from './basicConfig';
 
 const bindDom = (html: string, domId: string) => {
   let iframeDom = document.getElementById(domId) as HTMLIFrameElement | null;
@@ -28,7 +28,7 @@ const normalizeUrl = (url: string) => url.trim().replace(/\/$/, '');
  * On headless, derives from storeInfo.urls (store URL vs storefront URL) for the current channel.
  */
 export const getPrintInvoiceBaseUrl = (): string => {
-  if (platform === 'bigcommerce') return BigCommerceStorefrontAPIBaseURL;
+  if (platform === PLATFORM_BIGCOMMERCE) return BigCommerceStorefrontAPIBaseURL;
   const { storeInfo } = store.getState().global;
   const storeUrlNormalized = normalizeUrl(BigCommerceStorefrontAPIBaseURL);
   const urls = storeInfo?.urls ?? [];
@@ -46,7 +46,7 @@ export const getPrintInvoiceUrl = (orderId: string) =>
 export const b2bPrintInvoice = async (orderId: string, domId: string) => {
   const url = getPrintInvoiceUrl(orderId);
 
-  if (platform !== 'bigcommerce') {
+  if (platform !== PLATFORM_BIGCOMMERCE) {
     window.open(url);
     return;
   }

--- a/apps/storefront/src/utils/basicConfig.ts
+++ b/apps/storefront/src/utils/basicConfig.ts
@@ -1,15 +1,23 @@
+export const PLATFORM_BIGCOMMERCE = 'bigcommerce' as const;
+export const PLATFORM_CATALYST = 'catalyst' as const;
+
 export const {
   store_hash: storeHash,
   channel_id: channelId,
   disable_logout_button: disableLogoutButton,
   platform = 'custom',
+  bc_graphql_domain: bcGraphqlDomain = 'mybigcommerce.com',
 } = window.B3.setting;
 
 const generateBcStorefrontAPIBaseUrl = () => {
-  if (platform === 'bigcommerce') return window.origin;
-  if (channelId === 1) return `https://store-${storeHash}.mybigcommerce.com`;
+  if (platform === PLATFORM_BIGCOMMERCE) return window.origin;
+  if (channelId === 1) return `https://store-${storeHash}.${bcGraphqlDomain}`;
 
-  return `https://store-${storeHash}-${channelId}.mybigcommerce.com`;
+  return `https://store-${storeHash}-${channelId}.${bcGraphqlDomain}`;
 };
 
 export const BigCommerceStorefrontAPIBaseURL = generateBcStorefrontAPIBaseUrl();
+
+/** True for storefronts that talk directly to the BC Storefront GraphQL API: Stencil ('bigcommerce') and Catalyst ('catalyst'). */
+export const isBcStorefrontPlatform =
+  platform === PLATFORM_BIGCOMMERCE || platform === PLATFORM_CATALYST;


### PR DESCRIPTION

Jira: [B2B-5056](https://bigcommercecloud.atlassian.net/browse/B2B-5056)

## What/Why?

### Problem

The registerCompany BC Storefront GraphQL mutation was returning "Customer not authenticated" when submitted from a Catalyst storefront. The same flow worked correctly on Stencil.

Root cause: three gaps in how the buyer portal handled BC Storefront requests in a headless/cross-origin context.

* getBCGraphqlToken was guarded by platform !== 'bigcommerce', so the store-level BC Storefront bearer token (bcGraphqlToken) was never fetched in Catalyst. Without it, storefrontGQLRequest always routed to graphqlBCProxy rather than directly to BC.
* storefrontGQLRequest always used the proxy for non-Stencil platforms, even when a bearer token was available. In the proxy path, the guest request carries no customer authentication, so BC rejects registerCompany.
* graphqlBC did not include credentials: 'include', so the BC session cookie set by bcLogin was silently dropped by the browser on cross-origin responses and never sent on subsequent requests.
* Refactoring to remove hardcoded platform values everywhere

In Stencil, none of these matter: the page is served from the BC domain, making all Storefront API calls same-origin, so cookies work automatically and the bearer token is always fetched.

### Solution

Mirror the Stencil authentication flow for Catalyst:

*  Extend getBCGraphqlToken to run for platform === 'catalyst'. The storeFrontToken B2B mutation requires no authentication token, so this works before the user has a B2B session.
Route storefrontGQLRequest to graphqlBC (direct to BC) whenever bcGraphqlToken is present in the store, regardless of platform.
*  Add credentials: 'include' to graphqlBC fetches so the browser stores the BC session cookie returned by bcLogin and sends it on the registerCompany request. BC allows credentialed cross-origin requests from the Catalyst origin because storeFrontToken sets allowedCorsOrigins: [window.location.origin].
* Read bc_graphql_domain from window.B3.setting (injected by Catalyst) when building * BigCommerceStorefrontAPIBaseURL, so requests resolve correctly in local dev environments that use a non-production BC domain.

### Flow after this change

* ensureBcStorefrontGraphqlToken() → calls B2B storeFrontToken mutation → bcGraphqlToken stored in Redux
bcLogin → routes via graphqlBC directly to store-{hash}-{channel}.{domain}/graphql with credentials: 'include' → BC sets session cookie, browser stores it
*  registerCompany → same graphqlBC path, bearer token + session cookie → BC authenticates the customer 


## Rollout/Rollback
Revert 

## Testing


Manual testing of company registration on both Catalyst storefront and b2b-buyers portal


https://github.com/user-attachments/assets/8dcc4a55-cb93-4b41-9469-828b639b6e24


https://github.com/user-attachments/assets/37e4c2ae-2737-4930-af10-3c89cf9187b5





[B2B-5056]: https://bigcommercecloud.atlassian.net/browse/B2B-5056?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches authentication (login/logout, session cookies, token prefetch) and company registration GraphQL paths across Catalyst and Stencil; regressions could leave stale BC sessions or break registration.
> 
> **Overview**
> Fixes **Catalyst company registration** failing with "Customer not authenticated" by aligning headless BC Storefront calls with Stencil: **`getBCGraphqlToken`** now runs for Catalyst via **`isBcStorefrontPlatform`**, **`bcLogin` / `bcLogoutLogin` / `registerCompany`** use direct **`graphqlBC`** (not the cookie-less proxy), and **`graphqlBC`** sends **`credentials: 'include'`** so the session cookie from login is stored and sent cross-origin.
> 
> **Config and routing:** **`PLATFORM_*` constants**, optional **`bc_graphql_domain`** for BC GraphQL host URLs, and **`bc_graphql_domain`** typed on **`window.B3.setting`**.
> 
> **Logout:** **`useLogout`**, **`CatalystLogin`**, and **`HeadlessController` `user.logout`** prefetch **`bcGraphqlToken`** with **`ensureBcGraphqlToken`** before **`bcLogoutLogin`**, then call BC logout so the storefront session cookie is cleared; tests cover token prefetch and logout behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd29446744003eff97be17839671847a6e5d90a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->