### PR TITLE
fix(login): B2B-5212 Fix login and logout issues in the B2B Buyer Portal for active and inactive company users

### DIFF
--- a/apps/storefront/src/App.tsx
+++ b/apps/storefront/src/App.tsx
@@ -31,7 +31,7 @@ import setDayjsLocale from './utils/b3DateFormat/setDayjsLocale';
 import b2bLogger from './utils/b3Logger';
 import { isUserGotoLogin } from './utils/b3logout';
 import { isCompanyError } from './utils/companyUtils';
-import { getCompanyInfo, getCurrentCustomerInfo, loginInfo } from './utils/loginInfo';
+import { ensureBcGraphqlToken, getCompanyInfo, getCurrentCustomerInfo } from './utils/loginInfo';
 import { logoutSession } from './utils/logoutSession';
 import { removePreMountLoginMask, shouldUseDefaultLoginStyling } from './utils/preMountLoginMask';
 import { getGlobalStoreTax, getStoreConfigs, setStorefrontConfig } from './utils/storefrontConfig';
@@ -68,7 +68,6 @@ export default function App() {
   const isDefaultLoginStyling = useRef(shouldUseDefaultLoginStyling()).current;
   const currentClickedUrl = useAppSelector(({ global }) => global.currentClickedUrl);
   const isRegisterAndLogin = useAppSelector(({ global }) => global.isRegisterAndLogin);
-  const bcGraphqlToken = useAppSelector(({ company }) => company.tokens.bcGraphqlToken);
   const { quotesCreateActionsPermission, shoppingListCreateActionsPermission } =
     useAppSelector(rolePermissionSelector);
 
@@ -183,10 +182,8 @@ export default function App() {
           }
         }
 
-        // bc graphql token
-        if (!bcGraphqlToken) {
-          await loginInfo();
-        }
+        await ensureBcGraphqlToken();
+
         setChannelStoreType();
 
         // load the store config before fetching other data

--- a/apps/storefront/src/HeadlessController/index.tsx
+++ b/apps/storefront/src/HeadlessController/index.tsx
@@ -31,7 +31,7 @@ import { LineItem } from '@/utils/b3Product/b3Product';
 import createShoppingList from '@/utils/b3ShoppingList/b3ShoppingList';
 import b3TriggerCartNumber from '@/utils/b3TriggerCartNumber';
 import { channelId } from '@/utils/basicConfig';
-import { getCurrentCustomerInfo } from '@/utils/loginInfo';
+import { ensureBcGraphqlToken, getCurrentCustomerInfo } from '@/utils/loginInfo';
 import { logoutSession } from '@/utils/logoutSession';
 import { endMasquerade, startMasquerade } from '@/utils/masquerade';
 
@@ -241,6 +241,11 @@ export default function HeadlessController({ setOpenPage }: HeadlessControllerPr
             } finally {
               window.sessionStorage.clear();
               logoutSession();
+              try {
+                await ensureBcGraphqlToken();
+              } catch (e) {
+                b2bLogger.error(e);
+              }
               window.b2b.callbacks.dispatchEvent('on-logout');
             }
           },

