### PR TITLE
feat(quotes): BACK-719 ATS validation for complex products in choose-options flow

### DIFF
--- a/apps/storefront/src/hooks/useCatalogChooseOptionsBackorderDisplay.ts
+++ b/apps/storefront/src/hooks/useCatalogChooseOptionsBackorderDisplay.ts
@@ -2,11 +2,15 @@ import { useCallback, useMemo } from 'react';
 
 import { useBackorderStorefrontMessaging } from '@/hooks/useBackorderStorefrontMessaging';
 import { useB3Lang } from '@/lib/lang';
+import type { CatalogQuickVariantSku } from '@/shared/service/b2b/graphql/product';
 import type { ShoppingListProductItem, Variant } from '@/types';
 import type { BackorderDisplayFields } from '@/utils/backorderDisplayFromInventory';
 import {
+  getCatalogBackorderDisplayFields,
+  getCatalogBackorderDisplayQuantity,
   getCatalogInventoryRowFromSearchProduct,
   getCatalogProductRowDisplayState,
+  shouldBlockQuoteAtsAdd,
 } from '@/utils/catalogBackorderDisplay';
 
 interface UseCatalogChooseOptionsBackorderDisplayOptions {
@@ -14,12 +18,16 @@ interface UseCatalogChooseOptionsBackorderDisplayOptions {
   variantInfo?: Partial<Variant> | null;
   quantity: number | string;
   showAvailableToSellHelper?: boolean;
+  formatOnlyAvailable?: (count: number) => string;
+  inventoryBySku?: Record<string, CatalogQuickVariantSku>;
+  inventorySku?: string | null;
 }
 
 interface CatalogChooseOptionsBackorderDisplay {
   backorderUiEnabled: boolean;
   qtyHelperText: string;
   backorderFields: BackorderDisplayFields | null;
+  exceedsAvailableToSell: boolean;
 }
 
 export function useCatalogChooseOptionsBackorderDisplay({
@@ -27,34 +35,72 @@ export function useCatalogChooseOptionsBackorderDisplay({
   variantInfo,
   quantity,
   showAvailableToSellHelper = true,
+  formatOnlyAvailable: formatOnlyAvailableOverride,
+  inventoryBySku,
+  inventorySku,
 }: UseCatalogChooseOptionsBackorderDisplayOptions): CatalogChooseOptionsBackorderDisplay {
   const b3Lang = useB3Lang();
   const { isBackorderMessagingContextEnabled, hasAnyBackorderDisplay } =
     useBackorderStorefrontMessaging();
   const backorderUiEnabled = isBackorderMessagingContextEnabled && hasAnyBackorderDisplay;
 
-  const formatOnlyAvailable = useCallback(
+  const defaultFormatOnlyAvailable = useCallback(
     (count: number) =>
       b3Lang('purchasedProducts.quickAdd.inlineErrors.insufficientStockSku', { count }),
     [b3Lang],
   );
 
-  const inventoryRow = useMemo(
+  const formatOnlyAvailable = formatOnlyAvailableOverride ?? defaultFormatOnlyAvailable;
+
+  const searchInventoryRow = useMemo(
     () => (product ? getCatalogInventoryRowFromSearchProduct(product, variantInfo) : undefined),
     [product, variantInfo],
   );
 
-  return useMemo(
-    () => ({
+  const apiInventoryRow = useMemo(() => {
+    if (!inventoryBySku || !inventorySku) {
+      return undefined;
+    }
+
+    return inventoryBySku[inventorySku.toUpperCase()];
+  }, [inventoryBySku, inventorySku]);
+
+  const qty = Number(quantity) || 0;
+  const showHelper = showAvailableToSellHelper && backorderUiEnabled;
+  const useApiInventoryForAts = Boolean(inventoryBySku);
+
+  return useMemo(() => {
+    const atsInventoryRow = useApiInventoryForAts ? apiInventoryRow : searchInventoryRow;
+    const backorderInventoryRow = apiInventoryRow ?? searchInventoryRow;
+
+    const { qtyHelperText } = getCatalogProductRowDisplayState({
+      qty,
+      showAvailableToSellHelper: showHelper,
+      inventoryRow: atsInventoryRow,
       backorderUiEnabled,
-      ...getCatalogProductRowDisplayState({
-        qty: Number(quantity) || 0,
-        showAvailableToSellHelper: showAvailableToSellHelper && backorderUiEnabled,
-        inventoryRow,
-        backorderUiEnabled,
-        formatOnlyAvailable,
-      }),
-    }),
-    [quantity, inventoryRow, backorderUiEnabled, formatOnlyAvailable, showAvailableToSellHelper],
-  );
+      formatOnlyAvailable,
+    });
+
+    const backorderFields = backorderUiEnabled
+      ? getCatalogBackorderDisplayFields(
+          getCatalogBackorderDisplayQuantity(qty, backorderInventoryRow),
+          backorderInventoryRow,
+        )
+      : null;
+
+    return {
+      backorderUiEnabled,
+      qtyHelperText,
+      backorderFields,
+      exceedsAvailableToSell: showHelper && shouldBlockQuoteAtsAdd(qty, atsInventoryRow),
+    };
+  }, [
+    qty,
+    showHelper,
+    useApiInventoryForAts,
+    apiInventoryRow,
+    searchInventoryRow,
+    backorderUiEnabled,
+    formatOnlyAvailable,
+  ]);
 }

--- a/apps/storefront/src/pages/QuoteDraft/index.test.tsx
+++ b/apps/storefront/src/pages/QuoteDraft/index.test.tsx
@@ -3337,6 +3337,236 @@ describe('when the user is a B2B customer', () => {
           return dialog;
         };
 
+        const setupComplexProductChooseOptionsWithInventory = ({
+          availableToSell = 7,
+          totalOnHand = 2,
+          unlimitedBackorder = false,
+          isEnableProduct = false,
+          isBackorderMessagingEnabled = true,
+          inventoryFetchFails = false,
+          pendingInventoryFetch,
+          inventoryTracking = 'variant' as 'product' | 'variant',
+        }: {
+          availableToSell?: number;
+          totalOnHand?: number;
+          unlimitedBackorder?: boolean;
+          isEnableProduct?: boolean;
+          isBackorderMessagingEnabled?: boolean;
+          inventoryFetchFails?: boolean;
+          pendingInventoryFetch?: Promise<HttpResponse<VariantInfoResponse>>;
+          inventoryTracking?: 'product' | 'variant';
+        } = {}) => {
+          const productId = 9101;
+          const optionId = 60;
+          const sizeM = 202;
+          const variantSku = 'TEE-M';
+          const productSku = 'TEE-BASE';
+          const variantId = 5101;
+          const inventorySku = inventoryTracking === 'product' ? productSku : variantSku;
+
+          const variantM = buildVariantWith({
+            variant_id: variantId,
+            product_id: productId,
+            sku: variantSku,
+            purchasing_disabled: false,
+            option_values: [
+              {
+                id: sizeM,
+                label: 'M',
+                option_id: optionId,
+                option_display_name: 'Size',
+              },
+            ],
+            available_to_sell: inventoryTracking === 'product' ? 50 : 10,
+            unlimited_backorder: false,
+            total_on_hand: 2,
+            backorder_message: 'Lead time: 2-4 weeks',
+            bc_calculated_price: { tax_exclusive: 50 },
+          });
+
+          const variantS = buildVariantWith({
+            product_id: productId,
+            sku: 'TEE-S',
+            purchasing_disabled: false,
+            option_values: [
+              {
+                id: 201,
+                label: 'S',
+                option_id: optionId,
+                option_display_name: 'Size',
+              },
+            ],
+            bc_calculated_price: { tax_exclusive: 45 },
+          });
+
+          const sizeOption = buildSearchProductV3OptionWith({
+            id: optionId,
+            product_id: productId,
+            type: 'rectangles',
+            display_name: 'Size',
+            option_values: [
+              buildSearchProductV3OptionValueWith({ id: 201, label: 'S', is_default: false }),
+              buildSearchProductV3OptionValueWith({ id: sizeM, label: 'M', is_default: true }),
+            ],
+          });
+
+          const searchProducts = vi.fn<(...arg: unknown[]) => SearchProductsResponse>();
+
+          when(searchProducts)
+            .calledWith(stringContainingAll('search: "Size Tee"', 'currencyCode: "USD"'))
+            .thenReturn({
+              data: {
+                productsSearch: [
+                  buildSearchProductWith({
+                    id: productId,
+                    name: 'Size Tee',
+                    sku: productSku,
+                    inventoryTracking,
+                    availableToSell: 10,
+                    unlimitedBackorder: false,
+                    totalOnHand: 2,
+                    backorderMessage: 'Lead time: 2-4 weeks',
+                    optionsV3: [sizeOption],
+                    isPriceHidden: false,
+                    orderQuantityMinimum: 0,
+                    orderQuantityMaximum: 0,
+                    variants: [variantS, variantM],
+                  }),
+                ],
+              },
+            });
+
+          const getPriceProducts = vi.fn<(...arg: unknown[]) => PriceProductsResponse>();
+
+          when(getPriceProducts)
+            .calledWith({
+              storeHash: 'store-hash',
+              channelId: 1,
+              currencyCode: 'USD',
+              items: [{ productId, variantId, options: [] }],
+              customerGroupId: 0,
+            })
+            .thenReturn({
+              data: {
+                priceProducts: [
+                  buildProductPriceWith({
+                    productId,
+                    variantId,
+                  }),
+                ],
+              },
+            });
+
+          const variantInfo = buildVariantInfoWith({
+            variantSku: inventorySku,
+            minQuantity: 0,
+            purchasingDisabled: '0',
+            isStock: '1',
+            stock: 50,
+            productId: productId.toString(),
+            variantId: variantId.toString(),
+            inventoryTracking,
+            availableToSell,
+            unlimitedBackorder,
+            totalOnHand,
+            backorderMessage: 'Lead time: 2-4 weeks',
+          });
+
+          const getVariantInfoBySkus = vi.fn();
+
+          when(getVariantInfoBySkus)
+            .calledWith(expect.stringContaining(`variantSkus: ["${inventorySku}"]`))
+            .thenReturn(buildVariantInfoResponseWith({ data: { variantSku: [variantInfo] } }));
+
+          const validateProduct = vi.fn<(...arg: unknown[]) => ValidateProductResponse>();
+
+          when(validateProduct)
+            .calledWith(expect.any(Object))
+            .thenReturn({
+              data: {
+                validateProduct: buildValidateProductWith({ responseType: 'SUCCESS', message: '' }),
+              },
+            });
+
+          server.use(
+            graphql.query('Countries', () =>
+              HttpResponse.json({ data: { countries: [fakeCountry] } }),
+            ),
+            graphql.query('Addresses', () =>
+              HttpResponse.json({ data: { addresses: { totalCount: 0, edges: [] } } }),
+            ),
+            graphql.query('getQuoteExtraFields', () =>
+              HttpResponse.json({ data: { quoteExtraFieldsConfig: [] } }),
+            ),
+            graphql.query('SearchProducts', ({ query }) =>
+              HttpResponse.json(searchProducts(query)),
+            ),
+            graphql.query('priceProducts', ({ variables }) =>
+              HttpResponse.json(getPriceProducts(variables)),
+            ),
+            graphql.query('GetVariantInfoBySkus', ({ query }) => {
+              if (inventoryFetchFails) {
+                return HttpResponse.error();
+              }
+
+              if (pendingInventoryFetch) {
+                return pendingInventoryFetch;
+              }
+
+              return HttpResponse.json(getVariantInfoBySkus(query));
+            }),
+            graphql.query('ValidateProduct', ({ variables }) =>
+              HttpResponse.json(validateProduct(variables)),
+            ),
+          );
+
+          const quoteInfo = buildQuoteInfoStateWith({
+            draftQuoteInfo: {
+              contactInfo: { email: customerEmail },
+              billingAddress: noAddress,
+              shippingAddress: noAddress,
+            },
+            draftQuoteList: [],
+          });
+
+          renderWithProviders(<QuoteDraft setOpenPage={vi.fn()} />, {
+            preloadedState: {
+              ...preloadedState,
+              quoteInfo,
+              global: buildGlobalStateWith({
+                ...backorderMessagingGlobal,
+                blockPendingQuoteNonPurchasableOOS: { isEnableProduct },
+                featureFlags: {
+                  'BACK-134.backorders_phase_1_1_control_messaging_on_storefront':
+                    isBackorderMessagingEnabled,
+                },
+              }),
+            },
+          });
+
+          return { validateProduct, variantInfo, variantSku };
+        };
+
+        const openComplexChooseOptionsModal = async (variantSku: string) => {
+          await userEvent.click(screen.getByText('Add to quote'));
+          const searchProduct = screen.getByPlaceholderText('Search products');
+          await userEvent.type(searchProduct, 'Size Tee');
+          await userEvent.click(screen.getByRole('button', { name: 'Search product' }));
+
+          const dialog = await screen.findByRole('dialog');
+          await userEvent.click(within(dialog).getByRole('button', { name: 'Choose options' }));
+
+          const chooseOptionsDialog = await screen.findByRole('dialog', {
+            name: 'Choose options',
+          });
+
+          await waitFor(() => {
+            expect(within(chooseOptionsDialog).getByText(variantSku)).toBeInTheDocument();
+          });
+
+          return chooseOptionsDialog;
+        };
+
         it('shows Only X available, disables Add to quote, and keeps backorder lines when qty exceeds ATS', async () => {
           const { validateProduct } = setupSearchModalWithInventory();
 
@@ -3680,6 +3910,231 @@ describe('when the user is a B2B customer', () => {
           });
           expect(within(chooseOptionsDialog).getByText('8 will be backordered')).toBeVisible();
           expect(within(chooseOptionsDialog).getByText('Lead time: 2-4 weeks')).toBeVisible();
+        });
+
+        it('shows Only X available, disables Add to quote, and keeps backorder lines in choose options when qty exceeds ATS', async () => {
+          const { validateProduct, variantSku } = setupComplexProductChooseOptionsWithInventory();
+
+          const chooseOptionsDialog = await openComplexChooseOptionsModal(variantSku);
+          const quantityInput = within(chooseOptionsDialog).getByRole('spinbutton');
+
+          await userEvent.type(quantityInput, '10', {
+            initialSelectionStart: 0,
+            initialSelectionEnd: Infinity,
+          });
+
+          await waitFor(() => {
+            expect(within(chooseOptionsDialog).getByText('Only 7 available')).toBeVisible();
+          });
+
+          expect(within(chooseOptionsDialog).getByText('2 ready to ship')).toBeVisible();
+          expect(within(chooseOptionsDialog).getByText('5 will be backordered')).toBeVisible();
+          expect(within(chooseOptionsDialog).getByText('Lead time: 2-4 weeks')).toBeVisible();
+
+          const addToQuote = within(chooseOptionsDialog).getByRole('button', {
+            name: 'Add to quote',
+          });
+          expect(addToQuote).toBeDisabled();
+
+          expect(validateProduct).not.toHaveBeenCalled();
+          expect(screen.queryByText('Product was added to your quote.')).not.toBeInTheDocument();
+        });
+
+        it('uses product SKU for ATS in choose options when inventory tracking is product', async () => {
+          const { validateProduct, variantSku } = setupComplexProductChooseOptionsWithInventory({
+            inventoryTracking: 'product',
+          });
+
+          const chooseOptionsDialog = await openComplexChooseOptionsModal(variantSku);
+          const quantityInput = within(chooseOptionsDialog).getByRole('spinbutton');
+
+          await userEvent.type(quantityInput, '10', {
+            initialSelectionStart: 0,
+            initialSelectionEnd: Infinity,
+          });
+
+          await waitFor(() => {
+            expect(within(chooseOptionsDialog).getByText('Only 7 available')).toBeVisible();
+          });
+
+          expect(within(chooseOptionsDialog).getByText('2 ready to ship')).toBeVisible();
+          expect(within(chooseOptionsDialog).getByText('5 will be backordered')).toBeVisible();
+          expect(within(chooseOptionsDialog).getByText('Lead time: 2-4 weeks')).toBeVisible();
+
+          const addToQuote = within(chooseOptionsDialog).getByRole('button', {
+            name: 'Add to quote',
+          });
+          expect(addToQuote).toBeDisabled();
+
+          expect(validateProduct).not.toHaveBeenCalled();
+          expect(screen.queryByText('Product was added to your quote.')).not.toBeInTheDocument();
+        });
+
+        it('does not show ATS error in choose options when quantity is within available to sell', async () => {
+          const { variantSku } = setupComplexProductChooseOptionsWithInventory();
+
+          const chooseOptionsDialog = await openComplexChooseOptionsModal(variantSku);
+          const quantityInput = within(chooseOptionsDialog).getByRole('spinbutton');
+
+          await userEvent.type(quantityInput, '5', {
+            initialSelectionStart: 0,
+            initialSelectionEnd: Infinity,
+          });
+
+          await waitFor(() => {
+            expect(
+              within(chooseOptionsDialog).queryByText('Only 7 available'),
+            ).not.toBeInTheDocument();
+          });
+
+          expect(
+            within(chooseOptionsDialog).getByRole('button', { name: 'Add to quote' }),
+          ).toBeEnabled();
+        });
+
+        it('does not show ATS error in choose options when OOS quoting is enabled', async () => {
+          const { variantSku } = setupComplexProductChooseOptionsWithInventory({
+            isEnableProduct: true,
+          });
+
+          const chooseOptionsDialog = await openComplexChooseOptionsModal(variantSku);
+          const quantityInput = within(chooseOptionsDialog).getByRole('spinbutton');
+
+          await userEvent.type(quantityInput, '10', {
+            initialSelectionStart: 0,
+            initialSelectionEnd: Infinity,
+          });
+
+          await waitFor(() => {
+            expect(within(chooseOptionsDialog).getByText('2 ready to ship')).toBeVisible();
+          });
+
+          expect(
+            within(chooseOptionsDialog).queryByText('Only 7 available'),
+          ).not.toBeInTheDocument();
+          expect(
+            within(chooseOptionsDialog).getByRole('button', { name: 'Add to quote' }),
+          ).toBeEnabled();
+        });
+
+        it('does not show ATS error in choose options when unlimited backorder is true', async () => {
+          const { variantSku } = setupComplexProductChooseOptionsWithInventory({
+            unlimitedBackorder: true,
+          });
+
+          const chooseOptionsDialog = await openComplexChooseOptionsModal(variantSku);
+          const quantityInput = within(chooseOptionsDialog).getByRole('spinbutton');
+
+          await userEvent.type(quantityInput, '10', {
+            initialSelectionStart: 0,
+            initialSelectionEnd: Infinity,
+          });
+
+          await waitFor(() => {
+            expect(
+              within(chooseOptionsDialog).queryByText('Only 7 available'),
+            ).not.toBeInTheDocument();
+          });
+
+          expect(
+            within(chooseOptionsDialog).getByRole('button', { name: 'Add to quote' }),
+          ).toBeEnabled();
+        });
+
+        it('does not show ATS error in choose options when backorder messaging is disabled', async () => {
+          const { variantSku } = setupComplexProductChooseOptionsWithInventory({
+            isBackorderMessagingEnabled: false,
+          });
+
+          const chooseOptionsDialog = await openComplexChooseOptionsModal(variantSku);
+          const quantityInput = within(chooseOptionsDialog).getByRole('spinbutton');
+
+          await userEvent.type(quantityInput, '10', {
+            initialSelectionStart: 0,
+            initialSelectionEnd: Infinity,
+          });
+
+          expect(
+            within(chooseOptionsDialog).queryByText('Only 7 available'),
+          ).not.toBeInTheDocument();
+          expect(
+            within(chooseOptionsDialog).getByRole('button', { name: 'Add to quote' }),
+          ).toBeEnabled();
+        });
+
+        it('keeps Add to quote enabled in choose options with no ATS helper when inventory lookup fails', async () => {
+          const { validateProduct, variantSku } = setupComplexProductChooseOptionsWithInventory({
+            inventoryFetchFails: true,
+          });
+
+          const chooseOptionsDialog = await openComplexChooseOptionsModal(variantSku);
+          const quantityInput = within(chooseOptionsDialog).getByRole('spinbutton');
+
+          await userEvent.type(quantityInput, '10', {
+            initialSelectionStart: 0,
+            initialSelectionEnd: Infinity,
+          });
+
+          await waitFor(() => {
+            expect(
+              within(chooseOptionsDialog).queryByText('Only 7 available'),
+            ).not.toBeInTheDocument();
+          });
+
+          expect(within(chooseOptionsDialog).getByText('2 ready to ship')).toBeVisible();
+          expect(within(chooseOptionsDialog).getByText('8 will be backordered')).toBeVisible();
+
+          const addToQuote = within(chooseOptionsDialog).getByRole('button', {
+            name: 'Add to quote',
+          });
+          expect(addToQuote).toBeEnabled();
+
+          await userEvent.click(addToQuote);
+
+          expect(validateProduct).toHaveBeenCalled();
+          expect(await screen.findByText('Product was added to your quote.')).toBeInTheDocument();
+        });
+
+        it('keeps Add to quote enabled in choose options while inventory lookup is pending', async () => {
+          let resolveInventoryFetch!: (value: HttpResponse<VariantInfoResponse>) => void;
+          const pendingInventoryFetch = new Promise<HttpResponse<VariantInfoResponse>>(
+            (resolve) => {
+              resolveInventoryFetch = resolve;
+            },
+          );
+
+          const { validateProduct, variantInfo, variantSku } =
+            setupComplexProductChooseOptionsWithInventory({
+              pendingInventoryFetch,
+            });
+
+          const chooseOptionsDialog = await openComplexChooseOptionsModal(variantSku);
+          const quantityInput = within(chooseOptionsDialog).getByRole('spinbutton');
+
+          await userEvent.type(quantityInput, '10', {
+            initialSelectionStart: 0,
+            initialSelectionEnd: Infinity,
+          });
+
+          expect(
+            within(chooseOptionsDialog).queryByText('Only 7 available'),
+          ).not.toBeInTheDocument();
+
+          const addToQuote = within(chooseOptionsDialog).getByRole('button', {
+            name: 'Add to quote',
+          });
+          expect(addToQuote).toBeEnabled();
+
+          await userEvent.click(addToQuote);
+
+          expect(validateProduct).toHaveBeenCalled();
+          expect(await screen.findByText('Product was added to your quote.')).toBeInTheDocument();
+
+          resolveInventoryFetch(
+            HttpResponse.json(
+              buildVariantInfoResponseWith({ data: { variantSku: [variantInfo] } }),
+            ),
+          );
         });
       });
     });

--- a/apps/storefront/src/pages/ShoppingListDetails/components/ChooseOptionsDialog.tsx
+++ b/apps/storefront/src/pages/ShoppingListDetails/components/ChooseOptionsDialog.tsx
@@ -18,7 +18,9 @@ import B3Dialog from '@/components/B3Dialog';
 import BackorderMessage from '@/components/BackorderMessage';
 import B3Spin from '@/components/spin/B3Spin';
 import { PRODUCT_DEFAULT_IMAGE } from '@/constants';
+import { useBackorderStorefrontMessaging } from '@/hooks/useBackorderStorefrontMessaging';
 import { useCatalogChooseOptionsBackorderDisplay } from '@/hooks/useCatalogChooseOptionsBackorderDisplay';
+import { useCatalogInventoryBySku } from '@/hooks/useCatalogInventoryBySku';
 import { useIsBackorderEnabled } from '@/hooks/useIsBackorderEnabled';
 import { useB3Lang } from '@/lib/lang';
 import { searchProducts } from '@/shared/service/b2b';
@@ -33,6 +35,7 @@ import {
 } from '@/utils/b3Product/b3Product';
 import { snackbar } from '@/utils/b3Tip';
 import { Base64 } from '@/utils/base64';
+import { getCatalogInventorySku } from '@/utils/catalogBackorderDisplay';
 
 import { AllOptionProps, ShoppingListProductItem, SimpleObject, Variant } from '../../../types';
 import {
@@ -145,13 +148,33 @@ export default function ChooseOptionsDialog(props: ChooseOptionsDialogProps) {
   const [chooseOptionsProduct, setChooseOptionsProduct] = useState<ChooseOptionsProductProps[]>([]);
   const [isRequestLoading, setIsRequestLoading] = useState<boolean>(false);
   const isBackorderEnabled = useIsBackorderEnabled();
+  const { isBackorderMessagingContextEnabled, hasAnyBackorderDisplay } =
+    useBackorderStorefrontMessaging();
+  const backorderUiEnabled = isBackorderMessagingContextEnabled && hasAnyBackorderDisplay;
+  const showQuoteAtsHelper = type === 'quote' && backorderUiEnabled && !isEnableProduct;
+  const quoteInventorySku = getCatalogInventorySku(product, variantSku);
 
-  const { qtyHelperText, backorderFields } = useCatalogChooseOptionsBackorderDisplay({
-    product,
-    variantInfo,
-    quantity,
-    showAvailableToSellHelper: false,
+  const inventoryBySku = useCatalogInventoryBySku({
+    isActive: isOpen && showQuoteAtsHelper,
+    enabled: backorderUiEnabled,
+    skuDependencyKey: showQuoteAtsHelper ? quoteInventorySku : '',
   });
+
+  const formatQuoteOnlyAvailable = useCallback(
+    (count: number) => b3Lang('orderDetail.reorder.onlyAvailable', { count }),
+    [b3Lang],
+  );
+
+  const { qtyHelperText, backorderFields, exceedsAvailableToSell } =
+    useCatalogChooseOptionsBackorderDisplay({
+      product,
+      variantInfo,
+      quantity,
+      showAvailableToSellHelper: showQuoteAtsHelper,
+      formatOnlyAvailable: showQuoteAtsHelper ? formatQuoteOnlyAvailable : undefined,
+      inventoryBySku: showQuoteAtsHelper ? inventoryBySku : undefined,
+      inventorySku: quoteInventorySku,
+    });
 
   useEffect(() => {
     if (type === 'quote' && product) {
@@ -506,6 +529,10 @@ export default function ChooseOptionsDialog(props: ChooseOptionsDialogProps) {
   }, [chooseOptionsProduct]);
 
   const handleConfirmClicked = () => {
+    if (exceedsAvailableToSell) {
+      return;
+    }
+
     handleSubmit((value) => {
       const optionList = getOptionList(value);
 
@@ -549,6 +576,7 @@ export default function ChooseOptionsDialog(props: ChooseOptionsDialogProps) {
       handRightClick={handleConfirmClicked}
       title={b3Lang('shoppingList.chooseOptionsDialog.chooseOptions')}
       loading={isLoading || isRequestLoading}
+      disabledSaveBtn={exceedsAvailableToSell}
     >
       <B3Spin isSpinning={isLoading}>
         {product && (

--- a/apps/storefront/src/pages/quote/components/QuoteTable.tsx
+++ b/apps/storefront/src/pages/quote/components/QuoteTable.tsx
@@ -607,6 +607,7 @@ function QuoteTable({ total, items, updateSummary }: QuoteTableProps) {
           handleChooseOptionsDialogConfirm as unknown as (products: CustomFieldItems[]) => void
         }
         isEdit
+        type="quote"
       />
     </StyledQuoteTableContainer>
   );

--- a/apps/storefront/src/utils/catalogBackorderDisplay.test.ts
+++ b/apps/storefront/src/utils/catalogBackorderDisplay.test.ts
@@ -12,6 +12,7 @@ import {
   getCatalogBackorderDisplayQuantity,
   getCatalogBackorderFieldsForVariantSku,
   getCatalogInventoryRowFromSearchProduct,
+  getCatalogInventorySku,
   getCatalogProductRowDisplayState,
   getProductDetailsForPicklistSelections,
   productRequiresChooseOptionsBeforeAdd,
@@ -222,6 +223,27 @@ describe('catalogBackorderDisplay', () => {
       totalOnHand: -3,
       quantityBackordered: 13,
       backorderMessage: undefined,
+    });
+  });
+
+  describe('getCatalogInventorySku', () => {
+    it('returns product sku when inventory tracking is product', () => {
+      expect(
+        getCatalogInventorySku({ inventoryTracking: 'product', sku: 'TEE-BASE' }, 'TEE-M'),
+      ).toBe('TEE-BASE');
+    });
+
+    it('returns variant sku when inventory tracking is variant', () => {
+      expect(
+        getCatalogInventorySku({ inventoryTracking: 'variant', sku: 'TEE-BASE' }, 'TEE-M'),
+      ).toBe('TEE-M');
+    });
+
+    it('returns empty string when tracking is none or product is missing', () => {
+      expect(getCatalogInventorySku({ inventoryTracking: 'none', sku: 'TEE-BASE' }, 'TEE-M')).toBe(
+        '',
+      );
+      expect(getCatalogInventorySku(null, 'TEE-M')).toBe('');
     });
   });
 

--- a/apps/storefront/src/utils/catalogBackorderDisplay.ts
+++ b/apps/storefront/src/utils/catalogBackorderDisplay.ts
@@ -21,6 +21,22 @@ type SearchProductInventorySource = Pick<
   | 'backorderMessage'
 >;
 
+type CatalogInventorySkuSource = Pick<ShoppingListProductItem, 'inventoryTracking' | 'sku'>;
+
+export function getCatalogInventorySku(
+  product: CatalogInventorySkuSource | null | undefined,
+  variantSku?: string | null,
+): string {
+  const tracking = product?.inventoryTracking || 'none';
+  if (tracking === 'product') {
+    return product?.sku ?? '';
+  }
+  if (tracking === 'variant') {
+    return variantSku ?? '';
+  }
+  return '';
+}
+
 export function getCatalogInventoryRowFromSearchProduct(
   product: SearchProductInventorySource,
   variant?: Partial<Variant> | null,


### PR DESCRIPTION
Jira: [BACK-719](https://bigcommercecloud.atlassian.net/browse/BACK-718)

## What/Why?
Extend add-to-quote ATS validation to complex products in the Choose Options dialog, matching the existing simple-product behaviour in the quote search modal. When OOS quoting is disabled, and backorder messaging is enabled (i.e. `Feature_Backorder && BACK-134.backorders_phase_1_1_control_messaging_on_storefront`), users who select options and enter a quantity above available-to-sell see an "Only X available" error, and the Add to quote / Save option button is disabled. Applies to both the add flow and editing options on existing quote line items.

## Rollout/Rollback
Merge/revert. Change is gated by `Feature_Backorder && BACK-134.backorders_phase_1_1_control_messaging_on_storefront`.

## Testing
With OOS quoting disabled, inline error and button disabled, for both add and edit flows.

https://github.com/user-attachments/assets/9b442d74-7a1b-4ccc-98aa-1362fcbf8829

With OOS quoting enabled, no errors.

https://github.com/user-attachments/assets/93bcf64a-c614-4881-95f2-f4978894f1ef

With `Feature_Backorder && BACK-134.backorders_phase_1_1_control_messaging_on_storefront` disabled, no errors (until the quote is submitted, as before).

https://github.com/user-attachments/assets/ef34031e-b8ba-4b38-b310-1694e64f4fce

Ping @animesh1987 @benpratt77 

[BACK-719]: https://bigcommercecloud.atlassian.net/browse/BACK-719?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes quote add/edit gating and inventory sourcing for ATS; behavior is feature-flagged but affects when users can add line items and relies on async inventory fetch edge cases.
> 
> **Overview**
> Extends **quote** add-to-quote **available-to-sell (ATS)** checks to the **Choose options** dialog for complex products, aligning with the existing simple-product search modal behavior when backorder messaging is on and OOS quoting is off.
> 
> **Choose options** now resolves inventory via `GetVariantInfoBySkus` (using product vs variant SKU from `getCatalogInventorySku`), shows **Only X available**, keeps backorder copy, and **disables** Add to quote / Save when quantity exceeds ATS. Confirm is blocked when `exceedsAvailableToSell` is true. The quote **edit** path passes `type="quote"` from `QuoteTable`.
> 
> `useCatalogChooseOptionsBackorderDisplay` accepts optional API `inventoryBySku`, custom ATS copy, and returns `exceedsAvailableToSell`; ATS uses API rows when provided, while backorder display can still fall back to search data. Failed or pending inventory lookups do not show the ATS error (add stays allowed), covered by new `QuoteDraft` tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 230b7a584e7bf61259342f1ff0fccb102ba8eb13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->