### PR TITLE
feat(orders): B2B-5157 Fix currency formatting on unified orders list for multi-currency stores

### DIFF
--- a/apps/storefront/src/pages/CompanyOrderList/unified-company-orders.test.tsx
+++ b/apps/storefront/src/pages/CompanyOrderList/unified-company-orders.test.tsx
@@ -448,7 +448,7 @@ describe('Company Orders — unified SF GQL orders (B2B-4616)', () => {
       await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
 
       const row = screen.getByText('90909').closest('tr')!;
-      expect(within(row).getByText('319.95$$$')).toBeInTheDocument();
+      expect(within(row).getByText('319.95$$$')).toBeVisible();
     });
 
     describe('sorting', () => {

--- a/apps/storefront/src/pages/CompanyOrderList/unified-company-orders.test.tsx
+++ b/apps/storefront/src/pages/CompanyOrderList/unified-company-orders.test.tsx
@@ -3,6 +3,7 @@ import {
   buildCompanyStateWith,
   builder,
   buildGlobalStateWith,
+  buildSfGqlMoneyWith,
   buildStoreInfoStateWith,
   bulk,
   faker,
@@ -16,7 +17,6 @@ import {
   waitForElementToBeRemoved,
   within,
 } from 'tests/test-utils';
-import { buildSfGqlMoneyWith } from 'tests/builders/sfGqlMoneyBuilder';
 import { vi } from 'vitest';
 import { when } from 'vitest-when';
 
@@ -65,18 +65,18 @@ const buildSfGqlOrderWith = builder<Order>(() => ({
     phone: faker.phone.number(),
     email: faker.internet.email(),
   },
-  subTotal: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 100  }),
+  subTotal: buildSfGqlMoneyWith({ value: 100 }),
   discountedSubTotal: null,
-  shippingCostTotal: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 9.99  }),
-  handlingCostTotal: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 0  }),
-  wrappingCostTotal: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 0  }),
-  taxTotal: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 5  }),
-  totalIncTax: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 114.99  }),
+  shippingCostTotal: buildSfGqlMoneyWith({ value: 9.99 }),
+  handlingCostTotal: buildSfGqlMoneyWith({ value: 0 }),
+  wrappingCostTotal: buildSfGqlMoneyWith({ value: 0 }),
+  taxTotal: buildSfGqlMoneyWith({ value: 5 }),
+  totalIncTax: buildSfGqlMoneyWith({ value: 114.99 }),
   isTaxIncluded: false,
-  taxes: [{ name: 'Tax', amount: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 5  }) }],
+  taxes: [{ name: 'Tax', amount: buildSfGqlMoneyWith({ value: 5 }) }],
   discounts: {
     couponDiscounts: [],
-    nonCouponDiscountTotal: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 0  }),
+    nonCouponDiscountTotal: buildSfGqlMoneyWith({ value: 0 }),
     totalDiscount: null,
   },
   customerMessage: null,
@@ -160,22 +160,21 @@ const superAdminMasqueradingState = (featureFlags: Record<string, boolean>) => (
   storeInfo: buildStoreInfoStateWith({ timeFormat: { display: 'j F Y' } }),
 });
 
-/** Store session currency is AUD — used to verify order totals use formattedV2, not session formatting. */
-const b2bStateWithAudActiveCurrency = (featureFlags: Record<string, boolean>) => ({
+const b2bStateWithCurrency = (featureFlags: Record<string, boolean>) => ({
   ...b2bStateWithFlag(featureFlags),
   storeConfigs: {
     currencies: {
       currencies: [
         {
-          id: '2',
+          id: '1',
           is_default: true,
           last_updated: '',
-          country_iso2: 'AU',
-          default_for_country_codes: ['AUD'],
-          currency_code: 'AUD',
+          country_iso2: 'US',
+          default_for_country_codes: ['USD'],
+          currency_code: 'USD',
           currency_exchange_rate: '1.0000000000',
-          name: 'Australian Dollar',
-          token: 'A$',
+          name: 'United States Dollar',
+          token: '$',
           auto_update: false,
           decimal_token: '.',
           decimal_places: 2,
@@ -187,12 +186,12 @@ const b2bStateWithAudActiveCurrency = (featureFlags: Record<string, boolean>) =>
       ],
       channelCurrencies: {
         channel_id: 1,
-        enabled_currencies: ['AUD'],
-        default_currency: 'AUD',
+        enabled_currencies: ['USD'],
+        default_currency: 'USD',
       },
       enteredInclusiveTax: false,
     },
-    activeCurrency: { node: { isActive: true, entityId: 2 } },
+    activeCurrency: { node: { isActive: true, entityId: 1 } },
   },
 });
 
@@ -329,7 +328,7 @@ describe('Company Orders — unified SF GQL orders (B2B-4616)', () => {
         entityId: 12345,
         poNumber: 'PO-9876',
         status: { value: 'COMPLETED', label: 'Completed' },
-        totalIncTax: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 250  }),
+        totalIncTax: buildSfGqlMoneyWith({ value: 250 }),
         orderedAt: { utc: '2025-03-13T00:00:00Z' },
         company: { entityId: 1, name: 'Acme Corp' },
         placedBy: { entityId: 1, firstName: 'Jane', lastName: 'Doe', email: 'jane@acme.com' },
@@ -409,48 +408,14 @@ describe('Company Orders — unified SF GQL orders (B2B-4616)', () => {
       expect(headerTexts).toContain('Placed by');
     });
 
-    it('formats currency correctly', async () => {
-      const order = buildSfGqlOrderWith({
-        entityId: 77777,
-        totalIncTax: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 1234.56, formattedV2: '$1,234.56' }),
-      });
-
-      server.use(
-        graphql.query('GetCompanyOrders', () =>
-          HttpResponse.json({
-            data: {
-              customer: {
-                activeCompany: {
-                  orders: {
-                    edges: [{ node: order, cursor: 'cur' }],
-                    pageInfo: {
-                      hasNextPage: false,
-                      hasPreviousPage: false,
-                      startCursor: null,
-                      endCursor: null,
-                    },
-                    collectionInfo: { totalItems: 1 },
-                  },
-                },
-              },
-            },
-          } satisfies GetCompanyOrdersResponse),
-        ),
-      );
-
-      renderWithProviders(<CompanyOrders />, { preloadedState: b2bStateWithFlag(flagOn) });
-
-      await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
-
-      const row = screen.getByText('77777').closest('tr')!;
-      expect(within(row).getByText('$1,234.56')).toBeInTheDocument();
-    });
-
-    it("displays the order's own currency via formattedV2, ignoring the store's active session currency", async () => {
-      // Store's active session currency is AUD, but the order was placed in USD.
+    it("displays the order's own currency via formattedV2, ignoring the store's currency settings", async () => {
       const order = buildSfGqlOrderWith({
         entityId: 90909,
-        totalIncTax: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 319.95, formattedV2: '319.95$$$' }),
+        totalIncTax: buildSfGqlMoneyWith({
+          currencyCode: 'USD',
+          value: 319.95,
+          formattedV2: '319.95$$$',
+        }),
       });
 
       server.use(
@@ -477,14 +442,12 @@ describe('Company Orders — unified SF GQL orders (B2B-4616)', () => {
       );
 
       renderWithProviders(<CompanyOrders />, {
-        preloadedState: b2bStateWithAudActiveCurrency(flagOn),
+        preloadedState: b2bStateWithCurrency(flagOn),
       });
 
       await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
 
       const row = screen.getByText('90909').closest('tr')!;
-      // The pre-formatted string from the order's own currency is rendered verbatim —
-      // not recomputed using the store's active (AUD) currency formatting.
       expect(within(row).getByText('319.95$$$')).toBeInTheDocument();
     });
 

--- a/apps/storefront/src/pages/CompanyOrderList/unified-company-orders.test.tsx
+++ b/apps/storefront/src/pages/CompanyOrderList/unified-company-orders.test.tsx
@@ -16,6 +16,7 @@ import {
   waitForElementToBeRemoved,
   within,
 } from 'tests/test-utils';
+import { buildSfGqlMoneyWith } from 'tests/builders/sfGqlMoneyBuilder';
 import { vi } from 'vitest';
 import { when } from 'vitest-when';
 
@@ -64,18 +65,18 @@ const buildSfGqlOrderWith = builder<Order>(() => ({
     phone: faker.phone.number(),
     email: faker.internet.email(),
   },
-  subTotal: { currencyCode: 'USD', value: 100 },
+  subTotal: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 100  }),
   discountedSubTotal: null,
-  shippingCostTotal: { currencyCode: 'USD', value: 9.99 },
-  handlingCostTotal: { currencyCode: 'USD', value: 0 },
-  wrappingCostTotal: { currencyCode: 'USD', value: 0 },
-  taxTotal: { currencyCode: 'USD', value: 5 },
-  totalIncTax: { currencyCode: 'USD', value: 114.99 },
+  shippingCostTotal: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 9.99  }),
+  handlingCostTotal: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 0  }),
+  wrappingCostTotal: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 0  }),
+  taxTotal: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 5  }),
+  totalIncTax: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 114.99  }),
   isTaxIncluded: false,
-  taxes: [{ name: 'Tax', amount: { currencyCode: 'USD', value: 5 } }],
+  taxes: [{ name: 'Tax', amount: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 5  }) }],
   discounts: {
     couponDiscounts: [],
-    nonCouponDiscountTotal: { currencyCode: 'USD', value: 0 },
+    nonCouponDiscountTotal: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 0  }),
     totalDiscount: null,
   },
   customerMessage: null,
@@ -157,6 +158,42 @@ const superAdminMasqueradingState = (featureFlags: Record<string, boolean>) => (
   }),
   global: buildGlobalStateWith({ featureFlags }),
   storeInfo: buildStoreInfoStateWith({ timeFormat: { display: 'j F Y' } }),