--- a/apps/storefront/src/pages/Login/helper.ts
+++ b/apps/storefront/src/pages/Login/helper.ts
@@ -126,7 +126,6 @@ export const COMPANY_STATUS_MAPPINGS: Record<CompanyStatusKey, string> = {
 };
 
 export const SHOULD_LOGOUT_FLAGS: LoginFlagType[] = [
-  'loggedOutLogin',
   'pendingApprovalToViewPrices',
   'pendingApprovalToOrder',
   'pendingApprovalToAccessFeatures',

--- a/apps/storefront/src/pages/Login/index.test.tsx
+++ b/apps/storefront/src/pages/Login/index.test.tsx
@@ -429,8 +429,42 @@ describe('LoginPage', () => {
       const { navigation } = await renderBcFirstLoginAndSubmit();
 
       await waitFor(() => {
-        expect(snackbar.error).toHaveBeenCalledWith(pendingApprovalMessage);
+        expect(snackbar.error).toHaveBeenCalledTimes(1);
       });
+      expect(snackbar.error).toHaveBeenCalledWith(pendingApprovalMessage);
+      await waitFor(() => {
+        expect(logoutMock).toHaveBeenCalledWith({ showLogoutBanner: false });
+      });
+      expect(navigation).not.toHaveBeenCalledWith(expect.stringContaining('/shoppingLists'));
+    });
+
+    it('shows the pending-approval ordering message once and logs out when the token exchange returns that company error', async () => {
+      const logoutMock = vi.fn();
+      vi.mocked(useLogout).mockReturnValue(logoutMock);
+
+      const pendingApprovalMessage =
+        'Your business account is pending approval. Products, pricing, and ordering will be enabled after account approval.';
+
+      server.use(
+        bcGraphql.mutation('Login', () =>
+          HttpResponse.json({
+            data: {
+              login: { result: { token: 'bc', storefrontLoginToken: 'sf', permissions: [] } },
+            },
+          }),
+        ),
+        http.get(CURRENT_JWT_URL, () => HttpResponse.text('jwt-token')),
+        b2bGraphql.operation(() =>
+          HttpResponse.json({ errors: [{ message: pendingApprovalMessage }] }),
+        ),
+      );
+
+      const { navigation } = await renderBcFirstLoginAndSubmit();
+
+      await waitFor(() => {
+        expect(snackbar.error).toHaveBeenCalledTimes(1);
+      });
+      expect(snackbar.error).toHaveBeenCalledWith(pendingApprovalMessage);
       await waitFor(() => {
         expect(logoutMock).toHaveBeenCalledWith({ showLogoutBanner: false });
       });
@@ -577,7 +611,6 @@ describe('LoginPage', () => {
       'pendingApprovalToOrder',
       'pendingApprovalToAccessFeatures',
       'accountInactive',
-      'loggedOutLogin',
     ] as const)(
       'should logout without banner when loginFlag=%s and user is not logged in',
       async (loginFlag) => {
@@ -608,6 +641,27 @@ describe('LoginPage', () => {
         });
       },
     );
+
+    it('does not logout again when loginFlag=loggedOutLogin and user is already logged out', async () => {
+      const logoutMock = vi.fn();
+      vi.mocked(useLogout).mockReturnValue(logoutMock);
+
+      renderLoginPage({
+        preloadedState: {
+          company: buildCompanyStateWith({
+            customer: { role: CustomerRole.GUEST },
+            tokens: { B2BToken: '', bcGraphqlToken: 'storefront-token', currentCustomerJWT: '' },
+          }),
+        },
+        initialEntries: ['/?loginFlag=loggedOutLogin'],
+      });
+
+      await waitFor(() => {
+        expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
+      });
+
+      expect(logoutMock).not.toHaveBeenCalled();
+    });
 
     it('should not logout when loginFlag is not a logout-triggering flag', async () => {
       const logoutMock = vi.fn();

--- a/apps/storefront/src/pages/Login/index.tsx
+++ b/apps/storefront/src/pages/Login/index.tsx
@@ -122,11 +122,9 @@ function Login(props: PageProps) {
             (isLoggedIn && loginFlag === 'loggedOutLogin') ||
             (!isLoggedIn && SHOULD_LOGOUT_FLAGS.includes(loginFlag));
 
-          /*
-           * Guard against a second logout: logging out flips isLoggedIn to
-           * false and re-runs this effect, which would otherwise re-trigger
-           * logout via the !isLoggedIn branch. Only log out once per flag.
-           */
+          /* Guard against a second logout: logging out flips isLoggedIn to false and
+           * re-runs this effect, which would otherwise re-trigger the !isLoggedIn branch.
+           * loggedOutLogin is only handled while logged in; the post-sign-out re-run skips it. */
           if (shouldLogout && handledLogoutFlagRef.current !== loginFlag) {
             handledLogoutFlagRef.current = loginFlag;
             // Banner only when an actually-logged-in user is signing out.

--- a/apps/storefront/src/pages/Login/useLogout.test.tsx
+++ b/apps/storefront/src/pages/Login/useLogout.test.tsx
@@ -1,0 +1,94 @@
+import { set } from 'lodash-es';
+import {
+  buildB2BFeaturesStateWith,
+  buildCompanyStateWith,
+  faker,
+  graphql,
+  HttpResponse,
+  startMockServer,
+  waitFor,
+} from 'tests/test-utils';
+import { renderHookWithProviders } from 'tests/utils/hook-test-utils';
+
+import { CustomerRole } from '@/types';
+import b2bLogger from '@/utils/b3Logger';
+
+import { useLogout } from './useLogout';
+
+vi.mock('@/utils/b3Logger');
+
+const { server } = startMockServer();
+
+const bcGraphql = graphql.link(`${window.location.origin}/graphql`);
+const b2bGraphql = graphql.link('https://api-b2b.bigcommerce.com/graphql');
+
+describe('useLogout', () => {
+  it('fetches a fresh anonymous storefront token after clearing the session', async () => {
+    const freshToken = faker.string.uuid();
+
+    server.use(
+      bcGraphql.mutation('Logout', () =>
+        HttpResponse.json({ data: { logout: { result: 'success' } } }),
+      ),
+      b2bGraphql.mutation('storeFrontToken', () =>
+        HttpResponse.json({ data: { storeFrontToken: { token: freshToken } } }),
+      ),
+    );
+
+    const { result, store } = renderHookWithProviders(() => useLogout(), {
+      preloadedState: {
+        company: buildCompanyStateWith({
+          customer: { role: CustomerRole.ADMIN },
+          tokens: {
+            B2BToken: faker.string.uuid(),
+            bcGraphqlToken: faker.string.uuid(),
+            currentCustomerJWT: faker.string.uuid(),
+          },
+        }),
+        b2bFeatures: buildB2BFeaturesStateWith({
+          masqueradeCompany: { isAgenting: false },
+        }),
+      },
+    });
+
+    result.result.current({ showLogoutBanner: false });
+
+    await waitFor(() => {
+      expect(store.getState().company.tokens.bcGraphqlToken).toBe(freshToken);
+    });
+  });
+
+  it('still dispatches the on-logout event when storeFrontToken fails', async () => {
+    set(window, 'b2b.callbacks.dispatchEvent', vi.fn().mockReturnValue(true));
+
+    server.use(
+      bcGraphql.mutation('Logout', () =>
+        HttpResponse.json({ data: { logout: { result: 'success' } } }),
+      ),
+      b2bGraphql.mutation('storeFrontToken', () => HttpResponse.error()),
+    );
+
+    const { result } = renderHookWithProviders(() => useLogout(), {
+      preloadedState: {
+        company: buildCompanyStateWith({
+          customer: { role: CustomerRole.ADMIN },
+          tokens: {
+            B2BToken: faker.string.uuid(),
+            bcGraphqlToken: faker.string.uuid(),
+            currentCustomerJWT: faker.string.uuid(),
+          },
+        }),
+        b2bFeatures: buildB2BFeaturesStateWith({
+          masqueradeCompany: { isAgenting: false },
+        }),
+      },
+    });
+
+    result.result.current({ showLogoutBanner: true });
+
+    await waitFor(() => {
+      expect(window.b2b.callbacks.dispatchEvent).toHaveBeenCalledWith('on-logout', undefined);
+    });
+    expect(b2bLogger.error).toHaveBeenCalled();
+  });
+});

--- a/apps/storefront/src/pages/Login/useLogout.tsx
+++ b/apps/storefront/src/pages/Login/useLogout.tsx
@@ -5,6 +5,7 @@ import { endUserMasqueradingCompany, superAdminEndMasquerade } from '@/shared/se
 import { bcLogoutLogin } from '@/shared/service/bc';
 import { clearMasqueradeCompany, useAppDispatch, useAppSelector } from '@/store';
 import b2bLogger from '@/utils/b3Logger';
+import { ensureBcGraphqlToken } from '@/utils/loginInfo';
 import { logoutSession } from '@/utils/logoutSession';
 
 const useEndMasquerade = () => {
@@ -58,6 +59,11 @@ export const useLogout = () => {
         // SUP-1282 Clear sessionStorage to allow visitors to display the checkout page
         window.sessionStorage.clear();
         logoutSession();
+        try {
+          await ensureBcGraphqlToken();
+        } catch (e) {
+          b2bLogger.error(e);
+        }
         if (showLogoutBanner) {
           dispatchEvent('on-logout');
         }

--- a/apps/storefront/src/pages/Registered/RegisterSteps/steps/CompleteStep/bcHelpers.ts
+++ b/apps/storefront/src/pages/Registered/RegisterSteps/steps/CompleteStep/bcHelpers.ts
@@ -1,17 +1,9 @@
 import { bcLogin, bcLogoutLogin } from '@/shared/service/bc';
-import { store } from '@/store';
 import b2bLogger from '@/utils/b3Logger';
-import { loginInfo } from '@/utils/loginInfo';
 
 interface Credentials {
   email: string;
   password: string;
-}
-
-/** `registerCompany` uses Storefront GraphQL (`graphqlBC` or `graphqlBCProxy` by platform), which requires a storefront session token in the store. */
-export async function ensureBcStorefrontGraphqlToken(): Promise<void> {
-  if (store.getState().company.tokens.bcGraphqlToken) return;
-  await loginInfo();
 }
 
 /** Storefront login after account creation; throws if the login mutation returns errors. */

--- a/apps/storefront/src/pages/Registered/RegisterSteps/steps/CompleteStep/index.tsx
+++ b/apps/storefront/src/pages/Registered/RegisterSteps/steps/CompleteStep/index.tsx
@@ -15,17 +15,14 @@ import { RegisterCompanyStatus } from '@/shared/service/bc/graphql/company';
 import { CompanyStatus } from '@/types/company';
 import b2bLogger from '@/utils/b3Logger';
 import { channelId, storeHash } from '@/utils/basicConfig';
+import { ensureBcGraphqlToken } from '@/utils/loginInfo';
 
 import { RegisteredContext } from '../../../Context';
 import { RegisterFields } from '../../../types';
 import { PrimaryButton } from '../../PrimaryButton';
 import { InformationFourLabels, TipContent } from '../../styled';
 
-import {
-  ensureBcStorefrontGraphqlToken,
-  loginAndGetBcCustomer,
-  logoutBcCustomer,
-} from './bcHelpers';
+import { loginAndGetBcCustomer, logoutBcCustomer } from './bcHelpers';
 import { createCompany } from './createCompany';
 import { createCustomer } from './createCustomer';
 import { registerCompany } from './registerCompany';
@@ -292,7 +289,7 @@ export default function CompleteStep(props: CompleteStepProps) {
             );
 
             if (isRegisterCompanyFlowEnabled) {
-              await ensureBcStorefrontGraphqlToken();
+              await ensureBcGraphqlToken();
 
               const customerDetails = await loginAndGetBcCustomer(
                 {

--- a/apps/storefront/src/pages/Registered/index.test.tsx
+++ b/apps/storefront/src/pages/Registered/index.test.tsx
@@ -1026,7 +1026,7 @@ const preloadedStateB2bCompanyCreate = {
   }),
 };
 
-/** FF on: Storefront `registerCompany` + `bcLogin` after `createBCCompanyUser`. Prefetch `bcGraphqlToken` so `loginInfo` is not required in the happy path. */
+/** FF on: Storefront `registerCompany` + `bcLogin` after `createBCCompanyUser`. Prefetch `bcGraphqlToken` so `ensureBcGraphqlToken` early-returns without a network call. */
 const preloadedStateStorefrontRegisterCompany = {
   global: buildGlobalStateWith({
     featureFlags: { 'B2B-4466.use_register_company_flow': true },
@@ -1045,7 +1045,7 @@ describe('Registered Page', () => {
     vi.spyOn(companyGraphqlModule, 'registerCompany').mockResolvedValue(
       mockRegisterCompanyGraphqlApproved,
     );
-    vi.spyOn(loginInfoModule, 'loginInfo').mockImplementation(() => Promise.resolve());
+    vi.spyOn(loginInfoModule, 'ensureBcGraphqlToken').mockImplementation(() => Promise.resolve());
 
     vi.spyOn(b2bService, 'getB2BAccountFormFields').mockResolvedValue({
       accountFormFields: formType2Fields,
@@ -1174,7 +1174,7 @@ describe('Registered Page', () => {
         email: 'john.doe@example.com',
         password: 'Password123',
       });
-      expect(loginInfoModule.loginInfo).not.toHaveBeenCalled();
+      expect(loginInfoModule.ensureBcGraphqlToken).toHaveBeenCalledTimes(1);
       expect(screen.getByRole('heading', { name: 'Application submitted' })).toBeVisible();
       expect(
         screen.getByText(

--- a/apps/storefront/src/shared/service/b2b/graphql/global.ts
+++ b/apps/storefront/src/shared/service/b2b/graphql/global.ts
@@ -509,9 +509,12 @@ export const getB2BToken = (
   channelId = 1,
   includeLegacyFields = false,
 ) =>
-  B3Request.graphqlB2B<B2BTokenResponse>({
-    query: getB2BTokenQl(currentCustomerJWT, channelId, includeLegacyFields),
-  }).catch(mapToCompanyError);
+  B3Request.graphqlB2B<B2BTokenResponse>(
+    {
+      query: getB2BTokenQl(currentCustomerJWT, channelId, includeLegacyFields),
+    },
+    true,
+  ).catch(mapToCompanyError);
 
 export const getAgentInfo = (customerId: string | number) =>
   B3Request.graphqlB2B({

--- a/apps/storefront/src/shared/service/request/b3Fetch.ts
+++ b/apps/storefront/src/shared/service/request/b3Fetch.ts
@@ -95,7 +95,7 @@ const B3Request = {
    */
   graphqlB2B: function post<T extends DataWrapper | CustomFieldItems = CustomFieldItems>(
     data: GQLRequest,
-    customMessage = false,
+    suppressSnackbar = false,
   ): Promise<T extends DataWrapper ? T['data'] : T> {
     const { B2BToken } = store.getState().company.tokens;
     const config = {
@@ -128,7 +128,7 @@ const B3Request = {
       }
 
       if (message) {
-        if (!customMessage) {
+        if (!suppressSnackbar) {
           snackbar.error(message);
         }
 

--- a/apps/storefront/src/utils/loginInfo.test.ts
+++ b/apps/storefront/src/utils/loginInfo.test.ts
@@ -1,11 +1,17 @@
+import { graphql, HttpResponse, startMockServer } from 'tests/test-utils';
+
 import * as b2bService from '@/shared/service/b2b';
 import * as bcService from '@/shared/service/bc';
 import { store } from '@/store';
-import { setPermissionModules } from '@/store/slices/company';
+import { setBcGraphQLToken, setPermissionModules } from '@/store/slices/company';
 import { CompanyStatus, CustomerRole, UserTypes } from '@/types';
+import { snackbar } from '@/utils/b3Tip';
+import { CompanyError } from '@/utils/companyUtils';
 
 import b2bLogger from './b3Logger';
-import { getCurrentCustomerInfo } from './loginInfo';
+import { ensureBcGraphqlToken, getCurrentCustomerInfo } from './loginInfo';
+
+const { server } = startMockServer();
 
 const BC_AUTH_FLAG = 'PROJECT-7920.use_bc_login_and_authorisation';
 // keeps the account-hierarchy branch (and its extra requests) out of the path under test
@@ -135,5 +141,92 @@ describe('getCurrentCustomerInfo permissions source', () => {
     await getCurrentCustomerInfo();
 
     expect(store.dispatch).toHaveBeenCalledWith(setPermissionModules([]));
+  });
+});
+
+describe('getCurrentCustomerInfo company error during token exchange', () => {
+  const b2bGraphql = graphql.link('https://api-b2b.bigcommerce.com/graphql');
+  const pendingApprovalMessage =
+    'Your business account is pending approval. Products, pricing, and ordering will be enabled after account approval.';
+
+  beforeEach(() => {
+    vi.spyOn(store, 'dispatch').mockImplementation(() => undefined as never);
+    vi.spyOn(b2bLogger, 'error').mockImplementation(() => undefined);
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    vi.spyOn(snackbar, 'error');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('does not show a snackbar when getB2BToken returns a company error during init', async () => {
+    vi.spyOn(store, 'getState').mockReturnValue({
+      company: { tokens: { B2BToken: '', currentCustomerJWT: '' } },
+      global: { featureFlags: { [BC_AUTH_FLAG]: true } },
+    } as unknown as ReturnType<typeof store.getState>);
+
+    vi.spyOn(bcService, 'getCurrentCustomerJWT').mockResolvedValue('new-jwt');
+    server.use(
+      b2bGraphql.operation(() =>
+        HttpResponse.json({ errors: [{ message: pendingApprovalMessage }] }),
+      ),
+    );
+
+    await expect(getCurrentCustomerInfo()).rejects.toBeInstanceOf(CompanyError);
+
+    expect(snackbar.error).not.toHaveBeenCalled();
+  });
+});
+
+describe('ensureBcGraphqlToken', () => {
+  const b2bGraphql = graphql.link('https://api-b2b.bigcommerce.com/graphql');
+
+  beforeEach(() => {
+    vi.spyOn(store, 'dispatch').mockImplementation(() => undefined as never);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('coalesces concurrent storefront token requests into one network call', async () => {
+    vi.spyOn(store, 'getState').mockReturnValue({
+      company: { tokens: { B2BToken: '', bcGraphqlToken: '' } },
+    } as ReturnType<typeof store.getState>);
+
+    let requestCount = 0;
+    server.use(
+      b2bGraphql.mutation('storeFrontToken', () => {
+        requestCount += 1;
+        return HttpResponse.json({ data: { storeFrontToken: { token: 'fresh-token' } } });
+      }),
+    );
+
+    await Promise.all([ensureBcGraphqlToken(), ensureBcGraphqlToken()]);
+
+    expect(requestCount).toBe(1);
+    expect(store.dispatch).toHaveBeenCalledWith(setBcGraphQLToken('fresh-token'));
+  });
+
+  it('resets the in-flight state after a failed fetch, allowing a retry', async () => {
+    vi.spyOn(store, 'getState').mockReturnValue({
+      company: { tokens: { B2BToken: '', bcGraphqlToken: '' } },
+    } as ReturnType<typeof store.getState>);
+
+    let callCount = 0;
+    server.use(
+      b2bGraphql.mutation('storeFrontToken', () => {
+        callCount += 1;
+        return callCount === 1
+          ? HttpResponse.error()
+          : HttpResponse.json({ data: { storeFrontToken: { token: 'retry-token' } } });
+      }),
+    );
+
+    await expect(ensureBcGraphqlToken()).rejects.toThrow();
+    await ensureBcGraphqlToken();
+
+    expect(store.dispatch).toHaveBeenCalledWith(setBcGraphQLToken('retry-token'));
   });
 });

--- a/apps/storefront/src/utils/loginInfo.ts
+++ b/apps/storefront/src/utils/loginInfo.ts
@@ -53,13 +53,28 @@ const getLoginTokenInfo = () => {
   return data;
 };
 
-export const loginInfo = async () => {
-  const loginTokenInfo = getLoginTokenInfo();
+// Logout clears bcGraphqlToken and customer state, which re-runs App init while
+// useLogout also refetches the token — both can call ensureBcGraphqlToken at once.
+let pendingStorefrontToken: Promise<void> | null = null;
 
-  const token = await getBCGraphqlToken(loginTokenInfo);
-  if (token) {
-    store.dispatch(setBcGraphQLToken(token));
+export const ensureBcGraphqlToken = async (): Promise<void> => {
+  if (store.getState().company.tokens.bcGraphqlToken) {
+    return;
   }
+
+  if (!pendingStorefrontToken) {
+    pendingStorefrontToken = (async () => {
+      const loginTokenInfo = getLoginTokenInfo();
+      const token = await getBCGraphqlToken(loginTokenInfo);
+      if (token) {
+        store.dispatch(setBcGraphQLToken(token));
+      }
+    })().finally(() => {
+      pendingStorefrontToken = null;
+    });
+  }
+
+  await pendingStorefrontToken;
 };
 
 const clearCurrentCustomerInfo = async () => {


### PR DESCRIPTION
Jira: [B2B-5212](https://bigcommercecloud.atlassian.net/browse/B2B-5212)

## What/Why?
<!--
  A description about what this pull request implements and its purpose.
  Try to be detailed and describe any technical details to simplify the job
  of the reviewer and the individual on production support.
-->
This pull request refactors how the storefront GraphQL token (`bcGraphqlToken`) is fetched and managed throughout the application, improving reliability and reducing redundant network requests. It introduces a new utility function `ensureBcGraphqlToken` to centralize token retrieval, replaces previous ad hoc token-fetching logic, and updates all relevant usages and tests. Additionally, the logout flow is enhanced to always re-fetch the anonymous token, and related tests are updated and expanded. Minor improvements to error handling and logout logic are also included.

**Token management and fetching improvements:**

* Introduced `ensureBcGraphqlToken` in `utils/loginInfo.ts` to centralize and coalesce concurrent requests for the storefront GraphQL token, ensuring only one network call is made even if multiple requests are triggered simultaneously. The function replaces the previous `loginInfo`-based approach.
* Updated all imports and usages of token-fetching logic across the app to use `ensureBcGraphqlToken` instead of `loginInfo` or custom helpers (e.g., in `App.tsx`, `HeadlessController/index.tsx`, and registration steps). [[1]](diffhunk://#diff-1d578c494e0c959abc861c65f36894dbcdf3bc249ebc91e1a77c67a3c1d7503eL32-R32) [[2]](diffhunk://#diff-8513e6042c3c36cfaf6764505747b0d90f149c673c4c53f35387d2f131214dacL34-R34) [[3]](diffhunk://#diff-a7aef7350a86acb8b328c8951236296519f5311df603ce296803927243880f3bR18-R25) [[4]](diffhunk://#diff-a7aef7350a86acb8b328c8951236296519f5311df603ce296803927243880f3bL295-R292) [[5]](diffhunk://#diff-9f9545e7690656813e5e1561068af87534b9171d9c2f98c2e53de82ec50a2b96L2-L16)
* Removed the now-obsolete `ensureBcStorefrontGraphqlToken` helper and related code.

**Logout flow enhancements:**

* The logout logic (`useLogout`) now always refetches the anonymous storefront token after clearing the session, using `ensureBcGraphqlToken`, and logs errors if token fetching fails. [[1]](diffhunk://#diff-923ff641006de9115835e755561303131a984b2408d35e8982364740d192e6cdR8) [[2]](diffhunk://#diff-923ff641006de9115835e755561303131a984b2408d35e8982364740d192e6cdR62-R66) [[3]](diffhunk://#diff-8513e6042c3c36cfaf6764505747b0d90f149c673c4c53f35387d2f131214dacR244-R248)
* Updated and added tests to verify that the anonymous token is refetched on logout and that concurrent logouts do not cause redundant token requests. ([apps/storefront/src/pages/Login/useLogout.test.tsxR1-R52](diffhunk://#diff-0c8feefc074ec933eb28717484ecb3a15a54c56a13d2be1802dfaf9d66bed478R1-R52), F92f3f92L140R140)

**Login and error handling improvements:**

* Improved handling of company errors during token exchange, ensuring error messages are not redundantly shown in snackbars and that logout logic is not triggered multiple times for the same flag. [[1]](diffhunk://#diff-493b23bb55ac505c8a2e2ad3b941d5739be03dcebd4bc8fd4bff99e9bd9e2122R143-R227) [[2]](diffhunk://#diff-376d67043bd9df383131ef672afbaafb812bcb0e4bad8375167f10c3f7c69791R432-R467) [[3]](diffhunk://#diff-376d67043bd9df383131ef672afbaafb812bcb0e4bad8375167f10c3f7c69791R645-R665) [[4]](diffhunk://#diff-56c34cbdf6a69d646f7ceaefb3cb2e7b46dc95c787841c84cfb607d376887180L129) [[5]](diffhunk://#diff-fd4aa15ef6c953e480fa16141985f695bad80e0aad2b88b01a2163044e23c8d4L125-R127)
* Updated tests to cover these scenarios and ensure correct behavior. [[1]](diffhunk://#diff-376d67043bd9df383131ef672afbaafb812bcb0e4bad8375167f10c3f7c69791R432-R467) [[2]](diffhunk://#diff-376d67043bd9df383131ef672afbaafb812bcb0e4bad8375167f10c3f7c69791L580) [[3]](diffhunk://#diff-376d67043bd9df383131ef672afbaafb812bcb0e4bad8375167f10c3f7c69791R645-R665) [[4]](diffhunk://#diff-493b23bb55ac505c8a2e2ad3b941d5739be03dcebd4bc8fd4bff99e9bd9e2122R143-R227)

**Minor improvements:**

* Suppressed redundant snackbars for known company errors during token exchange. [[1]](diffhunk://#diff-00ab3245593b5223c1e713ca47009f5d3c7394c1513c3cce9e0783ffc2e2fb72L512-R517) [[2]](diffhunk://#diff-493b23bb55ac505c8a2e2ad3b941d5739be03dcebd4bc8fd4bff99e9bd9e2122R143-R227)
* Cleaned up imports and removed unused code.

These changes make token management more robust, prevent duplicate network requests, and ensure a consistent authentication state across the application.

## Rollout/Rollback
<!--
Detail how this change will be rolled out. Include reference to any
experiments and how the success will be measured as the experiment is
ramped.

Document rollback procedures. Is rolling back the change as simple as
rolling back an experiment or does it require reverting code? Are there
database migrations that may change our decision to roll forward instead of
back?
-->
Revert the PR

## Testing
<!--
Provide as much information as you can about how you tested and how another
Engineer can test your change. Include screenshots, or test run output
where appropriate.
-->

* Updated and expanded tests throughout the codebase to reflect the new token management logic, including concurrency, error handling, and registration flows. [[1]](diffhunk://#diff-ab3d782e4ac91af0e1a624e3103f6efabfc0075fff9bb4f3c5f503e3fc821ce4L1029-R1029) [[2]](diffhunk://#diff-ab3d782e4ac91af0e1a624e3103f6efabfc0075fff9bb4f3c5f503e3fc821ce4L1048-R1048) [[3]](diffhunk://#diff-ab3d782e4ac91af0e1a624e3103f6efabfc0075fff9bb4f3c5f503e3fc821ce4L1177-R1177) F92f3f92L140R140)
* Updated comments and documentation to clarify the new logic and intent. [[1]](diffhunk://#diff-ab3d782e4ac91af0e1a624e3103f6efabfc0075fff9bb4f3c5f503e3fc821ce4L1029-R1029) [[2]](diffhunk://#diff-99192a3e74bb01bcb0c4199bafcdf28eb5f81747989f99cd64c3f13b0adcec6dL56-R77)


## Demo

https://github.com/user-attachments/assets/cc41a7fc-1e6b-4f63-ba7e-384ad27857cb



[B2B-5212]: https://bigcommercecloud.atlassian.net/browse/B2B-5212?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication init, logout, and B2B token exchange error handling across the storefront; regressions could affect login, post-logout guest access, or duplicate/missing error messaging.
> 
> **Overview**
> Fixes buyer-portal login/logout reliability by **replacing ad-hoc `loginInfo` token fetching** with **`ensureBcGraphqlToken`**, which early-returns when a token exists, **deduplicates concurrent `storeFrontToken` requests**, and is used from **app init**, **`useLogout`**, **headless `user.logout`**, and **registration**.
> 
> **Logout** now **always refetches an anonymous storefront token** after `logoutSession`, so guest GraphQL keeps working without a full refresh. **Login URL handling** stops treating **`loggedOutLogin` as a forced logout for guests** (removed from `SHOULD_LOGOUT_FLAGS`) and clarifies that **`loggedOutLogin` only runs while still logged in**, avoiding a **second logout** that could clear a freshly fetched token.
> 
> **B2B token exchange** calls **`getB2BToken` with snackbar suppression** (`suppressSnackbar` on `graphqlB2B`) so **company-status errors** (pending/inactive) are shown **once** from login/init handling instead of duplicating global snackbars.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 791931e2c85790388297cca34439daa8c0b9cbb6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->