### PR TITLE
fix(invoices): B2B-4988 Optimize Invoice List

### DIFF
--- a/apps/storefront/src/lib/lang/locales/en.json
+++ b/apps/storefront/src/lib/lang/locales/en.json
@@ -164,6 +164,7 @@
   "orders.status.manualVerificationRequired": "Manual Verification Required",
   "orders.status.disputed": "Disputed",
   "orders.status.partiallyRefunded": "Partially Refunded",
+  "invoice.noDataText": "No invoices found. For Invoice ID, enter the full number, or the first or last digits.",
   "invoice.exportCsvText": "Export all as CSV",
   "invoice.exportSelectedAsCsv": "Export selected as CSV",
   "invoice.exportFilteredAsCsv": "Export filtered as CSV",

--- a/apps/storefront/src/pages/Invoice/index.tsx
+++ b/apps/storefront/src/pages/Invoice/index.tsx
@@ -977,6 +977,7 @@ function Invoice() {
               }
             />
           )}
+          noDataText={b3Lang('invoice.noDataText')}
         />
         {list.length > 0 && !isMobile && (
           <Box


### PR DESCRIPTION
Jira: [B2B-4988](https://bigcommercecloud.atlassian.net/browse/B2B-4988)

## What/Why?
<!--
  A description about what this pull request implements and its purpose.
  Try to be detailed and describe any technical details to simplify the job
  of the reviewer and the individual on production support.
-->
It modifies the display message shown when no invoices are found or when the Invoices API returns an empty response either on search or on load.

The goal is to provide clearer guidance to users by instructing them to enter either the full Invoice ID or the first/last digits, ensuring a more intuitive experience when searching for invoices.
## Rollout/Rollback
<!--
Detail how this change will be rolled out. Include reference to any
experiments and how the success will be measured as the experiment is
ramped.

Document rollback procedures. Is rolling back the change as simple as
rolling back an experiment or does it require reverting code? Are there
database migrations that may change our decision to roll forward instead of
back?
-->
Revert
## Testing
<!--
Provide as much information as you can about how you tested and how another
Engineer can test your change. Include screenshots, or test run output
where appropriate.
-->
Before
<img width="1508" height="907" alt="Before" src="https://github.com/user-attachments/assets/254f811e-9a79-4916-8a3d-3cb569846ea1" />
After
<img width="1508" height="907" alt="After" src="https://github.com/user-attachments/assets/5c89687d-1d12-4f73-a2cc-d17f1cfe95b0" />



[B2B-4988]: https://bigcommercecloud.atlassian.net/browse/B2B-4988?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy and UI-only wiring on the invoice list; no API, auth, or payment logic changes.
> 
> **Overview**
> When the invoice list is empty (initial load, filters, or search), users now see invoice-specific copy instead of a generic empty table state.
> 
> Adds **`invoice.noDataText`** in English and wires it into the Invoice page’s **`B3PaginationTable`** via **`noDataText`**, telling users that no invoices were found and how to search by Invoice ID (full number or first/last digits).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6926b90a07fd5d8b861d1ddb41ebc7b2cc46cf9d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->