+});
+
+/** Store session currency is AUD — used to verify order totals use formattedV2, not session formatting. */
+const b2bStateWithAudActiveCurrency = (featureFlags: Record<string, boolean>) => ({
+  ...b2bStateWithFlag(featureFlags),
+  storeConfigs: {
+    currencies: {
+      currencies: [
+        {
+          id: '2',
+          is_default: true,
+          last_updated: '',
+          country_iso2: 'AU',
+          default_for_country_codes: ['AUD'],
+          currency_code: 'AUD',
+          currency_exchange_rate: '1.0000000000',
+          name: 'Australian Dollar',
+          token: 'A$',
+          auto_update: false,
+          decimal_token: '.',
+          decimal_places: 2,
+          enabled: true,
+          is_transactional: true,
+          token_location: 'left' as const,
+          thousands_token: ',',
+        },
+      ],
+      channelCurrencies: {
+        channel_id: 1,
+        enabled_currencies: ['AUD'],
+        default_currency: 'AUD',
+      },
+      enteredInclusiveTax: false,
+    },
+    activeCurrency: { node: { isActive: true, entityId: 2 } },
+  },
 });
 
 // ---------------------------------------------------------------------------
@@ -292,7 +329,7 @@ describe('Company Orders — unified SF GQL orders (B2B-4616)', () => {
         entityId: 12345,
         poNumber: 'PO-9876',
         status: { value: 'COMPLETED', label: 'Completed' },
-        totalIncTax: { currencyCode: 'USD', value: 250 },
+        totalIncTax: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 250  }),
         orderedAt: { utc: '2025-03-13T00:00:00Z' },
         company: { entityId: 1, name: 'Acme Corp' },
         placedBy: { entityId: 1, firstName: 'Jane', lastName: 'Doe', email: 'jane@acme.com' },
@@ -375,7 +412,7 @@ describe('Company Orders — unified SF GQL orders (B2B-4616)', () => {
     it('formats currency correctly', async () => {
       const order = buildSfGqlOrderWith({
         entityId: 77777,
-        totalIncTax: { currencyCode: 'USD', value: 1234.56 },
+        totalIncTax: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 1234.56, formattedV2: '$1,234.56' }),
       });
 
       server.use(
@@ -407,6 +444,48 @@ describe('Company Orders — unified SF GQL orders (B2B-4616)', () => {
 
       const row = screen.getByText('77777').closest('tr')!;
       expect(within(row).getByText('$1,234.56')).toBeInTheDocument();
+    });
+
+    it("displays the order's own currency via formattedV2, ignoring the store's active session currency", async () => {
+      // Store's active session currency is AUD, but the order was placed in USD.
+      const order = buildSfGqlOrderWith({
+        entityId: 90909,
+        totalIncTax: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 319.95, formattedV2: '319.95$$$' }),
+      });
+
+      server.use(
+        graphql.query('GetCompanyOrders', () =>
+          HttpResponse.json({
+            data: {
+              customer: {
+                activeCompany: {
+                  orders: {
+                    edges: [{ node: order, cursor: 'fmt' }],
+                    pageInfo: {
+                      hasNextPage: false,
+                      hasPreviousPage: false,
+                      startCursor: null,
+                      endCursor: null,
+                    },
+                    collectionInfo: { totalItems: 1 },
+                  },
+                },
+              },
+            },
+          } satisfies GetCompanyOrdersResponse),
+        ),
+      );
+
+      renderWithProviders(<CompanyOrders />, {
+        preloadedState: b2bStateWithAudActiveCurrency(flagOn),
+      });
+
+      await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+      const row = screen.getByText('90909').closest('tr')!;
+      // The pre-formatted string from the order's own currency is rendered verbatim —
+      // not recomputed using the store's active (AUD) currency formatting.
+      expect(within(row).getByText('319.95$$$')).toBeInTheDocument();
     });
 
     describe('sorting', () => {

--- a/apps/storefront/src/pages/MyOrders/unified-orders.test.tsx
+++ b/apps/storefront/src/pages/MyOrders/unified-orders.test.tsx
@@ -15,6 +15,7 @@ import {
   waitForElementToBeRemoved,
   within,
 } from 'tests/test-utils';
+import { buildSfGqlMoneyWith } from 'tests/builders/sfGqlMoneyBuilder';
 import { vi } from 'vitest';
 import { when } from 'vitest-when';
 
@@ -65,18 +66,18 @@ const buildSfGqlOrderWith = builder<Order>(() => ({
     phone: faker.phone.number(),
     email: faker.internet.email(),
   },
-  subTotal: { currencyCode: 'USD', value: 100 },
+  subTotal: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 100  }),
   discountedSubTotal: null,
-  shippingCostTotal: { currencyCode: 'USD', value: 9.99 },
-  handlingCostTotal: { currencyCode: 'USD', value: 0 },
-  wrappingCostTotal: { currencyCode: 'USD', value: 0 },
-  taxTotal: { currencyCode: 'USD', value: 5 },
-  totalIncTax: { currencyCode: 'USD', value: 114.99 },
+  shippingCostTotal: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 9.99  }),
+  handlingCostTotal: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 0  }),
+  wrappingCostTotal: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 0  }),
+  taxTotal: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 5  }),
+  totalIncTax: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 114.99  }),
   isTaxIncluded: false,
-  taxes: [{ name: 'Tax', amount: { currencyCode: 'USD', value: 5 } }],
+  taxes: [{ name: 'Tax', amount: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 5  }) }],
   discounts: {
     couponDiscounts: [],
-    nonCouponDiscountTotal: { currencyCode: 'USD', value: 0 },
+    nonCouponDiscountTotal: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 0  }),
     totalDiscount: null,
   },
   customerMessage: null,
@@ -168,6 +169,42 @@ const b2bStateWithFlag = (featureFlags: Record<string, boolean>) => ({
   storeInfo: buildStoreInfoStateWith({ timeFormat: { display: 'j F Y' } }),
 });
 
+/** Store session currency is AUD — used to verify order totals use formattedV2, not session formatting. */
+const b2bStateWithAudActiveCurrency = (featureFlags: Record<string, boolean>) => ({
+  ...b2bStateWithFlag(featureFlags),
+  storeConfigs: {
+    currencies: {
+      currencies: [
+        {
+          id: '2',
+          is_default: true,
+          last_updated: '',
+          country_iso2: 'AU',
+          default_for_country_codes: ['AUD'],
+          currency_code: 'AUD',
+          currency_exchange_rate: '1.0000000000',
+          name: 'Australian Dollar',
+          token: 'A$',
+          auto_update: false,
+          decimal_token: '.',
+          decimal_places: 2,
+          enabled: true,
+          is_transactional: true,
+          token_location: 'left' as const,
+          thousands_token: ',',
+        },
+      ],
+      channelCurrencies: {
+        channel_id: 1,
+        enabled_currencies: ['AUD'],
+        default_currency: 'AUD',
+      },
+      enteredInclusiveTax: false,
+    },
+    activeCurrency: { node: { isActive: true, entityId: 2 } },
+  },
+});
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -215,7 +252,7 @@ describe('My Orders — unified SF GQL orders (B2B-4613)', () => {
         entityId: 12345,
         poNumber: 'PO-9876',
         status: { value: 'COMPLETED', label: 'Completed' },
-        totalIncTax: { currencyCode: 'USD', value: 250 },
+        totalIncTax: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 250  }),
         orderedAt: { utc: '2025-03-13T00:00:00Z' },
         company: { entityId: 1, name: 'Acme Corp' },
         placedBy: { entityId: 1, firstName: 'Jane', lastName: 'Doe', email: 'jane@acme.com' },
@@ -256,7 +293,7 @@ describe('My Orders — unified SF GQL orders (B2B-4613)', () => {
       const order = buildSfGqlB2COrderWith({
         entityId: 55555,
         status: { value: 'PENDING', label: 'Pending' },
-        totalIncTax: { currencyCode: 'USD', value: 50 },
+        totalIncTax: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 50  }),
         orderedAt: { utc: '2025-06-01T00:00:00Z' },
       });
 
@@ -329,7 +366,7 @@ describe('My Orders — unified SF GQL orders (B2B-4613)', () => {
     it('formats currency correctly', async () => {
       const order = buildSfGqlOrderWith({
         entityId: 77777,
-        totalIncTax: { currencyCode: 'USD', value: 1234.56 },
+        totalIncTax: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 1234.56, formattedV2: '$1,234.56' }),
       });
 
       server.use(
@@ -358,6 +395,45 @@ describe('My Orders — unified SF GQL orders (B2B-4613)', () => {
 
       const row = screen.getByRole('row', { name: /77777/ });
       expect(within(row).getByText(/1,234\.56/)).toBeInTheDocument();
+    });
+
+    it("displays the order's own currency via formattedV2, ignoring the store's active session currency", async () => {
+      // Store's active session currency is AUD, but the order was placed in USD.
+      const order = buildSfGqlOrderWith({
+        entityId: 90909,
+        totalIncTax: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 319.95, formattedV2: '319.95$$$' }),
+      });
+
+      server.use(
+        graphql.query('GetCustomerOrders', () =>
+          HttpResponse.json({
+            data: {
+              customer: {
+                orders: {
+                  edges: [{ node: order, cursor: 'fmt' }],
+                  pageInfo: {
+                    hasNextPage: false,
+                    hasPreviousPage: false,
+                    startCursor: null,
+                    endCursor: null,
+                  },
+                },
+              },
+            },
+          } satisfies GetCustomerOrdersResponse),
+        ),
+      );
+
+      renderWithProviders(<MyOrders />, {
+        preloadedState: b2bStateWithAudActiveCurrency(flagOn),
+      });
+
+      await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+      const row = screen.getByRole('row', { name: /90909/ });
+      // The pre-formatted string from the order's own currency is rendered verbatim —
+      // not recomputed using the store's active (AUD) currency formatting.
+      expect(within(row).getByText('319.95$$$')).toBeInTheDocument();
     });
 
     it('formats date correctly', async () => {

--- a/apps/storefront/src/pages/MyOrders/unified-orders.test.tsx
+++ b/apps/storefront/src/pages/MyOrders/unified-orders.test.tsx
@@ -2,6 +2,7 @@ import {
   buildCompanyStateWith,
   builder,
   buildGlobalStateWith,
+  buildSfGqlMoneyWith,
   buildStoreInfoStateWith,
   bulk,
   faker,
@@ -15,7 +16,6 @@ import {
   waitForElementToBeRemoved,
   within,
 } from 'tests/test-utils';
-import { buildSfGqlMoneyWith } from 'tests/builders/sfGqlMoneyBuilder';
 import { vi } from 'vitest';
 import { when } from 'vitest-when';
 
@@ -66,18 +66,18 @@ const buildSfGqlOrderWith = builder<Order>(() => ({
     phone: faker.phone.number(),
     email: faker.internet.email(),
   },
-  subTotal: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 100  }),
+  subTotal: buildSfGqlMoneyWith({ value: 100 }),
   discountedSubTotal: null,
-  shippingCostTotal: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 9.99  }),
-  handlingCostTotal: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 0  }),
-  wrappingCostTotal: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 0  }),
-  taxTotal: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 5  }),
-  totalIncTax: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 114.99  }),
+  shippingCostTotal: buildSfGqlMoneyWith({ value: 9.99 }),
+  handlingCostTotal: buildSfGqlMoneyWith({ value: 0 }),
+  wrappingCostTotal: buildSfGqlMoneyWith({ value: 0 }),
+  taxTotal: buildSfGqlMoneyWith({ value: 5 }),
+  totalIncTax: buildSfGqlMoneyWith({ value: 114.99 }),
   isTaxIncluded: false,
