### PR TITLE
fix(common): B2B-5235 Fail non-zero on error when updating store config via cURL

### DIFF
--- a/config/deploy/after.sh
+++ b/config/deploy/after.sh
@@ -46,15 +46,17 @@ cat <<EOF > deploy_revision_payload.json
 EOF
 
 # create revision
-curl --location --request POST "$B2B_API_BASE_URL/api/v3/stores/revisions" \
+response=$(curl --location --request POST "$B2B_API_BASE_URL/api/v3/stores/revisions" \
   --header "Authorization: Basic $B2B_API_DEPLOY_CREDENTIAL" \
   --header 'Content-Type: application/json' \
-  --data-binary @create_revision_payload.json
+  --data-binary @create_revision_payload.json)
+echo "revision: $response"
 
 # apply the revision
-curl --location --request POST "$B2B_API_BASE_URL/api/v3/stores/deployments" \
+response=$(curl --location --request POST "$B2B_API_BASE_URL/api/v3/stores/deployments" \
   --header "Authorization: Basic $B2B_API_DEPLOY_CREDENTIAL" \
   --header 'Content-Type: application/json' \
-  --data-binary @deploy_revision_payload.json
+  --data-binary @deploy_revision_payload.json)
+echo "deployment: $response"
 
 rm {create,deploy}_revision_payload.json

--- a/config/deploy/after.sh
+++ b/config/deploy/after.sh
@@ -46,6 +46,8 @@ cat <<EOF > deploy_revision_payload.json
 EOF
 
 # create revision
+
+echo "Base URL: $B2B_API_BASE_URL"
 response=$(curl --location --request POST "$B2B_API_BASE_URL/api/v3/stores/revisions" \
   --header "Authorization: Basic $B2B_API_DEPLOY_CREDENTIAL" \
   --header 'Content-Type: application/json' \

--- a/config/deploy/after.sh
+++ b/config/deploy/after.sh
@@ -49,6 +49,8 @@ EOF
 response=$(curl --location --request POST "$B2B_API_BASE_URL/api/v3/stores/revisions" \
   --header "Authorization: Basic $B2B_API_DEPLOY_CREDENTIAL" \
   --header 'Content-Type: application/json' \
+  --silent --show-error --fail-with-body \
+  --write-out "\nHTTP status:%{http_code}\n" \
   --data-binary @create_revision_payload.json)
 echo "revision: $response"
 
@@ -56,6 +58,8 @@ echo "revision: $response"
 response=$(curl --location --request POST "$B2B_API_BASE_URL/api/v3/stores/deployments" \
   --header "Authorization: Basic $B2B_API_DEPLOY_CREDENTIAL" \
   --header 'Content-Type: application/json' \
+  --silent --show-error --fail-with-body \
+  --write-out "\nHTTP status: %{http_code}\n" \
   --data-binary @deploy_revision_payload.json)
 echo "deployment: $response"
 


### PR DESCRIPTION
Jira: [B2B-5235](https://bigcommercecloud.atlassian.net/browse/B2B-5235)

DO NOT MERGE:
The purpose of this PR was to provide visibility into failures, which have since been confirmed through other means.
This PR should either:
* Be closed, based on the new direction
* Be updated to surface errors for oversight moving forward - in a way that is compatible with existing expectations

Currently, the post-deployment API calls will "fail" because of timeouts. However their launched tasks remain valid, eventually completing updates to all store configurations.
This script may need to surface ONLY authentication failures (as was the cause of the original motivation), however continuing to allow 5xx timeout errors will continue to mask any other kinds of problems.

## What/Why?
Okta SSO appears to be blocking the update of store configuration in B2BE after deployment of Buyer Portal.
This failure is passing silently.

This update will surface cURL request failures to provide observability on this suspicion, and greater awareness going forward.

## Rollout/Rollback
Revert the PR - CI/CD scripts only.

## Testing
Change to cURL args only in CI/CD post-deployment


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI/CD-only change to curl flags and logging in `after.sh`; no runtime app or auth logic changes.
> 
> **Overview**
> Post-deploy **`after.sh`** no longer lets B2B revision create/deploy **`curl`** calls fail quietly. Both POSTs now use **`--silent --show-error --fail-with-body`** so non-success HTTP responses exit with a non-zero status and the deploy step can fail in CI.
> 
> Responses are captured and logged (including **HTTP status**), and the B2B API base URL is printed before the revision request for easier debugging when store config updates fail (e.g. suspected SSO blocks).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d93e45d6f0dfb3e87cab89545c20bf36bbbef98e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

[B2B-5235]: https://bigcommercecloud.atlassian.net/browse/B2B-5235?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