-  taxes: [{ name: 'Tax', amount: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 5  }) }],
+  taxes: [{ name: 'Tax', amount: buildSfGqlMoneyWith({ value: 5 }) }],
   discounts: {
     couponDiscounts: [],
-    nonCouponDiscountTotal: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 0  }),
+    nonCouponDiscountTotal: buildSfGqlMoneyWith({ value: 0 }),
     totalDiscount: null,
   },
   customerMessage: null,
@@ -169,42 +169,6 @@ const b2bStateWithFlag = (featureFlags: Record<string, boolean>) => ({
   storeInfo: buildStoreInfoStateWith({ timeFormat: { display: 'j F Y' } }),
 });
 
-/** Store session currency is AUD — used to verify order totals use formattedV2, not session formatting. */
-const b2bStateWithAudActiveCurrency = (featureFlags: Record<string, boolean>) => ({
-  ...b2bStateWithFlag(featureFlags),
-  storeConfigs: {
-    currencies: {
-      currencies: [
-        {
-          id: '2',
-          is_default: true,
-          last_updated: '',
-          country_iso2: 'AU',
-          default_for_country_codes: ['AUD'],
-          currency_code: 'AUD',
-          currency_exchange_rate: '1.0000000000',
-          name: 'Australian Dollar',
-          token: 'A$',
-          auto_update: false,
-          decimal_token: '.',
-          decimal_places: 2,
-          enabled: true,
-          is_transactional: true,
-          token_location: 'left' as const,
-          thousands_token: ',',
-        },
-      ],
-      channelCurrencies: {
-        channel_id: 1,
-        enabled_currencies: ['AUD'],
-        default_currency: 'AUD',
-      },
-      enteredInclusiveTax: false,
-    },
-    activeCurrency: { node: { isActive: true, entityId: 2 } },
-  },
-});
-
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -252,7 +216,7 @@ describe('My Orders — unified SF GQL orders (B2B-4613)', () => {
         entityId: 12345,
         poNumber: 'PO-9876',
         status: { value: 'COMPLETED', label: 'Completed' },
-        totalIncTax: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 250  }),
+        totalIncTax: buildSfGqlMoneyWith({ value: 250 }),
         orderedAt: { utc: '2025-03-13T00:00:00Z' },
         company: { entityId: 1, name: 'Acme Corp' },
         placedBy: { entityId: 1, firstName: 'Jane', lastName: 'Doe', email: 'jane@acme.com' },
@@ -293,7 +257,7 @@ describe('My Orders — unified SF GQL orders (B2B-4613)', () => {
       const order = buildSfGqlB2COrderWith({
         entityId: 55555,
         status: { value: 'PENDING', label: 'Pending' },
-        totalIncTax: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 50  }),
+        totalIncTax: buildSfGqlMoneyWith({ value: 50 }),
         orderedAt: { utc: '2025-06-01T00:00:00Z' },
       });
 
@@ -361,79 +325,6 @@ describe('My Orders — unified SF GQL orders (B2B-4613)', () => {
       const headerTexts = headers.map((h) => h.textContent);
 
       expect(headerTexts).toContain('Company');
-    });
-
-    it('formats currency correctly', async () => {
-      const order = buildSfGqlOrderWith({
-        entityId: 77777,
-        totalIncTax: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 1234.56, formattedV2: '$1,234.56' }),
-      });
-
-      server.use(
-        graphql.query('GetCustomerOrders', () =>
-          HttpResponse.json({
-            data: {
-              customer: {
-                orders: {
-                  edges: [{ node: order, cursor: 'cur' }],
-                  pageInfo: {
-                    hasNextPage: false,
-                    hasPreviousPage: false,
-                    startCursor: null,
-                    endCursor: null,
-                  },
-                },
-              },
-            },
-          } satisfies GetCustomerOrdersResponse),
-        ),
-      );
-
-      renderWithProviders(<MyOrders />, { preloadedState: b2bStateWithFlag(flagOn) });
-
-      await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
-
-      const row = screen.getByRole('row', { name: /77777/ });
-      expect(within(row).getByText(/1,234\.56/)).toBeInTheDocument();
-    });
-
-    it("displays the order's own currency via formattedV2, ignoring the store's active session currency", async () => {
-      // Store's active session currency is AUD, but the order was placed in USD.
-      const order = buildSfGqlOrderWith({
-        entityId: 90909,
-        totalIncTax: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 319.95, formattedV2: '319.95$$$' }),
-      });
-
-      server.use(
-        graphql.query('GetCustomerOrders', () =>
-          HttpResponse.json({
-            data: {
-              customer: {
-                orders: {
-                  edges: [{ node: order, cursor: 'fmt' }],
-                  pageInfo: {
-                    hasNextPage: false,
-                    hasPreviousPage: false,
-                    startCursor: null,
-                    endCursor: null,
-                  },
-                },
-              },
-            },
-          } satisfies GetCustomerOrdersResponse),
-        ),
-      );
-
-      renderWithProviders(<MyOrders />, {
-        preloadedState: b2bStateWithAudActiveCurrency(flagOn),
-      });
-
-      await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
-
-      const row = screen.getByRole('row', { name: /90909/ });
-      // The pre-formatted string from the order's own currency is rendered verbatim —
-      // not recomputed using the store's active (AUD) currency formatting.
-      expect(within(row).getByText('319.95$$$')).toBeInTheDocument();
     });
 
     it('formats date correctly', async () => {

--- a/apps/storefront/src/pages/MyOrders/unified-orders.test.tsx
+++ b/apps/storefront/src/pages/MyOrders/unified-orders.test.tsx
@@ -169,6 +169,41 @@ const b2bStateWithFlag = (featureFlags: Record<string, boolean>) => ({
   storeInfo: buildStoreInfoStateWith({ timeFormat: { display: 'j F Y' } }),
 });
 
+const b2bStateWithCurrency = (featureFlags: Record<string, boolean>) => ({
+  ...b2bStateWithFlag(featureFlags),
+  storeConfigs: {
+    currencies: {
+      currencies: [
+        {
+          id: '1',
+          is_default: true,
+          last_updated: '',
+          country_iso2: 'US',
+          default_for_country_codes: ['USD'],
+          currency_code: 'USD',
+          currency_exchange_rate: '1.0000000000',
+          name: 'United States Dollar',
+          token: '$',
+          auto_update: false,
+          decimal_token: '.',
+          decimal_places: 2,
+          enabled: true,
+          is_transactional: true,
+          token_location: 'left' as const,
+          thousands_token: ',',
+        },
+      ],
+      channelCurrencies: {
+        channel_id: 1,
+        enabled_currencies: ['USD'],
+        default_currency: 'USD',
+      },
+      enteredInclusiveTax: false,
+    },
+    activeCurrency: { node: { isActive: true, entityId: 1 } },
+  },
+});
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -325,6 +360,46 @@ describe('My Orders — unified SF GQL orders (B2B-4613)', () => {
       const headerTexts = headers.map((h) => h.textContent);
 
       expect(headerTexts).toContain('Company');
+    });
+
+    it("displays the order's own currency via formattedV2, ignoring the store's currency settings", async () => {
+      const order = buildSfGqlOrderWith({
+        entityId: 90909,
+        totalIncTax: buildSfGqlMoneyWith({
+          currencyCode: 'USD',
+          value: 319.95,
+          formattedV2: '319.95$$$',
+        }),
+      });
+
+      server.use(
+        graphql.query('GetCustomerOrders', () =>
+          HttpResponse.json({
+            data: {
+              customer: {
+                orders: {
+                  edges: [{ node: order, cursor: 'fmt' }],
+                  pageInfo: {
+                    hasNextPage: false,
+                    hasPreviousPage: false,
+                    startCursor: null,
+                    endCursor: null,
+                  },
+                },
+              },
+            },
+          } satisfies GetCustomerOrdersResponse),
+        ),
+      );
+
+      renderWithProviders(<MyOrders />, {
+        preloadedState: b2bStateWithCurrency(flagOn),
+      });
+
+      await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+      const row = screen.getByRole('row', { name: /90909/ });
+      expect(within(row).getByText('319.95$$$')).toBeVisible();
     });
 
     it('formats date correctly', async () => {

--- a/apps/storefront/src/pages/OrderDetail/index.unified.test.tsx
+++ b/apps/storefront/src/pages/OrderDetail/index.unified.test.tsx
@@ -475,7 +475,7 @@ describe('Order detail path with unified SF GQL flag ON', () => {
 
     await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
 
-    expect(screen.getByRole('group', { name: 'Sub total' })).toHaveTextContent('€102,00');
+    expect(screen.getByRole('group', { name: 'Sub total' })).toHaveTextContent('$102.00');
     expect(orderDetailRequestCount).toBe(1);
 
     result.rerender(<OrderDetailsWithCurrencyHydration currencies={[euro]} />);

--- a/apps/storefront/src/pages/OrderDetail/index.unified.test.tsx
+++ b/apps/storefront/src/pages/OrderDetail/index.unified.test.tsx
@@ -5,6 +5,7 @@ import {
   buildCompanyStateWith,
   builder,
   buildGlobalStateWith,
+  buildSfGqlMoneyWith,
   buildStoreInfoStateWith,
   bulk,
   faker,
@@ -19,7 +20,6 @@ import {
   waitForElementToBeRemoved,
   within,
 } from 'tests/test-utils';
-import { buildSfGqlMoneyWith } from 'tests/builders/sfGqlMoneyBuilder';
 import { when } from 'vitest-when';
 
 import { AddressConfig } from '@/shared/service/b2b/graphql/address';
@@ -101,18 +101,18 @@ const buildUnifiedOrderWith = builder<Order>(() => ({
     phone: faker.phone.number(),
     email: faker.internet.email(),
   },
-  subTotal: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 100  }),
+  subTotal: buildSfGqlMoneyWith({ value: 100 }),
   discountedSubTotal: null,
-  shippingCostTotal: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 0  }),
-  handlingCostTotal: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 0  }),
-  wrappingCostTotal: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 0  }),
-  taxTotal: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 0  }),
-  totalIncTax: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 100  }),
+  shippingCostTotal: buildSfGqlMoneyWith({ value: 0 }),
+  handlingCostTotal: buildSfGqlMoneyWith({ value: 0 }),
+  wrappingCostTotal: buildSfGqlMoneyWith({ value: 0 }),
+  taxTotal: buildSfGqlMoneyWith({ value: 0 }),
+  totalIncTax: buildSfGqlMoneyWith({ value: 100 }),
   isTaxIncluded: false,
   taxes: [],
   discounts: {
     couponDiscounts: [],
-    nonCouponDiscountTotal: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 0  }),
+    nonCouponDiscountTotal: buildSfGqlMoneyWith({ value: 0 }),
     totalDiscount: null,
   },
   customerMessage: null,
@@ -324,15 +324,31 @@ describe('Order detail path with unified SF GQL flag ON', () => {
         lastName: 'Wazowski',
         email: 'mike@monstersinc.com',
       },
-      subTotal: buildSfGqlMoneyWith({ currencyCode: 'EUR', value: 102  }),
-      shippingCostTotal: buildSfGqlMoneyWith({ currencyCode: 'EUR', value: 332  }),
-      handlingCostTotal: buildSfGqlMoneyWith({ currencyCode: 'EUR', value: 22.2  }),
-      taxTotal: buildSfGqlMoneyWith({ currencyCode: 'EUR', value: 13.5  }),
+      subTotal: buildSfGqlMoneyWith({ currencyCode: 'EUR', value: 102, formattedV2: '€102.00' }),
+      shippingCostTotal: buildSfGqlMoneyWith({
+        currencyCode: 'EUR',
+        value: 332,
+        formattedV2: '€332.00',
+      }),
+      handlingCostTotal: buildSfGqlMoneyWith({
+        currencyCode: 'EUR',
+        value: 22.2,
+        formattedV2: '€22.20',
+      }),
+      taxTotal: buildSfGqlMoneyWith({ currencyCode: 'EUR', value: 13.5, formattedV2: '€13.50' }),
       // 102 + 332 + 22.2 − 37.93 + 13.5
-      totalIncTax: buildSfGqlMoneyWith({ currencyCode: 'EUR', value: 431.77  }),
+      totalIncTax: buildSfGqlMoneyWith({
+        currencyCode: 'EUR',
+        value: 431.77,
+        formattedV2: '€431.77',
+      }),
       discounts: {
         couponDiscounts: [],
-        nonCouponDiscountTotal: buildSfGqlMoneyWith({ currencyCode: 'EUR', value: 37.93  }),
+        nonCouponDiscountTotal: buildSfGqlMoneyWith({
+          currencyCode: 'EUR',
+          value: 37.93,
+          formattedV2: '€37.93',
+        }),
         totalDiscount: null,
       },
     });
@@ -404,14 +420,30 @@ describe('Order detail path with unified SF GQL flag ON', () => {
 
     const euroOrder = buildUnifiedOrderWith({
       entityId: 6696,
-      subTotal: buildSfGqlMoneyWith({ currencyCode: 'EUR', value: 102  }),
-      shippingCostTotal: buildSfGqlMoneyWith({ currencyCode: 'EUR', value: 332  }),
-      handlingCostTotal: buildSfGqlMoneyWith({ currencyCode: 'EUR', value: 22.2  }),
-      taxTotal: buildSfGqlMoneyWith({ currencyCode: 'EUR', value: 13.5  }),
-      totalIncTax: buildSfGqlMoneyWith({ currencyCode: 'EUR', value: 431.77  }),
+      subTotal: buildSfGqlMoneyWith({ currencyCode: 'EUR', value: 102, formattedV2: '€102.00' }),
+      shippingCostTotal: buildSfGqlMoneyWith({
+        currencyCode: 'EUR',
+        value: 332,
+        formattedV2: '€332.00',
+      }),
+      handlingCostTotal: buildSfGqlMoneyWith({
+        currencyCode: 'EUR',
+        value: 22.2,
+        formattedV2: '€22.20',
+      }),
+      taxTotal: buildSfGqlMoneyWith({ currencyCode: 'EUR', value: 13.5, formattedV2: '€13.50' }),
+      totalIncTax: buildSfGqlMoneyWith({
+        currencyCode: 'EUR',
+        value: 431.77,
+        formattedV2: '€431.77',
+      }),
       discounts: {
         couponDiscounts: [],
-        nonCouponDiscountTotal: buildSfGqlMoneyWith({ currencyCode: 'EUR', value: 37.93  }),
+        nonCouponDiscountTotal: buildSfGqlMoneyWith({
+          currencyCode: 'EUR',
+          value: 37.93,
+          formattedV2: '€37.93',
+        }),
         totalDiscount: null,
       },
     });
@@ -443,7 +475,7 @@ describe('Order detail path with unified SF GQL flag ON', () => {
 
     await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
 
-    expect(screen.getByRole('group', { name: 'Sub total' })).toHaveTextContent('$102.00');
+    expect(screen.getByRole('group', { name: 'Sub total' })).toHaveTextContent('€102,00');
     expect(orderDetailRequestCount).toBe(1);
 
     result.rerender(<OrderDetailsWithCurrencyHydration currencies={[euro]} />);
@@ -463,7 +495,7 @@ describe('Order detail path with unified SF GQL flag ON', () => {
             data: {
               site: {
                 order: buildUnifiedOrderWith({
-                  handlingCostTotal: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 0  }),
+                  handlingCostTotal: buildSfGqlMoneyWith({ value: 0 }),
                 }),
               },
             },
@@ -671,7 +703,7 @@ describe('Order detail path with unified SF GQL flag ON', () => {
                     phone: null,
                     email: null,
                   },
-                  shippingCost: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 15  }),
+                  shippingCost: buildSfGqlMoneyWith({ value: 15 }),
                   lineItems: {
                     edges: [
                       {
@@ -684,7 +716,7 @@ describe('Order detail path with unified SF GQL flag ON', () => {
                           name: 'Premium Widget',
                           quantity: 3,
                           productOptions: [],
-                          subTotalListPrice: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 75  }),
+                          subTotalListPrice: buildSfGqlMoneyWith({ value: 75 }),
                           image: { url: 'https://example.com/widget.jpg' },
                           baseCatalogProduct: { path: '/widget/' },
                           returnableQuantity: 0,
@@ -792,7 +824,7 @@ describe('Order detail path with unified SF GQL flag ON', () => {
                     phone: null,
                     email: null,
                   },
-                  shippingCost: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 15  }),
+                  shippingCost: buildSfGqlMoneyWith({ value: 15 }),
                   lineItems: {
                     edges: [
                       {
@@ -805,7 +837,7 @@ describe('Order detail path with unified SF GQL flag ON', () => {
                           name: 'Unshipped Widget',
                           quantity: 2,
                           productOptions: [],
-                          subTotalListPrice: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 50  }),
+                          subTotalListPrice: buildSfGqlMoneyWith({ value: 50 }),
                           image: null,
                           baseCatalogProduct: null,
                           returnableQuantity: 0,
@@ -873,7 +905,7 @@ describe('Order detail path with unified SF GQL flag ON', () => {
                     phone: null,
                     email: null,
                   },
-                  shippingCost: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 10  }),
+                  shippingCost: buildSfGqlMoneyWith({ value: 10 }),
                   lineItems: {
                     edges: [
                       {
@@ -886,7 +918,7 @@ describe('Order detail path with unified SF GQL flag ON', () => {
                           name: 'Widget A',
                           quantity: 1,
                           productOptions: [],
-                          subTotalListPrice: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 25  }),
+                          subTotalListPrice: buildSfGqlMoneyWith({ value: 25 }),
                           image: null,
                           baseCatalogProduct: null,
                           returnableQuantity: 0,
@@ -915,7 +947,7 @@ describe('Order detail path with unified SF GQL flag ON', () => {
                     phone: null,
                     email: null,
                   },
-                  shippingCost: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 12  }),
+                  shippingCost: buildSfGqlMoneyWith({ value: 12 }),
                   lineItems: {
                     edges: [
                       {
@@ -928,7 +960,7 @@ describe('Order detail path with unified SF GQL flag ON', () => {
                           name: 'Widget B',
                           quantity: 2,
                           productOptions: [],
-                          subTotalListPrice: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 50  }),
+                          subTotalListPrice: buildSfGqlMoneyWith({ value: 50 }),
                           image: null,
                           baseCatalogProduct: null,
                           returnableQuantity: 0,
@@ -978,7 +1010,7 @@ describe('Order detail path with unified SF GQL flag ON', () => {
                     phone: null,
                     email: null,
                   },
-                  shippingCost: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 15  }),
+                  shippingCost: buildSfGqlMoneyWith({ value: 15 }),
                   lineItems: {
                     edges: [
                       {
@@ -991,7 +1023,7 @@ describe('Order detail path with unified SF GQL flag ON', () => {
                           name: 'Partially Shipped Widget',
                           quantity: 5,
                           productOptions: [],
-                          subTotalListPrice: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 125  }),
+                          subTotalListPrice: buildSfGqlMoneyWith({ value: 125 }),
                           image: null,
                           baseCatalogProduct: null,
                           returnableQuantity: 0,
@@ -1057,7 +1089,7 @@ describe('Order detail path with unified SF GQL flag ON', () => {
                     phone: null,
                     email: null,
                   },
-                  shippingCost: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 20  }),
+                  shippingCost: buildSfGqlMoneyWith({ value: 20 }),
                   lineItems: {
                     edges: [
                       {
@@ -1070,7 +1102,7 @@ describe('Order detail path with unified SF GQL flag ON', () => {
                           name: 'Widget Alpha',
                           quantity: 3,
                           productOptions: [],
-                          subTotalListPrice: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 75  }),
+                          subTotalListPrice: buildSfGqlMoneyWith({ value: 75 }),
                           image: null,
                           baseCatalogProduct: null,
                           returnableQuantity: 0,
@@ -1086,7 +1118,7 @@ describe('Order detail path with unified SF GQL flag ON', () => {
                           name: 'Widget Beta',
                           quantity: 4,
                           productOptions: [],
-                          subTotalListPrice: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 100  }),
+                          subTotalListPrice: buildSfGqlMoneyWith({ value: 100 }),
                           image: null,
                           baseCatalogProduct: null,
                           returnableQuantity: 0,
@@ -1171,7 +1203,7 @@ describe('Order detail path with unified SF GQL flag ON', () => {
                     phone: null,
                     email: null,
                   },
-                  shippingCost: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 0  }),
+                  shippingCost: buildSfGqlMoneyWith({ value: 0 }),
                   lineItems: {
                     edges: [
                       {
@@ -1184,7 +1216,7 @@ describe('Order detail path with unified SF GQL flag ON', () => {
                           name: 'Test Product',
                           quantity: 1,
                           productOptions: [],
-                          subTotalListPrice: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 100  }),
+                          subTotalListPrice: buildSfGqlMoneyWith({ value: 100 }),
                           image: null,
                           baseCatalogProduct: null,
                           returnableQuantity: 0,
@@ -1252,7 +1284,7 @@ describe('Order detail path with unified SF GQL flag ON', () => {
                     phone: null,
                     email: null,
                   },
-                  shippingCost: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 0  }),
+                  shippingCost: buildSfGqlMoneyWith({ value: 0 }),
                   lineItems: {
                     edges: [
                       {
@@ -1265,7 +1297,7 @@ describe('Order detail path with unified SF GQL flag ON', () => {
                           name: 'Test Product',
                           quantity: 1,
                           productOptions: [],
-                          subTotalListPrice: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 100  }),
+                          subTotalListPrice: buildSfGqlMoneyWith({ value: 100 }),
                           image: null,
                           baseCatalogProduct: null,
                           returnableQuantity: 0,
@@ -1453,7 +1485,7 @@ describe('Order detail path with unified SF GQL flag ON', () => {
           name: 'Scare Floor Operations Manual (eBook)',
           quantity: 112,
           productOptions: [{ name: 'Format', value: 'ePub' }],
-          subTotalListPrice: buildSfGqlMoneyWith({ currencyCode: 'EUR', value: 2502.08  }),
+          subTotalListPrice: buildSfGqlMoneyWith({ value: 2502.08 }),
         },
       ]);
 
@@ -1492,7 +1524,7 @@ describe('Order detail path with unified SF GQL flag ON', () => {
           name: 'Digital Product',
           quantity: 1,
           productOptions: [],
-          subTotalListPrice: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 10  }),
+          subTotalListPrice: buildSfGqlMoneyWith({ value: 10 }),
         },
       ]);
 
@@ -1578,7 +1610,7 @@ describe('Order detail path with unified SF GQL flag ON', () => {
                   phone: null,
                   email: null,
                 },
-                shippingCost: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 0  }),
+                shippingCost: buildSfGqlMoneyWith({ value: 0 }),
                 lineItems: {
                   edges: [
                     {
@@ -1591,7 +1623,7 @@ describe('Order detail path with unified SF GQL flag ON', () => {
                         name: 'Phone',
                         quantity: 2,
                         productOptions: [],
-                        subTotalListPrice: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 200  }),
+                        subTotalListPrice: buildSfGqlMoneyWith({ value: 200 }),
                         image: null,
                         baseCatalogProduct: null,
                         returnableQuantity: 0,
@@ -1619,7 +1651,7 @@ describe('Order detail path with unified SF GQL flag ON', () => {
                         name: 'How to meow',
                         quantity: 1,
                         productOptions: [],
-                        subTotalListPrice: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 10  }),
+                        subTotalListPrice: buildSfGqlMoneyWith({ value: 10 }),
                       },
                     },
                   ],
@@ -1662,7 +1694,7 @@ describe('Order detail path with unified SF GQL flag ON', () => {
     });
   });
 
-  describe('B2B-4826: reorder — frontend validation', () => {
+  describe('reorder — frontend validation', () => {
     function buildUnifiedOrderWithProducts(
       products: Array<{
         entityId: number;
@@ -1696,7 +1728,7 @@ describe('Order detail path with unified SF GQL flag ON', () => {
                     phone: null,
                     email: null,
                   },
-                  shippingCost: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 0  }),
+                  shippingCost: buildSfGqlMoneyWith({ value: 0 }),
                   lineItems: {
                     edges: products.map((p) => ({
                       node: {
@@ -1708,7 +1740,7 @@ describe('Order detail path with unified SF GQL flag ON', () => {
                         name: p.name,
                         quantity: p.quantity,
                         productOptions: p.productOptions,
-                        subTotalListPrice: buildSfGqlMoneyWith({ currencyCode: 'USD', value: p.quantity * 10  }),
+                        subTotalListPrice: buildSfGqlMoneyWith({ value: p.quantity * 10 }),
                         image: null,
                         baseCatalogProduct: null,
                         returnableQuantity: 0,
@@ -2121,7 +2153,7 @@ describe('Order detail path with unified SF GQL flag ON', () => {
                     phone: null,
                     email: null,
                   },
-                  shippingCost: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 0  }),
+                  shippingCost: buildSfGqlMoneyWith({ value: 0 }),
                   lineItems: {
                     edges: products.map((p) => ({
                       node: {
@@ -2133,7 +2165,7 @@ describe('Order detail path with unified SF GQL flag ON', () => {
                         name: p.name,
                         quantity: p.quantity,
                         productOptions: p.productOptions,
-                        subTotalListPrice: buildSfGqlMoneyWith({ currencyCode: 'USD', value: p.quantity * 10  }),
+                        subTotalListPrice: buildSfGqlMoneyWith({ value: p.quantity * 10 }),
                         image: null,
                         baseCatalogProduct: null,
                         returnableQuantity: 0,
@@ -2784,7 +2816,7 @@ describe('Order detail path with unified SF GQL flag ON', () => {
                     phone: null,
                     email: null,
                   },
-                  shippingCost: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 0  }),
+                  shippingCost: buildSfGqlMoneyWith({ value: 0 }),
                   lineItems: {
                     edges: products.map((p) => ({
                       node: {
@@ -2796,7 +2828,7 @@ describe('Order detail path with unified SF GQL flag ON', () => {
                         name: p.name,
                         quantity: p.quantity,
                         productOptions: p.productOptions,
-                        subTotalListPrice: buildSfGqlMoneyWith({ currencyCode: 'USD', value: p.quantity * 10  }),
+                        subTotalListPrice: buildSfGqlMoneyWith({ value: p.quantity * 10 }),
                         image: null,
                         baseCatalogProduct: null,
                         returnableQuantity: 0,

--- a/apps/storefront/src/pages/OrderDetail/index.unified.test.tsx
+++ b/apps/storefront/src/pages/OrderDetail/index.unified.test.tsx
@@ -19,11 +19,12 @@ import {
   waitForElementToBeRemoved,
   within,
 } from 'tests/test-utils';
+import { buildSfGqlMoneyWith } from 'tests/builders/sfGqlMoneyBuilder';
 import { when } from 'vitest-when';
 
 import { AddressConfig } from '@/shared/service/b2b/graphql/address';
 import { CustomerOrderStatues, CustomerOrderStatus } from '@/shared/service/b2b/graphql/orders';
-import type { GetOrderDetailResponse, Order } from '@/shared/service/bc/graphql/orders';
+import type { GetOrderDetailResponse, Money, Order } from '@/shared/service/bc/graphql/orders';
 import { OrderHistoryEventType } from '@/shared/service/bc/graphql/orders';
 import { useAppDispatch } from '@/store';
 import { setCurrencies } from '@/store/slices/storeConfigs';
@@ -100,18 +101,18 @@ const buildUnifiedOrderWith = builder<Order>(() => ({
     phone: faker.phone.number(),
     email: faker.internet.email(),
   },
-  subTotal: { currencyCode: 'USD', value: 100 },
+  subTotal: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 100  }),
   discountedSubTotal: null,
-  shippingCostTotal: { currencyCode: 'USD', value: 0 },
-  handlingCostTotal: { currencyCode: 'USD', value: 0 },
-  wrappingCostTotal: { currencyCode: 'USD', value: 0 },
-  taxTotal: { currencyCode: 'USD', value: 0 },
-  totalIncTax: { currencyCode: 'USD', value: 100 },
+  shippingCostTotal: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 0  }),
+  handlingCostTotal: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 0  }),
+  wrappingCostTotal: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 0  }),
+  taxTotal: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 0  }),
+  totalIncTax: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 100  }),
   isTaxIncluded: false,
   taxes: [],
   discounts: {
     couponDiscounts: [],
-    nonCouponDiscountTotal: { currencyCode: 'USD', value: 0 },
+    nonCouponDiscountTotal: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 0  }),
     totalDiscount: null,
   },
   customerMessage: null,
@@ -323,15 +324,15 @@ describe('Order detail path with unified SF GQL flag ON', () => {
         lastName: 'Wazowski',
         email: 'mike@monstersinc.com',
       },
-      subTotal: { currencyCode: 'EUR', value: 102 },
-      shippingCostTotal: { currencyCode: 'EUR', value: 332 },
-      handlingCostTotal: { currencyCode: 'EUR', value: 22.2 },
-      taxTotal: { currencyCode: 'EUR', value: 13.5 },
+      subTotal: buildSfGqlMoneyWith({ currencyCode: 'EUR', value: 102  }),
+      shippingCostTotal: buildSfGqlMoneyWith({ currencyCode: 'EUR', value: 332  }),
+      handlingCostTotal: buildSfGqlMoneyWith({ currencyCode: 'EUR', value: 22.2  }),
+      taxTotal: buildSfGqlMoneyWith({ currencyCode: 'EUR', value: 13.5  }),
       // 102 + 332 + 22.2 − 37.93 + 13.5
-      totalIncTax: { currencyCode: 'EUR', value: 431.77 },
+      totalIncTax: buildSfGqlMoneyWith({ currencyCode: 'EUR', value: 431.77  }),
       discounts: {
         couponDiscounts: [],
-        nonCouponDiscountTotal: { currencyCode: 'EUR', value: 37.93 },
+        nonCouponDiscountTotal: buildSfGqlMoneyWith({ currencyCode: 'EUR', value: 37.93  }),
         totalDiscount: null,
       },
     });
@@ -403,14 +404,14 @@ describe('Order detail path with unified SF GQL flag ON', () => {
 
     const euroOrder = buildUnifiedOrderWith({
       entityId: 6696,
-      subTotal: { currencyCode: 'EUR', value: 102 },
-      shippingCostTotal: { currencyCode: 'EUR', value: 332 },
-      handlingCostTotal: { currencyCode: 'EUR', value: 22.2 },
-      taxTotal: { currencyCode: 'EUR', value: 13.5 },
-      totalIncTax: { currencyCode: 'EUR', value: 431.77 },
+      subTotal: buildSfGqlMoneyWith({ currencyCode: 'EUR', value: 102  }),
+      shippingCostTotal: buildSfGqlMoneyWith({ currencyCode: 'EUR', value: 332  }),
+      handlingCostTotal: buildSfGqlMoneyWith({ currencyCode: 'EUR', value: 22.2  }),
+      taxTotal: buildSfGqlMoneyWith({ currencyCode: 'EUR', value: 13.5  }),
+      totalIncTax: buildSfGqlMoneyWith({ currencyCode: 'EUR', value: 431.77  }),
       discounts: {
         couponDiscounts: [],
-        nonCouponDiscountTotal: { currencyCode: 'EUR', value: 37.93 },
+        nonCouponDiscountTotal: buildSfGqlMoneyWith({ currencyCode: 'EUR', value: 37.93  }),
         totalDiscount: null,
       },
     });
@@ -462,7 +463,7 @@ describe('Order detail path with unified SF GQL flag ON', () => {
             data: {
               site: {
                 order: buildUnifiedOrderWith({
-                  handlingCostTotal: { currencyCode: 'USD', value: 0 },
+                  handlingCostTotal: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 0  }),
                 }),
               },
             },
@@ -670,7 +671,7 @@ describe('Order detail path with unified SF GQL flag ON', () => {
                     phone: null,
                     email: null,
                   },
-                  shippingCost: { currencyCode: 'USD', value: 15 },
+                  shippingCost: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 15  }),
                   lineItems: {
                     edges: [
                       {
@@ -683,7 +684,7 @@ describe('Order detail path with unified SF GQL flag ON', () => {
                           name: 'Premium Widget',
                           quantity: 3,
                           productOptions: [],
-                          subTotalListPrice: { currencyCode: 'USD', value: 75 },
+                          subTotalListPrice: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 75  }),
                           image: { url: 'https://example.com/widget.jpg' },
                           baseCatalogProduct: { path: '/widget/' },
                           returnableQuantity: 0,
@@ -791,7 +792,7 @@ describe('Order detail path with unified SF GQL flag ON', () => {
                     phone: null,
                     email: null,
                   },
-                  shippingCost: { currencyCode: 'USD', value: 15 },
+                  shippingCost: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 15  }),
                   lineItems: {
                     edges: [
                       {
@@ -804,7 +805,7 @@ describe('Order detail path with unified SF GQL flag ON', () => {
                           name: 'Unshipped Widget',
                           quantity: 2,
                           productOptions: [],
-                          subTotalListPrice: { currencyCode: 'USD', value: 50 },
+                          subTotalListPrice: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 50  }),
                           image: null,
                           baseCatalogProduct: null,
                           returnableQuantity: 0,
@@ -872,7 +873,7 @@ describe('Order detail path with unified SF GQL flag ON', () => {
                     phone: null,
                     email: null,
                   },
-                  shippingCost: { currencyCode: 'USD', value: 10 },
+                  shippingCost: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 10  }),
                   lineItems: {
                     edges: [
                       {
@@ -885,7 +886,7 @@ describe('Order detail path with unified SF GQL flag ON', () => {
                           name: 'Widget A',
                           quantity: 1,
                           productOptions: [],
-                          subTotalListPrice: { currencyCode: 'USD', value: 25 },
+                          subTotalListPrice: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 25  }),
                           image: null,
                           baseCatalogProduct: null,
                           returnableQuantity: 0,
@@ -914,7 +915,7 @@ describe('Order detail path with unified SF GQL flag ON', () => {
                     phone: null,
                     email: null,
                   },
-                  shippingCost: { currencyCode: 'USD', value: 12 },
+                  shippingCost: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 12  }),
                   lineItems: {
                     edges: [
                       {
@@ -927,7 +928,7 @@ describe('Order detail path with unified SF GQL flag ON', () => {
                           name: 'Widget B',
                           quantity: 2,
                           productOptions: [],
-                          subTotalListPrice: { currencyCode: 'USD', value: 50 },
+                          subTotalListPrice: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 50  }),
                           image: null,
                           baseCatalogProduct: null,
                           returnableQuantity: 0,
@@ -977,7 +978,7 @@ describe('Order detail path with unified SF GQL flag ON', () => {
                     phone: null,
                     email: null,
                   },
-                  shippingCost: { currencyCode: 'USD', value: 15 },
+                  shippingCost: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 15  }),
                   lineItems: {
                     edges: [
                       {
@@ -990,7 +991,7 @@ describe('Order detail path with unified SF GQL flag ON', () => {
                           name: 'Partially Shipped Widget',
                           quantity: 5,
                           productOptions: [],
-                          subTotalListPrice: { currencyCode: 'USD', value: 125 },
+                          subTotalListPrice: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 125  }),
                           image: null,
                           baseCatalogProduct: null,
                           returnableQuantity: 0,
@@ -1056,7 +1057,7 @@ describe('Order detail path with unified SF GQL flag ON', () => {
                     phone: null,
                     email: null,
                   },
-                  shippingCost: { currencyCode: 'USD', value: 20 },
+                  shippingCost: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 20  }),
                   lineItems: {
                     edges: [
                       {
@@ -1069,7 +1070,7 @@ describe('Order detail path with unified SF GQL flag ON', () => {
                           name: 'Widget Alpha',
                           quantity: 3,
                           productOptions: [],
-                          subTotalListPrice: { currencyCode: 'USD', value: 75 },
+                          subTotalListPrice: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 75  }),
                           image: null,
                           baseCatalogProduct: null,
                           returnableQuantity: 0,
@@ -1085,7 +1086,7 @@ describe('Order detail path with unified SF GQL flag ON', () => {
                           name: 'Widget Beta',
                           quantity: 4,
                           productOptions: [],
-                          subTotalListPrice: { currencyCode: 'USD', value: 100 },
+                          subTotalListPrice: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 100  }),
                           image: null,
                           baseCatalogProduct: null,
                           returnableQuantity: 0,
@@ -1170,7 +1171,7 @@ describe('Order detail path with unified SF GQL flag ON', () => {
                     phone: null,
                     email: null,
                   },
-                  shippingCost: { currencyCode: 'USD', value: 0 },
+                  shippingCost: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 0  }),
                   lineItems: {
                     edges: [
                       {
@@ -1183,7 +1184,7 @@ describe('Order detail path with unified SF GQL flag ON', () => {
                           name: 'Test Product',
                           quantity: 1,
                           productOptions: [],
-                          subTotalListPrice: { currencyCode: 'USD', value: 100 },
+                          subTotalListPrice: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 100  }),
                           image: null,
                           baseCatalogProduct: null,
                           returnableQuantity: 0,
@@ -1251,7 +1252,7 @@ describe('Order detail path with unified SF GQL flag ON', () => {
                     phone: null,
                     email: null,
                   },
-                  shippingCost: { currencyCode: 'USD', value: 0 },
+                  shippingCost: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 0  }),
                   lineItems: {
                     edges: [
                       {
@@ -1264,7 +1265,7 @@ describe('Order detail path with unified SF GQL flag ON', () => {
                           name: 'Test Product',
                           quantity: 1,
                           productOptions: [],
-                          subTotalListPrice: { currencyCode: 'USD', value: 100 },
+                          subTotalListPrice: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 100  }),
                           image: null,
                           baseCatalogProduct: null,
                           returnableQuantity: 0,
@@ -1389,7 +1390,7 @@ describe('Order detail path with unified SF GQL flag ON', () => {
         name: string;
         quantity: number;
         productOptions: Array<{ name: string; value: string }>;
-        subTotalListPrice: { currencyCode: string; value: number };
+        subTotalListPrice: Money;
       }>,
       physicalConsignment?: Order['consignments'],
     ) {
@@ -1452,7 +1453,7 @@ describe('Order detail path with unified SF GQL flag ON', () => {
           name: 'Scare Floor Operations Manual (eBook)',
           quantity: 112,
           productOptions: [{ name: 'Format', value: 'ePub' }],
-          subTotalListPrice: { currencyCode: 'EUR', value: 2502.08 },
+          subTotalListPrice: buildSfGqlMoneyWith({ currencyCode: 'EUR', value: 2502.08  }),
         },
       ]);
 
@@ -1491,7 +1492,7 @@ describe('Order detail path with unified SF GQL flag ON', () => {
           name: 'Digital Product',
           quantity: 1,
           productOptions: [],
-          subTotalListPrice: { currencyCode: 'USD', value: 10 },
+          subTotalListPrice: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 10  }),
         },
       ]);
 
@@ -1577,7 +1578,7 @@ describe('Order detail path with unified SF GQL flag ON', () => {
                   phone: null,
                   email: null,
                 },
-                shippingCost: { currencyCode: 'USD', value: 0 },
+                shippingCost: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 0  }),
                 lineItems: {
                   edges: [
                     {
@@ -1590,7 +1591,7 @@ describe('Order detail path with unified SF GQL flag ON', () => {
                         name: 'Phone',
                         quantity: 2,
                         productOptions: [],
-                        subTotalListPrice: { currencyCode: 'USD', value: 200 },
+                        subTotalListPrice: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 200  }),
                         image: null,
                         baseCatalogProduct: null,
                         returnableQuantity: 0,
@@ -1618,7 +1619,7 @@ describe('Order detail path with unified SF GQL flag ON', () => {
                         name: 'How to meow',
                         quantity: 1,
                         productOptions: [],
-                        subTotalListPrice: { currencyCode: 'USD', value: 10 },
+                        subTotalListPrice: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 10  }),
                       },
                     },
                   ],
@@ -1695,7 +1696,7 @@ describe('Order detail path with unified SF GQL flag ON', () => {
                     phone: null,
                     email: null,
                   },
-                  shippingCost: { currencyCode: 'USD', value: 0 },
+                  shippingCost: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 0  }),
                   lineItems: {
                     edges: products.map((p) => ({
                       node: {
@@ -1707,7 +1708,7 @@ describe('Order detail path with unified SF GQL flag ON', () => {
                         name: p.name,
                         quantity: p.quantity,
                         productOptions: p.productOptions,
-                        subTotalListPrice: { currencyCode: 'USD', value: p.quantity * 10 },
+                        subTotalListPrice: buildSfGqlMoneyWith({ currencyCode: 'USD', value: p.quantity * 10  }),
                         image: null,
                         baseCatalogProduct: null,
                         returnableQuantity: 0,
@@ -2120,7 +2121,7 @@ describe('Order detail path with unified SF GQL flag ON', () => {
                     phone: null,
                     email: null,
                   },
-                  shippingCost: { currencyCode: 'USD', value: 0 },
+                  shippingCost: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 0  }),
                   lineItems: {
                     edges: products.map((p) => ({
                       node: {
@@ -2132,7 +2133,7 @@ describe('Order detail path with unified SF GQL flag ON', () => {
                         name: p.name,
                         quantity: p.quantity,
                         productOptions: p.productOptions,
-                        subTotalListPrice: { currencyCode: 'USD', value: p.quantity * 10 },
+                        subTotalListPrice: buildSfGqlMoneyWith({ currencyCode: 'USD', value: p.quantity * 10  }),
                         image: null,
                         baseCatalogProduct: null,
                         returnableQuantity: 0,
@@ -2783,7 +2784,7 @@ describe('Order detail path with unified SF GQL flag ON', () => {
                     phone: null,
                     email: null,
                   },
-                  shippingCost: { currencyCode: 'USD', value: 0 },
+                  shippingCost: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 0  }),
                   lineItems: {
                     edges: products.map((p) => ({
                       node: {
@@ -2795,7 +2796,7 @@ describe('Order detail path with unified SF GQL flag ON', () => {
                         name: p.name,
                         quantity: p.quantity,
                         productOptions: p.productOptions,
-                        subTotalListPrice: { currencyCode: 'USD', value: p.quantity * 10 },
+                        subTotalListPrice: buildSfGqlMoneyWith({ currencyCode: 'USD', value: p.quantity * 10  }),
                         image: null,
                         baseCatalogProduct: null,
                         returnableQuantity: 0,

--- a/apps/storefront/src/pages/order/Order.tsx
+++ b/apps/storefront/src/pages/order/Order.tsx
@@ -347,10 +347,12 @@ function Order({ isCompanyOrder = false }: OrderProps) {
       {
         key: 'totalIncTax',
         title: b3Lang('orders.grandTotal'),
-        render: ({ money, totalIncTax }) =>
-          money
+        render: ({ money, totalIncTax, formattedTotalIncTax }) => {
+          if (formattedTotalIncTax) return formattedTotalIncTax;
+          return money
             ? ordersCurrencyFormat(JSON.parse(JSON.parse(money)), totalIncTax)
-            : currencyFormat(totalIncTax),
+            : currencyFormat(totalIncTax);
+        },
         align: 'right',
         width: '8%',
         isSortable: true,

--- a/apps/storefront/src/pages/order/OrderItemCard.tsx
+++ b/apps/storefront/src/pages/order/OrderItemCard.tsx
@@ -10,19 +10,7 @@ import { currencyFormat } from '@/utils/b3CurrencyFormat';
 import { displayFormat } from '@/utils/b3DateFormat';
 
 import OrderStatus from './components/OrderStatus';
-
-interface ListItem {
-  orderId: string;
-  firstName: string;
-  lastName: string;
-  poNumber?: string;
-  status: string;
-  statusText?: string;
-  totalIncTax: string;
-  /** Pre-formatted grand total in the order's own currency, from SF GQL Money.formattedV2. */
-  formattedTotalIncTax?: string;
-  createdAt: string;
-}
+import type { ListItem } from './mapSfGqlOrderToListItem';
 
 interface OrderItemCardProps {
   goToDetail: () => void;
@@ -42,9 +30,9 @@ export function OrderItemCard({ item, goToDetail }: OrderItemCardProps) {
   const isB2BUser = useAppSelector(isB2BUserSelector);
   const customer = useAppSelector(({ company }) => company.customer);
 
-  const getName = (item: ListItem) => {
+  const getName = (listItem: ListItem) => {
     if (isB2BUser) {
-      return `by ${item.firstName} ${item.lastName}`;
+      return `by ${listItem.firstName} ${listItem.lastName}`;
     }
     return `by ${customer.firstName} ${customer.lastName}`;
   };

--- a/apps/storefront/src/pages/order/OrderItemCard.tsx
+++ b/apps/storefront/src/pages/order/OrderItemCard.tsx
@@ -19,6 +19,8 @@ interface ListItem {
   status: string;
   statusText?: string;
   totalIncTax: string;
+  /** Pre-formatted grand total in the order's own currency, from SF GQL Money.formattedV2. */
+  formattedTotalIncTax?: string;
   createdAt: string;
 }
 
@@ -87,7 +89,7 @@ export function OrderItemCard({ item, goToDetail }: OrderItemCardProps) {
             minHeight: '1.43em',
           }}
         >
-          {currencyFormat(item.totalIncTax)}
+          {item.formattedTotalIncTax || currencyFormat(item.totalIncTax)}
         </Typography>
 
         <Box

--- a/apps/storefront/src/pages/order/mapSfGqlOrderToListItem.test.ts
+++ b/apps/storefront/src/pages/order/mapSfGqlOrderToListItem.test.ts
@@ -1,7 +1,7 @@
+import { buildSfGqlMoneyWith } from 'tests/test-utils';
 import { describe, expect, it } from 'vitest';
 
 import type { Order as SfGqlOrder } from '@/shared/service/bc/graphql/orders';
-import { buildSfGqlMoneyWith } from 'tests/builders/sfGqlMoneyBuilder';
 
 import { mapSfGqlOrderToListItem } from './mapSfGqlOrderToListItem';
 
@@ -24,14 +24,13 @@ const baseOrder: SfGqlOrder = {
     phone: null,
     email: null,
   },
-  subTotal: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 319.95, formattedV2: '$319.95' }),
+  subTotal: buildSfGqlMoneyWith({ value: 319.95 }),
   discountedSubTotal: null,
-  shippingCostTotal: buildSfGqlMoneyWith({ value: 0, formattedV2: '$0.00' }),
-  handlingCostTotal: buildSfGqlMoneyWith({ value: 0, formattedV2: '$0.00' }),
-  wrappingCostTotal: buildSfGqlMoneyWith({ value: 0, formattedV2: '$0.00' }),
-  taxTotal: buildSfGqlMoneyWith({ value: 0, formattedV2: '$0.00' }),
+  shippingCostTotal: buildSfGqlMoneyWith({ value: 0 }),
+  handlingCostTotal: buildSfGqlMoneyWith({ value: 0 }),
+  wrappingCostTotal: buildSfGqlMoneyWith({ value: 0 }),
+  taxTotal: buildSfGqlMoneyWith({ value: 0 }),
   totalIncTax: buildSfGqlMoneyWith({
-    currencyCode: 'USD',
     value: 319.95,
     formattedV2: '319.95$$$',
   }),
@@ -39,7 +38,7 @@ const baseOrder: SfGqlOrder = {
   taxes: [],
   discounts: {
     couponDiscounts: [],
-    nonCouponDiscountTotal: buildSfGqlMoneyWith({ value: 0, formattedV2: '$0.00' }),
+    nonCouponDiscountTotal: buildSfGqlMoneyWith({ value: 0 }),
     totalDiscount: null,
   },
   customerMessage: null,

--- a/apps/storefront/src/pages/order/mapSfGqlOrderToListItem.test.ts
+++ b/apps/storefront/src/pages/order/mapSfGqlOrderToListItem.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+
+import type { Order as SfGqlOrder } from '@/shared/service/bc/graphql/orders';
+import { buildSfGqlMoneyWith } from 'tests/builders/sfGqlMoneyBuilder';
+
+import { mapSfGqlOrderToListItem } from './mapSfGqlOrderToListItem';
+
+const baseOrder: SfGqlOrder = {
+  entityId: 90909,
+  orderedAt: { utc: '2026-01-01T00:00:00Z' },
+  updatedAt: { utc: '2026-01-01T00:00:00Z' },
+  status: { value: 'PENDING', label: 'Pending' },
+  billingAddress: {
+    firstName: null,
+    lastName: null,
+    company: null,
+    address1: null,
+    address2: null,
+    city: null,
+    stateOrProvince: null,
+    postalCode: '',
+    country: '',
+    countryCode: '',
+    phone: null,
+    email: null,
+  },
+  subTotal: buildSfGqlMoneyWith({ currencyCode: 'USD', value: 319.95, formattedV2: '$319.95' }),
+  discountedSubTotal: null,
+  shippingCostTotal: buildSfGqlMoneyWith({ value: 0, formattedV2: '$0.00' }),
+  handlingCostTotal: buildSfGqlMoneyWith({ value: 0, formattedV2: '$0.00' }),
+  wrappingCostTotal: buildSfGqlMoneyWith({ value: 0, formattedV2: '$0.00' }),
+  taxTotal: buildSfGqlMoneyWith({ value: 0, formattedV2: '$0.00' }),
+  totalIncTax: buildSfGqlMoneyWith({
+    currencyCode: 'USD',
+    value: 319.95,
+    formattedV2: '319.95$$$',
+  }),
+  isTaxIncluded: false,
+  taxes: [],
+  discounts: {
+    couponDiscounts: [],
+    nonCouponDiscountTotal: buildSfGqlMoneyWith({ value: 0, formattedV2: '$0.00' }),
+    totalDiscount: null,
+  },
+  customerMessage: null,
+  totalProductQuantity: 1,
+  consignments: null,
+  reference: null,
+  poNumber: null,
+  company: null,
+  placedBy: null,
+  history: [],
+  quote: null,
+  invoice: null,
+  extraFields: [],
+};
+
+describe('mapSfGqlOrderToListItem', () => {
+  it('carries the pre-formatted currency string from totalIncTax.formattedV2', () => {
+    const item = mapSfGqlOrderToListItem(baseOrder);
+
+    expect(item.formattedTotalIncTax).toBe('319.95$$$');
+    expect(item.totalIncTax).toBe('319.95');
+  });
+
+  it('passes through the cursor when provided', () => {
+    const item = mapSfGqlOrderToListItem(baseOrder, 'cursor-abc');
+
+    expect(item.cursor).toBe('cursor-abc');
+  });
+});

--- a/apps/storefront/src/pages/order/mapSfGqlOrderToListItem.ts
+++ b/apps/storefront/src/pages/order/mapSfGqlOrderToListItem.ts
@@ -7,6 +7,8 @@ export interface ListItem {
   orderId: string;
   poNumber?: string;
   money?: string;
+  /** Pre-formatted grand total in the order's own currency, from SF GQL Money.formattedV2. */
+  formattedTotalIncTax?: string;
   totalIncTax: string;
   status: string;
   statusText?: string;
@@ -21,6 +23,7 @@ export const mapSfGqlOrderToListItem = (order: SfGqlOrder, cursor?: string): Lis
   orderId: String(order.entityId),
   poNumber: order.poNumber || '',
   totalIncTax: String(order.totalIncTax.value),
+  formattedTotalIncTax: order.totalIncTax.formattedV2,
   status: order.status.label,
   statusText: order.status.label,
   createdAt: String(Math.floor(new Date(order.orderedAt.utc).getTime() / 1000)),

--- a/apps/storefront/src/pages/order/mapSfGqlOrderToListItem.ts
+++ b/apps/storefront/src/pages/order/mapSfGqlOrderToListItem.ts
@@ -13,7 +13,6 @@ export interface ListItem {
   status: string;
   statusText?: string;
   createdAt: string;
-  companyName: string;
   companyInfo?: CompanyInfoTypes;
   /** Cursor from the SF GQL edge — populated for unified order paths only. */
   cursor?: string;
@@ -29,7 +28,6 @@ export const mapSfGqlOrderToListItem = (order: SfGqlOrder, cursor?: string): Lis
   createdAt: String(Math.floor(new Date(order.orderedAt.utc).getTime() / 1000)),
   firstName: order.placedBy?.firstName || '',
   lastName: order.placedBy?.lastName || '',
-  companyName: order.company?.name || '',
   companyInfo: order.company
     ? {
         companyName: order.company.name,
@@ -43,6 +41,5 @@ export const mapSfGqlOrderToListItem = (order: SfGqlOrder, cursor?: string): Lis
         bcId: '',
       }
     : undefined,
-  money: '',
   cursor,
 });

--- a/apps/storefront/src/shared/service/bc/graphql/base.ts
+++ b/apps/storefront/src/shared/service/bc/graphql/base.ts
@@ -8,6 +8,8 @@
 export interface Money {
   currencyCode: string;
   value: number;
+  /** Pre-formatted display string in the order's own currency, e.g. "$319.95". */
+  formattedV2: string;
 }
 
 export interface PageInfo {

--- a/apps/storefront/src/shared/service/bc/graphql/base.ts
+++ b/apps/storefront/src/shared/service/bc/graphql/base.ts
@@ -8,7 +8,6 @@
 export interface Money {
   currencyCode: string;
   value: number;
-  /** Pre-formatted display string in the order's own currency, e.g. "$319.95". */
   formattedV2: string;
 }
 

--- a/apps/storefront/src/shared/service/bc/graphql/orders.ts
+++ b/apps/storefront/src/shared/service/bc/graphql/orders.ts
@@ -346,7 +346,8 @@ export interface GetCustomersWithOrdersResponse {
 // ===========================================================================
 
 const moneyFields = `currencyCode
-  value`;
+  value
+  formattedV2`;
 
 const orderStatusFields = `status {
     value

--- a/apps/storefront/tests/builders/sfGqlMoneyBuilder.ts
+++ b/apps/storefront/tests/builders/sfGqlMoneyBuilder.ts
@@ -1,20 +1,19 @@
-import type { Money } from '@/shared/service/bc/graphql/orders';
+import { builder } from 'tests/builder';
 
-import { builder } from 'tests/test-utils';
+import type { Money } from '@/shared/service/bc/graphql/base';
 
 const buildSfGqlMoneyDefaults = builder<Money>(() => ({
   currencyCode: 'USD',
   value: 100,
-  formattedV2: '100',
+  formattedV2: '$100.00',
 }));
 
-/** Builds SF GQL Money objects for unified order tests. */
 export const buildSfGqlMoneyWith = (
   overrides: Parameters<typeof buildSfGqlMoneyDefaults>[0] = 'WHATEVER_VALUES',
 ): Money => {
   const money = buildSfGqlMoneyDefaults(overrides);
   if (overrides !== 'WHATEVER_VALUES' && overrides.formattedV2 === undefined) {
-    return { ...money, formattedV2: String(money.value) };
+    return { ...money, formattedV2: `$${money.value.toFixed(2)}` };
   }
   return money;
 };

--- a/apps/storefront/tests/builders/sfGqlMoneyBuilder.ts
+++ b/apps/storefront/tests/builders/sfGqlMoneyBuilder.ts
@@ -1,0 +1,20 @@
+import type { Money } from '@/shared/service/bc/graphql/orders';
+
+import { builder } from 'tests/test-utils';
+
+const buildSfGqlMoneyDefaults = builder<Money>(() => ({
+  currencyCode: 'USD',
+  value: 100,
+  formattedV2: '100',
+}));
+
+/** Builds SF GQL Money objects for unified order tests. */
+export const buildSfGqlMoneyWith = (
+  overrides: Parameters<typeof buildSfGqlMoneyDefaults>[0] = 'WHATEVER_VALUES',
+): Money => {
+  const money = buildSfGqlMoneyDefaults(overrides);
+  if (overrides !== 'WHATEVER_VALUES' && overrides.formattedV2 === undefined) {
+    return { ...money, formattedV2: String(money.value) };
+  }
+  return money;
+};

--- a/apps/storefront/tests/test-utils.tsx
+++ b/apps/storefront/tests/test-utils.tsx
@@ -161,6 +161,7 @@ export * from '@testing-library/react';
 export { default as userEvent } from '@testing-library/user-event';
 
 export { builder, bulk } from 'tests/builder';
+export { buildSfGqlMoneyWith } from 'tests/builders/sfGqlMoneyBuilder';
 export * from 'tests/storeStateBuilders';
 export * from 'tests/quoteBuilders';
 export { faker } from '@faker-js/faker';


### PR DESCRIPTION
Jira: [B2B-5157](https://bigcommercecloud.atlassian.net/browse/B2B-5157)

## What/Why?
The current unified SF GQL order list displays incorrect grand-total, for example, a USD order on a store with AUD as the default currency renders as A$90 instead of $90.00. This PR is to fix the display price issue in unified SF GQL order list when an order’s transaction currency differs from the shopper’s active session currency. 

This fix applies for both desktop and mobile version. But the issue still there for legacy mobile at the moment, will not include fix for legacy in this ticket

## Rollout/Rollback
Behind FF `buyer_portal_unified_sf_gql_orders`, and we can revert this PR if needed

## Testing
With mocked data in local

Desktop:
<img width="1345" height="459" alt="Screenshot 2026-07-06 at 12 47 02 pm" src="https://github.com/user-attachments/assets/c7312c9a-054c-417f-ab97-4aa4c98e038c" />

Mobile:
<img width="495" height="731" alt="Screenshot 2026-07-06 at 12 47 15 pm" src="https://github.com/user-attachments/assets/ac01d23b-1c57-4154-9a81-a1a967ecfce8" />

[B2B-5157]: https://bigcommercecloud.atlassian.net/browse/B2B-5157?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how order totals are displayed on a customer-facing path; behavior is gated by the unified SF GQL orders flag and falls back to existing formatters, but misformatted API values would show incorrect amounts.
> 
> **Overview**
> Fixes **incorrect grand totals** on unified My Orders and Company Orders when an order’s transaction currency differs from the shopper’s active store currency (e.g. USD order shown with AUD symbols).
> 
> The SF GQL **`Money`** projection and order queries now request **`formattedV2`**. **`mapSfGqlOrderToListItem`** exposes it as **`formattedTotalIncTax`**, and the desktop table (**`Order`**) and mobile card (**`OrderItemCard`**) render that string first instead of **`currencyFormat`** / legacy **`money`** parsing. Legacy formatting remains when the pre-formatted value is missing.
> 
> Tests add **`buildSfGqlMoneyWith`**, preload store currency where needed, and assert the UI shows the API’s formatted string rather than client-side formatting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6213adf1ceb22a50ea8404deeb3840dcc2fbe8b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->