### PR TITLE
feat(common): B2B-4938 update account settings via native BC Storefro…

### DIFF
--- a/apps/storefront/.eslintrc.cjs
+++ b/apps/storefront/.eslintrc.cjs
@@ -141,6 +141,7 @@ module.exports = {
     {
       files: [
         'src/pages/AccountSetting/index.tsx',
+        'src/pages/AccountSetting/useAccountSettingsSubmit.ts',
         'src/pages/AccountSetting/utils.ts',
         'src/pages/AddressList/components/AddressForm.tsx',
         'src/pages/Invoice/InvoiceItemCard.tsx',

--- a/apps/storefront/src/hooks/useStorefrontCaptcha.ts
+++ b/apps/storefront/src/hooks/useStorefrontCaptcha.ts
@@ -1,0 +1,35 @@
+import { useEffect, useState } from 'react';
+
+import { getStorefrontToken } from '@/shared/service/b2b/graphql/recaptcha';
+import b2bLogger from '@/utils/b3Logger';
+
+interface StorefrontCaptcha {
+  isCaptchaEnabled: boolean;
+  captchaSiteKey: string;
+}
+
+// Loads the storefront reCaptcha config (whether it's enabled + the site key) once, when
+// `enabled` is true. Shared by the flows that submit reCaptcha-protected storefront
+// mutations (account settings, forgot password) so the load logic isn't duplicated.
+export function useStorefrontCaptcha(enabled = true): StorefrontCaptcha {
+  const [isCaptchaEnabled, setIsCaptchaEnabled] = useState(false);
+  const [captchaSiteKey, setCaptchaSiteKey] = useState('');
+
+  useEffect(() => {
+    if (!enabled) return;
+    const loadConfig = async () => {
+      try {
+        const reCaptcha = await getStorefrontToken();
+        if (reCaptcha) {
+          setIsCaptchaEnabled(reCaptcha.isEnabledOnStorefront);
+          setCaptchaSiteKey(reCaptcha.siteKey);
+        }
+      } catch (error) {
+        b2bLogger.error(error);
+      }
+    };
+    loadConfig();
+  }, [enabled]);
+
+  return { isCaptchaEnabled, captchaSiteKey };
+}

--- a/apps/storefront/src/hooks/useStorefrontCaptcha.ts
+++ b/apps/storefront/src/hooks/useStorefrontCaptcha.ts
@@ -6,6 +6,7 @@ import b2bLogger from '@/utils/b3Logger';
 interface StorefrontCaptcha {
   isCaptchaEnabled: boolean;
   captchaSiteKey: string;
+  isCaptchaConfigLoading: boolean;
 }
 
 // Loads the storefront reCaptcha config (whether it's enabled + the site key) once, when
@@ -14,9 +15,14 @@ interface StorefrontCaptcha {
 export function useStorefrontCaptcha(enabled = true): StorefrontCaptcha {
   const [isCaptchaEnabled, setIsCaptchaEnabled] = useState(false);
   const [captchaSiteKey, setCaptchaSiteKey] = useState('');
+  const [isCaptchaConfigLoading, setIsCaptchaConfigLoading] = useState(enabled);
 
   useEffect(() => {
-    if (!enabled) return;
+    if (!enabled) {
+      setIsCaptchaConfigLoading(false);
+      return;
+    }
+    setIsCaptchaConfigLoading(true);
     const loadConfig = async () => {
       try {
         const reCaptcha = await getStorefrontToken();
@@ -26,10 +32,12 @@ export function useStorefrontCaptcha(enabled = true): StorefrontCaptcha {
         }
       } catch (error) {
         b2bLogger.error(error);
+      } finally {
+        setIsCaptchaConfigLoading(false);
       }
     };
     loadConfig();
   }, [enabled]);
 
-  return { isCaptchaEnabled, captchaSiteKey };
+  return { isCaptchaEnabled, captchaSiteKey, isCaptchaConfigLoading };
 }

--- a/apps/storefront/src/lib/lang/locales/en.json
+++ b/apps/storefront/src/lib/lang/locales/en.json
@@ -629,6 +629,7 @@
   "accountSettings.notification.updateEmailPassword": "Please type in your current password to update your email address.",
   "accountSettings.notification.noEdits": "You haven't made any edits",
   "accountSettings.notification.passwordNotMatch": "The current password does not match",
+  "accountSettings.notification.fieldCannotBeSaved": "This value can't be saved. Please review it and try again.",
   "accountSettings.registeredToB2b.title": "Upgrade to a business account",
   "accountSettings.registeredToB2b.description": "Access company level features like company specific pricing, buyer roles and permissions and more by completing a quick setup.",
   "accountSettings.registeredToB2b.upgrade": "Upgrade",

--- a/apps/storefront/src/pages/AccountSetting/index.test.tsx
+++ b/apps/storefront/src/pages/AccountSetting/index.test.tsx
@@ -596,3 +596,114 @@ describe('native SF GQL form-field updates', () => {
     expect(capturedPassword).toEqual({ currentPassword: 'OldPass1!', newPassword: 'NewPass1!' });
   });
 });
+
+// When the dedupe flag is on and the previous save persisted `isFinishUpdate`
+// in sessionStorage, mounting the page runs `init` once to refresh the data and
+// then flips `isFinishUpdate` back to false. That reset re-triggers the effect,
+// which must be skipped so the storefront config is not fetched twice.
+describe('dedupe storefront config fetch calls (B2B-5309.dedupe_storefront_config_fetch_calls)', () => {
+  const buildB2CCompanyState = () =>
+    buildCompanyStateWith({
+      customer: buildCustomerWith({
+        id: 123,
+        userType: UserTypes.MULTIPLE_B2C,
+        role: CustomerRole.B2C,
+      }),
+      companyInfo: { id: '79', companyName: 'b2bc', status: CompanyStatus.INACTIVE },
+      permissions: [],
+    });
+
+  const dedupeEnabledFlags = {
+    'PROJECT-7920.use_bc_account_settings': true,
+    'B2B-5309.dedupe_storefront_config_fetch_calls': true,
+  };
+
+  afterEach(() => {
+    sessionStorage.clear();
+  });
+
+  it('skips the redundant reload triggered when isFinishUpdate resets after a successful update', async () => {
+    // Simulate "an update just finished" — the page persists this flag itself.
+    sessionStorage.setItem('sf-isFinishUpdate', 'true');
+
+    let formFieldsCalls = 0;
+    server.use(
+      graphql.query('B2BAccountFormFields', () => {
+        formFieldsCalls += 1;
+
+        return HttpResponse.json({ data: { accountFormFields: [] } });
+      }),
+      graphql.query('CustomerDetails', () =>
+        HttpResponse.json({
+          data: {
+            customer: {
+              firstName: 'Jane',
+              lastName: 'Doe',
+              company: 'ACME',
+              phoneNumber: '1234567890',
+              email: 'jane.doe@example.com',
+              formFields: [],
+            },
+          },
+        }),
+      ),
+    );
+
+    renderWithProviders(<AccountSetting />, {
+      preloadedState: {
+        company: buildB2CCompanyState(),
+        global: buildGlobalStateWith({ featureFlags: dedupeEnabledFlags }),
+      },
+    });
+
+    // The post-update success notification confirms the update path ran.
+    expect(await screen.findByText('Your account details have been updated.')).toBeInTheDocument();
+
+    // The follow-up effect run (isFinishUpdate -> false) is skipped, so the
+    // storefront config is only fetched once.
+    await waitFor(() => expect(formFieldsCalls).toBe(1));
+  });
+
+  it('retries the reload when the post-update fetch fails so account data is not left stale', async () => {
+    sessionStorage.setItem('sf-isFinishUpdate', 'true');
+
+    let formFieldsCalls = 0;
+    server.use(
+      graphql.query('B2BAccountFormFields', () => {
+        formFieldsCalls += 1;
+
+        // Fail the first (post-update) load, then succeed on the retry.
+        if (formFieldsCalls === 1) {
+          return HttpResponse.error();
+        }
+
+        return HttpResponse.json({ data: { accountFormFields: [] } });
+      }),
+      graphql.query('CustomerDetails', () =>
+        HttpResponse.json({
+          data: {
+            customer: {
+              firstName: 'Jane',
+              lastName: 'Doe',
+              company: 'ACME',
+              phoneNumber: '1234567890',
+              email: 'jane.doe@example.com',
+              formFields: [],
+            },
+          },
+        }),
+      ),
+    );
+
+    renderWithProviders(<AccountSetting />, {
+      preloadedState: {
+        company: buildB2CCompanyState(),
+        global: buildGlobalStateWith({ featureFlags: dedupeEnabledFlags }),
+      },
+    });
+
+    // Because the failed run must not set the skip flag, the reset of
+    // isFinishUpdate re-runs init, which retries the fetch (a second call).
+    await waitFor(() => expect(formFieldsCalls).toBe(2));
+  });
+});

--- a/apps/storefront/src/pages/AccountSetting/index.test.tsx
+++ b/apps/storefront/src/pages/AccountSetting/index.test.tsx
@@ -23,6 +23,14 @@ vi.mock('@/utils/basicConfig', async (importOriginal) => ({
   isCatalystPlatform: () => true,
 }));
 
+// useStorefrontCaptcha issues an anonymous reCaptcha-config query that MSW can't intercept
+// (and warns about, failing the suite via fail-on-console). Stub it so no request is made;
+// reCaptcha stays disabled, which is what these tests exercise.
+vi.mock('@/shared/service/b2b/graphql/recaptcha', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/shared/service/b2b/graphql/recaptcha')>()),
+  getStorefrontToken: vi.fn().mockResolvedValue({ isEnabledOnStorefront: false, siteKey: '' }),
+}));
+
 const { server } = startMockServer();
 
 const buildCustomerWith = builder<Customer>(() => ({

--- a/apps/storefront/src/pages/AccountSetting/index.test.tsx
+++ b/apps/storefront/src/pages/AccountSetting/index.test.tsx
@@ -421,6 +421,11 @@ describe('native SF GQL form-field updates', () => {
           },
         }),
       ),
+      graphql.query('CustomerFormFieldSettings', () =>
+        HttpResponse.json({
+          data: { site: { settings: { formFields: { customer: [] } } } },
+        }),
+      ),
       graphql.mutation('UpdateCustomer', ({ variables }) => {
         capturedInput = variables.input;
         return HttpResponse.json({
@@ -486,6 +491,11 @@ describe('native SF GQL form-field updates', () => {
           },
         }),
       ),
+      graphql.query('CustomerFormFieldSettings', () =>
+        HttpResponse.json({
+          data: { site: { settings: { formFields: { customer: [] } } } },
+        }),
+      ),
       graphql.mutation('UpdateCompanyUser', ({ variables }) => {
         capturedInput = variables.input;
         return HttpResponse.json({ data: { company: { updateCompanyUser: { errors: [] } } } });
@@ -509,5 +519,80 @@ describe('native SF GQL form-field updates', () => {
 
     await waitFor(() => expect(capturedInput).toBeDefined());
     expect(capturedInput?.formFields).toEqual({ texts: [{ fieldEntityId: 27, text: 'Lee' }] });
+  });
+
+  it('changes a BC customer password via the dedicated changePassword mutation', async () => {
+    const customer = buildCustomerWith({
+      id: 123,
+      userType: UserTypes.MULTIPLE_B2C,
+      role: CustomerRole.SUPER_ADMIN,
+      emailAddress: 'jane.doe@example.com',
+    });
+
+    const companyState = buildCompanyStateWith({
+      customer,
+      companyInfo: { id: '79', companyName: 'b2bc', status: CompanyStatus.INACTIVE },
+      permissions: [],
+    });
+
+    let capturedPassword: { currentPassword?: string; newPassword?: string } | undefined;
+
+    server.use(
+      graphql.query('B2BAccountFormFields', () =>
+        HttpResponse.json({ data: { accountFormFields: accountFormFieldsWithCustom } }),
+      ),
+      graphql.query('CustomerDetails', () =>
+        HttpResponse.json({
+          data: {
+            customer: {
+              firstName: 'Jane',
+              lastName: 'Doe',
+              company: 'ACME',
+              phoneNumber: '1234567890',
+              email: 'jane.doe@example.com',
+              formFields: [],
+            },
+          },
+        }),
+      ),
+      graphql.query('CustomerFormFieldSettings', () =>
+        HttpResponse.json({
+          data: { site: { settings: { formFields: { customer: [] } } } },
+        }),
+      ),
+      graphql.mutation('UpdateCustomer', () =>
+        HttpResponse.json({
+          data: { customer: { updateCustomer: { customer: { firstName: 'Jane' } } } },
+        }),
+      ),
+      graphql.mutation('ChangeCustomerPassword', ({ variables }) => {
+        capturedPassword = variables;
+        return HttpResponse.json({
+          data: { customer: { changePassword: { errors: [] } } },
+        });
+      }),
+    );
+
+    const { user, result } = renderWithProviders(<AccountSetting />, {
+      preloadedState: {
+        company: companyState,
+        global: buildGlobalStateWith({
+          featureFlags: { 'PROJECT-7920.use_bc_account_settings': true },
+        }),
+      },
+    });
+
+    await waitForElementToBeRemoved(() => screen.queryByText(/loading/i));
+
+    // Password fields render as type=password inputs (no textbox role); target them by name.
+    const input = (name: string) =>
+      result.container.querySelector<HTMLInputElement>(`input[name="${name}"]`)!;
+    await user.type(input('currentPassword'), 'OldPass1!');
+    await user.type(input('password'), 'NewPass1!');
+    await user.type(input('confirmPassword'), 'NewPass1!');
+    await user.click(within(result.container).getByRole('button', { name: /save updates/i }));
+
+    await waitFor(() => expect(capturedPassword).toBeDefined());
+    expect(capturedPassword).toEqual({ currentPassword: 'OldPass1!', newPassword: 'NewPass1!' });
   });
 });

--- a/apps/storefront/src/pages/AccountSetting/index.test.tsx
+++ b/apps/storefront/src/pages/AccountSetting/index.test.tsx
@@ -10,6 +10,7 @@ import {
   startMockServer,
   waitFor,
   waitForElementToBeRemoved,
+  within,
 } from 'tests/test-utils';
 
 import { CompanyStatus, Customer, CustomerRole, LoginTypes, UserTypes } from '@/types';
@@ -420,7 +421,7 @@ describe('native SF GQL form-field updates', () => {
       }),
     );
 
-    const { user } = renderWithProviders(<AccountSetting />, {
+    const { user, result } = renderWithProviders(<AccountSetting />, {
       preloadedState: {
         company: companyState,
         global: buildGlobalStateWith({
@@ -431,8 +432,9 @@ describe('native SF GQL form-field updates', () => {
 
     await waitForElementToBeRemoved(() => screen.queryByText(/loading/i));
 
-    await user.type(screen.getByRole('textbox', { name: /middle name/i }), 'Lee');
-    await user.click(screen.getByRole('button', { name: /save updates/i }));
+    const view = within(result.container);
+    await user.type(view.getByRole('textbox', { name: /middle name/i }), 'Lee');
+    await user.click(view.getByRole('button', { name: /save updates/i }));
 
     await waitFor(() => expect(capturedInput).toBeDefined());
     expect(capturedInput?.formFields).toEqual({ texts: [{ fieldEntityId: 27, text: 'Lee' }] });
@@ -482,7 +484,7 @@ describe('native SF GQL form-field updates', () => {
       }),
     );
 
-    const { user } = renderWithProviders(<AccountSetting />, {
+    const { user, result } = renderWithProviders(<AccountSetting />, {
       preloadedState: {
         company: companyState,
         global: buildGlobalStateWith({
@@ -493,8 +495,9 @@ describe('native SF GQL form-field updates', () => {
 
     await waitForElementToBeRemoved(() => screen.queryByText(/loading/i));
 
-    await user.type(screen.getByRole('textbox', { name: /middle name/i }), 'Lee');
-    await user.click(screen.getByRole('button', { name: /save updates/i }));
+    const view = within(result.container);
+    await user.type(view.getByRole('textbox', { name: /middle name/i }), 'Lee');
+    await user.click(view.getByRole('button', { name: /save updates/i }));
 
     await waitFor(() => expect(capturedInput).toBeDefined());
     expect(capturedInput?.formFields).toEqual({ texts: [{ fieldEntityId: 27, text: 'Lee' }] });

--- a/apps/storefront/src/pages/AccountSetting/index.test.tsx
+++ b/apps/storefront/src/pages/AccountSetting/index.test.tsx
@@ -82,6 +82,11 @@ const mockAccountSettingsQueries = () =>
         },
       }),
     ),
+    graphql.query('CustomerFormFieldSettings', () =>
+      HttpResponse.json({
+        data: { site: { settings: { formFields: { customer: [] } } } },
+      }),
+    ),
   );
 
 describe('B2B Upgrade Banner', () => {
@@ -326,5 +331,172 @@ describe('dedupe storefront config fetch calls (B2B-5309.dedupe_storefront_confi
     // Because the failed run must not set the skip flag, the reset of
     // isFinishUpdate re-runs init, which retries the fetch (a second call).
     await waitFor(() => expect(formFieldsCalls).toBe(2));
+  });
+});
+
+// Contact fields (so email validation short-circuits) plus a visible custom form field
+// (groupId 2) whose entityId is encoded in its fieldId (field_27).
+const accountFormFieldsWithCustom = [
+  {
+    id: '1',
+    formType: 1,
+    fieldId: 'field_first_name',
+    groupId: 1,
+    groupName: 'Contact Information',
+    isRequired: true,
+    visible: true,
+    labelName: 'First Name',
+    fieldName: 'first_name',
+    fieldType: 'text',
+  },
+  {
+    id: '2',
+    formType: 1,
+    fieldId: 'field_email',
+    groupId: 1,
+    groupName: 'Contact Information',
+    isRequired: true,
+    visible: true,
+    labelName: 'Email Address',
+    fieldName: 'email',
+    fieldType: 'text',
+  },
+  {
+    id: '11',
+    formType: 1,
+    fieldFrom: 10,
+    fieldId: 'field_27',
+    groupId: 2,
+    groupName: 'Additional Information',
+    isRequired: false,
+    visible: true,
+    labelName: 'Middle name',
+    fieldName: 'middle_name',
+    fieldType: 'text',
+    custom: true,
+  },
+];
+
+describe('native SF GQL form-field updates', () => {
+  it('sends a BC custom form field through customer.updateCustomer keyed by fieldEntityId', async () => {
+    const customer = buildCustomerWith({
+      id: 123,
+      userType: UserTypes.MULTIPLE_B2C,
+      role: CustomerRole.SUPER_ADMIN,
+      emailAddress: 'jane.doe@example.com',
+    });
+
+    const companyState = buildCompanyStateWith({
+      customer,
+      companyInfo: { id: '79', companyName: 'b2bc', status: CompanyStatus.INACTIVE },
+      permissions: [],
+    });
+
+    let capturedInput: { formFields?: unknown } | undefined;
+
+    server.use(
+      graphql.query('B2BAccountFormFields', () =>
+        HttpResponse.json({ data: { accountFormFields: accountFormFieldsWithCustom } }),
+      ),
+      graphql.query('CustomerDetails', () =>
+        HttpResponse.json({
+          data: {
+            customer: {
+              firstName: 'Jane',
+              lastName: 'Doe',
+              company: 'ACME',
+              phoneNumber: '1234567890',
+              email: 'jane.doe@example.com',
+              formFields: [],
+            },
+          },
+        }),
+      ),
+      graphql.mutation('UpdateCustomer', ({ variables }) => {
+        capturedInput = variables.input;
+        return HttpResponse.json({
+          data: { customer: { updateCustomer: { customer: { firstName: 'Jane' } } } },
+        });
+      }),
+    );
+
+    const { user } = renderWithProviders(<AccountSetting />, {
+      preloadedState: {
+        company: companyState,
+        global: buildGlobalStateWith({
+          featureFlags: { 'PROJECT-7920.use_bc_account_settings': true },
+        }),
+      },
+    });
+
+    await waitForElementToBeRemoved(() => screen.queryByText(/loading/i));
+
+    await user.type(screen.getByRole('textbox', { name: /middle name/i }), 'Lee');
+    await user.click(screen.getByRole('button', { name: /save updates/i }));
+
+    await waitFor(() => expect(capturedInput).toBeDefined());
+    expect(capturedInput?.formFields).toEqual({ texts: [{ fieldEntityId: 27, text: 'Lee' }] });
+  });
+
+  it('sends a B2B custom form field through company.updateCompanyUser keyed by fieldEntityId', async () => {
+    const customer = buildCustomerWith({
+      id: 123,
+      userType: UserTypes.MULTIPLE_B2C,
+      role: CustomerRole.JUNIOR_BUYER,
+      emailAddress: 'jane.doe@example.com',
+    });
+
+    const companyState = buildCompanyStateWith({
+      customer,
+      companyInfo: { id: '79', companyName: 'b2bc', status: CompanyStatus.APPROVED },
+      permissions: [],
+    });
+
+    let capturedInput: { formFields?: unknown } | undefined;
+
+    server.use(
+      graphql.query('B2BAccountFormFields', () =>
+        HttpResponse.json({ data: { accountFormFields: accountFormFieldsWithCustom } }),
+      ),
+      graphql.query('CompanyUserDetails', () =>
+        HttpResponse.json({
+          data: {
+            company: {
+              companyUser: {
+                firstName: 'Jane',
+                lastName: 'Doe',
+                company: 'ACME',
+                companyRoleName: 'Buyer',
+                phoneNumber: '1234567890',
+                email: 'jane.doe@example.com',
+                extraFields: [],
+                formFields: [],
+              },
+            },
+          },
+        }),
+      ),
+      graphql.mutation('UpdateCompanyUser', ({ variables }) => {
+        capturedInput = variables.input;
+        return HttpResponse.json({ data: { company: { updateCompanyUser: { errors: [] } } } });
+      }),
+    );
+
+    const { user } = renderWithProviders(<AccountSetting />, {
+      preloadedState: {
+        company: companyState,
+        global: buildGlobalStateWith({
+          featureFlags: { 'PROJECT-7920.use_bc_account_settings': true },
+        }),
+      },
+    });
+
+    await waitForElementToBeRemoved(() => screen.queryByText(/loading/i));
+
+    await user.type(screen.getByRole('textbox', { name: /middle name/i }), 'Lee');
+    await user.click(screen.getByRole('button', { name: /save updates/i }));
+
+    await waitFor(() => expect(capturedInput).toBeDefined());
+    expect(capturedInput?.formFields).toEqual({ texts: [{ fieldEntityId: 27, text: 'Lee' }] });
   });
 });

--- a/apps/storefront/src/pages/AccountSetting/index.tsx
+++ b/apps/storefront/src/pages/AccountSetting/index.tsx
@@ -354,6 +354,24 @@ function AccountSetting() {
     formFields?: CustomerFormFieldsInput,
   ): Promise<boolean> => {
     if (useBcAccountSettings && isBCUser) {
+      const customerInput = buildUpdateCustomerInput(payload, formFields);
+      const hasProfileUpdate = Object.keys(customerInput).length > 0;
+
+      // Check the reCaptcha gates up front (they guard updateCustomer) so a gate can't fail
+      // AFTER the password has already been committed below.
+      if (hasProfileUpdate) {
+        if (isCaptchaConfigLoading) {
+          snackbar.error(b3Lang('global.error.genericMessage'));
+          return false;
+        }
+        if (isCaptchaEnabled && !captchaToken) {
+          snackbar.error(b3Lang('login.loginText.missingCaptcha'));
+          return false;
+        }
+      }
+
+      // Password change (its own mutation, no reCaptcha) runs first: its common failure — a
+      // wrong current password — then fails fast before any profile data is written.
       if (payload.newPassword) {
         const ok = await runMutation(() =>
           changeCustomerPassword(
@@ -366,21 +384,12 @@ function AccountSetting() {
         );
         if (!ok) return false;
       }
-      const customerInput = buildUpdateCustomerInput(payload, formFields);
-      if (Object.keys(customerInput).length === 0) return true;
 
-      // Don't submit until the reCaptcha config has loaded, otherwise isCaptchaEnabled is
-      // still false and we'd send customer.updateCustomer without a token the storefront needs.
-      if (isCaptchaConfigLoading) {
-        snackbar.error(b3Lang('global.error.genericMessage'));
-        return false;
-      }
-      if (isCaptchaEnabled && !captchaToken) {
-        snackbar.error(b3Lang('login.loginText.missingCaptcha'));
-        return false;
-      }
+      if (!hasProfileUpdate) return true;
+
+      let ok;
       try {
-        return await runMutation(() =>
+        ok = await runMutation(() =>
           updateCustomerDetails(customerInput, captchaToken || undefined).then((res) => ({
             errors: res.errors,
           })),
@@ -389,6 +398,13 @@ function AccountSetting() {
         // reCaptcha v2 tokens are single-use; drop it so a retry forces a fresh solve.
         setCaptchaToken('');
       }
+      // The password (if changed) already committed; if the profile update then failed, force a
+      // re-login so the session stays consistent with the changed password (and the user isn't
+      // stuck re-entering a now-stale current password on retry).
+      if (!ok && payload.newPassword) {
+        navigate('/login?loginFlag=loggedOutLogin');
+      }
+      return ok;
     }
 
     if (useBcAccountSettings && !isBCUser) {

--- a/apps/storefront/src/pages/AccountSetting/index.tsx
+++ b/apps/storefront/src/pages/AccountSetting/index.tsx
@@ -25,13 +25,17 @@ import {
   updateBCAccountSettings,
 } from '@/shared/service/b2b';
 import {
+  changeCustomerPassword,
   getCompanyUserDetails,
   getCustomerDetails,
   getCustomerFormFieldDefinitions,
   updateCompanyUserDetails,
   updateCustomerDetails,
 } from '@/shared/service/bc';
-import { CustomerFormFieldDefinition } from '@/shared/service/bc/graphql/accountSetting';
+import {
+  CustomerFormFieldDefinition,
+  CustomerFormFieldsInput,
+} from '@/shared/service/bc/graphql/accountSetting';
 import { isB2BUserSelector, useAppSelector } from '@/store';
 import { CustomerRole, UserTypes } from '@/types';
 import { Fields, ParamProps } from '@/types/accountSetting';
@@ -46,12 +50,12 @@ import { UpgradeBanner } from './UpgradeBanner';
 import {
   b2bSubmitDataProcessing,
   bcSubmitDataProcessing,
+  buildFormFieldsInput,
   buildUpdateCompanyUserInput,
   buildUpdateCustomerInput,
+  collectChangedExtraFields,
   collectChangedFormFields,
-  fieldTypeNeedsOptions,
-  findPasswordFieldEntityId,
-  getUnsendableFormFields,
+  CONTACT_GROUP_ID,
   initB2BInfo,
   initBcInfo,
   mapUserToAccountInfo,
@@ -219,12 +223,11 @@ function AccountSetting() {
 
         let accountSettings;
         if (useBcAccountSettings) {
-          // Scalar/text/number fields get their entityId from the `field_<id>` fieldId, so
-          // definitions are only needed to resolve option ids for choice/checkbox fields.
-          // Both customer.updateCustomer and company.updateCompanyUser use them, so fetch for
-          // either user type in parallel with the account read.
+          // Definitions supply choice option ids AND the entityId fallback (by label) for any
+          // custom field whose fieldId isn't `field_<id>`, so fetch them whenever the form has
+          // any custom field — not only choice fields.
           const needsDefinitions = [...contactInformation, ...additionalInformation].some(
-            (item) => item.custom && fieldTypeNeedsOptions(item.fieldType),
+            (item) => item.custom,
           );
           const definitionsPromise = needsDefinitions
             ? getCustomerFormFieldDefinitions()
@@ -321,10 +324,51 @@ function AccountSetting() {
     }));
   };
 
+  const runMutation = async (
+    run: () => Promise<{
+      errors?: Array<{ message: string }>;
+      resultErrors?: Array<{ message?: string }> | null;
+    }>,
+  ): Promise<boolean> => {
+    let result;
+    try {
+      result = await run();
+    } catch (error) {
+      b2bLogger.error(error);
+      snackbar.error(b3Lang('global.error.genericMessage'));
+      return false;
+    }
+    if (result.errors?.length || result.resultErrors?.length) {
+      const message = result.errors?.[0]?.message || result.resultErrors?.[0]?.message;
+      snackbar.error(message || b3Lang('global.error.genericMessage'));
+      return false;
+    }
+    return true;
+  };
+
   // Sends the prepared payload to the right backend for the current user/flag combination.
-  // Returns true on success; false means an error was already surfaced and the caller stops.
-  const dispatchUpdate = async (payload: Partial<ParamProps>): Promise<boolean> => {
+  // `formFields` is the pre-resolved entityId-keyed group (built once by the caller). Returns
+  // true on success; false means an error was already surfaced and the caller stops.
+  const dispatchUpdate = async (
+    payload: Partial<ParamProps>,
+    formFields?: CustomerFormFieldsInput,
+  ): Promise<boolean> => {
     if (useBcAccountSettings && isBCUser) {
+      if (payload.newPassword) {
+        const ok = await runMutation(() =>
+          changeCustomerPassword(
+            (payload.currentPassword as string) || '',
+            payload.newPassword as string,
+          ).then((res) => ({
+            errors: res.errors,
+            resultErrors: res.data?.customer?.changePassword?.errors,
+          })),
+        );
+        if (!ok) return false;
+      }
+      const customerInput = buildUpdateCustomerInput(payload, formFields);
+      if (Object.keys(customerInput).length === 0) return true;
+
       // Don't submit until the reCaptcha config has loaded, otherwise isCaptchaEnabled is
       // still false and we'd send customer.updateCustomer without a token the storefront needs.
       if (isCaptchaConfigLoading) {
@@ -335,45 +379,25 @@ function AccountSetting() {
         snackbar.error(b3Lang('login.loginText.missingCaptcha'));
         return false;
       }
-      let response;
       try {
-        response = await updateCustomerDetails(
-          buildUpdateCustomerInput(payload, customerFormFieldDefs),
-          captchaToken || undefined,
+        return await runMutation(() =>
+          updateCustomerDetails(customerInput, captchaToken || undefined).then((res) => ({
+            errors: res.errors,
+          })),
         );
-      } catch (error) {
-        b2bLogger.error(error);
-        snackbar.error(b3Lang('global.error.genericMessage'));
-        return false;
       } finally {
         // reCaptcha v2 tokens are single-use; drop it so a retry forces a fresh solve.
         setCaptchaToken('');
       }
-      if (response.errors?.length) {
-        snackbar.error(response.errors[0]?.message || b3Lang('global.error.genericMessage'));
-        return false;
-      }
-      return true;
     }
 
     if (useBcAccountSettings && !isBCUser) {
-      let response;
-      try {
-        response = await updateCompanyUserDetails(
-          buildUpdateCompanyUserInput(payload, customerFormFieldDefs),
-        );
-      } catch (error) {
-        b2bLogger.error(error);
-        snackbar.error(b3Lang('global.error.genericMessage'));
-        return false;
-      }
-      const companyUserErrors = response.data?.company?.updateCompanyUser?.errors;
-      if (response.errors?.length || companyUserErrors?.length) {
-        const message = response.errors?.[0]?.message || companyUserErrors?.[0]?.message;
-        snackbar.error(message || b3Lang('global.error.genericMessage'));
-        return false;
-      }
-      return true;
+      return runMutation(() =>
+        updateCompanyUserDetails(buildUpdateCompanyUserInput(payload, formFields)).then((res) => ({
+          errors: res.errors,
+          resultErrors: res.data?.company?.updateCompanyUser?.errors,
+        })),
+      );
     }
 
     // Legacy b2b middleware path (flag off).
@@ -419,24 +443,44 @@ function AccountSetting() {
           const dataProcessingFn = isBCUser ? bcSubmitDataProcessing : b2bSubmitDataProcessing;
           let payload = dataProcessingFn(data, accountSettings, decryptionFields, extraFields);
 
-          // The native SF GQL updates carry custom form fields collected directly from the
-          // form (the submit processor misses them). Only *changed* fields are sent, and a
-          // form-field-only edit is treated as non-pristine so it isn't dropped as "no edits".
+          // Native SF GQL form fields are resolved to their entityId-keyed groups once here;
+          // the same build reports any changed field that can't be sent so we fail loudly.
+          let customerFormFields;
           if (useBcAccountSettings) {
+            // BC keeps every custom field as an entityId-keyed form field; for B2B the
+            // company-user's own custom fields (contact group) are name-keyed extraFields,
+            // while any additional BC form fields stay entityId-keyed.
+            const formFieldConfig = isBCUser
+              ? accountInfoFormFields
+              : accountInfoFormFields.filter((item) => item.groupId !== CONTACT_GROUP_ID);
             const changedFormFields = collectChangedFormFields(
               data,
-              accountInfoFormFields,
+              formFieldConfig,
               accountSettings?.formFields || [],
+              customerFormFieldDefs,
             );
-            // Fail loudly if any changed field can't actually be sent (unmapped choice option,
-            // cleared number/checkbox, missing entityId) instead of reporting a save that
-            // silently dropped the edit.
-            if (getUnsendableFormFields(changedFormFields, customerFormFieldDefs).length > 0) {
+            const changedExtraFields = isBCUser
+              ? []
+              : collectChangedExtraFields(
+                  data,
+                  accountInfoFormFields,
+                  accountSettings?.extraFields || [],
+                );
+
+            const { formFields, unsendable } = buildFormFieldsInput(
+              changedFormFields,
+              customerFormFieldDefs,
+            );
+            // Fail loudly if a changed form field can't be sent (unmapped choice option, cleared
+            // number/checkbox, missing entityId) rather than reporting a save that dropped it.
+            if (unsendable.length > 0) {
               snackbar.error(b3Lang('global.error.genericMessage'));
               return;
             }
-            if (!payload && changedFormFields.length > 0) payload = {};
-            if (payload) payload.formFields = changedFormFields;
+            customerFormFields = formFields;
+            // Treat a field-only edit as non-pristine so it isn't dropped as "no edits".
+            if (!payload && (formFields || changedExtraFields.length > 0)) payload = {};
+            if (payload && changedExtraFields.length > 0) payload.extraFields = changedExtraFields;
           }
 
           if (payload) {
@@ -457,20 +501,7 @@ function AccountSetting() {
             return;
           }
 
-          // customer.updateCustomer sends the password as a form field; if we can't resolve
-          // its entityId we can't change it — bail before the logout-on-password-change below
-          // so we don't sign the user out on an update that never applied the new password.
-          if (
-            useBcAccountSettings &&
-            isBCUser &&
-            payload.newPassword &&
-            findPasswordFieldEntityId(customerFormFieldDefs) === undefined
-          ) {
-            snackbar.error(b3Lang('global.error.genericMessage'));
-            return;
-          }
-
-          const succeeded = await dispatchUpdate(payload);
+          const succeeded = await dispatchUpdate(payload, customerFormFields);
           if (!succeeded) return;
 
           if (

--- a/apps/storefront/src/pages/AccountSetting/index.tsx
+++ b/apps/storefront/src/pages/AccountSetting/index.tsx
@@ -6,11 +6,13 @@ import trim from 'lodash-es/trim';
 
 import { B3CustomForm } from '@/components/B3CustomForm';
 import CustomButton from '@/components/button/CustomButton';
+import { Captcha } from '@/components/captcha/Captcha';
 import { b3HexToRgb, getContrastColor } from '@/components/outSideComponents/utils/b3CustomStyles';
 import B3Spin from '@/components/spin/B3Spin';
 import { useFeatureFlag } from '@/hooks/useFeatureFlag';
 import { useMobile } from '@/hooks/useMobile';
 import useStorageState from '@/hooks/useStorageState';
+import { useStorefrontCaptcha } from '@/hooks/useStorefrontCaptcha';
 import { useB3Lang } from '@/lib/lang';
 import { CustomStyleContext } from '@/shared/customStyleButton';
 import {
@@ -22,10 +24,18 @@ import {
   updateB2BAccountSettings,
   updateBCAccountSettings,
 } from '@/shared/service/b2b';
-import { getCompanyUserDetails, getCustomerDetails } from '@/shared/service/bc';
+import {
+  getCompanyUserDetails,
+  getCustomerDetails,
+  getCustomerFormFieldDefinitions,
+  updateCompanyUserDetails,
+  updateCustomerDetails,
+} from '@/shared/service/bc';
+import { CustomerFormFieldDefinition } from '@/shared/service/bc/graphql/accountSetting';
 import { isB2BUserSelector, useAppSelector } from '@/store';
 import { CustomerRole, UserTypes } from '@/types';
 import { Fields, ParamProps } from '@/types/accountSetting';
+import b2bLogger from '@/utils/b3Logger';
 import { B3SStorage } from '@/utils/b3Storage';
 import { snackbar } from '@/utils/b3Tip';
 import { channelId, isCatalystPlatform } from '@/utils/basicConfig';
@@ -36,6 +46,10 @@ import { UpgradeBanner } from './UpgradeBanner';
 import {
   b2bSubmitDataProcessing,
   bcSubmitDataProcessing,
+  buildUpdateCompanyUserInput,
+  buildUpdateCustomerInput,
+  collectChangedFormFields,
+  fieldTypeNeedsOptions,
   initB2BInfo,
   initBcInfo,
   mapUserToAccountInfo,
@@ -136,6 +150,11 @@ function AccountSetting() {
   const dedupeStorefrontConfigFetchCalls = useFeatureFlag(
     'B2B-5309.dedupe_storefront_config_fetch_calls',
   );
+
+  // BC customers update via customer.updateCustomer, which needs a reCaptcha token
+  // when reCaptcha is enabled on the storefront.
+  const isCustomerUpdate = useBcAccountSettings && isBCUser;
+
   const [isMobile] = useMobile();
 
   const navigate = useNavigate();
@@ -145,8 +164,16 @@ function AccountSetting() {
   const [extraFields, setExtraFields] = useState<Partial<Fields>[]>([]);
   const [isLoading, setLoading] = useState<boolean>(false);
   const [accountSettings, setAccountSettings] = useState<any>({});
+  const [customerFormFieldDefs, setCustomerFormFieldDefs] = useState<CustomerFormFieldDefinition[]>(
+    [],
+  );
+  const [captchaToken, setCaptchaToken] = useState<string>('');
   const [isVisible, setIsVisible] = useState<boolean>(false);
   const skipNextInitRef = useRef(false);
+
+  // BC customer.updateCustomer needs a reCaptcha token when reCaptcha is enabled on the
+  // storefront; load that config (shared with the forgot-password flow).
+  const { isCaptchaEnabled, captchaSiteKey } = useStorefrontCaptcha(isCustomerUpdate);
 
   useEffect(() => {
     const init = async () => {
@@ -178,9 +205,25 @@ function AccountSetting() {
         if (useBcAccountSettings) {
           let userData;
           if (isBCUser) {
-            const response = await getCustomerDetails();
+            // Scalar/text/number fields get their entityId from the `field_<id>` fieldId, so
+            // definitions are only needed to resolve option ids for choice/checkbox fields.
+            const needsDefinitions = [...contactInformation, ...additionalInformation].some(
+              (item) => item.custom && fieldTypeNeedsOptions(item.fieldType),
+            );
+            const [response, definitions] = await Promise.all([
+              getCustomerDetails(),
+              needsDefinitions ? getCustomerFormFieldDefinitions() : Promise.resolve(undefined),
+            ]);
             if (response.errors?.length) throw new Error(response.errors[0]?.message);
             userData = response.data?.customer;
+            // Surface (don't swallow) a failed definitions fetch — it's what blocks choice
+            // fields from resolving their option entityIds.
+            if (definitions?.errors?.length) {
+              b2bLogger.error(
+                `Customer form-field definitions unavailable: ${definitions.errors[0]?.message}`,
+              );
+            }
+            setCustomerFormFieldDefs(definitions?.data?.site?.settings?.formFields?.customer ?? []);
           } else {
             const response = await getCompanyUserDetails();
             if (response.errors?.length) throw new Error(response.errors[0]?.message);
@@ -259,6 +302,48 @@ function AccountSetting() {
     }));
   };
 
+  // Sends the prepared payload to the right backend for the current user/flag combination.
+  // Returns true on success; false means an error was already surfaced and the caller stops.
+  const dispatchUpdate = async (payload: Partial<ParamProps>): Promise<boolean> => {
+    if (useBcAccountSettings && isBCUser) {
+      if (isCaptchaEnabled && !captchaToken) {
+        snackbar.error(b3Lang('login.loginText.missingCaptcha'));
+        return false;
+      }
+      let response;
+      try {
+        response = await updateCustomerDetails(
+          buildUpdateCustomerInput(payload, customerFormFieldDefs),
+          captchaToken || undefined,
+        );
+      } finally {
+        // reCaptcha v2 tokens are single-use; drop it so a retry forces a fresh solve.
+        setCaptchaToken('');
+      }
+      if (response.errors?.length) {
+        snackbar.error(response.errors[0]?.message || b3Lang('global.error.genericMessage'));
+        return false;
+      }
+      return true;
+    }
+
+    if (useBcAccountSettings && !isBCUser) {
+      const response = await updateCompanyUserDetails(buildUpdateCompanyUserInput(payload));
+      const companyUserErrors = response.data?.company?.updateCompanyUser?.errors;
+      if (response.errors?.length || companyUserErrors?.length) {
+        const message = response.errors?.[0]?.message || companyUserErrors?.[0]?.message;
+        snackbar.error(message || b3Lang('global.error.genericMessage'));
+        return false;
+      }
+      return true;
+    }
+
+    // Legacy b2b middleware path (flag off).
+    const requestFn = isBCUser ? updateBCAccountSettings : updateB2BAccountSettings;
+    await requestFn(payload);
+    return true;
+  };
+
   const handleAddUserClick = () => {
     handleSubmit(async (data: CustomFieldItems) => {
       setLoading(true);
@@ -294,10 +379,34 @@ function AccountSetting() {
 
         if (isValid && emailFlag && passwordFlag) {
           const dataProcessingFn = isBCUser ? bcSubmitDataProcessing : b2bSubmitDataProcessing;
-          const payload = dataProcessingFn(data, accountSettings, decryptionFields, extraFields);
+          let payload = dataProcessingFn(data, accountSettings, decryptionFields, extraFields);
+
+          // The native SF GQL updates carry custom form fields collected directly from the
+          // form (the submit processor misses them). Only *changed* fields are sent, and a
+          // form-field-only edit is treated as non-pristine so it isn't dropped as "no edits".
+          if (useBcAccountSettings) {
+            const changedFormFields = collectChangedFormFields(
+              data,
+              accountInfoFormFields,
+              accountSettings?.formFields || [],
+            );
+            // A changed choice/checkbox field can only be sent if its option ids resolved from
+            // the definitions; if they didn't load, fail loudly instead of silently dropping it.
+            const hasUnresolvableChoice = changedFormFields.some(
+              (formField) =>
+                fieldTypeNeedsOptions(formField.fieldType) && customerFormFieldDefs.length === 0,
+            );
+            if (hasUnresolvableChoice) {
+              snackbar.error(b3Lang('global.error.genericMessage'));
+              return;
+            }
+            if (!payload && changedFormFields.length > 0) payload = {};
+            if (payload) payload.formFields = changedFormFields;
+          }
 
           if (payload) {
-            if (!isBCUser) {
+            // Legacy B2B middleware still expects name-based extra fields + companyId.
+            if (!useBcAccountSettings && !isBCUser) {
               payload.companyId = companyId;
               payload.extraFields = handleGetUserExtraFields(data, accountInfoFormFields);
             }
@@ -313,8 +422,8 @@ function AccountSetting() {
             return;
           }
 
-          const requestFn = isBCUser ? updateBCAccountSettings : updateB2BAccountSettings;
-          await requestFn(payload);
+          const succeeded = await dispatchUpdate(payload);
+          if (!succeeded) return;
 
           if (
             (data.password && data.currentPassword) ||
@@ -386,6 +495,12 @@ function AccountSetting() {
             getValues={getValues}
             setValue={setValue}
           />
+
+          {isCustomerUpdate && isCaptchaEnabled && (
+            <Box sx={{ mt: '20px' }}>
+              <Captcha siteKey={captchaSiteKey} size="normal" handleGetKey={setCaptchaToken} />
+            </Box>
+          )}
 
           <CustomButton
             sx={{

--- a/apps/storefront/src/pages/AccountSetting/index.tsx
+++ b/apps/storefront/src/pages/AccountSetting/index.tsx
@@ -33,6 +33,7 @@ import {
   updateCustomerDetails,
 } from '@/shared/service/bc';
 import {
+  CompanyUserExtraFieldsInput,
   CustomerFormFieldDefinition,
   CustomerFormFieldsInput,
 } from '@/shared/service/bc/graphql/accountSetting';
@@ -50,6 +51,7 @@ import { UpgradeBanner } from './UpgradeBanner';
 import {
   b2bSubmitDataProcessing,
   bcSubmitDataProcessing,
+  buildExtraFieldsInput,
   buildFormFieldsInput,
   buildUpdateCompanyUserInput,
   buildUpdateCustomerInput,
@@ -352,13 +354,14 @@ function AccountSetting() {
   const dispatchUpdate = async (
     payload: Partial<ParamProps>,
     formFields?: CustomerFormFieldsInput,
+    extraFields?: CompanyUserExtraFieldsInput,
   ): Promise<boolean> => {
     if (useBcAccountSettings && isBCUser) {
       const customerInput = buildUpdateCustomerInput(payload, formFields);
       const hasProfileUpdate = Object.keys(customerInput).length > 0;
 
-      // Check the reCaptcha gates up front (they guard updateCustomer) so a gate can't fail
-      // AFTER the password has already been committed below.
+      // Check the reCaptcha gates up front (they guard updateCustomer) so we don't attempt the
+      // details update — and its password follow-up — with a token that can't be accepted.
       if (hasProfileUpdate) {
         if (isCaptchaConfigLoading) {
           snackbar.error(b3Lang('global.error.genericMessage'));
@@ -370,10 +373,26 @@ function AccountSetting() {
         }
       }
 
-      // Password change (its own mutation, no reCaptcha) runs first: its common failure — a
-      // wrong current password — then fails fast before any profile data is written.
+      // Update the profile details first; only change the password if that succeeds so we never
+      // commit a password change against a details update that failed.
+      if (hasProfileUpdate) {
+        let ok;
+        try {
+          ok = await runMutation(() =>
+            updateCustomerDetails(customerInput, captchaToken || undefined).then((res) => ({
+              errors: res.errors,
+            })),
+          );
+        } finally {
+          // reCaptcha v2 tokens are single-use; drop it so a retry forces a fresh solve.
+          setCaptchaToken('');
+        }
+        if (!ok) return false;
+      }
+
+      // Details update succeeded (or there was none); now change the password if requested.
       if (payload.newPassword) {
-        const ok = await runMutation(() =>
+        return runMutation(() =>
           changeCustomerPassword(
             (payload.currentPassword as string) || '',
             payload.newPassword as string,
@@ -382,34 +401,16 @@ function AccountSetting() {
             resultErrors: res.data?.customer?.changePassword?.errors,
           })),
         );
-        if (!ok) return false;
       }
 
-      if (!hasProfileUpdate) return true;
-
-      let ok;
-      try {
-        ok = await runMutation(() =>
-          updateCustomerDetails(customerInput, captchaToken || undefined).then((res) => ({
-            errors: res.errors,
-          })),
-        );
-      } finally {
-        // reCaptcha v2 tokens are single-use; drop it so a retry forces a fresh solve.
-        setCaptchaToken('');
-      }
-      // The password (if changed) already committed; if the profile update then failed, force a
-      // re-login so the session stays consistent with the changed password (and the user isn't
-      // stuck re-entering a now-stale current password on retry).
-      if (!ok && payload.newPassword) {
-        navigate('/login?loginFlag=loggedOutLogin');
-      }
-      return ok;
+      return true;
     }
 
     if (useBcAccountSettings && !isBCUser) {
       return runMutation(() =>
-        updateCompanyUserDetails(buildUpdateCompanyUserInput(payload, formFields)).then((res) => ({
+        updateCompanyUserDetails(
+          buildUpdateCompanyUserInput(payload, formFields, extraFields),
+        ).then((res) => ({
           errors: res.errors,
           resultErrors: res.data?.company?.updateCompanyUser?.errors,
         })),
@@ -459,9 +460,10 @@ function AccountSetting() {
           const dataProcessingFn = isBCUser ? bcSubmitDataProcessing : b2bSubmitDataProcessing;
           let payload = dataProcessingFn(data, accountSettings, decryptionFields, extraFields);
 
-          // Native SF GQL form fields are resolved to their entityId-keyed groups once here;
-          // the same build reports any changed field that can't be sent so we fail loudly.
+          // Native SF GQL custom fields are resolved to their typed groups once here; the same
+          // build reports any changed field that can't be sent so we fail loudly.
           let customerFormFields;
+          let customerExtraFields;
           if (useBcAccountSettings) {
             // BC keeps every custom field as an entityId-keyed form field; for B2B the
             // company-user's own custom fields (contact group) are name-keyed extraFields,
@@ -487,16 +489,19 @@ function AccountSetting() {
               changedFormFields,
               customerFormFieldDefs,
             );
-            // Fail loudly if a changed form field can't be sent (unmapped choice option, cleared
-            // number/checkbox, missing entityId) rather than reporting a save that dropped it.
-            if (unsendable.length > 0) {
+            const { extraFields, unsendable: unsendableExtra } =
+              buildExtraFieldsInput(changedExtraFields);
+            // Fail loudly if a changed field can't be sent (unmapped choice option, cleared
+            // number/date, missing entityId, or an array-valued extra field) rather than
+            // reporting a save that silently dropped the edit.
+            if (unsendable.length > 0 || unsendableExtra.length > 0) {
               snackbar.error(b3Lang('global.error.genericMessage'));
               return;
             }
             customerFormFields = formFields;
+            customerExtraFields = extraFields;
             // Treat a field-only edit as non-pristine so it isn't dropped as "no edits".
-            if (!payload && (formFields || changedExtraFields.length > 0)) payload = {};
-            if (payload && changedExtraFields.length > 0) payload.extraFields = changedExtraFields;
+            if (!payload && (formFields || extraFields)) payload = {};
           }
 
           if (payload) {
@@ -517,7 +522,7 @@ function AccountSetting() {
             return;
           }
 
-          const succeeded = await dispatchUpdate(payload, customerFormFields);
+          const succeeded = await dispatchUpdate(payload, customerFormFields, customerExtraFields);
           if (!succeeded) return;
 
           if (

--- a/apps/storefront/src/pages/AccountSetting/index.tsx
+++ b/apps/storefront/src/pages/AccountSetting/index.tsx
@@ -50,6 +50,7 @@ import {
   buildUpdateCustomerInput,
   collectChangedFormFields,
   fieldTypeNeedsOptions,
+  getUnsendableFormFields,
   initB2BInfo,
   initBcInfo,
   mapUserToAccountInfo,
@@ -408,13 +409,10 @@ function AccountSetting() {
               accountInfoFormFields,
               accountSettings?.formFields || [],
             );
-            // A changed choice/checkbox field can only be sent if its option ids resolved from
-            // the definitions; if they didn't load, fail loudly instead of silently dropping it.
-            const hasUnresolvableChoice = changedFormFields.some(
-              (formField) =>
-                fieldTypeNeedsOptions(formField.fieldType) && customerFormFieldDefs.length === 0,
-            );
-            if (hasUnresolvableChoice) {
+            // Fail loudly if any changed field can't actually be sent (unmapped choice option,
+            // cleared number/checkbox, missing entityId) instead of reporting a save that
+            // silently dropped the edit.
+            if (getUnsendableFormFields(changedFormFields, customerFormFieldDefs).length > 0) {
               snackbar.error(b3Lang('global.error.genericMessage'));
               return;
             }

--- a/apps/storefront/src/pages/AccountSetting/index.tsx
+++ b/apps/storefront/src/pages/AccountSetting/index.tsx
@@ -174,7 +174,8 @@ function AccountSetting() {
 
   // BC customer.updateCustomer needs a reCaptcha token when reCaptcha is enabled on the
   // storefront; load that config (shared with the forgot-password flow).
-  const { isCaptchaEnabled, captchaSiteKey } = useStorefrontCaptcha(isCustomerUpdate);
+  const { isCaptchaEnabled, captchaSiteKey, isCaptchaConfigLoading } =
+    useStorefrontCaptcha(isCustomerUpdate);
 
   useEffect(() => {
     const init = async () => {
@@ -323,6 +324,12 @@ function AccountSetting() {
   // Returns true on success; false means an error was already surfaced and the caller stops.
   const dispatchUpdate = async (payload: Partial<ParamProps>): Promise<boolean> => {
     if (useBcAccountSettings && isBCUser) {
+      // Don't submit until the reCaptcha config has loaded, otherwise isCaptchaEnabled is
+      // still false and we'd send customer.updateCustomer without a token the storefront needs.
+      if (isCaptchaConfigLoading) {
+        snackbar.error(b3Lang('global.error.genericMessage'));
+        return false;
+      }
       if (isCaptchaEnabled && !captchaToken) {
         snackbar.error(b3Lang('login.loginText.missingCaptcha'));
         return false;
@@ -333,6 +340,10 @@ function AccountSetting() {
           buildUpdateCustomerInput(payload, customerFormFieldDefs),
           captchaToken || undefined,
         );
+      } catch (error) {
+        b2bLogger.error(error);
+        snackbar.error(b3Lang('global.error.genericMessage'));
+        return false;
       } finally {
         // reCaptcha v2 tokens are single-use; drop it so a retry forces a fresh solve.
         setCaptchaToken('');
@@ -345,9 +356,16 @@ function AccountSetting() {
     }
 
     if (useBcAccountSettings && !isBCUser) {
-      const response = await updateCompanyUserDetails(
-        buildUpdateCompanyUserInput(payload, customerFormFieldDefs),
-      );
+      let response;
+      try {
+        response = await updateCompanyUserDetails(
+          buildUpdateCompanyUserInput(payload, customerFormFieldDefs),
+        );
+      } catch (error) {
+        b2bLogger.error(error);
+        snackbar.error(b3Lang('global.error.genericMessage'));
+        return false;
+      }
       const companyUserErrors = response.data?.company?.updateCompanyUser?.errors;
       if (response.errors?.length || companyUserErrors?.length) {
         const message = response.errors?.[0]?.message || companyUserErrors?.[0]?.message;

--- a/apps/storefront/src/pages/AccountSetting/index.tsx
+++ b/apps/storefront/src/pages/AccountSetting/index.tsx
@@ -50,6 +50,7 @@ import {
   buildUpdateCustomerInput,
   collectChangedFormFields,
   fieldTypeNeedsOptions,
+  findPasswordFieldEntityId,
   getUnsendableFormFields,
   initB2BInfo,
   initBcInfo,
@@ -453,6 +454,19 @@ function AccountSetting() {
 
           if (!payload) {
             snackbar.success(b3Lang('accountSettings.notification.noEdits'));
+            return;
+          }
+
+          // customer.updateCustomer sends the password as a form field; if we can't resolve
+          // its entityId we can't change it — bail before the logout-on-password-change below
+          // so we don't sign the user out on an update that never applied the new password.
+          if (
+            useBcAccountSettings &&
+            isBCUser &&
+            payload.newPassword &&
+            findPasswordFieldEntityId(customerFormFieldDefs) === undefined
+          ) {
+            snackbar.error(b3Lang('global.error.genericMessage'));
             return;
           }
 

--- a/apps/storefront/src/pages/AccountSetting/index.tsx
+++ b/apps/storefront/src/pages/AccountSetting/index.tsx
@@ -1,6 +1,5 @@
 import { useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { useForm } from 'react-hook-form';
-import { useNavigate } from 'react-router-dom';
 import { Box } from '@mui/material';
 import trim from 'lodash-es/trim';
 
@@ -21,47 +20,25 @@ import {
   getB2BAccountFormFields,
   getB2BAccountSettings,
   getBCAccountSettings,
-  updateB2BAccountSettings,
-  updateBCAccountSettings,
 } from '@/shared/service/b2b';
 import {
-  changeCustomerPassword,
   getCompanyUserDetails,
   getCustomerDetails,
   getCustomerFormFieldDefinitions,
-  updateCompanyUserDetails,
-  updateCustomerDetails,
 } from '@/shared/service/bc';
-import {
-  CompanyUserExtraFieldsInput,
-  CustomerFormFieldDefinition,
-  CustomerFormFieldsInput,
-} from '@/shared/service/bc/graphql/accountSetting';
+import { CustomerFormFieldDefinition } from '@/shared/service/bc/graphql/accountSetting';
 import { isB2BUserSelector, useAppSelector } from '@/store';
 import { CustomerRole, UserTypes } from '@/types';
 import { Fields, ParamProps } from '@/types/accountSetting';
 import b2bLogger from '@/utils/b3Logger';
-import { B3SStorage } from '@/utils/b3Storage';
 import { snackbar } from '@/utils/b3Tip';
 import { channelId, isCatalystPlatform } from '@/utils/basicConfig';
-import { deCodeField, getAccountFormFields } from '@/utils/registerUtils';
+import { getAccountFormFields } from '@/utils/registerUtils';
 
 import { getAccountSettingsFields, getPasswordModifiedFields } from './config';
 import { UpgradeBanner } from './UpgradeBanner';
-import {
-  b2bSubmitDataProcessing,
-  bcSubmitDataProcessing,
-  buildExtraFieldsInput,
-  buildFormFieldsInput,
-  buildUpdateCompanyUserInput,
-  buildUpdateCustomerInput,
-  collectChangedExtraFields,
-  collectChangedFormFields,
-  CONTACT_GROUP_ID,
-  initB2BInfo,
-  initBcInfo,
-  mapUserToAccountInfo,
-} from './utils';
+import { useAccountSettingsSubmit } from './useAccountSettingsSubmit';
+import { initB2BInfo, initBcInfo, mapUserToAccountInfo } from './utils';
 
 function useData() {
   const isB2BUser = useAppSelector(isB2BUserSelector);
@@ -164,8 +141,6 @@ function AccountSetting() {
   const isCustomerUpdate = useBcAccountSettings && isBCUser;
 
   const [isMobile] = useMobile();
-
-  const navigate = useNavigate();
 
   const [accountInfoFormFields, setAccountInfoFormFields] = useState<Partial<Fields>[]>([]);
   const [decryptionFields, setDecryptionFields] = useState<Partial<Fields>[]>([]);
@@ -313,233 +288,28 @@ function AccountSetting() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isFinishUpdate, useBcAccountSettings]);
 
-  const handleGetUserExtraFields = (
-    data: CustomFieldItems,
-    accountInfoFormFields: Partial<Fields>[],
-  ) => {
-    const userExtraFields = accountInfoFormFields.filter(
-      (item: CustomFieldItems) => item.custom && item.groupId === 1,
-    );
-    return userExtraFields.map((item: CustomFieldItems) => ({
-      fieldName: deCodeField(item?.name || ''),
-      fieldValue: data[item.name],
-    }));
-  };
-
-  const runMutation = async (
-    run: () => Promise<{
-      errors?: Array<{ message: string }>;
-      resultErrors?: Array<{ message?: string }> | null;
-    }>,
-  ): Promise<boolean> => {
-    let result;
-    try {
-      result = await run();
-    } catch (error) {
-      b2bLogger.error(error);
-      snackbar.error(b3Lang('global.error.genericMessage'));
-      return false;
-    }
-    if (result.errors?.length || result.resultErrors?.length) {
-      const message = result.errors?.[0]?.message || result.resultErrors?.[0]?.message;
-      snackbar.error(message || b3Lang('global.error.genericMessage'));
-      return false;
-    }
-    return true;
-  };
-
-  // Sends the prepared payload to the right backend for the current user/flag combination.
-  // `formFields` is the pre-resolved entityId-keyed group (built once by the caller). Returns
-  // true on success; false means an error was already surfaced and the caller stops.
-  const dispatchUpdate = async (
-    payload: Partial<ParamProps>,
-    formFields?: CustomerFormFieldsInput,
-    extraFields?: CompanyUserExtraFieldsInput,
-  ): Promise<boolean> => {
-    if (useBcAccountSettings && isBCUser) {
-      const customerInput = buildUpdateCustomerInput(payload, formFields);
-      const hasProfileUpdate = Object.keys(customerInput).length > 0;
-
-      // Check the reCaptcha gates up front (they guard updateCustomer) so we don't attempt the
-      // details update — and its password follow-up — with a token that can't be accepted.
-      if (hasProfileUpdate) {
-        if (isCaptchaConfigLoading) {
-          snackbar.error(b3Lang('global.error.genericMessage'));
-          return false;
-        }
-        if (isCaptchaEnabled && !captchaToken) {
-          snackbar.error(b3Lang('login.loginText.missingCaptcha'));
-          return false;
-        }
-      }
-
-      // Update the profile details first; only change the password if that succeeds so we never
-      // commit a password change against a details update that failed.
-      if (hasProfileUpdate) {
-        let ok;
-        try {
-          ok = await runMutation(() =>
-            updateCustomerDetails(customerInput, captchaToken || undefined).then((res) => ({
-              errors: res.errors,
-            })),
-          );
-        } finally {
-          // reCaptcha v2 tokens are single-use; drop it so a retry forces a fresh solve.
-          setCaptchaToken('');
-        }
-        if (!ok) return false;
-      }
-
-      // Details update succeeded (or there was none); now change the password if requested.
-      if (payload.newPassword) {
-        return runMutation(() =>
-          changeCustomerPassword(
-            (payload.currentPassword as string) || '',
-            payload.newPassword as string,
-          ).then((res) => ({
-            errors: res.errors,
-            resultErrors: res.data?.customer?.changePassword?.errors,
-          })),
-        );
-      }
-
-      return true;
-    }
-
-    if (useBcAccountSettings && !isBCUser) {
-      return runMutation(() =>
-        updateCompanyUserDetails(
-          buildUpdateCompanyUserInput(payload, formFields, extraFields),
-        ).then((res) => ({
-          errors: res.errors,
-          resultErrors: res.data?.company?.updateCompanyUser?.errors,
-        })),
-      );
-    }
-
-    // Legacy b2b middleware path (flag off).
-    const requestFn = isBCUser ? updateBCAccountSettings : updateB2BAccountSettings;
-    await requestFn(payload);
-    return true;
-  };
-
-  const handleAddUserClick = () => {
-    handleSubmit(async (data: CustomFieldItems) => {
-      setLoading(true);
-
-      try {
-        const isValid = await validateEmailValue(data.email);
-
-        if (!isValid) {
-          setError('email', {
-            type: 'custom',
-            message: b3Lang('accountSettings.notification.emailExists'),
-          });
-        }
-
-        const emailFlag = emailValidation(data);
-
-        if (!emailFlag) {
-          snackbar.error(b3Lang('accountSettings.notification.updateEmailPassword'));
-        }
-
-        const passwordFlag = passwordValidation(data);
-
-        if (!passwordFlag) {
-          setError('confirmPassword', {
-            type: 'manual',
-            message: b3Lang('global.registerComplete.passwordMatchPrompt'),
-          });
-          setError('password', {
-            type: 'manual',
-            message: b3Lang('global.registerComplete.passwordMatchPrompt'),
-          });
-        }
-
-        if (isValid && emailFlag && passwordFlag) {
-          const dataProcessingFn = isBCUser ? bcSubmitDataProcessing : b2bSubmitDataProcessing;
-          let payload = dataProcessingFn(data, accountSettings, decryptionFields, extraFields);
-
-          // Native SF GQL custom fields are resolved to their typed groups once here; the same
-          // build reports any changed field that can't be sent so we fail loudly.
-          let customerFormFields;
-          let customerExtraFields;
-          if (useBcAccountSettings) {
-            // BC keeps every custom field as an entityId-keyed form field; for B2B the
-            // company-user's own custom fields (contact group) are name-keyed extraFields,
-            // while any additional BC form fields stay entityId-keyed.
-            const formFieldConfig = isBCUser
-              ? accountInfoFormFields
-              : accountInfoFormFields.filter((item) => item.groupId !== CONTACT_GROUP_ID);
-            const changedFormFields = collectChangedFormFields(
-              data,
-              formFieldConfig,
-              accountSettings?.formFields || [],
-              customerFormFieldDefs,
-            );
-            const changedExtraFields = isBCUser
-              ? []
-              : collectChangedExtraFields(
-                  data,
-                  accountInfoFormFields,
-                  accountSettings?.extraFields || [],
-                );
-
-            const { formFields, unsendable } = buildFormFieldsInput(
-              changedFormFields,
-              customerFormFieldDefs,
-            );
-            const { extraFields, unsendable: unsendableExtra } =
-              buildExtraFieldsInput(changedExtraFields);
-            // Fail loudly if a changed field can't be sent (unmapped choice option, cleared
-            // number/date, missing entityId, or an array-valued extra field) rather than
-            // reporting a save that silently dropped the edit.
-            if (unsendable.length > 0 || unsendableExtra.length > 0) {
-              snackbar.error(b3Lang('global.error.genericMessage'));
-              return;
-            }
-            customerFormFields = formFields;
-            customerExtraFields = extraFields;
-            // Treat a field-only edit as non-pristine so it isn't dropped as "no edits".
-            if (!payload && (formFields || extraFields)) payload = {};
-          }
-
-          if (payload) {
-            // Legacy B2B middleware still expects name-based extra fields + companyId.
-            if (!useBcAccountSettings && !isBCUser) {
-              payload.companyId = companyId;
-              payload.extraFields = handleGetUserExtraFields(data, accountInfoFormFields);
-            }
-
-            if (payload.newPassword === '' && payload.confirmPassword === '') {
-              delete payload.newPassword;
-              delete payload.confirmPassword;
-            }
-          }
-
-          if (!payload) {
-            snackbar.success(b3Lang('accountSettings.notification.noEdits'));
-            return;
-          }
-
-          const succeeded = await dispatchUpdate(payload, customerFormFields, customerExtraFields);
-          if (!succeeded) return;
-
-          if (
-            (data.password && data.currentPassword) ||
-            customer.emailAddress !== trim(data.email)
-          ) {
-            navigate('/login?loginFlag=loggedOutLogin');
-          } else {
-            B3SStorage.clear();
-            setIsFinishUpdate(true);
-          }
-        }
-      } finally {
-        setLoading(false);
-      }
-    })();
-  };
+  const { handleAddUserClick } = useAccountSettingsSubmit({
+    isBCUser,
+    useBcAccountSettings,
+    companyId,
+    customer,
+    accountSettings,
+    decryptionFields,
+    extraFields,
+    accountInfoFormFields,
+    customerFormFieldDefs,
+    captchaToken,
+    setCaptchaToken,
+    isCaptchaEnabled,
+    isCaptchaConfigLoading,
+    validateEmailValue,
+    emailValidation,
+    passwordValidation,
+    handleSubmit,
+    setError,
+    setLoading,
+    setIsFinishUpdate,
+  });
 
   const translatedFields = useMemo(() => {
     const fieldTranslations: Record<string, string> = {

--- a/apps/storefront/src/pages/AccountSetting/index.tsx
+++ b/apps/storefront/src/pages/AccountSetting/index.tsx
@@ -201,33 +201,49 @@ function AccountSetting() {
         const additionalInformation = (accountFormFields?.additionalInformation ??
           []) as Partial<Fields>[];
 
+        // Store the customer form-field definitions (option entityIds for choice fields),
+        // surfacing — not swallowing — a failed fetch since it's what blocks choice fields.
+        const applyFormFieldDefinitions = (
+          definitions: Awaited<ReturnType<typeof getCustomerFormFieldDefinitions>> | undefined,
+        ) => {
+          if (definitions?.errors?.length) {
+            b2bLogger.error(
+              `Customer form-field definitions unavailable: ${definitions.errors[0]?.message}`,
+            );
+          }
+          setCustomerFormFieldDefs(definitions?.data?.site?.settings?.formFields?.customer ?? []);
+        };
+
         let accountSettings;
         if (useBcAccountSettings) {
+          // Scalar/text/number fields get their entityId from the `field_<id>` fieldId, so
+          // definitions are only needed to resolve option ids for choice/checkbox fields.
+          // Both customer.updateCustomer and company.updateCompanyUser use them, so fetch for
+          // either user type in parallel with the account read.
+          const needsDefinitions = [...contactInformation, ...additionalInformation].some(
+            (item) => item.custom && fieldTypeNeedsOptions(item.fieldType),
+          );
+          const definitionsPromise = needsDefinitions
+            ? getCustomerFormFieldDefinitions()
+            : Promise.resolve(undefined);
+
           let userData;
           if (isBCUser) {
-            // Scalar/text/number fields get their entityId from the `field_<id>` fieldId, so
-            // definitions are only needed to resolve option ids for choice/checkbox fields.
-            const needsDefinitions = [...contactInformation, ...additionalInformation].some(
-              (item) => item.custom && fieldTypeNeedsOptions(item.fieldType),
-            );
             const [response, definitions] = await Promise.all([
               getCustomerDetails(),
-              needsDefinitions ? getCustomerFormFieldDefinitions() : Promise.resolve(undefined),
+              definitionsPromise,
             ]);
             if (response.errors?.length) throw new Error(response.errors[0]?.message);
             userData = response.data?.customer;
-            // Surface (don't swallow) a failed definitions fetch — it's what blocks choice
-            // fields from resolving their option entityIds.
-            if (definitions?.errors?.length) {
-              b2bLogger.error(
-                `Customer form-field definitions unavailable: ${definitions.errors[0]?.message}`,
-              );
-            }
-            setCustomerFormFieldDefs(definitions?.data?.site?.settings?.formFields?.customer ?? []);
+            applyFormFieldDefinitions(definitions);
           } else {
-            const response = await getCompanyUserDetails();
+            const [response, definitions] = await Promise.all([
+              getCompanyUserDetails(),
+              definitionsPromise,
+            ]);
             if (response.errors?.length) throw new Error(response.errors[0]?.message);
             userData = response.data?.company?.companyUser;
+            applyFormFieldDefinitions(definitions);
           }
 
           if (!userData) throw new Error('Account settings response did not include a user');
@@ -328,7 +344,9 @@ function AccountSetting() {
     }
 
     if (useBcAccountSettings && !isBCUser) {
-      const response = await updateCompanyUserDetails(buildUpdateCompanyUserInput(payload));
+      const response = await updateCompanyUserDetails(
+        buildUpdateCompanyUserInput(payload, customerFormFieldDefs),
+      );
       const companyUserErrors = response.data?.company?.updateCompanyUser?.errors;
       if (response.errors?.length || companyUserErrors?.length) {
         const message = response.errors?.[0]?.message || companyUserErrors?.[0]?.message;

--- a/apps/storefront/src/pages/AccountSetting/index.tsx
+++ b/apps/storefront/src/pages/AccountSetting/index.tsx
@@ -1,4 +1,4 @@
-import { useContext, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { Box } from '@mui/material';
 import trim from 'lodash-es/trim';
@@ -151,7 +151,13 @@ function AccountSetting() {
     [],
   );
   const [captchaToken, setCaptchaToken] = useState<string>('');
+  const [captchaKey, setCaptchaKey] = useState(0);
   const [isVisible, setIsVisible] = useState<boolean>(false);
+
+  const resetCaptcha = useCallback(() => {
+    setCaptchaToken('');
+    setCaptchaKey((key) => key + 1);
+  }, []);
   const skipNextInitRef = useRef(false);
 
   // BC customer.updateCustomer needs a reCaptcha token when reCaptcha is enabled on the
@@ -299,7 +305,7 @@ function AccountSetting() {
     accountInfoFormFields,
     customerFormFieldDefs,
     captchaToken,
-    setCaptchaToken,
+    resetCaptcha,
     isCaptchaEnabled,
     isCaptchaConfigLoading,
     validateEmailValue,
@@ -368,7 +374,12 @@ function AccountSetting() {
 
           {isCustomerUpdate && isCaptchaEnabled && (
             <Box sx={{ mt: '20px' }}>
-              <Captcha siteKey={captchaSiteKey} size="normal" handleGetKey={setCaptchaToken} />
+              <Captcha
+                key={captchaKey}
+                siteKey={captchaSiteKey}
+                size="normal"
+                handleGetKey={setCaptchaToken}
+              />
             </Box>
           )}
 

--- a/apps/storefront/src/pages/AccountSetting/useAccountSettingsSubmit.ts
+++ b/apps/storefront/src/pages/AccountSetting/useAccountSettingsSubmit.ts
@@ -44,7 +44,7 @@ interface UseAccountSettingsSubmitParams {
   accountInfoFormFields: Partial<Fields>[];
   customerFormFieldDefs: CustomerFormFieldDefinition[];
   captchaToken: string;
-  setCaptchaToken: (token: string) => void;
+  resetCaptcha: () => void;
   isCaptchaEnabled: boolean;
   isCaptchaConfigLoading: boolean;
   validateEmailValue: (email: string) => Promise<boolean>;
@@ -71,7 +71,7 @@ export function useAccountSettingsSubmit({
   accountInfoFormFields,
   customerFormFieldDefs,
   captchaToken,
-  setCaptchaToken,
+  resetCaptcha,
   isCaptchaEnabled,
   isCaptchaConfigLoading,
   validateEmailValue,
@@ -156,8 +156,8 @@ export function useAccountSettingsSubmit({
             })),
           );
         } finally {
-          // reCaptcha v2 tokens are single-use; drop it so a retry forces a fresh solve.
-          setCaptchaToken('');
+          // reCaptcha v2 tokens are single-use; reset the widget so a retry can issue a new one.
+          resetCaptcha();
         }
         if (!ok) return false;
       }

--- a/apps/storefront/src/pages/AccountSetting/useAccountSettingsSubmit.ts
+++ b/apps/storefront/src/pages/AccountSetting/useAccountSettingsSubmit.ts
@@ -121,13 +121,17 @@ export function useAccountSettingsSubmit({
   };
 
   // Sends the prepared payload to the right backend for the current user/flag combination.
-  // `formFields` is the pre-resolved entityId-keyed group (built once by the caller). Returns
-  // true on success; false means an error was already surfaced and the caller stops.
+  // `formFields` is the pre-resolved entityId-keyed group (built once by the caller).
+  // `profileCommitted` tells the caller whether any profile changes were actually saved
+  // server-side, independent of `ok` — a password change is the last step, and if it fails
+  // after the profile details already succeeded, the caller still needs to reflect the
+  // committed profile change (e.g. force a re-login on a changed email) instead of treating
+  // the whole save as a no-op.
   const dispatchUpdate = async (
     payload: Partial<ParamProps>,
     formFields?: CustomerFormFieldsInput,
     extraFields?: CompanyUserExtraFieldsInput,
-  ): Promise<boolean> => {
+  ): Promise<{ ok: boolean; profileCommitted: boolean }> => {
     if (useBcAccountSettings && isBCUser) {
       const customerInput = buildUpdateCustomerInput(payload, formFields);
       const hasProfileUpdate = Object.keys(customerInput).length > 0;
@@ -137,34 +141,40 @@ export function useAccountSettingsSubmit({
       if (hasProfileUpdate) {
         if (isCaptchaConfigLoading) {
           snackbar.error(b3Lang('global.error.genericMessage'));
-          return false;
+          return { ok: false, profileCommitted: false };
         }
         if (isCaptchaEnabled && !captchaToken) {
           snackbar.error(b3Lang('login.loginText.missingCaptcha'));
-          return false;
+          return { ok: false, profileCommitted: false };
         }
       }
 
       // Update the profile details first; only change the password if that succeeds so we never
       // commit a password change against a details update that failed.
+      // `profileCommitted` only flips to true once an actual details update has succeeded — a
+      // password-only save (hasProfileUpdate false) must never report a profile commit, or a
+      // failed password change would be treated as if something had still been saved.
+      let profileCommitted = false;
       if (hasProfileUpdate) {
         let ok;
         try {
           ok = await runMutation(() =>
             updateCustomerDetails(customerInput, captchaToken || undefined).then((res) => ({
               errors: res.errors,
+              resultErrors: res.data?.customer?.updateCustomer?.errors,
             })),
           );
         } finally {
           // reCaptcha v2 tokens are single-use; reset the widget so a retry can issue a new one.
           resetCaptcha();
         }
-        if (!ok) return false;
+        if (!ok) return { ok: false, profileCommitted: false };
+        profileCommitted = true;
       }
 
       // Details update succeeded (or there was none); now change the password if requested.
       if (payload.newPassword) {
-        return runMutation(() =>
+        const passwordOk = await runMutation(() =>
           changeCustomerPassword(
             (payload.currentPassword as string) || '',
             payload.newPassword as string,
@@ -173,13 +183,14 @@ export function useAccountSettingsSubmit({
             resultErrors: res.data?.customer?.changePassword?.errors,
           })),
         );
+        return { ok: passwordOk, profileCommitted };
       }
 
-      return true;
+      return { ok: true, profileCommitted };
     }
 
     if (useBcAccountSettings && !isBCUser) {
-      return runMutation(() =>
+      const ok = await runMutation(() =>
         updateCompanyUserDetails(
           buildUpdateCompanyUserInput(payload, formFields, extraFields),
         ).then((res) => ({
@@ -187,12 +198,13 @@ export function useAccountSettingsSubmit({
           resultErrors: res.data?.company?.updateCompanyUser?.errors,
         })),
       );
+      return { ok, profileCommitted: ok };
     }
 
     // Legacy b2b middleware path (flag off).
     const requestFn = isBCUser ? updateBCAccountSettings : updateB2BAccountSettings;
     await requestFn(payload);
-    return true;
+    return { ok: true, profileCommitted: true };
   };
 
   const handleAddUserClick = () => {
@@ -306,11 +318,16 @@ export function useAccountSettingsSubmit({
             return;
           }
 
-          const succeeded = await dispatchUpdate(payload, customerFormFields, customerExtraFields);
-          if (!succeeded) return;
+          const { ok, profileCommitted } = await dispatchUpdate(
+            payload,
+            customerFormFields,
+            customerExtraFields,
+          );
+          // Nothing was saved server-side — stop; the error was already surfaced.
+          if (!ok && !profileCommitted) return;
 
           if (
-            (data.password && data.currentPassword) ||
+            (ok && data.password && data.currentPassword) ||
             customer.emailAddress !== trim(data.email)
           ) {
             navigate('/login?loginFlag=loggedOutLogin');

--- a/apps/storefront/src/pages/AccountSetting/useAccountSettingsSubmit.ts
+++ b/apps/storefront/src/pages/AccountSetting/useAccountSettingsSubmit.ts
@@ -1,0 +1,329 @@
+import { FieldValues, UseFormHandleSubmit, UseFormSetError } from 'react-hook-form';
+import { useNavigate } from 'react-router-dom';
+import trim from 'lodash-es/trim';
+
+import { useB3Lang } from '@/lib/lang';
+import { updateB2BAccountSettings, updateBCAccountSettings } from '@/shared/service/b2b';
+import {
+  changeCustomerPassword,
+  updateCompanyUserDetails,
+  updateCustomerDetails,
+} from '@/shared/service/bc';
+import {
+  CompanyUserExtraFieldsInput,
+  CustomerFormFieldDefinition,
+  CustomerFormFieldsInput,
+} from '@/shared/service/bc/graphql/accountSetting';
+import { Fields, ParamProps } from '@/types/accountSetting';
+import { Customer } from '@/types/company';
+import b2bLogger from '@/utils/b3Logger';
+import { B3SStorage } from '@/utils/b3Storage';
+import { snackbar } from '@/utils/b3Tip';
+import { deCodeField } from '@/utils/registerUtils';
+
+import {
+  b2bSubmitDataProcessing,
+  bcSubmitDataProcessing,
+  buildExtraFieldsInput,
+  buildFormFieldsInput,
+  buildUpdateCompanyUserInput,
+  buildUpdateCustomerInput,
+  collectChangedExtraFields,
+  collectChangedFormFields,
+  CONTACT_GROUP_ID,
+} from './utils';
+
+interface UseAccountSettingsSubmitParams {
+  isBCUser: boolean;
+  useBcAccountSettings: boolean;
+  companyId: number;
+  customer: Customer;
+  accountSettings: any;
+  decryptionFields: Partial<Fields>[];
+  extraFields: Partial<Fields>[];
+  accountInfoFormFields: Partial<Fields>[];
+  customerFormFieldDefs: CustomerFormFieldDefinition[];
+  captchaToken: string;
+  setCaptchaToken: (token: string) => void;
+  isCaptchaEnabled: boolean;
+  isCaptchaConfigLoading: boolean;
+  validateEmailValue: (email: string) => Promise<boolean>;
+  emailValidation: (data: Partial<ParamProps>) => boolean;
+  passwordValidation: (data: Partial<ParamProps>) => boolean;
+  handleSubmit: UseFormHandleSubmit<FieldValues>;
+  setError: UseFormSetError<FieldValues>;
+  setLoading: (isLoading: boolean) => void;
+  setIsFinishUpdate: (value: boolean) => void;
+}
+
+// Save/update for the account-settings form: resolves the submitted data into the right
+// backend payload (BC native mutations vs. the legacy B2B middleware) and runs it. Grouped
+// into its own hook — runMutation, dispatchUpdate, and handleAddUserClick are all part of the
+// same save path and were making AccountSetting/index.tsx harder to follow as it grew.
+export function useAccountSettingsSubmit({
+  isBCUser,
+  useBcAccountSettings,
+  companyId,
+  customer,
+  accountSettings,
+  decryptionFields,
+  extraFields,
+  accountInfoFormFields,
+  customerFormFieldDefs,
+  captchaToken,
+  setCaptchaToken,
+  isCaptchaEnabled,
+  isCaptchaConfigLoading,
+  validateEmailValue,
+  emailValidation,
+  passwordValidation,
+  handleSubmit,
+  setError,
+  setLoading,
+  setIsFinishUpdate,
+}: UseAccountSettingsSubmitParams) {
+  const b3Lang = useB3Lang();
+  const navigate = useNavigate();
+
+  const handleGetUserExtraFields = (
+    data: CustomFieldItems,
+    accountInfoFormFields: Partial<Fields>[],
+  ) => {
+    const userExtraFields = accountInfoFormFields.filter(
+      (item: CustomFieldItems) => item.custom && item.groupId === 1,
+    );
+    return userExtraFields.map((item: CustomFieldItems) => ({
+      fieldName: deCodeField(item?.name || ''),
+      fieldValue: data[item.name],
+    }));
+  };
+
+  const runMutation = async (
+    run: () => Promise<{
+      errors?: Array<{ message: string }>;
+      resultErrors?: Array<{ message?: string }> | null;
+    }>,
+  ): Promise<boolean> => {
+    let result;
+    try {
+      result = await run();
+    } catch (error) {
+      b2bLogger.error(error);
+      snackbar.error(b3Lang('global.error.genericMessage'));
+      return false;
+    }
+    if (result.errors?.length || result.resultErrors?.length) {
+      const message = result.errors?.[0]?.message || result.resultErrors?.[0]?.message;
+      snackbar.error(message || b3Lang('global.error.genericMessage'));
+      return false;
+    }
+    return true;
+  };
+
+  // Sends the prepared payload to the right backend for the current user/flag combination.
+  // `formFields` is the pre-resolved entityId-keyed group (built once by the caller). Returns
+  // true on success; false means an error was already surfaced and the caller stops.
+  const dispatchUpdate = async (
+    payload: Partial<ParamProps>,
+    formFields?: CustomerFormFieldsInput,
+    extraFields?: CompanyUserExtraFieldsInput,
+  ): Promise<boolean> => {
+    if (useBcAccountSettings && isBCUser) {
+      const customerInput = buildUpdateCustomerInput(payload, formFields);
+      const hasProfileUpdate = Object.keys(customerInput).length > 0;
+
+      // Check the reCaptcha gates up front (they guard updateCustomer) so we don't attempt the
+      // details update — and its password follow-up — with a token that can't be accepted.
+      if (hasProfileUpdate) {
+        if (isCaptchaConfigLoading) {
+          snackbar.error(b3Lang('global.error.genericMessage'));
+          return false;
+        }
+        if (isCaptchaEnabled && !captchaToken) {
+          snackbar.error(b3Lang('login.loginText.missingCaptcha'));
+          return false;
+        }
+      }
+
+      // Update the profile details first; only change the password if that succeeds so we never
+      // commit a password change against a details update that failed.
+      if (hasProfileUpdate) {
+        let ok;
+        try {
+          ok = await runMutation(() =>
+            updateCustomerDetails(customerInput, captchaToken || undefined).then((res) => ({
+              errors: res.errors,
+            })),
+          );
+        } finally {
+          // reCaptcha v2 tokens are single-use; drop it so a retry forces a fresh solve.
+          setCaptchaToken('');
+        }
+        if (!ok) return false;
+      }
+
+      // Details update succeeded (or there was none); now change the password if requested.
+      if (payload.newPassword) {
+        return runMutation(() =>
+          changeCustomerPassword(
+            (payload.currentPassword as string) || '',
+            payload.newPassword as string,
+          ).then((res) => ({
+            errors: res.errors,
+            resultErrors: res.data?.customer?.changePassword?.errors,
+          })),
+        );
+      }
+
+      return true;
+    }
+
+    if (useBcAccountSettings && !isBCUser) {
+      return runMutation(() =>
+        updateCompanyUserDetails(
+          buildUpdateCompanyUserInput(payload, formFields, extraFields),
+        ).then((res) => ({
+          errors: res.errors,
+          resultErrors: res.data?.company?.updateCompanyUser?.errors,
+        })),
+      );
+    }
+
+    // Legacy b2b middleware path (flag off).
+    const requestFn = isBCUser ? updateBCAccountSettings : updateB2BAccountSettings;
+    await requestFn(payload);
+    return true;
+  };
+
+  const handleAddUserClick = () => {
+    handleSubmit(async (data: CustomFieldItems) => {
+      setLoading(true);
+
+      try {
+        const isValid = await validateEmailValue(data.email);
+
+        if (!isValid) {
+          setError('email', {
+            type: 'custom',
+            message: b3Lang('accountSettings.notification.emailExists'),
+          });
+        }
+
+        const emailFlag = emailValidation(data);
+
+        if (!emailFlag) {
+          snackbar.error(b3Lang('accountSettings.notification.updateEmailPassword'));
+        }
+
+        const passwordFlag = passwordValidation(data);
+
+        if (!passwordFlag) {
+          setError('confirmPassword', {
+            type: 'manual',
+            message: b3Lang('global.registerComplete.passwordMatchPrompt'),
+          });
+          setError('password', {
+            type: 'manual',
+            message: b3Lang('global.registerComplete.passwordMatchPrompt'),
+          });
+        }
+
+        if (isValid && emailFlag && passwordFlag) {
+          const dataProcessingFn = isBCUser ? bcSubmitDataProcessing : b2bSubmitDataProcessing;
+          let payload = dataProcessingFn(data, accountSettings, decryptionFields, extraFields);
+
+          // Native SF GQL custom fields are resolved to their typed groups once here; the same
+          // build reports any changed field that can't be sent so we fail loudly.
+          let customerFormFields;
+          let customerExtraFields;
+          if (useBcAccountSettings) {
+            // BC keeps every custom field as an entityId-keyed form field; for B2B the
+            // company-user's own custom fields (contact group) are name-keyed extraFields,
+            // while any additional BC form fields stay entityId-keyed.
+            const formFieldConfig = isBCUser
+              ? accountInfoFormFields
+              : accountInfoFormFields.filter((item) => item.groupId !== CONTACT_GROUP_ID);
+            const changedFormFields = collectChangedFormFields(
+              data,
+              formFieldConfig,
+              accountSettings?.formFields || [],
+              customerFormFieldDefs,
+            );
+            const changedExtraFields = isBCUser
+              ? []
+              : collectChangedExtraFields(
+                  data,
+                  accountInfoFormFields,
+                  accountSettings?.extraFields || [],
+                );
+
+            const { formFields, unsendable } = buildFormFieldsInput(
+              changedFormFields,
+              customerFormFieldDefs,
+            );
+            const { extraFields, unsendable: unsendableExtra } =
+              buildExtraFieldsInput(changedExtraFields);
+            // Fail loudly if a changed field can't be sent (unmapped choice option, cleared
+            // number/date, missing entityId, or an array-valued extra field) rather than
+            // reporting a save that silently dropped the edit. Surface the error on the
+            // specific control(s) so the user knows which value to fix; fall back to the
+            // generic snackbar only if a field couldn't be traced back to its control.
+            if (unsendable.length > 0 || unsendableExtra.length > 0) {
+              const fieldMessage = b3Lang('accountSettings.notification.fieldCannotBeSaved');
+              let hasFieldLevelError = false;
+              [...unsendable, ...unsendableExtra].forEach((field) => {
+                if (field.formName) {
+                  hasFieldLevelError = true;
+                  setError(field.formName, { type: 'custom', message: fieldMessage });
+                }
+              });
+              if (!hasFieldLevelError) {
+                snackbar.error(b3Lang('global.error.genericMessage'));
+              }
+              return;
+            }
+            customerFormFields = formFields;
+            customerExtraFields = extraFields;
+            // Treat a field-only edit as non-pristine so it isn't dropped as "no edits".
+            if (!payload && (formFields || extraFields)) payload = {};
+          }
+
+          if (payload) {
+            // Legacy B2B middleware still expects name-based extra fields + companyId.
+            if (!useBcAccountSettings && !isBCUser) {
+              payload.companyId = companyId;
+              payload.extraFields = handleGetUserExtraFields(data, accountInfoFormFields);
+            }
+
+            if (payload.newPassword === '' && payload.confirmPassword === '') {
+              delete payload.newPassword;
+              delete payload.confirmPassword;
+            }
+          }
+
+          if (!payload) {
+            snackbar.success(b3Lang('accountSettings.notification.noEdits'));
+            return;
+          }
+
+          const succeeded = await dispatchUpdate(payload, customerFormFields, customerExtraFields);
+          if (!succeeded) return;
+
+          if (
+            (data.password && data.currentPassword) ||
+            customer.emailAddress !== trim(data.email)
+          ) {
+            navigate('/login?loginFlag=loggedOutLogin');
+          } else {
+            B3SStorage.clear();
+            setIsFinishUpdate(true);
+          }
+        }
+      } finally {
+        setLoading(false);
+      }
+    })();
+  };
+
+  return { handleAddUserClick };
+}

--- a/apps/storefront/src/pages/AccountSetting/utils.test.ts
+++ b/apps/storefront/src/pages/AccountSetting/utils.test.ts
@@ -15,6 +15,7 @@ import {
   buildUpdateCompanyUserInput,
   buildUpdateCustomerInput,
   collectChangedFormFields,
+  getUnsendableFormFields,
   initB2BInfo,
   initBcInfo,
   mapUserToAccountInfo,
@@ -577,6 +578,54 @@ describe('buildUpdateCompanyUserInput', () => {
     });
 
     expect(input).toEqual({ firstName: 'Ada' });
+  });
+});
+
+describe('getUnsendableFormFields', () => {
+  const definitions: CustomerFormFieldDefinition[] = [
+    {
+      __typename: 'MultipleChoicesFormField',
+      entityId: 14,
+      label: 'fChoice',
+      options: [{ entityId: 99, label: 'A' }],
+    },
+  ];
+
+  it('returns nothing when every field maps', () => {
+    expect(
+      getUnsendableFormFields(
+        [
+          { name: 'fText', value: 'x', fieldType: 'text', fieldEntityId: 10 },
+          { name: 'fChoice', value: 'A', fieldType: 'dropdown', fieldEntityId: 14 },
+        ],
+        definitions,
+      ),
+    ).toEqual([]);
+  });
+
+  it('flags a choice whose label is not in the definitions', () => {
+    const field = { name: 'fChoice', value: 'B', fieldType: 'dropdown', fieldEntityId: 14 };
+    expect(getUnsendableFormFields([field], definitions)).toEqual([field]);
+  });
+
+  it('flags a cleared number and a cleared checkbox (no empty form)', () => {
+    const num = { name: 'Age', value: '', fieldType: 'number', fieldEntityId: 12 };
+    const checks = { name: 'Interests', value: [], fieldType: 'checkbox', fieldEntityId: 15 };
+    expect(getUnsendableFormFields([num, checks], definitions)).toEqual([num, checks]);
+  });
+
+  it('flags a field with no resolved entityId', () => {
+    const field = { name: 'Mystery', value: 'x', fieldType: 'text', fieldEntityId: undefined };
+    expect(getUnsendableFormFields([field], definitions)).toEqual([field]);
+  });
+
+  it('does not flag a cleared text field (empty text is a valid clear)', () => {
+    expect(
+      getUnsendableFormFields(
+        [{ name: 'fText', value: '', fieldType: 'text', fieldEntityId: 10 }],
+        definitions,
+      ),
+    ).toEqual([]);
   });
 });
 

--- a/apps/storefront/src/pages/AccountSetting/utils.test.ts
+++ b/apps/storefront/src/pages/AccountSetting/utils.test.ts
@@ -403,7 +403,6 @@ describe('buildFormFieldsInput', () => {
   // fields only need the fieldEntityId carried on each submitted entry.
   const definitions: CustomerFormFieldDefinition[] = [
     {
-      __typename: 'MultipleChoicesFormField',
       entityId: 14,
       label: 'fChoice',
       options: [
@@ -412,7 +411,6 @@ describe('buildFormFieldsInput', () => {
       ],
     },
     {
-      __typename: 'CheckboxesFormField',
       entityId: 15,
       label: 'fChecks',
       options: [
@@ -689,7 +687,7 @@ describe('collectChangedFormFields', () => {
       { nn: 25 },
       nonNumericFields,
       [],
-      [{ __typename: 'NumberFormField', entityId: 26, label: 'Age' }],
+      [{ entityId: 26, label: 'Age' }],
     );
 
     expect(result.fieldEntityId).toBe(26);

--- a/apps/storefront/src/pages/AccountSetting/utils.test.ts
+++ b/apps/storefront/src/pages/AccountSetting/utils.test.ts
@@ -454,12 +454,13 @@ describe('buildFormFieldsInput', () => {
     expect(formFields?.multipleChoices).toEqual([{ fieldEntityId: 14, fieldValueEntityId: 99 }]);
   });
 
-  it('clears text ("") and checkbox ([]) which are representable, and skips an emptied number without blocking', () => {
+  it('clears text ("") and checkbox ([]) which are representable, and flags an emptied number as unsendable', () => {
+    // A number has no "empty" form, so a cleared one is unsendable — not sent, not silently dropped.
+    const clearedNumber = { name: 'Age', value: '', fieldType: 'number', fieldEntityId: 12 };
     const { formFields, unsendable } = buildFormFieldsInput(
       [
         { name: 'fText', value: '', fieldType: 'text', fieldEntityId: 10 },
-        // A number has no "empty" form, so a cleared one is skipped — not sent, not unsendable.
-        { name: 'Age', value: '', fieldType: 'number', fieldEntityId: 12 },
+        clearedNumber,
         { name: 'fChecks', value: [], fieldType: 'checkbox', fieldEntityId: 15 },
       ],
       definitions,
@@ -469,7 +470,7 @@ describe('buildFormFieldsInput', () => {
       texts: [{ fieldEntityId: 10, text: '' }],
       checkboxes: [{ fieldEntityId: 15, fieldValueEntityIds: [] }],
     });
-    expect(unsendable).toEqual([]);
+    expect(unsendable).toEqual([clearedNumber]);
   });
 
   it('flags an unmapped choice, a missing entityId, and a partial checkbox as unsendable', () => {
@@ -495,17 +496,16 @@ describe('buildFormFieldsInput', () => {
     expect(unsendable).toEqual([unmappedChoice, noEntityId, partialCheckbox]);
   });
 
-  it('skips a cleared date and a cleared dropdown without blocking (not unsendable)', () => {
+  it('flags a cleared date and a cleared dropdown as unsendable (no empty form to send)', () => {
+    const clearedDate = { name: 'fDate', value: '', fieldType: 'date', fieldEntityId: 13 };
+    const clearedDropdown = { name: 'fChoice', value: '', fieldType: 'dropdown', fieldEntityId: 14 };
     const { formFields, unsendable } = buildFormFieldsInput(
-      [
-        { name: 'fDate', value: '', fieldType: 'date', fieldEntityId: 13 },
-        { name: 'fChoice', value: '', fieldType: 'dropdown', fieldEntityId: 14 },
-      ],
+      [clearedDate, clearedDropdown],
       definitions,
     );
 
     expect(formFields).toBeUndefined();
-    expect(unsendable).toEqual([]);
+    expect(unsendable).toEqual([clearedDate, clearedDropdown]);
   });
 });
 

--- a/apps/storefront/src/pages/AccountSetting/utils.test.ts
+++ b/apps/storefront/src/pages/AccountSetting/utils.test.ts
@@ -661,6 +661,27 @@ describe('collectChangedFormFields', () => {
     ]);
   });
 
+  it('keys by label when bcLabel is empty (getAccountFormFields leaves bcLabel unset)', () => {
+    // The config only supplied labelName, so bcLabel is '' and the display name lives on label.
+    const labelOnly = [
+      field({
+        name: 'field_28',
+        label: 'Preferences',
+        fieldType: 'text',
+        fieldId: 'field_28',
+        custom: true,
+      }),
+    ];
+    // Unchanged against the stored value keyed by that label → not reported as changed.
+    expect(
+      collectChangedFormFields({ field_28: 'x' }, labelOnly, [{ name: 'Preferences', value: 'x' }]),
+    ).toEqual([]);
+    // Changed → keyed by label, entityId parsed from fieldId.
+    expect(
+      collectChangedFormFields({ field_28: 'y' }, labelOnly, [{ name: 'Preferences', value: 'x' }]),
+    ).toEqual([{ name: 'Preferences', value: 'y', fieldType: 'text', fieldEntityId: 28 }]);
+  });
+
   it('does not treat an untouched date as changed (ISO original vs YYYY-MM-DD submitted)', () => {
     const dateFields = [
       field({ name: 'dob', bcLabel: 'DOB', fieldType: 'date', fieldId: 'field_30', custom: true }),

--- a/apps/storefront/src/pages/AccountSetting/utils.test.ts
+++ b/apps/storefront/src/pages/AccountSetting/utils.test.ts
@@ -6,12 +6,13 @@ import type {
   CustomerFormFieldDefinition,
   FormFieldValue,
 } from '@/shared/service/bc/graphql/accountSetting';
-import type { Fields, ParamProps } from '@/types/accountSetting';
+import type { Fields } from '@/types/accountSetting';
 import { Base64 } from '@/utils/base64';
 
 import {
   b2bSubmitDataProcessing,
   bcSubmitDataProcessing,
+  buildExtraFieldsInput,
   buildFormFieldsInput,
   buildUpdateCompanyUserInput,
   buildUpdateCustomerInput,
@@ -567,40 +568,45 @@ describe('buildUpdateCompanyUserInput', () => {
     });
   });
 
-  it('attaches the pre-resolved formFields group', () => {
+  it('attaches the pre-resolved formFields and extraFields groups', () => {
     const input = buildUpdateCompanyUserInput(
       { firstName: 'Ada' },
       { numbers: [{ fieldEntityId: 26, number: 28 }] },
+      { texts: [{ name: 'Nickname', text: 'AT' }] },
     );
 
     expect(input.formFields).toEqual({ numbers: [{ fieldEntityId: 26, number: 28 }] });
+    expect(input.extraFields).toEqual({ texts: [{ name: 'Nickname', text: 'AT' }] });
   });
+});
 
-  it('routes company-user extra fields into the name-keyed extraFields groups (no entityId)', () => {
-    const input = buildUpdateCompanyUserInput({
-      extraFields: [
-        { name: 'Nickname', value: 'AT', fieldType: 'text' },
-        { name: 'Bio', value: 'hi', fieldType: 'multiline' },
-        { name: 'Age', value: '25', fieldType: 'number' },
-        { name: 'Tier', value: 'Gold', fieldType: 'dropdown' },
-      ],
-    } as Partial<ParamProps>);
+describe('buildExtraFieldsInput', () => {
+  it('routes company-user extra fields into the name-keyed groups by field type', () => {
+    const { extraFields, unsendable } = buildExtraFieldsInput([
+      { name: 'Nickname', value: 'AT', fieldType: 'text' },
+      { name: 'Bio', value: 'hi', fieldType: 'multiline' },
+      { name: 'Age', value: '25', fieldType: 'number' },
+      { name: 'Tier', value: 'Gold', fieldType: 'dropdown' },
+    ]);
 
-    expect(input.extraFields).toEqual({
+    expect(unsendable).toEqual([]);
+    expect(extraFields).toEqual({
       texts: [{ name: 'Nickname', text: 'AT' }],
       multilineTexts: [{ name: 'Bio', multilineText: 'hi' }],
       numbers: [{ name: 'Age', number: '25' }],
       multipleChoices: [{ name: 'Tier', fieldValue: 'Gold' }],
     });
-    expect(input.formFields).toBeUndefined();
   });
 
-  it('skips an array-valued extra field rather than sending a comma-joined string', () => {
-    const input = buildUpdateCompanyUserInput({
-      extraFields: [{ name: 'Multi', value: ['a', 'b'], fieldType: 'text' }],
-    } as Partial<ParamProps>);
+  it('flags an array-valued (checkbox) extra field as unsendable instead of dropping it', () => {
+    const multi = { name: 'Multi', value: ['a', 'b'], fieldType: 'checkbox' };
+    const { extraFields, unsendable } = buildExtraFieldsInput([
+      multi,
+      { name: 'Nickname', value: 'AT', fieldType: 'text' },
+    ]);
 
-    expect(input.extraFields).toBeUndefined();
+    expect(extraFields).toEqual({ texts: [{ name: 'Nickname', text: 'AT' }] });
+    expect(unsendable).toEqual([multi]);
   });
 });
 

--- a/apps/storefront/src/pages/AccountSetting/utils.test.ts
+++ b/apps/storefront/src/pages/AccountSetting/utils.test.ts
@@ -589,6 +589,15 @@ describe('getUnsendableFormFields', () => {
       label: 'fChoice',
       options: [{ entityId: 99, label: 'A' }],
     },
+    {
+      __typename: 'CheckboxesFormField',
+      entityId: 15,
+      label: 'fChecks',
+      options: [
+        { entityId: 7, label: 'x' },
+        { entityId: 8, label: 'y' },
+      ],
+    },
   ];
 
   it('returns nothing when every field maps', () => {
@@ -617,6 +626,21 @@ describe('getUnsendableFormFields', () => {
   it('flags a field with no resolved entityId', () => {
     const field = { name: 'Mystery', value: 'x', fieldType: 'text', fieldEntityId: undefined };
     expect(getUnsendableFormFields([field], definitions)).toEqual([field]);
+  });
+
+  it('flags a checkbox when only some selected labels resolve (no partial send)', () => {
+    const field = {
+      name: 'fChecks',
+      value: ['x', 'unknown'],
+      fieldType: 'checkbox',
+      fieldEntityId: 15,
+    };
+    expect(getUnsendableFormFields([field], definitions)).toEqual([field]);
+  });
+
+  it('does not flag a checkbox when every selected label resolves', () => {
+    const field = { name: 'fChecks', value: ['x', 'y'], fieldType: 'checkbox', fieldEntityId: 15 };
+    expect(getUnsendableFormFields([field], definitions)).toEqual([]);
   });
 
   it('does not flag a cleared text field (empty text is a valid clear)', () => {

--- a/apps/storefront/src/pages/AccountSetting/utils.test.ts
+++ b/apps/storefront/src/pages/AccountSetting/utils.test.ts
@@ -6,16 +6,17 @@ import type {
   CustomerFormFieldDefinition,
   FormFieldValue,
 } from '@/shared/service/bc/graphql/accountSetting';
-import type { Fields } from '@/types/accountSetting';
+import type { Fields, ParamProps } from '@/types/accountSetting';
 import { Base64 } from '@/utils/base64';
 
 import {
   b2bSubmitDataProcessing,
   bcSubmitDataProcessing,
+  buildFormFieldsInput,
   buildUpdateCompanyUserInput,
   buildUpdateCustomerInput,
+  collectChangedExtraFields,
   collectChangedFormFields,
-  getUnsendableFormFields,
   initB2BInfo,
   initBcInfo,
   mapUserToAccountInfo,
@@ -397,7 +398,7 @@ describe('mapUserToAccountInfo', () => {
   });
 });
 
-describe('buildUpdateCustomerInput', () => {
+describe('buildFormFieldsInput', () => {
   // Choice fields need their options (entityId per label) from the definitions; scalar
   // fields only need the fieldEntityId carried on each submitted entry.
   const definitions: CustomerFormFieldDefinition[] = [
@@ -421,6 +422,95 @@ describe('buildUpdateCustomerInput', () => {
     },
   ];
 
+  it('routes each form field into its typed group using the fieldEntityId on the entry', () => {
+    const { formFields, unsendable } = buildFormFieldsInput(
+      [
+        { name: 'fText', value: 'new', fieldType: 'text', fieldEntityId: 10 },
+        { name: 'fMulti', value: 'multi', fieldType: 'multiline', fieldEntityId: 11 },
+        { name: 'Age', value: '25', fieldType: 'number', fieldEntityId: 12 },
+        { name: 'fDate', value: '2026-06-10', fieldType: 'date', fieldEntityId: 13 },
+        { name: 'fChoice', value: 'B', fieldType: 'dropdown', fieldEntityId: 14 },
+        { name: 'fChecks', value: ['x', 'y'], fieldType: 'checkbox', fieldEntityId: 15 },
+      ],
+      definitions,
+    );
+
+    expect(unsendable).toEqual([]);
+    expect(formFields).toEqual({
+      texts: [{ fieldEntityId: 10, text: 'new' }],
+      multilineTexts: [{ fieldEntityId: 11, multilineText: 'multi' }],
+      numbers: [{ fieldEntityId: 12, number: 25 }],
+      dates: [{ fieldEntityId: 13, date: '2026-06-10T00:00:00.000Z' }],
+      multipleChoices: [{ fieldEntityId: 14, fieldValueEntityId: 100 }],
+      checkboxes: [{ fieldEntityId: 15, fieldValueEntityIds: [7, 8] }],
+    });
+  });
+
+  it('maps a changed choice selection to the picked option entityId', () => {
+    const { formFields } = buildFormFieldsInput(
+      [{ name: 'fChoice', value: 'A', fieldType: 'dropdown', fieldEntityId: 14 }],
+      definitions,
+    );
+
+    expect(formFields?.multipleChoices).toEqual([{ fieldEntityId: 14, fieldValueEntityId: 99 }]);
+  });
+
+  it('clears text ("") and checkbox ([]) which are representable, and skips an emptied number without blocking', () => {
+    const { formFields, unsendable } = buildFormFieldsInput(
+      [
+        { name: 'fText', value: '', fieldType: 'text', fieldEntityId: 10 },
+        // A number has no "empty" form, so a cleared one is skipped — not sent, not unsendable.
+        { name: 'Age', value: '', fieldType: 'number', fieldEntityId: 12 },
+        { name: 'fChecks', value: [], fieldType: 'checkbox', fieldEntityId: 15 },
+      ],
+      definitions,
+    );
+
+    expect(formFields).toEqual({
+      texts: [{ fieldEntityId: 10, text: '' }],
+      checkboxes: [{ fieldEntityId: 15, fieldValueEntityIds: [] }],
+    });
+    expect(unsendable).toEqual([]);
+  });
+
+  it('flags an unmapped choice, a missing entityId, and a partial checkbox as unsendable', () => {
+    const unmappedChoice = {
+      name: 'fChoice',
+      value: 'Z',
+      fieldType: 'dropdown',
+      fieldEntityId: 14,
+    };
+    const noEntityId = { name: 'Mystery', value: 'x', fieldType: 'text', fieldEntityId: undefined };
+    const partialCheckbox = {
+      name: 'fChecks',
+      value: ['x', 'unknown'],
+      fieldType: 'checkbox',
+      fieldEntityId: 15,
+    };
+    const { formFields, unsendable } = buildFormFieldsInput(
+      [unmappedChoice, noEntityId, partialCheckbox],
+      definitions,
+    );
+
+    expect(formFields).toBeUndefined();
+    expect(unsendable).toEqual([unmappedChoice, noEntityId, partialCheckbox]);
+  });
+
+  it('skips a cleared date and a cleared dropdown without blocking (not unsendable)', () => {
+    const { formFields, unsendable } = buildFormFieldsInput(
+      [
+        { name: 'fDate', value: '', fieldType: 'date', fieldEntityId: 13 },
+        { name: 'fChoice', value: '', fieldType: 'dropdown', fieldEntityId: 14 },
+      ],
+      definitions,
+    );
+
+    expect(formFields).toBeUndefined();
+    expect(unsendable).toEqual([]);
+  });
+});
+
+describe('buildUpdateCustomerInput', () => {
   it('maps scalar fields, mapping phoneNumber to phone', () => {
     const input = buildUpdateCustomerInput({
       firstName: 'Ada',
@@ -439,97 +529,22 @@ describe('buildUpdateCustomerInput', () => {
     });
   });
 
-  it('routes each form field into its typed group using the fieldEntityId carried on the entry', () => {
+  it('attaches the pre-resolved formFields group', () => {
     const input = buildUpdateCustomerInput(
-      {
-        formFields: [
-          { name: 'fText', value: 'new', fieldType: 'text', fieldEntityId: 10 },
-          { name: 'fMulti', value: 'multi', fieldType: 'multiline', fieldEntityId: 11 },
-          { name: 'Age', value: '25', fieldType: 'number', fieldEntityId: 12 },
-          { name: 'fDate', value: '2026-06-10', fieldType: 'date', fieldEntityId: 13 },
-          { name: 'fChoice', value: 'B', fieldType: 'dropdown', fieldEntityId: 14 },
-          { name: 'fChecks', value: ['x', 'y'], fieldType: 'checkbox', fieldEntityId: 15 },
-        ],
-      },
-      definitions,
+      { firstName: 'Ada' },
+      { texts: [{ fieldEntityId: 10, text: 'new' }] },
     );
 
-    expect(input.formFields).toEqual({
-      texts: [{ fieldEntityId: 10, text: 'new' }],
-      multilineTexts: [{ fieldEntityId: 11, multilineText: 'multi' }],
-      numbers: [{ fieldEntityId: 12, number: 25 }],
-      dates: [{ fieldEntityId: 13, date: '2026-06-10' }],
-      multipleChoices: [{ fieldEntityId: 14, fieldValueEntityId: 100 }],
-      checkboxes: [{ fieldEntityId: 15, fieldValueEntityIds: [7, 8] }],
-    });
-  });
-
-  it('emits scalar fields with no definitions at all (entityId comes from the entry)', () => {
-    const input = buildUpdateCustomerInput({
-      formFields: [{ name: 'Age', value: '25', fieldType: 'number', fieldEntityId: 26 }],
-    });
-
-    expect(input.formFields).toEqual({ numbers: [{ fieldEntityId: 26, number: 25 }] });
-  });
-
-  it('maps a changed choice selection to the picked option entityId', () => {
-    const input = buildUpdateCustomerInput(
-      { formFields: [{ name: 'fChoice', value: 'A', fieldType: 'dropdown', fieldEntityId: 14 }] },
-      definitions,
-    );
-
-    expect(input.formFields?.multipleChoices).toEqual([
-      { fieldEntityId: 14, fieldValueEntityId: 99 },
-    ]);
-  });
-
-  it('skips a choice whose selected label matches no option', () => {
-    const input = buildUpdateCustomerInput(
-      {
-        formFields: [
-          { name: 'fChoice', value: 'not an option', fieldType: 'dropdown', fieldEntityId: 14 },
-        ],
-      },
-      definitions,
-    );
-
-    expect(input.formFields).toBeUndefined();
-  });
-
-  it('skips a form field whose fieldEntityId could not be resolved', () => {
-    const input = buildUpdateCustomerInput({
+    expect(input).toEqual({
       firstName: 'Ada',
-      formFields: [{ name: 'unknown', value: 'x', fieldType: 'text', fieldEntityId: undefined }],
+      formFields: { texts: [{ fieldEntityId: 10, text: 'new' }] },
     });
+  });
+
+  it('does not put the password in the customer input (BC uses changePassword)', () => {
+    const input = buildUpdateCustomerInput({ firstName: 'Ada', newPassword: 'NewPass1!' });
 
     expect(input).toEqual({ firstName: 'Ada' });
-  });
-
-  it('sends an emptied text field (to clear it) but skips emptied number/checkbox fields', () => {
-    // Callers pass only changed fields, so an empty text value is an intentional clear.
-    const input = buildUpdateCustomerInput({
-      formFields: [
-        { name: 'fText', value: '', fieldType: 'text', fieldEntityId: 10 },
-        { name: 'Age', value: '', fieldType: 'number', fieldEntityId: 12 },
-        { name: 'fChecks', value: [], fieldType: 'checkbox', fieldEntityId: 15 },
-      ],
-    });
-
-    expect(input.formFields).toEqual({ texts: [{ fieldEntityId: 10, text: '' }] });
-  });
-
-  it('sends a new password under the Password form field entityId from the definitions', () => {
-    const input = buildUpdateCustomerInput({ newPassword: 'NewPass1!' }, [
-      { __typename: 'PasswordFormField', entityId: 2, label: 'Password' },
-    ]);
-
-    expect(input.formFields).toEqual({ passwords: [{ fieldEntityId: 2, password: 'NewPass1!' }] });
-  });
-
-  it('does not emit a password when the Password field is not in the definitions', () => {
-    const input = buildUpdateCustomerInput({ newPassword: 'NewPass1!' }, definitions);
-
-    expect(input.formFields).toBeUndefined();
   });
 });
 
@@ -554,116 +569,40 @@ describe('buildUpdateCompanyUserInput', () => {
     });
   });
 
-  it('routes form fields into the entityId-keyed groups using the fieldEntityId on each entry', () => {
+  it('attaches the pre-resolved formFields group', () => {
     const input = buildUpdateCompanyUserInput(
-      {
-        formFields: [
-          { name: 'Age', value: '28', fieldType: 'number', fieldEntityId: 26 },
-          { name: 'Middle name', value: 'Lee', fieldType: 'text', fieldEntityId: 27 },
-          { name: 'fChoice', value: 'B', fieldType: 'dropdown', fieldEntityId: 14 },
-        ],
-      },
-      [
-        {
-          __typename: 'MultipleChoicesFormField',
-          entityId: 14,
-          label: 'fChoice',
-          options: [
-            { entityId: 99, label: 'A' },
-            { entityId: 100, label: 'B' },
-          ],
-        },
-      ],
+      { firstName: 'Ada' },
+      { numbers: [{ fieldEntityId: 26, number: 28 }] },
     );
 
-    expect(input.formFields).toEqual({
-      numbers: [{ fieldEntityId: 26, number: 28 }],
-      texts: [{ fieldEntityId: 27, text: 'Lee' }],
-      multipleChoices: [{ fieldEntityId: 14, fieldValueEntityId: 100 }],
-    });
+    expect(input.formFields).toEqual({ numbers: [{ fieldEntityId: 26, number: 28 }] });
   });
 
-  it('omits empty scalars and drops empty form fields', () => {
+  it('routes company-user extra fields into the name-keyed extraFields groups (no entityId)', () => {
     const input = buildUpdateCompanyUserInput({
-      firstName: 'Ada',
-      currentPassword: '',
-      newPassword: '',
-      formFields: [{ name: 'Age', value: '', fieldType: 'number', fieldEntityId: 26 }],
-    });
-
-    expect(input).toEqual({ firstName: 'Ada' });
-  });
-});
-
-describe('getUnsendableFormFields', () => {
-  const definitions: CustomerFormFieldDefinition[] = [
-    {
-      __typename: 'MultipleChoicesFormField',
-      entityId: 14,
-      label: 'fChoice',
-      options: [{ entityId: 99, label: 'A' }],
-    },
-    {
-      __typename: 'CheckboxesFormField',
-      entityId: 15,
-      label: 'fChecks',
-      options: [
-        { entityId: 7, label: 'x' },
-        { entityId: 8, label: 'y' },
+      extraFields: [
+        { name: 'Nickname', value: 'AT', fieldType: 'text' },
+        { name: 'Bio', value: 'hi', fieldType: 'multiline' },
+        { name: 'Age', value: '25', fieldType: 'number' },
+        { name: 'Tier', value: 'Gold', fieldType: 'dropdown' },
       ],
-    },
-  ];
+    } as Partial<ParamProps>);
 
-  it('returns nothing when every field maps', () => {
-    expect(
-      getUnsendableFormFields(
-        [
-          { name: 'fText', value: 'x', fieldType: 'text', fieldEntityId: 10 },
-          { name: 'fChoice', value: 'A', fieldType: 'dropdown', fieldEntityId: 14 },
-        ],
-        definitions,
-      ),
-    ).toEqual([]);
+    expect(input.extraFields).toEqual({
+      texts: [{ name: 'Nickname', text: 'AT' }],
+      multilineTexts: [{ name: 'Bio', multilineText: 'hi' }],
+      numbers: [{ name: 'Age', number: '25' }],
+      multipleChoices: [{ name: 'Tier', fieldValue: 'Gold' }],
+    });
+    expect(input.formFields).toBeUndefined();
   });
 
-  it('flags a choice whose label is not in the definitions', () => {
-    const field = { name: 'fChoice', value: 'B', fieldType: 'dropdown', fieldEntityId: 14 };
-    expect(getUnsendableFormFields([field], definitions)).toEqual([field]);
-  });
+  it('skips an array-valued extra field rather than sending a comma-joined string', () => {
+    const input = buildUpdateCompanyUserInput({
+      extraFields: [{ name: 'Multi', value: ['a', 'b'], fieldType: 'text' }],
+    } as Partial<ParamProps>);
 
-  it('flags a cleared number and a cleared checkbox (no empty form)', () => {
-    const num = { name: 'Age', value: '', fieldType: 'number', fieldEntityId: 12 };
-    const checks = { name: 'Interests', value: [], fieldType: 'checkbox', fieldEntityId: 15 };
-    expect(getUnsendableFormFields([num, checks], definitions)).toEqual([num, checks]);
-  });
-
-  it('flags a field with no resolved entityId', () => {
-    const field = { name: 'Mystery', value: 'x', fieldType: 'text', fieldEntityId: undefined };
-    expect(getUnsendableFormFields([field], definitions)).toEqual([field]);
-  });
-
-  it('flags a checkbox when only some selected labels resolve (no partial send)', () => {
-    const field = {
-      name: 'fChecks',
-      value: ['x', 'unknown'],
-      fieldType: 'checkbox',
-      fieldEntityId: 15,
-    };
-    expect(getUnsendableFormFields([field], definitions)).toEqual([field]);
-  });
-
-  it('does not flag a checkbox when every selected label resolves', () => {
-    const field = { name: 'fChecks', value: ['x', 'y'], fieldType: 'checkbox', fieldEntityId: 15 };
-    expect(getUnsendableFormFields([field], definitions)).toEqual([]);
-  });
-
-  it('does not flag a cleared text field (empty text is a valid clear)', () => {
-    expect(
-      getUnsendableFormFields(
-        [{ name: 'fText', value: '', fieldType: 'text', fieldEntityId: 10 }],
-        definitions,
-      ),
-    ).toEqual([]);
+    expect(input.extraFields).toBeUndefined();
   });
 });
 
@@ -722,5 +661,62 @@ describe('collectChangedFormFields', () => {
       { name: 'Age', value: 25, fieldType: 'number', fieldEntityId: 26 },
       { name: 'Middle name', value: 'Lee', fieldType: 'text', fieldEntityId: 27 },
     ]);
+  });
+
+  it('does not treat an untouched date as changed (ISO original vs YYYY-MM-DD submitted)', () => {
+    const dateFields = [
+      field({ name: 'dob', bcLabel: 'DOB', fieldType: 'date', fieldId: 'field_30', custom: true }),
+    ];
+    // Stored value is a full ISO string; the datepicker submits date-only for the same day.
+    const changed = collectChangedFormFields({ dob: '2026-07-09' }, dateFields, [
+      { name: 'DOB', value: '2026-07-09T00:00:00Z' },
+    ]);
+
+    expect(changed).toEqual([]);
+  });
+
+  it('falls back to the definitions (by label) for entityId when the fieldId is not field_<id>', () => {
+    const nonNumericFields = [
+      field({
+        name: 'nn',
+        bcLabel: 'Age',
+        fieldType: 'number',
+        fieldId: 'field_age',
+        custom: true,
+      }),
+    ];
+    const [result] = collectChangedFormFields(
+      { nn: 25 },
+      nonNumericFields,
+      [],
+      [{ __typename: 'NumberFormField', entityId: 26, label: 'Age' }],
+    );
+
+    expect(result.fieldEntityId).toBe(26);
+  });
+});
+
+describe('collectChangedExtraFields', () => {
+  // Company-user extra fields are the custom contact-group (groupId 1) fields, keyed by the
+  // decoded field name and matched against the read's extraFields (fieldName/fieldValue).
+  const nicknameField = Base64.encode('nickname');
+  const fields = [
+    field({ name: nicknameField, fieldType: 'text', custom: true, groupId: 1 }),
+    // groupId 2 (a form field) is not an extra field.
+    field({ name: 'field_26', bcLabel: 'Age', fieldType: 'number', custom: true, groupId: 2 }),
+  ];
+
+  it('collects only changed groupId-1 custom fields, keyed by decoded field name', () => {
+    const data = { [nicknameField]: 'AT', field_26: 25 };
+    expect(
+      collectChangedExtraFields(data, fields, [{ fieldName: 'nickname', fieldValue: '' }]),
+    ).toEqual([{ name: 'nickname', value: 'AT', fieldType: 'text' }]);
+  });
+
+  it('drops an extra field whose value matches the original', () => {
+    const data = { [nicknameField]: 'AT' };
+    expect(
+      collectChangedExtraFields(data, fields, [{ fieldName: 'nickname', fieldValue: 'AT' }]),
+    ).toEqual([]);
   });
 });

--- a/apps/storefront/src/pages/AccountSetting/utils.test.ts
+++ b/apps/storefront/src/pages/AccountSetting/utils.test.ts
@@ -517,6 +517,20 @@ describe('buildUpdateCustomerInput', () => {
 
     expect(input.formFields).toEqual({ texts: [{ fieldEntityId: 10, text: '' }] });
   });
+
+  it('sends a new password under the Password form field entityId from the definitions', () => {
+    const input = buildUpdateCustomerInput({ newPassword: 'NewPass1!' }, [
+      { __typename: 'PasswordFormField', entityId: 2, label: 'Password' },
+    ]);
+
+    expect(input.formFields).toEqual({ passwords: [{ fieldEntityId: 2, password: 'NewPass1!' }] });
+  });
+
+  it('does not emit a password when the Password field is not in the definitions', () => {
+    const input = buildUpdateCustomerInput({ newPassword: 'NewPass1!' }, definitions);
+
+    expect(input.formFields).toBeUndefined();
+  });
 });
 
 describe('buildUpdateCompanyUserInput', () => {

--- a/apps/storefront/src/pages/AccountSetting/utils.test.ts
+++ b/apps/storefront/src/pages/AccountSetting/utils.test.ts
@@ -498,7 +498,12 @@ describe('buildFormFieldsInput', () => {
 
   it('flags a cleared date and a cleared dropdown as unsendable (no empty form to send)', () => {
     const clearedDate = { name: 'fDate', value: '', fieldType: 'date', fieldEntityId: 13 };
-    const clearedDropdown = { name: 'fChoice', value: '', fieldType: 'dropdown', fieldEntityId: 14 };
+    const clearedDropdown = {
+      name: 'fChoice',
+      value: '',
+      fieldType: 'dropdown',
+      fieldEntityId: 14,
+    };
     const { formFields, unsendable } = buildFormFieldsInput(
       [clearedDate, clearedDropdown],
       definitions,

--- a/apps/storefront/src/pages/AccountSetting/utils.test.ts
+++ b/apps/storefront/src/pages/AccountSetting/utils.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import type {
   AccountSettingExtraFieldValue,
   CompanyUser,
+  CustomerFormFieldDefinition,
   FormFieldValue,
 } from '@/shared/service/bc/graphql/accountSetting';
 import type { Fields } from '@/types/accountSetting';
@@ -11,9 +12,13 @@ import { Base64 } from '@/utils/base64';
 import {
   b2bSubmitDataProcessing,
   bcSubmitDataProcessing,
+  buildUpdateCompanyUserInput,
+  buildUpdateCustomerInput,
+  collectChangedFormFields,
   initB2BInfo,
   initBcInfo,
   mapUserToAccountInfo,
+  parseFieldEntityId,
 } from './utils';
 
 // `deCodeField` Base64-decodes every field name except those in the
@@ -388,5 +393,247 @@ describe('mapUserToAccountInfo', () => {
     expect(result.formFields).toEqual([{ name: 'fText', value: 'a' }]);
     expect(result.extraFields).not.toContain(undefined);
     expect(result.formFields).not.toContain(undefined);
+  });
+});
+
+describe('buildUpdateCustomerInput', () => {
+  // Choice fields need their options (entityId per label) from the definitions; scalar
+  // fields only need the fieldEntityId carried on each submitted entry.
+  const definitions: CustomerFormFieldDefinition[] = [
+    {
+      __typename: 'MultipleChoicesFormField',
+      entityId: 14,
+      label: 'fChoice',
+      options: [
+        { entityId: 99, label: 'A' },
+        { entityId: 100, label: 'B' },
+      ],
+    },
+    {
+      __typename: 'CheckboxesFormField',
+      entityId: 15,
+      label: 'fChecks',
+      options: [
+        { entityId: 7, label: 'x' },
+        { entityId: 8, label: 'y' },
+      ],
+    },
+  ];
+
+  it('maps scalar fields, mapping phoneNumber to phone', () => {
+    const input = buildUpdateCustomerInput({
+      firstName: 'Ada',
+      lastName: 'Lovelace',
+      email: 'ada@example.com',
+      company: 'AE',
+      phoneNumber: '5551234',
+    });
+
+    expect(input).toEqual({
+      firstName: 'Ada',
+      lastName: 'Lovelace',
+      email: 'ada@example.com',
+      company: 'AE',
+      phone: '5551234',
+    });
+  });
+
+  it('routes each form field into its typed group using the fieldEntityId carried on the entry', () => {
+    const input = buildUpdateCustomerInput(
+      {
+        formFields: [
+          { name: 'fText', value: 'new', fieldType: 'text', fieldEntityId: 10 },
+          { name: 'fMulti', value: 'multi', fieldType: 'multiline', fieldEntityId: 11 },
+          { name: 'Age', value: '25', fieldType: 'number', fieldEntityId: 12 },
+          { name: 'fDate', value: '2026-06-10', fieldType: 'date', fieldEntityId: 13 },
+          { name: 'fChoice', value: 'B', fieldType: 'dropdown', fieldEntityId: 14 },
+          { name: 'fChecks', value: ['x', 'y'], fieldType: 'checkbox', fieldEntityId: 15 },
+        ],
+      },
+      definitions,
+    );
+
+    expect(input.formFields).toEqual({
+      texts: [{ fieldEntityId: 10, text: 'new' }],
+      multilineTexts: [{ fieldEntityId: 11, multilineText: 'multi' }],
+      numbers: [{ fieldEntityId: 12, number: 25 }],
+      dates: [{ fieldEntityId: 13, date: '2026-06-10' }],
+      multipleChoices: [{ fieldEntityId: 14, fieldValueEntityId: 100 }],
+      checkboxes: [{ fieldEntityId: 15, fieldValueEntityIds: [7, 8] }],
+    });
+  });
+
+  it('emits scalar fields with no definitions at all (entityId comes from the entry)', () => {
+    const input = buildUpdateCustomerInput({
+      formFields: [{ name: 'Age', value: '25', fieldType: 'number', fieldEntityId: 26 }],
+    });
+
+    expect(input.formFields).toEqual({ numbers: [{ fieldEntityId: 26, number: 25 }] });
+  });
+
+  it('maps a changed choice selection to the picked option entityId', () => {
+    const input = buildUpdateCustomerInput(
+      { formFields: [{ name: 'fChoice', value: 'A', fieldType: 'dropdown', fieldEntityId: 14 }] },
+      definitions,
+    );
+
+    expect(input.formFields?.multipleChoices).toEqual([
+      { fieldEntityId: 14, fieldValueEntityId: 99 },
+    ]);
+  });
+
+  it('skips a choice whose selected label matches no option', () => {
+    const input = buildUpdateCustomerInput(
+      {
+        formFields: [
+          { name: 'fChoice', value: 'not an option', fieldType: 'dropdown', fieldEntityId: 14 },
+        ],
+      },
+      definitions,
+    );
+
+    expect(input.formFields).toBeUndefined();
+  });
+
+  it('skips a form field whose fieldEntityId could not be resolved', () => {
+    const input = buildUpdateCustomerInput({
+      firstName: 'Ada',
+      formFields: [{ name: 'unknown', value: 'x', fieldType: 'text', fieldEntityId: undefined }],
+    });
+
+    expect(input).toEqual({ firstName: 'Ada' });
+  });
+
+  it('sends an emptied text field (to clear it) but skips emptied number/checkbox fields', () => {
+    // Callers pass only changed fields, so an empty text value is an intentional clear.
+    const input = buildUpdateCustomerInput({
+      formFields: [
+        { name: 'fText', value: '', fieldType: 'text', fieldEntityId: 10 },
+        { name: 'Age', value: '', fieldType: 'number', fieldEntityId: 12 },
+        { name: 'fChecks', value: [], fieldType: 'checkbox', fieldEntityId: 15 },
+      ],
+    });
+
+    expect(input.formFields).toEqual({ texts: [{ fieldEntityId: 10, text: '' }] });
+  });
+});
+
+describe('buildUpdateCompanyUserInput', () => {
+  it('maps scalar fields including current/new password (no company field)', () => {
+    const input = buildUpdateCompanyUserInput({
+      firstName: 'Ada',
+      lastName: 'Lovelace',
+      email: 'ada@example.com',
+      phoneNumber: '5551234',
+      currentPassword: 'old-pass',
+      newPassword: 'new-pass',
+    });
+
+    expect(input).toEqual({
+      firstName: 'Ada',
+      lastName: 'Lovelace',
+      email: 'ada@example.com',
+      phone: '5551234',
+      currentPassword: 'old-pass',
+      newPassword: 'new-pass',
+    });
+  });
+
+  it('routes form fields into the entityId-keyed groups using the fieldEntityId on each entry', () => {
+    const input = buildUpdateCompanyUserInput(
+      {
+        formFields: [
+          { name: 'Age', value: '28', fieldType: 'number', fieldEntityId: 26 },
+          { name: 'Middle name', value: 'Lee', fieldType: 'text', fieldEntityId: 27 },
+          { name: 'fChoice', value: 'B', fieldType: 'dropdown', fieldEntityId: 14 },
+        ],
+      },
+      [
+        {
+          __typename: 'MultipleChoicesFormField',
+          entityId: 14,
+          label: 'fChoice',
+          options: [
+            { entityId: 99, label: 'A' },
+            { entityId: 100, label: 'B' },
+          ],
+        },
+      ],
+    );
+
+    expect(input.formFields).toEqual({
+      numbers: [{ fieldEntityId: 26, number: 28 }],
+      texts: [{ fieldEntityId: 27, text: 'Lee' }],
+      multipleChoices: [{ fieldEntityId: 14, fieldValueEntityId: 100 }],
+    });
+  });
+
+  it('omits empty scalars and drops empty form fields', () => {
+    const input = buildUpdateCompanyUserInput({
+      firstName: 'Ada',
+      currentPassword: '',
+      newPassword: '',
+      formFields: [{ name: 'Age', value: '', fieldType: 'number', fieldEntityId: 26 }],
+    });
+
+    expect(input).toEqual({ firstName: 'Ada' });
+  });
+});
+
+describe('parseFieldEntityId', () => {
+  it('extracts the numeric entityId from a field_<id> fieldId', () => {
+    expect(parseFieldEntityId('field_26')).toBe(26);
+  });
+
+  it('returns undefined for non-matching or missing fieldIds', () => {
+    expect(parseFieldEntityId('field_email')).toBeUndefined();
+    expect(parseFieldEntityId('26')).toBeUndefined();
+    expect(parseFieldEntityId(undefined)).toBeUndefined();
+  });
+});
+
+describe('collectChangedFormFields', () => {
+  const fields = [
+    field({
+      name: 'field_26',
+      bcLabel: 'Age',
+      fieldType: 'number',
+      fieldId: 'field_26',
+      custom: true,
+    }),
+    field({
+      name: 'field_27',
+      bcLabel: 'Middle name',
+      fieldType: 'text',
+      fieldId: 'field_27',
+      custom: true,
+    }),
+    // Non-custom contact field is skipped.
+    field({ name: firstNameField, bcLabel: 'First Name', fieldId: 'field_first_name' }),
+  ];
+  const data = { field_26: 25, field_27: 'Lee', [firstNameField]: 'Ada' };
+
+  it('collects only custom fields, keyed by bcLabel with the parsed fieldEntityId', () => {
+    expect(collectChangedFormFields(data, fields, [])).toEqual([
+      { name: 'Age', value: 25, fieldType: 'number', fieldEntityId: 26 },
+      { name: 'Middle name', value: 'Lee', fieldType: 'text', fieldEntityId: 27 },
+    ]);
+  });
+
+  it('drops fields whose value matches the original, normalizing typed vs string values', () => {
+    // Age stored as the JS number 25 equals the string form value; Middle name changed.
+    expect(
+      collectChangedFormFields(data, fields, [
+        { name: 'Age', value: 25 },
+        { name: 'Middle name', value: 'Lee' },
+      ]),
+    ).toEqual([]);
+  });
+
+  it('keeps a field whose value differs from the original', () => {
+    expect(collectChangedFormFields(data, fields, [{ name: 'Age', value: 24 }])).toEqual([
+      { name: 'Age', value: 25, fieldType: 'number', fieldEntityId: 26 },
+      { name: 'Middle name', value: 'Lee', fieldType: 'text', fieldEntityId: 27 },
+    ]);
   });
 });

--- a/apps/storefront/src/pages/AccountSetting/utils.test.ts
+++ b/apps/storefront/src/pages/AccountSetting/utils.test.ts
@@ -113,6 +113,27 @@ describe('initB2BInfo', () => {
     expect(unmatched.default).toBeUndefined();
   });
 
+  it('clears the registerUtils today placeholder when a date field has no stored value', () => {
+    const additionalInformation = [
+      field({ bcLabel: 'DOB', label: 'DOB', fieldType: 'date', default: '2026-07-29' }),
+    ];
+
+    const [result] = initB2BInfo({ formFields: [] }, [], [], additionalInformation);
+
+    expect(result.default).toBe('');
+  });
+
+  it('clears the today placeholder for an unset date extra field in contact information', () => {
+    const dobField = Base64.encode('dob');
+    const contactInformation = [
+      field({ name: dobField, fieldType: 'date', custom: true, default: '2026-07-29' }),
+    ];
+
+    const [result] = initB2BInfo({ ...accountInfo, extraFields: [] }, contactInformation, [], []);
+
+    expect(result.default).toBe('');
+  });
+
   it('handles missing extraFields and formFields without throwing', () => {
     const contactInformation = [field({ name: firstNameField })];
 
@@ -152,6 +173,28 @@ describe('initBcInfo', () => {
     const [result] = initBcInfo(accountInfo, [], additionalInformation);
 
     expect(result.default).toBe('Weekly');
+  });
+
+  it('clears the registerUtils today placeholder when a date field has no stored value', () => {
+    const additionalInformation = [
+      field({ bcLabel: 'DOB', label: 'DOB', fieldType: 'date', default: '2026-07-29' }),
+    ];
+
+    const [result] = initBcInfo({ formFields: [] }, [], additionalInformation);
+
+    expect(result.default).toBe('');
+  });
+
+  it('keeps a stored date default for additional information fields', () => {
+    const additionalInformation = [field({ bcLabel: 'DOB', label: 'DOB', fieldType: 'date' })];
+
+    const [result] = initBcInfo(
+      { formFields: [{ name: 'DOB', value: '2026-06-10T00:00:00Z' }] },
+      [],
+      additionalInformation,
+    );
+
+    expect(result.default).toBe('2026-06-10T00:00:00Z');
   });
 });
 
@@ -723,6 +766,21 @@ describe('collectChangedFormFields', () => {
     ]);
 
     expect(changed).toEqual([]);
+  });
+
+  it('does not report an unset date field as changed when the form value is blank', () => {
+    const dateFields = [
+      field({
+        name: 'dob',
+        bcLabel: 'DOB',
+        fieldType: 'date',
+        fieldId: 'field_30',
+        custom: true,
+        default: '',
+      }),
+    ];
+
+    expect(collectChangedFormFields({ dob: '' }, dateFields, [])).toEqual([]);
   });
 
   it('falls back to the definitions (by label) for entityId when the fieldId is not field_<id>', () => {

--- a/apps/storefront/src/pages/AccountSetting/utils.test.ts
+++ b/apps/storefront/src/pages/AccountSetting/utils.test.ts
@@ -134,6 +134,24 @@ describe('initB2BInfo', () => {
     expect(result.default).toBe('');
   });
 
+  it('keeps the incoming placeholder for an unset date field when useBcAccountSettings is false', () => {
+    const additionalInformation = [
+      field({ bcLabel: 'DOB', label: 'DOB', fieldType: 'date', default: '2026-07-29' }),
+    ];
+
+    const [result] = initB2BInfo({ formFields: [] }, [], [], additionalInformation, false);
+
+    expect(result.default).toBe('2026-07-29');
+  });
+
+  it('does not fall back to matching by label when useBcAccountSettings is false', () => {
+    const additionalInformation = [field({ label: 'Newsletter' })];
+
+    const [result] = initB2BInfo(accountInfo, [], [], additionalInformation, false);
+
+    expect(result.default).toBeUndefined();
+  });
+
   it('handles missing extraFields and formFields without throwing', () => {
     const contactInformation = [field({ name: firstNameField })];
 
@@ -183,6 +201,24 @@ describe('initBcInfo', () => {
     const [result] = initBcInfo({ formFields: [] }, [], additionalInformation);
 
     expect(result.default).toBe('');
+  });
+
+  it('keeps the incoming placeholder for an unset date field when useBcAccountSettings is false', () => {
+    const additionalInformation = [
+      field({ bcLabel: 'DOB', label: 'DOB', fieldType: 'date', default: '2026-07-29' }),
+    ];
+
+    const [result] = initBcInfo({ formFields: [] }, [], additionalInformation, false);
+
+    expect(result.default).toBe('2026-07-29');
+  });
+
+  it('does not fall back to matching by label when useBcAccountSettings is false', () => {
+    const additionalInformation = [field({ label: 'Newsletter' })];
+
+    const [result] = initBcInfo(accountInfo, [], additionalInformation, false);
+
+    expect(result.default).toBeUndefined();
   });
 
   it('keeps a stored date default for additional information fields', () => {
@@ -304,6 +340,44 @@ describe('bcSubmitDataProcessing', () => {
     const result = bcSubmitDataProcessing(data, accountInfo, decryptionFields, []);
 
     expect(result).toMatchObject({ firstName: 'Grace', company: 'New Co' });
+  });
+
+  it('omits unchanged contact fields from the payload by default (native path)', () => {
+    const data = {
+      [firstNameField]: 'Grace',
+      [lastNameField]: 'Lovelace',
+      [phoneField]: '5551234',
+      [emailField]: 'ada@example.com',
+      [companyField]: 'Analytical Engines',
+    };
+
+    const result = bcSubmitDataProcessing(data, accountInfo, decryptionFields, []);
+
+    expect(result).toMatchObject({ firstName: 'Grace' });
+    expect(result).not.toHaveProperty('lastName');
+    expect(result).not.toHaveProperty('phoneNumber');
+    expect(result).not.toHaveProperty('email');
+    expect(result).not.toHaveProperty('company');
+  });
+
+  it('always includes unchanged contact fields when useBcAccountSettings is false (legacy payload shape)', () => {
+    const data = {
+      [firstNameField]: 'Grace',
+      [lastNameField]: 'Lovelace',
+      [phoneField]: '5551234',
+      [emailField]: 'ada@example.com',
+      [companyField]: 'Analytical Engines',
+    };
+
+    const result = bcSubmitDataProcessing(data, accountInfo, decryptionFields, [], false);
+
+    expect(result).toMatchObject({
+      firstName: 'Grace',
+      lastName: 'Lovelace',
+      phoneNumber: '5551234',
+      email: 'ada@example.com',
+      company: 'Analytical Engines',
+    });
   });
 
   it('pushes form-field changes and maps password to newPassword', () => {
@@ -802,6 +876,32 @@ describe('collectChangedFormFields', () => {
 
     expect(result.fieldEntityId).toBe(26);
   });
+
+  it('keeps a required field unchanged — BC revalidates required fields on every update', () => {
+    const requiredFields = [
+      field({
+        name: 'field_26',
+        bcLabel: 'Age',
+        fieldType: 'number',
+        fieldId: 'field_26',
+        custom: true,
+        required: true,
+      }),
+    ];
+
+    expect(
+      collectChangedFormFields({ field_26: 25 }, requiredFields, [{ name: 'Age', value: 25 }]),
+    ).toEqual([
+      {
+        name: 'Age',
+        value: 25,
+        fieldType: 'number',
+        fieldEntityId: 26,
+        formName: 'field_26',
+        required: true,
+      },
+    ]);
+  });
 });
 
 describe('collectChangedExtraFields', () => {
@@ -826,5 +926,20 @@ describe('collectChangedExtraFields', () => {
     expect(
       collectChangedExtraFields(data, fields, [{ fieldName: 'nickname', fieldValue: 'AT' }]),
     ).toEqual([]);
+  });
+
+  it('keeps a required extra field unchanged — BC revalidates required fields on every update', () => {
+    const requiredFields = [
+      field({ name: nicknameField, fieldType: 'text', custom: true, groupId: 1, required: true }),
+    ];
+    const data = { [nicknameField]: 'AT' };
+
+    expect(
+      collectChangedExtraFields(data, requiredFields, [
+        { fieldName: 'nickname', fieldValue: 'AT' },
+      ]),
+    ).toEqual([
+      { name: 'nickname', value: 'AT', fieldType: 'text', formName: nicknameField, required: true },
+    ]);
   });
 });

--- a/apps/storefront/src/pages/AccountSetting/utils.test.ts
+++ b/apps/storefront/src/pages/AccountSetting/utils.test.ts
@@ -650,8 +650,14 @@ describe('collectChangedFormFields', () => {
 
   it('collects only custom fields, keyed by bcLabel with the parsed fieldEntityId', () => {
     expect(collectChangedFormFields(data, fields, [])).toEqual([
-      { name: 'Age', value: 25, fieldType: 'number', fieldEntityId: 26 },
-      { name: 'Middle name', value: 'Lee', fieldType: 'text', fieldEntityId: 27 },
+      { name: 'Age', value: 25, fieldType: 'number', fieldEntityId: 26, formName: 'field_26' },
+      {
+        name: 'Middle name',
+        value: 'Lee',
+        fieldType: 'text',
+        fieldEntityId: 27,
+        formName: 'field_27',
+      },
     ]);
   });
 
@@ -667,8 +673,14 @@ describe('collectChangedFormFields', () => {
 
   it('keeps a field whose value differs from the original', () => {
     expect(collectChangedFormFields(data, fields, [{ name: 'Age', value: 24 }])).toEqual([
-      { name: 'Age', value: 25, fieldType: 'number', fieldEntityId: 26 },
-      { name: 'Middle name', value: 'Lee', fieldType: 'text', fieldEntityId: 27 },
+      { name: 'Age', value: 25, fieldType: 'number', fieldEntityId: 26, formName: 'field_26' },
+      {
+        name: 'Middle name',
+        value: 'Lee',
+        fieldType: 'text',
+        fieldEntityId: 27,
+        formName: 'field_27',
+      },
     ]);
   });
 
@@ -690,7 +702,15 @@ describe('collectChangedFormFields', () => {
     // Changed → keyed by label, entityId parsed from fieldId.
     expect(
       collectChangedFormFields({ field_28: 'y' }, labelOnly, [{ name: 'Preferences', value: 'x' }]),
-    ).toEqual([{ name: 'Preferences', value: 'y', fieldType: 'text', fieldEntityId: 28 }]);
+    ).toEqual([
+      {
+        name: 'Preferences',
+        value: 'y',
+        fieldType: 'text',
+        fieldEntityId: 28,
+        formName: 'field_28',
+      },
+    ]);
   });
 
   it('does not treat an untouched date as changed (ISO original vs YYYY-MM-DD submitted)', () => {
@@ -740,7 +760,7 @@ describe('collectChangedExtraFields', () => {
     const data = { [nicknameField]: 'AT', field_26: 25 };
     expect(
       collectChangedExtraFields(data, fields, [{ fieldName: 'nickname', fieldValue: '' }]),
-    ).toEqual([{ name: 'nickname', value: 'AT', fieldType: 'text' }]);
+    ).toEqual([{ name: 'nickname', value: 'AT', fieldType: 'text', formName: nicknameField }]);
   });
 
   it('drops an extra field whose value matches the original', () => {

--- a/apps/storefront/src/pages/AccountSetting/utils.ts
+++ b/apps/storefront/src/pages/AccountSetting/utils.ts
@@ -414,17 +414,27 @@ export function buildFormFieldsInput(
   return { formFields: Object.keys(formFields).length > 0 ? formFields : undefined, unsendable };
 }
 
-function buildExtraFieldsInput(
-  submitted: Array<{ name: string; value: unknown; fieldType?: string }> | undefined,
-): CompanyUserExtraFieldsInput | undefined {
+type ExtraFieldEntry = { name: string; value: unknown; fieldType?: string };
+
+// Builds the name-keyed CompanyUserExtraFieldsInput from changed company-user extra fields.
+// The extraFields groups (texts/multilineTexts/numbers/multipleChoices) are all scalar, so an
+// array value (e.g. a contact-group checkbox) can't be represented — it's reported in
+// `unsendable` so the caller can fail loudly instead of silently dropping the edit.
+export function buildExtraFieldsInput(submitted: ExtraFieldEntry[] | undefined): {
+  extraFields?: CompanyUserExtraFieldsInput;
+  unsendable: ExtraFieldEntry[];
+} {
   const extraFields: CompanyUserExtraFieldsInput = {};
+  const unsendable: ExtraFieldEntry[] = [];
   const seen = new Set<string>();
 
-  (submitted ?? []).forEach(({ name, value, fieldType }) => {
+  (submitted ?? []).forEach((entry) => {
+    const { name, value, fieldType } = entry;
     if (!name || seen.has(name)) return;
-    // Company-user extra fields have no multi-value (checkbox) group, so an array value can't
-    // be represented — skip it rather than coerce it into a comma-joined string.
-    if (Array.isArray(value)) return;
+    if (Array.isArray(value)) {
+      unsendable.push(entry);
+      return;
+    }
     seen.add(name);
     const text = String(value ?? '');
     switch (fieldType) {
@@ -445,7 +455,7 @@ function buildExtraFieldsInput(
     }
   });
 
-  return Object.keys(extraFields).length > 0 ? extraFields : undefined;
+  return { extraFields: Object.keys(extraFields).length > 0 ? extraFields : undefined, unsendable };
 }
 
 // Contact scalars shared by both mutation inputs (phoneNumber -> phone).
@@ -475,6 +485,7 @@ export function buildUpdateCustomerInput(
 export function buildUpdateCompanyUserInput(
   payload: Partial<ParamProps>,
   formFields?: CustomerFormFieldsInput,
+  extraFields?: CompanyUserExtraFieldsInput,
 ): UpdateCompanyUserInput {
   const input: UpdateCompanyUserInput = {};
 
@@ -482,11 +493,7 @@ export function buildUpdateCompanyUserInput(
   if (payload.currentPassword) input.currentPassword = payload.currentPassword as string;
   if (payload.newPassword) input.newPassword = payload.newPassword as string;
   if (formFields && Object.keys(formFields).length > 0) input.formFields = formFields;
-
-  const extraFields = buildExtraFieldsInput(
-    payload.extraFields as Array<{ name: string; value: unknown; fieldType?: string }> | undefined,
-  );
-  if (extraFields) input.extraFields = extraFields;
+  if (extraFields && Object.keys(extraFields).length > 0) input.extraFields = extraFields;
 
   return input;
 }

--- a/apps/storefront/src/pages/AccountSetting/utils.ts
+++ b/apps/storefront/src/pages/AccountSetting/utils.ts
@@ -1,7 +1,11 @@
 import {
   AccountSettingExtraFieldValue as ExtraFieldValue,
   CompanyUser,
+  CustomerFormFieldDefinition,
+  CustomerFormFieldsInput,
   FormFieldValue,
+  UpdateCompanyUserInput,
+  UpdateCustomerInput,
 } from '@/shared/service/bc/graphql/accountSetting';
 import { Fields, ParamProps } from '@/types/accountSetting';
 import { deCodeField } from '@/utils/registerUtils';
@@ -238,6 +242,7 @@ export const bcSubmitDataProcessing = (
           param.formFields.push({
             name: field?.bcLabel || '',
             value: data[key],
+            fieldType: field.fieldType,
           });
           flag = false;
           const account = (accountSettings?.formFields || []).find(
@@ -266,6 +271,184 @@ export const bcSubmitDataProcessing = (
 
   return param;
 };
+
+// Choice field types whose selected option must be resolved to an entityId via the
+// form-field definitions (the mutations take an id, not a label). Kept as one exported
+// list so the "which fields need definitions" gate and the emit routing can't drift apart.
+export const CHOICE_FIELD_TYPES = ['dropdown', 'radio', 'checkbox'];
+export const fieldTypeNeedsOptions = (fieldType?: string): boolean =>
+  CHOICE_FIELD_TYPES.includes(fieldType ?? '');
+
+// Normalizes a stored or submitted value for change comparison so a typed stored value
+// (number 25, string[] ['a']) and its string form value ('25', ['a']) compare equal.
+function normalizeForCompare(value: unknown): string {
+  if (value === null || value === undefined) return '';
+  if (Array.isArray(value)) return JSON.stringify(value);
+  return String(value);
+}
+
+// Coerces a submitted value to a finite number, or undefined when empty/non-numeric,
+// so a cleared Number field is skipped rather than written as 0 (Number('') === 0).
+function toFiniteNumber(value: unknown): number | undefined {
+  if (value === '' || value === null || value === undefined) return undefined;
+  const num = Number(value);
+  return Number.isFinite(num) ? num : undefined;
+}
+
+// Builds the shared entityId-keyed form-field groups for customer.updateCustomer and
+// company.updateCompanyUser. Each submitted field carries its fieldEntityId (parsed from
+// the form config's `field_<id>` fieldId). Callers pass only *changed* fields, so an empty
+// text/multiline/date value is an intentional clear and is sent through; number and choice
+// fields can't represent "empty" in their typed group, so a cleared one is skipped. Choice
+// selections map the picked option's label to its own entityId via the definitions.
+// Returns undefined when nothing maps.
+function buildFormFieldsInput(
+  submitted: Partial<ParamProps>['formFields'],
+  definitions: CustomerFormFieldDefinition[],
+): CustomerFormFieldsInput | undefined {
+  const defByEntityId = new Map(definitions.map((def) => [def.entityId, def]));
+  const formFields: CustomerFormFieldsInput = {};
+  const seen = new Set<number>();
+
+  const optionEntityId = (fieldEntityId: number, value: unknown) =>
+    defByEntityId.get(fieldEntityId)?.options?.find((option) => option.label === String(value))
+      ?.entityId;
+
+  const emit = (
+    fieldEntityId: number | undefined,
+    fieldType: string | undefined,
+    value: unknown,
+  ) => {
+    if (fieldEntityId === undefined || seen.has(fieldEntityId)) return;
+    switch (fieldType) {
+      case 'multiline':
+        seen.add(fieldEntityId);
+        (formFields.multilineTexts ??= []).push({
+          fieldEntityId,
+          multilineText: String(value ?? ''),
+        });
+        break;
+      case 'number': {
+        const num = toFiniteNumber(value);
+        if (num === undefined) return;
+        seen.add(fieldEntityId);
+        (formFields.numbers ??= []).push({ fieldEntityId, number: num });
+        break;
+      }
+      case 'date':
+        seen.add(fieldEntityId);
+        (formFields.dates ??= []).push({ fieldEntityId, date: String(value ?? '') });
+        break;
+      case 'dropdown':
+      case 'radio': {
+        const fieldValueEntityId = optionEntityId(fieldEntityId, value);
+        if (fieldValueEntityId === undefined) return;
+        seen.add(fieldEntityId);
+        (formFields.multipleChoices ??= []).push({ fieldEntityId, fieldValueEntityId });
+        break;
+      }
+      case 'checkbox': {
+        const values = Array.isArray(value) ? value : [value];
+        const fieldValueEntityIds = values
+          .map((choice) => optionEntityId(fieldEntityId, choice))
+          .filter((id): id is number => id !== undefined);
+        if (fieldValueEntityIds.length === 0) return;
+        seen.add(fieldEntityId);
+        (formFields.checkboxes ??= []).push({ fieldEntityId, fieldValueEntityIds });
+        break;
+      }
+      case 'text':
+      default:
+        seen.add(fieldEntityId);
+        (formFields.texts ??= []).push({ fieldEntityId, text: String(value ?? '') });
+        break;
+    }
+  };
+
+  (submitted ?? []).forEach(({ fieldEntityId, value, fieldType }) =>
+    emit(fieldEntityId, fieldType, value),
+  );
+
+  return Object.keys(formFields).length > 0 ? formFields : undefined;
+}
+
+// Contact scalars shared by both mutation inputs (phoneNumber -> phone).
+function assignSharedScalars(
+  input: Pick<UpdateCustomerInput, 'firstName' | 'lastName' | 'email' | 'phone'>,
+  payload: Partial<ParamProps>,
+): void {
+  if (payload.firstName !== undefined) input.firstName = payload.firstName as string;
+  if (payload.lastName !== undefined) input.lastName = payload.lastName as string;
+  if (payload.email !== undefined) input.email = payload.email as string;
+  if (payload.phoneNumber !== undefined) input.phone = payload.phoneNumber as string;
+}
+
+// Builds the BC-native customer.updateCustomer input from the submit payload.
+export function buildUpdateCustomerInput(
+  payload: Partial<ParamProps>,
+  definitions: CustomerFormFieldDefinition[] = [],
+): UpdateCustomerInput {
+  const input: UpdateCustomerInput = {};
+
+  assignSharedScalars(input, payload);
+  if (payload.company !== undefined) input.company = payload.company as string;
+
+  const formFields = buildFormFieldsInput(payload.formFields, definitions);
+  if (formFields) input.formFields = formFields;
+
+  return input;
+}
+
+// Builds the B2B company.updateCompanyUser input. Form fields use the same entityId-keyed
+// shape as customer.updateCustomer; the scalars carry current/new password instead of company.
+export function buildUpdateCompanyUserInput(
+  payload: Partial<ParamProps>,
+  definitions: CustomerFormFieldDefinition[] = [],
+): UpdateCompanyUserInput {
+  const input: UpdateCompanyUserInput = {};
+
+  assignSharedScalars(input, payload);
+  if (payload.currentPassword) input.currentPassword = payload.currentPassword as string;
+  if (payload.newPassword) input.newPassword = payload.newPassword as string;
+
+  const formFields = buildFormFieldsInput(payload.formFields, definitions);
+  if (formFields) input.formFields = formFields;
+
+  return input;
+}
+
+// Parses the numeric form-field entityId encoded in a `field_<id>` config fieldId
+// (e.g. "field_26" -> 26). Returns undefined when the fieldId isn't in that shape.
+export function parseFieldEntityId(fieldId?: string): number | undefined {
+  const match = /^field_(\d+)$/.exec(fieldId ?? '');
+  return match ? Number(match[1]) : undefined;
+}
+
+// Collects the custom form fields for the native SF GQL updates straight from the form
+// values and returns only the ones that actually CHANGED from their stored original. The
+// form registers each field under `name` (the submit processor's fieldId capture misses
+// them), so read data[item.name]; the entityId the mutations need is encoded in the
+// `field_<id>` fieldId. Values are normalized before comparison so a typed stored value
+// (number/array) and its string form value don't read as a spurious change, and an unchanged
+// field isn't re-sent on an unrelated edit.
+export function collectChangedFormFields(
+  data: CustomFieldItems,
+  accountInfoFormFields: Partial<Fields>[],
+  originalFormFields: Array<{ name?: string; value?: unknown }>,
+): NonNullable<ParamProps['formFields']> {
+  return accountInfoFormFields
+    .filter((item) => item.custom)
+    .map((item) => ({
+      name: item.bcLabel || '',
+      value: data[item.name || ''],
+      fieldType: item.fieldType,
+      fieldEntityId: parseFieldEntityId(item.fieldId),
+    }))
+    .filter((formField) => {
+      const original = originalFormFields.find((item) => item.name === formField.name);
+      return normalizeForCompare(original?.value) !== normalizeForCompare(formField.value);
+    });
+}
 
 function extractExtraFieldValue(field: ExtraFieldValue) {
   switch (field.__typename) {

--- a/apps/storefront/src/pages/AccountSetting/utils.ts
+++ b/apps/storefront/src/pages/AccountSetting/utils.ts
@@ -307,10 +307,11 @@ function toIsoDateTime(raw: string): string | undefined {
 // Builds the shared entityId-keyed form-field groups for customer.updateCustomer and
 // company.updateCompanyUser. Each submitted field carries its fieldEntityId (parsed from
 // the form config's `field_<id>` fieldId). Callers pass only *changed* fields, so an empty
-// text/multiline/date value is an intentional clear and is sent through. A field that can't
-// be represented — missing fieldEntityId, an unmapped choice label, or a cleared number/
-// checkbox (no empty form) — is collected into `unsendable` instead, so the caller can fail
-// loudly rather than report a save that silently dropped the user's edit.
+// text/multiline value ('') and an empty checkbox selection ([]) are intentional clears that
+// the input can represent, and are sent through. A field that can't be represented — missing
+// fieldEntityId, an unmapped choice label, or a cleared number/date/choice (no empty form) —
+// is collected into `unsendable` instead, so the caller can fail loudly rather than report a
+// save that silently dropped the user's edit.
 export function buildFormFieldsInput(
   submitted: Partial<ParamProps>['formFields'],
   definitions: CustomerFormFieldDefinition[] = [],
@@ -325,8 +326,9 @@ export function buildFormFieldsInput(
       ?.entityId;
 
   // Number/date/choice fields have no "empty" representation in the entityId-keyed input, so a
-  // cleared one (value blank) is skipped rather than sent or flagged — it must not block the
-  // rest of the save. Text/multiline clear via '' and checkbox clears via [] (handled below).
+  // cleared one (value blank) can't be sent — it's flagged as unsendable so the caller fails
+  // loudly instead of reporting a save that silently dropped the clear (a lone clear would
+  // otherwise look like "no edits"). Text/multiline clear via '' and checkbox via [] below.
   const isBlank = (value: unknown) =>
     value === null ||
     value === undefined ||
@@ -348,7 +350,10 @@ export function buildFormFieldsInput(
         });
         break;
       case 'number': {
-        if (isBlank(value)) return;
+        if (isBlank(value)) {
+          unsendable.push(formField);
+          return;
+        }
         const num = toFiniteNumber(value);
         if (num === undefined) {
           unsendable.push(formField);
@@ -359,7 +364,10 @@ export function buildFormFieldsInput(
         break;
       }
       case 'date': {
-        if (isBlank(value)) return;
+        if (isBlank(value)) {
+          unsendable.push(formField);
+          return;
+        }
         const iso = toIsoDateTime(String(value).trim());
         if (iso === undefined) {
           unsendable.push(formField);
@@ -371,7 +379,10 @@ export function buildFormFieldsInput(
       }
       case 'dropdown':
       case 'radio': {
-        if (isBlank(value)) return;
+        if (isBlank(value)) {
+          unsendable.push(formField);
+          return;
+        }
         const fieldValueEntityId = optionEntityId(fieldEntityId, value);
         if (fieldValueEntityId === undefined) {
           unsendable.push(formField);

--- a/apps/storefront/src/pages/AccountSetting/utils.ts
+++ b/apps/storefront/src/pages/AccountSetting/utils.ts
@@ -275,7 +275,7 @@ export const bcSubmitDataProcessing = (
 // Choice field types whose selected option must be resolved to an entityId via the
 // form-field definitions (the mutations take an id, not a label). Kept as one exported
 // list so the "which fields need definitions" gate and the emit routing can't drift apart.
-export const CHOICE_FIELD_TYPES = ['dropdown', 'radio', 'checkbox'];
+const CHOICE_FIELD_TYPES = ['dropdown', 'radio', 'checkbox'];
 export const fieldTypeNeedsOptions = (fieldType?: string): boolean =>
   CHOICE_FIELD_TYPES.includes(fieldType ?? '');
 

--- a/apps/storefront/src/pages/AccountSetting/utils.ts
+++ b/apps/storefront/src/pages/AccountSetting/utils.ts
@@ -1,6 +1,7 @@
 import {
   AccountSettingExtraFieldValue as ExtraFieldValue,
   CompanyUser,
+  CompanyUserExtraFieldsInput,
   CustomerFormFieldDefinition,
   CustomerFormFieldsInput,
   FormFieldValue,
@@ -12,6 +13,10 @@ import { deCodeField } from '@/utils/registerUtils';
 import { validatorRules } from '@/utils/validatorRules';
 
 const emailValidate = validatorRules(['email']);
+
+// The "Contact Information" form-field group. For B2B, custom fields in this group are the
+// company user's own name-keyed extra fields; other groups are entityId-keyed form fields.
+export const CONTACT_GROUP_ID = 1;
 
 export const initB2BInfo = (
   accountSettings: any,
@@ -242,7 +247,6 @@ export const bcSubmitDataProcessing = (
           param.formFields.push({
             name: field?.bcLabel || '',
             value: data[key],
-            fieldType: field.fieldType,
           });
           flag = false;
           const account = (accountSettings?.formFields || []).find(
@@ -272,18 +276,13 @@ export const bcSubmitDataProcessing = (
   return param;
 };
 
-// Choice field types whose selected option must be resolved to an entityId via the
-// form-field definitions (the mutations take an id, not a label). Kept as one exported
-// list so the "which fields need definitions" gate and the emit routing can't drift apart.
-const CHOICE_FIELD_TYPES = ['dropdown', 'radio', 'checkbox'];
-export const fieldTypeNeedsOptions = (fieldType?: string): boolean =>
-  CHOICE_FIELD_TYPES.includes(fieldType ?? '');
-
 // Normalizes a stored or submitted value for change comparison so a typed stored value
 // (number 25, string[] ['a']) and its string form value ('25', ['a']) compare equal.
 function normalizeForCompare(value: unknown): string {
   if (value === null || value === undefined) return '';
-  if (Array.isArray(value)) return JSON.stringify(value);
+  // An empty array (e.g. an unchecked checkbox) is "empty", equal to unset — otherwise a
+  // never-set checkbox rendered as [] reads as a spurious change from undefined.
+  if (Array.isArray(value)) return value.length === 0 ? '' : JSON.stringify(value);
   return String(value);
 }
 
@@ -295,6 +294,16 @@ function toFiniteNumber(value: unknown): number | undefined {
   return Number.isFinite(num) ? num : undefined;
 }
 
+// BC's date form-field input is a DateTime, so a date is sent as an ISO string. A plain
+// calendar date (YYYY-MM-DD, the datepicker's default output) is mapped explicitly to UTC
+// midnight to avoid `new Date`'s local-timezone parsing shifting the day. Anything else falls
+// back to Date parsing; an unparseable value returns undefined.
+function toIsoDateTime(raw: string): string | undefined {
+  if (/^\d{4}-\d{2}-\d{2}$/.test(raw)) return `${raw}T00:00:00.000Z`;
+  const parsed = new Date(raw);
+  return Number.isNaN(parsed.getTime()) ? undefined : parsed.toISOString();
+}
+
 // Builds the shared entityId-keyed form-field groups for customer.updateCustomer and
 // company.updateCompanyUser. Each submitted field carries its fieldEntityId (parsed from
 // the form config's `field_<id>` fieldId). Callers pass only *changed* fields, so an empty
@@ -302,9 +311,9 @@ function toFiniteNumber(value: unknown): number | undefined {
 // be represented — missing fieldEntityId, an unmapped choice label, or a cleared number/
 // checkbox (no empty form) — is collected into `unsendable` instead, so the caller can fail
 // loudly rather than report a save that silently dropped the user's edit.
-function buildFormFieldsInput(
+export function buildFormFieldsInput(
   submitted: Partial<ParamProps>['formFields'],
-  definitions: CustomerFormFieldDefinition[],
+  definitions: CustomerFormFieldDefinition[] = [],
 ): { formFields?: CustomerFormFieldsInput; unsendable: NonNullable<ParamProps['formFields']> } {
   const defByEntityId = new Map(definitions.map((def) => [def.entityId, def]));
   const formFields: CustomerFormFieldsInput = {};
@@ -314,6 +323,15 @@ function buildFormFieldsInput(
   const optionEntityId = (fieldEntityId: number, value: unknown) =>
     defByEntityId.get(fieldEntityId)?.options?.find((option) => option.label === String(value))
       ?.entityId;
+
+  // Number/date/choice fields have no "empty" representation in the entityId-keyed input, so a
+  // cleared one (value blank) is skipped rather than sent or flagged — it must not block the
+  // rest of the save. Text/multiline clear via '' and checkbox clears via [] (handled below).
+  const isBlank = (value: unknown) =>
+    value === null ||
+    value === undefined ||
+    (typeof value === 'string' && value.trim() === '') ||
+    (Array.isArray(value) && value.length === 0);
 
   const emit = (formField: NonNullable<ParamProps['formFields']>[number]) => {
     const { fieldEntityId, fieldType, value } = formField;
@@ -330,6 +348,7 @@ function buildFormFieldsInput(
         });
         break;
       case 'number': {
+        if (isBlank(value)) return;
         const num = toFiniteNumber(value);
         if (num === undefined) {
           unsendable.push(formField);
@@ -339,12 +358,20 @@ function buildFormFieldsInput(
         (formFields.numbers ??= []).push({ fieldEntityId, number: num });
         break;
       }
-      case 'date':
+      case 'date': {
+        if (isBlank(value)) return;
+        const iso = toIsoDateTime(String(value).trim());
+        if (iso === undefined) {
+          unsendable.push(formField);
+          return;
+        }
         seen.add(fieldEntityId);
-        (formFields.dates ??= []).push({ fieldEntityId, date: String(value ?? '') });
+        (formFields.dates ??= []).push({ fieldEntityId, date: iso });
         break;
+      }
       case 'dropdown':
       case 'radio': {
+        if (isBlank(value)) return;
         const fieldValueEntityId = optionEntityId(fieldEntityId, value);
         if (fieldValueEntityId === undefined) {
           unsendable.push(formField);
@@ -355,10 +382,18 @@ function buildFormFieldsInput(
         break;
       }
       case 'checkbox': {
-        const values = Array.isArray(value) ? value : [value];
+        const values = Array.isArray(value) ? value : [];
+        // An empty selection is an intentional clear — send an empty id list.
+        if (values.length === 0) {
+          seen.add(fieldEntityId);
+          (formFields.checkboxes ??= []).push({ fieldEntityId, fieldValueEntityIds: [] });
+          break;
+        }
         const mapped = values.map((choice) => optionEntityId(fieldEntityId, choice));
         const fieldValueEntityIds = mapped.filter((id): id is number => id !== undefined);
-        if (fieldValueEntityIds.length === 0 || fieldValueEntityIds.length !== mapped.length) {
+        // Unsendable if any selected label failed to resolve — otherwise part of the user's
+        // selection would be dropped silently.
+        if (fieldValueEntityIds.length !== mapped.length) {
           unsendable.push(formField);
           return;
         }
@@ -379,13 +414,38 @@ function buildFormFieldsInput(
   return { formFields: Object.keys(formFields).length > 0 ? formFields : undefined, unsendable };
 }
 
-// The changed form fields that buildFormFieldsInput can't send (see above). The caller uses
-// this to surface an error instead of a misleading "saved" when an edit would be dropped.
-export function getUnsendableFormFields(
-  submitted: Partial<ParamProps>['formFields'],
-  definitions: CustomerFormFieldDefinition[] = [],
-): NonNullable<ParamProps['formFields']> {
-  return buildFormFieldsInput(submitted, definitions).unsendable;
+function buildExtraFieldsInput(
+  submitted: Array<{ name: string; value: unknown; fieldType?: string }> | undefined,
+): CompanyUserExtraFieldsInput | undefined {
+  const extraFields: CompanyUserExtraFieldsInput = {};
+  const seen = new Set<string>();
+
+  (submitted ?? []).forEach(({ name, value, fieldType }) => {
+    if (!name || seen.has(name)) return;
+    // Company-user extra fields have no multi-value (checkbox) group, so an array value can't
+    // be represented — skip it rather than coerce it into a comma-joined string.
+    if (Array.isArray(value)) return;
+    seen.add(name);
+    const text = String(value ?? '');
+    switch (fieldType) {
+      case 'multiline':
+        (extraFields.multilineTexts ??= []).push({ name, multilineText: text });
+        break;
+      case 'number':
+        (extraFields.numbers ??= []).push({ name, number: text });
+        break;
+      case 'dropdown':
+      case 'radio':
+        (extraFields.multipleChoices ??= []).push({ name, fieldValue: text });
+        break;
+      case 'text':
+      default:
+        (extraFields.texts ??= []).push({ name, text });
+        break;
+    }
+  });
+
+  return Object.keys(extraFields).length > 0 ? extraFields : undefined;
 }
 
 // Contact scalars shared by both mutation inputs (phoneNumber -> phone).
@@ -399,54 +459,34 @@ function assignSharedScalars(
   if (payload.phoneNumber !== undefined) input.phone = payload.phoneNumber as string;
 }
 
-// The definitions entityId of the customer's password form field, if present.
-// customer.updateCustomer takes the password as a form field (unlike company.updateCompanyUser
-// which uses a top-level newPassword scalar), so the caller needs this to send a change.
-export function findPasswordFieldEntityId(
-  definitions: CustomerFormFieldDefinition[] = [],
-): number | undefined {
-  return definitions.find((def) => def.__typename === 'PasswordFormField')?.entityId;
-}
-
-// Builds the BC-native customer.updateCustomer input from the submit payload.
 export function buildUpdateCustomerInput(
   payload: Partial<ParamProps>,
-  definitions: CustomerFormFieldDefinition[] = [],
+  formFields?: CustomerFormFieldsInput,
 ): UpdateCustomerInput {
   const input: UpdateCustomerInput = {};
 
   assignSharedScalars(input, payload);
   if (payload.company !== undefined) input.company = payload.company as string;
-
-  const { formFields = {} } = buildFormFieldsInput(payload.formFields, definitions);
-
-  // Password is a BC customer form field; send a change under the Password field's entityId.
-  const passwordFieldEntityId = findPasswordFieldEntityId(definitions);
-  if (payload.newPassword && passwordFieldEntityId !== undefined) {
-    formFields.passwords = [
-      { fieldEntityId: passwordFieldEntityId, password: payload.newPassword as string },
-    ];
-  }
-
-  if (Object.keys(formFields).length > 0) input.formFields = formFields;
+  if (formFields && Object.keys(formFields).length > 0) input.formFields = formFields;
 
   return input;
 }
 
-// Builds the B2B company.updateCompanyUser input. Form fields use the same entityId-keyed
-// shape as customer.updateCustomer; the scalars carry current/new password instead of company.
 export function buildUpdateCompanyUserInput(
   payload: Partial<ParamProps>,
-  definitions: CustomerFormFieldDefinition[] = [],
+  formFields?: CustomerFormFieldsInput,
 ): UpdateCompanyUserInput {
   const input: UpdateCompanyUserInput = {};
 
   assignSharedScalars(input, payload);
   if (payload.currentPassword) input.currentPassword = payload.currentPassword as string;
   if (payload.newPassword) input.newPassword = payload.newPassword as string;
+  if (formFields && Object.keys(formFields).length > 0) input.formFields = formFields;
 
-  const { formFields } = buildFormFieldsInput(payload.formFields, definitions);
-  if (formFields) input.formFields = formFields;
+  const extraFields = buildExtraFieldsInput(
+    payload.extraFields as Array<{ name: string; value: unknown; fieldType?: string }> | undefined,
+  );
+  if (extraFields) input.extraFields = extraFields;
 
   return input;
 }
@@ -458,29 +498,68 @@ export function parseFieldEntityId(fieldId?: string): number | undefined {
   return match ? Number(match[1]) : undefined;
 }
 
+// The stored date value is a full ISO string (date.utc), while the form submits YYYY-MM-DD;
+// compare on the date-only portion so an untouched date isn't seen as changed and re-sent.
+const toDateOnly = (value: unknown): string => String(value ?? '').slice(0, 10);
+
+const isValueChanged = (
+  originalValue: unknown,
+  submittedValue: unknown,
+  fieldType?: string,
+): boolean => {
+  if (fieldType === 'date') return toDateOnly(originalValue) !== toDateOnly(submittedValue);
+  return normalizeForCompare(originalValue) !== normalizeForCompare(submittedValue);
+};
+
 // Collects the custom form fields for the native SF GQL updates straight from the form
 // values and returns only the ones that actually CHANGED from their stored original. The
 // form registers each field under `name` (the submit processor's fieldId capture misses
-// them), so read data[item.name]; the entityId the mutations need is encoded in the
-// `field_<id>` fieldId. Values are normalized before comparison so a typed stored value
-// (number/array) and its string form value don't read as a spurious change, and an unchanged
-// field isn't re-sent on an unrelated edit.
+// them), so read data[item.name]; the entityId the mutations need comes from the `field_<id>`
+// fieldId, falling back to the form-field definitions (matched by label) when the fieldId
+// isn't in that shape.
 export function collectChangedFormFields(
   data: CustomFieldItems,
   accountInfoFormFields: Partial<Fields>[],
   originalFormFields: Array<{ name?: string; value?: unknown }>,
+  definitions: CustomerFormFieldDefinition[] = [],
 ): NonNullable<ParamProps['formFields']> {
+  const entityIdByLabel = new Map(definitions.map((def) => [def.label, def.entityId]));
   return accountInfoFormFields
     .filter((item) => item.custom)
-    .map((item) => ({
-      name: item.bcLabel || '',
-      value: data[item.name || ''],
-      fieldType: item.fieldType,
-      fieldEntityId: parseFieldEntityId(item.fieldId),
-    }))
+    .map((item) => {
+      const name = item.bcLabel || '';
+      return {
+        name,
+        value: data[item.name || ''],
+        fieldType: item.fieldType,
+        fieldEntityId: parseFieldEntityId(item.fieldId) ?? entityIdByLabel.get(name),
+      };
+    })
     .filter((formField) => {
       const original = originalFormFields.find((item) => item.name === formField.name);
-      return normalizeForCompare(original?.value) !== normalizeForCompare(formField.value);
+      return isValueChanged(original?.value, formField.value, formField.fieldType);
+    });
+}
+
+// Collects the company-user extra fields that changed — the name-keyed custom fields in the
+// contact group (groupId 1), matched from the read's extraFields. Unlike form fields these
+// need no entityId or definitions (the mutation keys them by name), so they work through the
+// proxy. Returns {name, value, fieldType} entries keyed by the decoded field name.
+export function collectChangedExtraFields(
+  data: CustomFieldItems,
+  accountInfoFormFields: Partial<Fields>[],
+  originalExtraFields: Array<{ fieldName?: string; fieldValue?: unknown }>,
+): Array<{ name: string; value: unknown; fieldType?: string }> {
+  return accountInfoFormFields
+    .filter((item) => item.custom && item.groupId === CONTACT_GROUP_ID)
+    .map((item) => ({
+      name: deCodeField(item.name || ''),
+      value: data[item.name || ''],
+      fieldType: item.fieldType,
+    }))
+    .filter((extraField) => {
+      const original = originalExtraFields.find((item) => item.fieldName === extraField.name);
+      return isValueChanged(original?.fieldValue, extraField.value);
     });
 }
 

--- a/apps/storefront/src/pages/AccountSetting/utils.ts
+++ b/apps/storefront/src/pages/AccountSetting/utils.ts
@@ -399,6 +399,15 @@ function assignSharedScalars(
   if (payload.phoneNumber !== undefined) input.phone = payload.phoneNumber as string;
 }
 
+// The definitions entityId of the customer's password form field, if present.
+// customer.updateCustomer takes the password as a form field (unlike company.updateCompanyUser
+// which uses a top-level newPassword scalar), so the caller needs this to send a change.
+export function findPasswordFieldEntityId(
+  definitions: CustomerFormFieldDefinition[] = [],
+): number | undefined {
+  return definitions.find((def) => def.__typename === 'PasswordFormField')?.entityId;
+}
+
 // Builds the BC-native customer.updateCustomer input from the submit payload.
 export function buildUpdateCustomerInput(
   payload: Partial<ParamProps>,
@@ -409,8 +418,17 @@ export function buildUpdateCustomerInput(
   assignSharedScalars(input, payload);
   if (payload.company !== undefined) input.company = payload.company as string;
 
-  const { formFields } = buildFormFieldsInput(payload.formFields, definitions);
-  if (formFields) input.formFields = formFields;
+  const { formFields = {} } = buildFormFieldsInput(payload.formFields, definitions);
+
+  // Password is a BC customer form field; send a change under the Password field's entityId.
+  const passwordFieldEntityId = findPasswordFieldEntityId(definitions);
+  if (payload.newPassword && passwordFieldEntityId !== undefined) {
+    formFields.passwords = [
+      { fieldEntityId: passwordFieldEntityId, password: payload.newPassword as string },
+    ];
+  }
+
+  if (Object.keys(formFields).length > 0) input.formFields = formFields;
 
   return input;
 }

--- a/apps/storefront/src/pages/AccountSetting/utils.ts
+++ b/apps/storefront/src/pages/AccountSetting/utils.ts
@@ -356,10 +356,9 @@ function buildFormFieldsInput(
       }
       case 'checkbox': {
         const values = Array.isArray(value) ? value : [value];
-        const fieldValueEntityIds = values
-          .map((choice) => optionEntityId(fieldEntityId, choice))
-          .filter((id): id is number => id !== undefined);
-        if (fieldValueEntityIds.length === 0) {
+        const mapped = values.map((choice) => optionEntityId(fieldEntityId, choice));
+        const fieldValueEntityIds = mapped.filter((id): id is number => id !== undefined);
+        if (fieldValueEntityIds.length === 0 || fieldValueEntityIds.length !== mapped.length) {
           unsendable.push(formField);
           return;
         }

--- a/apps/storefront/src/pages/AccountSetting/utils.ts
+++ b/apps/storefront/src/pages/AccountSetting/utils.ts
@@ -298,28 +298,29 @@ function toFiniteNumber(value: unknown): number | undefined {
 // Builds the shared entityId-keyed form-field groups for customer.updateCustomer and
 // company.updateCompanyUser. Each submitted field carries its fieldEntityId (parsed from
 // the form config's `field_<id>` fieldId). Callers pass only *changed* fields, so an empty
-// text/multiline/date value is an intentional clear and is sent through; number and choice
-// fields can't represent "empty" in their typed group, so a cleared one is skipped. Choice
-// selections map the picked option's label to its own entityId via the definitions.
-// Returns undefined when nothing maps.
+// text/multiline/date value is an intentional clear and is sent through. A field that can't
+// be represented — missing fieldEntityId, an unmapped choice label, or a cleared number/
+// checkbox (no empty form) — is collected into `unsendable` instead, so the caller can fail
+// loudly rather than report a save that silently dropped the user's edit.
 function buildFormFieldsInput(
   submitted: Partial<ParamProps>['formFields'],
   definitions: CustomerFormFieldDefinition[],
-): CustomerFormFieldsInput | undefined {
+): { formFields?: CustomerFormFieldsInput; unsendable: NonNullable<ParamProps['formFields']> } {
   const defByEntityId = new Map(definitions.map((def) => [def.entityId, def]));
   const formFields: CustomerFormFieldsInput = {};
+  const unsendable: NonNullable<ParamProps['formFields']> = [];
   const seen = new Set<number>();
 
   const optionEntityId = (fieldEntityId: number, value: unknown) =>
     defByEntityId.get(fieldEntityId)?.options?.find((option) => option.label === String(value))
       ?.entityId;
 
-  const emit = (
-    fieldEntityId: number | undefined,
-    fieldType: string | undefined,
-    value: unknown,
-  ) => {
-    if (fieldEntityId === undefined || seen.has(fieldEntityId)) return;
+  const emit = (formField: NonNullable<ParamProps['formFields']>[number]) => {
+    const { fieldEntityId, fieldType, value } = formField;
+    if (fieldEntityId === undefined || seen.has(fieldEntityId)) {
+      unsendable.push(formField);
+      return;
+    }
     switch (fieldType) {
       case 'multiline':
         seen.add(fieldEntityId);
@@ -330,7 +331,10 @@ function buildFormFieldsInput(
         break;
       case 'number': {
         const num = toFiniteNumber(value);
-        if (num === undefined) return;
+        if (num === undefined) {
+          unsendable.push(formField);
+          return;
+        }
         seen.add(fieldEntityId);
         (formFields.numbers ??= []).push({ fieldEntityId, number: num });
         break;
@@ -342,7 +346,10 @@ function buildFormFieldsInput(
       case 'dropdown':
       case 'radio': {
         const fieldValueEntityId = optionEntityId(fieldEntityId, value);
-        if (fieldValueEntityId === undefined) return;
+        if (fieldValueEntityId === undefined) {
+          unsendable.push(formField);
+          return;
+        }
         seen.add(fieldEntityId);
         (formFields.multipleChoices ??= []).push({ fieldEntityId, fieldValueEntityId });
         break;
@@ -352,7 +359,10 @@ function buildFormFieldsInput(
         const fieldValueEntityIds = values
           .map((choice) => optionEntityId(fieldEntityId, choice))
           .filter((id): id is number => id !== undefined);
-        if (fieldValueEntityIds.length === 0) return;
+        if (fieldValueEntityIds.length === 0) {
+          unsendable.push(formField);
+          return;
+        }
         seen.add(fieldEntityId);
         (formFields.checkboxes ??= []).push({ fieldEntityId, fieldValueEntityIds });
         break;
@@ -365,11 +375,18 @@ function buildFormFieldsInput(
     }
   };
 
-  (submitted ?? []).forEach(({ fieldEntityId, value, fieldType }) =>
-    emit(fieldEntityId, fieldType, value),
-  );
+  (submitted ?? []).forEach(emit);
 
-  return Object.keys(formFields).length > 0 ? formFields : undefined;
+  return { formFields: Object.keys(formFields).length > 0 ? formFields : undefined, unsendable };
+}
+
+// The changed form fields that buildFormFieldsInput can't send (see above). The caller uses
+// this to surface an error instead of a misleading "saved" when an edit would be dropped.
+export function getUnsendableFormFields(
+  submitted: Partial<ParamProps>['formFields'],
+  definitions: CustomerFormFieldDefinition[] = [],
+): NonNullable<ParamProps['formFields']> {
+  return buildFormFieldsInput(submitted, definitions).unsendable;
 }
 
 // Contact scalars shared by both mutation inputs (phoneNumber -> phone).
@@ -393,7 +410,7 @@ export function buildUpdateCustomerInput(
   assignSharedScalars(input, payload);
   if (payload.company !== undefined) input.company = payload.company as string;
 
-  const formFields = buildFormFieldsInput(payload.formFields, definitions);
+  const { formFields } = buildFormFieldsInput(payload.formFields, definitions);
   if (formFields) input.formFields = formFields;
 
   return input;
@@ -411,7 +428,7 @@ export function buildUpdateCompanyUserInput(
   if (payload.currentPassword) input.currentPassword = payload.currentPassword as string;
   if (payload.newPassword) input.newPassword = payload.newPassword as string;
 
-  const formFields = buildFormFieldsInput(payload.formFields, definitions);
+  const { formFields } = buildFormFieldsInput(payload.formFields, definitions);
   if (formFields) input.formFields = formFields;
 
   return input;

--- a/apps/storefront/src/pages/AccountSetting/utils.ts
+++ b/apps/storefront/src/pages/AccountSetting/utils.ts
@@ -69,7 +69,7 @@ export const initB2BInfo = (
 
   additionalInformation.forEach((item: Partial<Fields>) => {
     const formFields = (accountSettings?.formFields || []).find(
-      (field: Partial<Fields>) => field.name === item.bcLabel,
+      (field: Partial<Fields>) => field.name === (item.bcLabel || item.label),
     );
     const infoItem = item;
     if (formFields) infoItem.default = formFields.value;
@@ -105,7 +105,7 @@ export const initBcInfo = (
 
   additionalInformation.forEach((item: Partial<Fields>) => {
     const formFields = (accountSettings?.formFields || []).find(
-      (field: Partial<Fields>) => field.name === item.bcLabel,
+      (field: Partial<Fields>) => field.name === (item.bcLabel || item.label),
     );
     const infoItem = item;
     if (formFields) infoItem.default = formFields.value;
@@ -527,7 +527,10 @@ export function collectChangedFormFields(
   return accountInfoFormFields
     .filter((item) => item.custom)
     .map((item) => {
-      const name = item.bcLabel || '';
+      // The field's display label is the key that matches the stored formFields name and the
+      // definition label. getAccountFormFields leaves bcLabel empty when the config supplies
+      // only labelName (kept on `label`), so fall back to label.
+      const name = item.bcLabel || item.label || '';
       return {
         name,
         value: data[item.name || ''],

--- a/apps/storefront/src/pages/AccountSetting/utils.ts
+++ b/apps/storefront/src/pages/AccountSetting/utils.ts
@@ -425,7 +425,14 @@ export function buildFormFieldsInput(
   return { formFields: Object.keys(formFields).length > 0 ? formFields : undefined, unsendable };
 }
 
-type ExtraFieldEntry = { name: string; value: unknown; fieldType?: string };
+type ExtraFieldEntry = {
+  name: string;
+  value: unknown;
+  fieldType?: string;
+  // The react-hook-form registered name, carried through so an unsendable field can be
+  // traced back to the control it belongs to (for a field-level error).
+  formName?: string;
+};
 
 // Builds the name-keyed CompanyUserExtraFieldsInput from changed company-user extra fields.
 // The extraFields groups (texts/multilineTexts/numbers/multipleChoices) are all scalar, so an
@@ -554,6 +561,9 @@ export function collectChangedFormFields(
         value: data[item.name || ''],
         fieldType: item.fieldType,
         fieldEntityId: parseFieldEntityId(item.fieldId) ?? entityIdByLabel.get(name),
+        // The react-hook-form registered name, carried through so an unsendable field can be
+        // traced back to the control it belongs to (for a field-level error).
+        formName: item.name,
       };
     })
     .filter((formField) => {
@@ -570,13 +580,14 @@ export function collectChangedExtraFields(
   data: CustomFieldItems,
   accountInfoFormFields: Partial<Fields>[],
   originalExtraFields: Array<{ fieldName?: string; fieldValue?: unknown }>,
-): Array<{ name: string; value: unknown; fieldType?: string }> {
+): ExtraFieldEntry[] {
   return accountInfoFormFields
     .filter((item) => item.custom && item.groupId === CONTACT_GROUP_ID)
     .map((item) => ({
       name: deCodeField(item.name || ''),
       value: data[item.name || ''],
       fieldType: item.fieldType,
+      formName: item.name,
     }))
     .filter((extraField) => {
       const original = originalExtraFields.find((item) => item.fieldName === extraField.name);

--- a/apps/storefront/src/pages/AccountSetting/utils.ts
+++ b/apps/storefront/src/pages/AccountSetting/utils.ts
@@ -44,6 +44,7 @@ export const initB2BInfo = (
   contactInformation: Partial<Fields>[],
   accountB2BFormFields: Partial<Fields>[],
   additionalInformation: Partial<Fields>[],
+  useBcAccountSettings: boolean = true,
 ) => {
   const extraFields = accountSettings?.extraFields || [];
   contactInformation.forEach((item: Partial<Fields>) => {
@@ -72,22 +73,28 @@ export const initB2BInfo = (
       );
 
       if (currentField) {
-        applyStoredCustomFieldDefault(currentField, extraField.fieldValue);
+        if (useBcAccountSettings) {
+          applyStoredCustomFieldDefault(currentField, extraField.fieldValue);
+        } else {
+          currentField.default = extraField.fieldValue;
+        }
       }
     });
   }
 
   // Custom contact fields with no stored extra value still inherit registerUtils' today
   // placeholder for date fields — clear those so unrelated saves aren't treated as edits.
-  contactInformation.forEach((item) => {
-    if (!item.custom || item.fieldType !== 'date') return;
-    const extraField = extraFields.find(
-      (field: CustomFieldItems) => deCodeField(item?.name || '') === field.fieldName,
-    );
-    if (!extraField) {
-      applyStoredCustomFieldDefault(item, undefined);
-    }
-  });
+  if (useBcAccountSettings) {
+    contactInformation.forEach((item) => {
+      if (!item.custom || item.fieldType !== 'date') return;
+      const extraField = extraFields.find(
+        (field: CustomFieldItems) => deCodeField(item?.name || '') === field.fieldName,
+      );
+      if (!extraField) {
+        applyStoredCustomFieldDefault(item, undefined);
+      }
+    });
+  }
 
   accountB2BFormFields.forEach((item: Partial<Fields>) => {
     const formField = item;
@@ -102,9 +109,14 @@ export const initB2BInfo = (
 
   additionalInformation.forEach((item: Partial<Fields>) => {
     const formFields = (accountSettings?.formFields || []).find(
-      (field: Partial<Fields>) => field.name === (item.bcLabel || item.label),
+      (field: Partial<Fields>) =>
+        field.name === (useBcAccountSettings ? item.bcLabel || item.label : item.bcLabel),
     );
-    applyStoredCustomFieldDefault(item, formFields?.value);
+    if (useBcAccountSettings) {
+      applyStoredCustomFieldDefault(item, formFields?.value);
+    } else if (formFields) {
+      item.default = formFields.value;
+    }
   });
 
   return [...contactInformation, ...accountB2BFormFields, ...additionalInformation];
@@ -114,6 +126,7 @@ export const initBcInfo = (
   accountSettings: any,
   contactInformation: Partial<Fields>[],
   additionalInformation: Partial<Fields>[],
+  useBcAccountSettings: boolean = true,
 ) => {
   contactInformation.forEach((item: Partial<Fields>) => {
     const contactInfoItem = item;
@@ -137,9 +150,14 @@ export const initBcInfo = (
 
   additionalInformation.forEach((item: Partial<Fields>) => {
     const formFields = (accountSettings?.formFields || []).find(
-      (field: Partial<Fields>) => field.name === (item.bcLabel || item.label),
+      (field: Partial<Fields>) =>
+        field.name === (useBcAccountSettings ? item.bcLabel || item.label : item.bcLabel),
     );
-    applyStoredCustomFieldDefault(item, formFields?.value);
+    if (useBcAccountSettings) {
+      applyStoredCustomFieldDefault(item, formFields?.value);
+    } else if (formFields) {
+      item.default = formFields.value;
+    }
   });
 
   return [...contactInformation, ...additionalInformation];
@@ -240,6 +258,7 @@ export const bcSubmitDataProcessing = (
   accountSettings: any,
   decryptionFields: Partial<Fields>[],
   extraFields: Partial<Fields>[],
+  useBcAccountSettings: boolean = true,
 ) => {
   const param: Partial<ParamProps> = {};
   param.formFields = [];
@@ -249,31 +268,30 @@ export const bcSubmitDataProcessing = (
     decryptionFields.forEach((item: Partial<Fields>) => {
       if (key === item.name) {
         flag = false;
-        if (
-          deCodeField(item.name) === 'first_name' &&
-          accountSettings.firstName !== data[item.name]
-        ) {
-          pristine = false;
-          param.firstName = data[item.name];
+        if (deCodeField(item.name) === 'first_name') {
+          const changed = accountSettings.firstName !== data[item.name];
+          if (changed) pristine = false;
+          if (changed || !useBcAccountSettings) param.firstName = data[item.name];
         }
-        if (
-          deCodeField(item.name) === 'last_name' &&
-          accountSettings.lastName !== data[item.name]
-        ) {
-          pristine = false;
-          param.lastName = data[item.name];
+        if (deCodeField(item.name) === 'last_name') {
+          const changed = accountSettings.lastName !== data[item.name];
+          if (changed) pristine = false;
+          if (changed || !useBcAccountSettings) param.lastName = data[item.name];
         }
-        if (deCodeField(item.name) === 'phone' && accountSettings.phoneNumber !== data[item.name]) {
-          pristine = false;
-          param.phoneNumber = data[item.name];
+        if (deCodeField(item.name) === 'phone') {
+          const changed = accountSettings.phoneNumber !== data[item.name];
+          if (changed) pristine = false;
+          if (changed || !useBcAccountSettings) param.phoneNumber = data[item.name];
         }
-        if (deCodeField(item.name) === 'email' && accountSettings.email !== data[item.name]) {
-          pristine = false;
-          param.email = data[item.name];
+        if (deCodeField(item.name) === 'email') {
+          const changed = accountSettings.email !== data[item.name];
+          if (changed) pristine = false;
+          if (changed || !useBcAccountSettings) param.email = data[item.name];
         }
-        if (deCodeField(item.name) === 'company' && accountSettings.company !== data[item.name]) {
-          pristine = false;
-          param.company = data[item.name];
+        if (deCodeField(item.name) === 'company') {
+          const changed = accountSettings.company !== data[item.name];
+          if (changed) pristine = false;
+          if (changed || !useBcAccountSettings) param.company = data[item.name];
         }
       }
     });
@@ -469,6 +487,9 @@ type ExtraFieldEntry = {
   // The react-hook-form registered name, carried through so an unsendable field can be
   // traced back to the control it belongs to (for a field-level error).
   formName?: string;
+  // Carried through so a required field is resent even when unchanged — see
+  // collectChangedFormFields.
+  required?: boolean;
 };
 
 // Builds the name-keyed CompanyUserExtraFieldsInput from changed company-user extra fields.
@@ -574,11 +595,13 @@ const isValueChanged = (
 };
 
 // Collects the custom form fields for the native SF GQL updates straight from the form
-// values and returns only the ones that actually CHANGED from their stored original. The
-// form registers each field under `name` (the submit processor's fieldId capture misses
-// them), so read data[item.name]; the entityId the mutations need comes from the `field_<id>`
-// fieldId, falling back to the form-field definitions (matched by label) when the fieldId
-// isn't in that shape.
+// values. Returns the ones that actually CHANGED from their stored original, plus any
+// required field regardless of change — BC revalidates every required custom field on each
+// update call, so an unchanged required field must still be resent or the save is rejected
+// as if that field were missing. The form registers each field under `name` (the submit
+// processor's fieldId capture misses them), so read data[item.name]; the entityId the
+// mutations need comes from the `field_<id>` fieldId, falling back to the form-field
+// definitions (matched by label) when the fieldId isn't in that shape.
 export function collectChangedFormFields(
   data: CustomFieldItems,
   accountInfoFormFields: Partial<Fields>[],
@@ -601,9 +624,11 @@ export function collectChangedFormFields(
         // The react-hook-form registered name, carried through so an unsendable field can be
         // traced back to the control it belongs to (for a field-level error).
         formName: item.name,
+        required: item.required,
       };
     })
     .filter((formField) => {
+      if (formField.required) return true;
       const original = originalFormFields.find((item) => item.name === formField.name);
       return isValueChanged(original?.value, formField.value, formField.fieldType);
     });
@@ -612,7 +637,9 @@ export function collectChangedFormFields(
 // Collects the company-user extra fields that changed — the name-keyed custom fields in the
 // contact group (groupId 1), matched from the read's extraFields. Unlike form fields these
 // need no entityId or definitions (the mutation keys them by name), so they work through the
-// proxy. Returns {name, value, fieldType} entries keyed by the decoded field name.
+// proxy. Also keeps any required field regardless of change, matching collectChangedFormFields
+// — BC revalidates required custom fields on every update, so an unchanged required field must
+// still be resent. Returns {name, value, fieldType} entries keyed by the decoded field name.
 export function collectChangedExtraFields(
   data: CustomFieldItems,
   accountInfoFormFields: Partial<Fields>[],
@@ -625,8 +652,10 @@ export function collectChangedExtraFields(
       value: data[item.name || ''],
       fieldType: item.fieldType,
       formName: item.name,
+      required: item.required,
     }))
     .filter((extraField) => {
+      if (extraField.required) return true;
       const original = originalExtraFields.find((item) => item.fieldName === extraField.name);
       return isValueChanged(original?.fieldValue, extraField.value);
     });

--- a/apps/storefront/src/pages/AccountSetting/utils.ts
+++ b/apps/storefront/src/pages/AccountSetting/utils.ts
@@ -14,6 +14,27 @@ import { validatorRules } from '@/utils/validatorRules';
 
 const emailValidate = validatorRules(['email']);
 
+// registerUtils assigns today's date to empty date fields for registration forms; on account
+// settings an unset date must stay blank so saving unrelated fields isn't treated as a date edit.
+const applyStoredCustomFieldDefault = (
+  fieldConfig: Partial<Fields>,
+  storedValue: unknown,
+): void => {
+  const hasStoredValue =
+    storedValue !== undefined &&
+    storedValue !== null &&
+    !(typeof storedValue === 'string' && storedValue.trim() === '');
+
+  if (hasStoredValue) {
+    fieldConfig.default = storedValue;
+    return;
+  }
+
+  if (fieldConfig.fieldType === 'date') {
+    fieldConfig.default = '';
+  }
+};
+
 // The "Contact Information" form-field group. For B2B, custom fields in this group are the
 // company user's own name-keyed extra fields; other groups are entityId-keyed form fields.
 export const CONTACT_GROUP_ID = 1;
@@ -51,10 +72,22 @@ export const initB2BInfo = (
       );
 
       if (currentField) {
-        currentField.default = extraField.fieldValue;
+        applyStoredCustomFieldDefault(currentField, extraField.fieldValue);
       }
     });
   }
+
+  // Custom contact fields with no stored extra value still inherit registerUtils' today
+  // placeholder for date fields — clear those so unrelated saves aren't treated as edits.
+  contactInformation.forEach((item) => {
+    if (!item.custom || item.fieldType !== 'date') return;
+    const extraField = extraFields.find(
+      (field: CustomFieldItems) => deCodeField(item?.name || '') === field.fieldName,
+    );
+    if (!extraField) {
+      applyStoredCustomFieldDefault(item, undefined);
+    }
+  });
 
   accountB2BFormFields.forEach((item: Partial<Fields>) => {
     const formField = item;
@@ -71,8 +104,7 @@ export const initB2BInfo = (
     const formFields = (accountSettings?.formFields || []).find(
       (field: Partial<Fields>) => field.name === (item.bcLabel || item.label),
     );
-    const infoItem = item;
-    if (formFields) infoItem.default = formFields.value;
+    applyStoredCustomFieldDefault(item, formFields?.value);
   });
 
   return [...contactInformation, ...accountB2BFormFields, ...additionalInformation];
@@ -107,8 +139,7 @@ export const initBcInfo = (
     const formFields = (accountSettings?.formFields || []).find(
       (field: Partial<Fields>) => field.name === (item.bcLabel || item.label),
     );
-    const infoItem = item;
-    if (formFields) infoItem.default = formFields.value;
+    applyStoredCustomFieldDefault(item, formFields?.value);
   });
 
   return [...contactInformation, ...additionalInformation];

--- a/apps/storefront/src/pages/AccountSetting/utils.ts
+++ b/apps/storefront/src/pages/AccountSetting/utils.ts
@@ -26,7 +26,7 @@ const applyStoredCustomFieldDefault = (
     !(typeof storedValue === 'string' && storedValue.trim() === '');
 
   if (hasStoredValue) {
-    fieldConfig.default = storedValue;
+    fieldConfig.default = storedValue as Partial<Fields>['default'];
     return;
   }
 
@@ -249,24 +249,30 @@ export const bcSubmitDataProcessing = (
     decryptionFields.forEach((item: Partial<Fields>) => {
       if (key === item.name) {
         flag = false;
-        if (deCodeField(item.name) === 'first_name') {
-          if (accountSettings.firstName !== data[item.name]) pristine = false;
+        if (
+          deCodeField(item.name) === 'first_name' &&
+          accountSettings.firstName !== data[item.name]
+        ) {
+          pristine = false;
           param.firstName = data[item.name];
         }
-        if (deCodeField(item.name) === 'last_name') {
-          if (accountSettings.lastName !== data[item.name]) pristine = false;
+        if (
+          deCodeField(item.name) === 'last_name' &&
+          accountSettings.lastName !== data[item.name]
+        ) {
+          pristine = false;
           param.lastName = data[item.name];
         }
-        if (deCodeField(item.name) === 'phone') {
-          if (accountSettings.phoneNumber !== data[item.name]) pristine = false;
+        if (deCodeField(item.name) === 'phone' && accountSettings.phoneNumber !== data[item.name]) {
+          pristine = false;
           param.phoneNumber = data[item.name];
         }
-        if (deCodeField(item.name) === 'email') {
-          if (accountSettings.email !== data[item.name]) pristine = false;
+        if (deCodeField(item.name) === 'email' && accountSettings.email !== data[item.name]) {
+          pristine = false;
           param.email = data[item.name];
         }
-        if (deCodeField(item.name) === 'company') {
-          if (accountSettings.company !== data[item.name]) pristine = false;
+        if (deCodeField(item.name) === 'company' && accountSettings.company !== data[item.name]) {
+          pristine = false;
           param.company = data[item.name];
         }
       }

--- a/apps/storefront/src/pages/ForgotPassword/index.tsx
+++ b/apps/storefront/src/pages/ForgotPassword/index.tsx
@@ -9,10 +9,11 @@ import CustomButton from '@/components/button/CustomButton';
 import { Captcha } from '@/components/captcha/Captcha';
 import B3Spin from '@/components/spin/B3Spin';
 import { useMobile } from '@/hooks/useMobile';
+import { useStorefrontCaptcha } from '@/hooks/useStorefrontCaptcha';
 import { useB3Lang } from '@/lib/lang';
 import { CustomStyleContext } from '@/shared/customStyleButton';
 import { GlobalContext } from '@/shared/global';
-import { getStorefrontToken, requestResetPassword } from '@/shared/service/b2b/graphql/recaptcha';
+import { requestResetPassword } from '@/shared/service/b2b/graphql/recaptcha';
 import b2bLogger from '@/utils/b3Logger';
 
 import { getForgotPasswordFields } from '../Login/helper';
@@ -199,25 +200,8 @@ export function ForgotPassword({
 export default function Page({ setOpenPage }: PageProps) {
   const { logo } = useContext(GlobalContext).state;
   const { loginPageDisplay } = useContext(CustomStyleContext).state;
-  const [isEnabledOnStorefront, setIsEnabledOnStorefront] = useState(false);
-  const [storefrontSiteKey, setStorefrontSiteKey] = useState('');
-
-  useEffect(() => {
-    const getIsEnabledOnStorefront = async () => {
-      try {
-        const response = await getStorefrontToken();
-
-        if (response) {
-          setIsEnabledOnStorefront(response.isEnabledOnStorefront);
-          setStorefrontSiteKey(response.siteKey);
-        }
-      } catch (e) {
-        b2bLogger.error(e);
-      }
-    };
-
-    getIsEnabledOnStorefront();
-  }, []);
+  const { isCaptchaEnabled: isEnabledOnStorefront, captchaSiteKey: storefrontSiteKey } =
+    useStorefrontCaptcha();
 
   return (
     <ForgotPassword

--- a/apps/storefront/src/shared/service/bc/graphql/accountSetting.ts
+++ b/apps/storefront/src/shared/service/bc/graphql/accountSetting.ts
@@ -188,7 +188,6 @@ export interface CustomerFormFieldOption {
 }
 
 export interface CustomerFormFieldDefinition {
-  __typename: string;
   entityId: number;
   label: string;
   options?: CustomerFormFieldOption[];
@@ -212,7 +211,6 @@ const QUERY_CUSTOMER_FORM_FIELD_SETTINGS = `query CustomerFormFieldSettings {
     settings {
       formFields {
         customer {
-          __typename
           entityId
           label
           ... on PicklistFormField { options { entityId label } }

--- a/apps/storefront/src/shared/service/bc/graphql/accountSetting.ts
+++ b/apps/storefront/src/shared/service/bc/graphql/accountSetting.ts
@@ -173,3 +173,175 @@ export async function getCustomerDetails(): Promise<CustomerResponse> {
     query: QUERY_CUSTOMER_DETAILS,
   });
 }
+
+// ===========================================================================
+// Customer form-field definitions (site.settings.formFields.customer)
+// ===========================================================================
+
+// The definitions list every customer form field with its entityId — including
+// fields the customer has no value for yet (which customer.formFields omits). This
+// is the authoritative source of fieldEntityId for the customer.updateCustomer input.
+// Choice fields also expose their options, so a selected label maps to its own entityId.
+export interface CustomerFormFieldOption {
+  entityId: number;
+  label: string;
+}
+
+export interface CustomerFormFieldDefinition {
+  __typename: string;
+  entityId: number;
+  label: string;
+  options?: CustomerFormFieldOption[];
+}
+
+export interface CustomerFormFieldSettingsResponse {
+  data?: {
+    site?: {
+      settings?: {
+        formFields?: {
+          customer?: CustomerFormFieldDefinition[];
+        };
+      };
+    };
+  };
+  errors?: Array<{ message: string }>;
+}
+
+const QUERY_CUSTOMER_FORM_FIELD_SETTINGS = `query CustomerFormFieldSettings {
+  site {
+    settings {
+      formFields {
+        customer {
+          __typename
+          entityId
+          label
+          ... on MultipleChoicesFormField { options { entityId label } }
+          ... on CheckboxesFormField { options { entityId label } }
+        }
+      }
+    }
+  }
+}`;
+
+export async function getCustomerFormFieldDefinitions(): Promise<CustomerFormFieldSettingsResponse> {
+  return storefrontGQLRequest<CustomerFormFieldSettingsResponse>({
+    query: QUERY_CUSTOMER_FORM_FIELD_SETTINGS,
+  });
+}
+
+// ===========================================================================
+// Update mutation (BC-native customer.updateCustomer)
+// ===========================================================================
+
+// Typed form-field groups mirror the BC Storefront CustomerFormFieldsInput; each
+// entry is keyed by the field's numeric fieldEntityId (resolved from the definitions).
+export interface CustomerFormFieldsInput {
+  checkboxes?: Array<{ fieldEntityId: number; fieldValueEntityIds: number[] }>;
+  multipleChoices?: Array<{ fieldEntityId: number; fieldValueEntityId: number }>;
+  numbers?: Array<{ fieldEntityId: number; number: number }>;
+  dates?: Array<{ fieldEntityId: number; date: string }>;
+  passwords?: Array<{ fieldEntityId: number; password: string }>;
+  multilineTexts?: Array<{ fieldEntityId: number; multilineText: string }>;
+  texts?: Array<{ fieldEntityId: number; text: string }>;
+}
+
+export interface UpdateCustomerInput {
+  firstName?: string;
+  lastName?: string;
+  company?: string;
+  phone?: string;
+  email?: string;
+  formFields?: CustomerFormFieldsInput;
+}
+
+export interface UpdateCustomerResponse {
+  data?: {
+    customer?: {
+      updateCustomer?: {
+        customer?: Customer;
+      };
+    };
+  };
+  errors?: Array<{ message: string }>;
+}
+
+// customer.updateCustomer needs a reCaptchaV2 token when reCaptcha is enabled on the
+// storefront, so the token argument is only added when one is supplied.
+const updateCustomerMutation = (
+  withReCaptcha: boolean,
+) => `mutation UpdateCustomer($input: UpdateCustomerInput!${
+  withReCaptcha ? ', $reCaptchaToken: String!' : ''
+}) {
+  customer {
+    updateCustomer(input: $input${withReCaptcha ? ', reCaptchaV2: { token: $reCaptchaToken }' : ''}) {
+      customer {
+        firstName
+        lastName
+        company
+        phoneNumber: phone
+        email
+      }
+    }
+  }
+}`;
+
+export async function updateCustomerDetails(
+  input: UpdateCustomerInput,
+  reCaptchaToken?: string,
+): Promise<UpdateCustomerResponse> {
+  return storefrontGQLRequest<UpdateCustomerResponse>({
+    query: updateCustomerMutation(Boolean(reCaptchaToken)),
+    variables: reCaptchaToken ? { input, reCaptchaToken } : { input },
+  });
+}
+
+// ===========================================================================
+// Update mutation (B2B company user: company.updateCompanyUser)
+// ===========================================================================
+
+// company.updateCompanyUser uses the same entityId-keyed form-field groups as
+// customer.updateCustomer; only the scalar fields differ (it carries current/new
+// password instead of company).
+export interface UpdateCompanyUserInput {
+  firstName?: string;
+  lastName?: string;
+  email?: string;
+  phone?: string;
+  currentPassword?: string;
+  newPassword?: string;
+  formFields?: CustomerFormFieldsInput;
+}
+
+// The result's `errors` carries business validation failures (returned with a 200
+// and no top-level GraphQL errors), so the caller must check it.
+export interface UpdateCompanyUserResponse {
+  data?: {
+    company?: {
+      updateCompanyUser?: {
+        errors?: Array<{ code?: string; field?: string; message: string }>;
+      };
+    };
+  };
+  errors?: Array<{ message: string }>;
+}
+
+const MUTATION_UPDATE_COMPANY_USER = `mutation UpdateCompanyUser($input: UpdateCompanyUserInput!) {
+  company {
+    updateCompanyUser(input: $input) {
+      errors {
+        code
+        field
+        message
+      }
+    }
+  }
+}`;
+
+export async function updateCompanyUserDetails(
+  input: UpdateCompanyUserInput,
+): Promise<UpdateCompanyUserResponse> {
+  return storefrontGQLRequest<UpdateCompanyUserResponse>({
+    query: MUTATION_UPDATE_COMPANY_USER,
+    variables: { input },
+  });
+}

--- a/apps/storefront/src/shared/service/bc/graphql/accountSetting.ts
+++ b/apps/storefront/src/shared/service/bc/graphql/accountSetting.ts
@@ -215,7 +215,8 @@ const QUERY_CUSTOMER_FORM_FIELD_SETTINGS = `query CustomerFormFieldSettings {
           __typename
           entityId
           label
-          ... on MultipleChoicesFormField { options { entityId label } }
+          ... on PicklistFormField { options { entityId label } }
+          ... on RadioButtonsFormField { options { entityId label } }
           ... on CheckboxesFormField { options { entityId label } }
         }
       }
@@ -233,14 +234,14 @@ export async function getCustomerFormFieldDefinitions(): Promise<CustomerFormFie
 // Update mutation (BC-native customer.updateCustomer)
 // ===========================================================================
 
-// Typed form-field groups mirror the BC Storefront CustomerFormFieldsInput; each
-// entry is keyed by the field's numeric fieldEntityId (resolved from the definitions).
+// Typed form-field groups mirror the BC Storefront CustomerFormFieldsInput; each entry is
+// keyed by the field's numeric fieldEntityId. (Password is not here — BC customers change it
+// via customer.changePassword, B2B via the updateCompanyUser scalar.)
 export interface CustomerFormFieldsInput {
   checkboxes?: Array<{ fieldEntityId: number; fieldValueEntityIds: number[] }>;
   multipleChoices?: Array<{ fieldEntityId: number; fieldValueEntityId: number }>;
   numbers?: Array<{ fieldEntityId: number; number: number }>;
   dates?: Array<{ fieldEntityId: number; date: string }>;
-  passwords?: Array<{ fieldEntityId: number; password: string }>;
   multilineTexts?: Array<{ fieldEntityId: number; multilineText: string }>;
   texts?: Array<{ fieldEntityId: number; text: string }>;
 }
@@ -296,12 +297,65 @@ export async function updateCustomerDetails(
 }
 
 // ===========================================================================
+// Change password (BC customer.changePassword)
+// ===========================================================================
+
+// BC customer password changes go through the dedicated changePassword mutation (plain
+// currentPassword/newPassword scalars) — no form-field entityId or definitions needed.
+export interface ChangeCustomerPasswordResponse {
+  data?: {
+    customer?: {
+      changePassword?: {
+        errors?: Array<{ __typename?: string; message?: string; path?: string[] }>;
+      };
+    };
+  };
+  errors?: Array<{ message: string }>;
+}
+
+// The password values are passed as variables (not interpolated) so they're never embedded
+// in the query string.
+const MUTATION_CHANGE_CUSTOMER_PASSWORD = `mutation ChangeCustomerPassword($currentPassword: String!, $newPassword: String!) {
+  customer {
+    changePassword(input: { currentPassword: $currentPassword, newPassword: $newPassword }) {
+      errors {
+        __typename
+        ... on ValidationError { message path }
+        ... on CustomerDoesNotExistError { message }
+        ... on CustomerPasswordError { message }
+        ... on CustomerNotLoggedInError { message }
+      }
+    }
+  }
+}`;
+
+export async function changeCustomerPassword(
+  currentPassword: string,
+  newPassword: string,
+): Promise<ChangeCustomerPasswordResponse> {
+  return storefrontGQLRequest<ChangeCustomerPasswordResponse>({
+    query: MUTATION_CHANGE_CUSTOMER_PASSWORD,
+    variables: { currentPassword, newPassword },
+  });
+}
+
+// ===========================================================================
 // Update mutation (B2B company user: company.updateCompanyUser)
 // ===========================================================================
 
+// Company-user extra fields are name-keyed (no entityId) — the company-user equivalent of
+// customer form fields. Types mirror companyExtraFieldsType: text/multiline/number/dropdown.
+export interface CompanyUserExtraFieldsInput {
+  texts?: Array<{ name: string; text: string }>;
+  multilineTexts?: Array<{ name: string; multilineText: string }>;
+  numbers?: Array<{ name: string; number: string }>;
+  multipleChoices?: Array<{ name: string; fieldValue: string }>;
+}
+
 // company.updateCompanyUser uses the same entityId-keyed form-field groups as
 // customer.updateCustomer; only the scalar fields differ (it carries current/new
-// password instead of company).
+// password instead of company). It also accepts name-keyed extraFields for the
+// company-user's own custom fields (which don't have a BC form-field entityId).
 export interface UpdateCompanyUserInput {
   firstName?: string;
   lastName?: string;
@@ -310,6 +364,7 @@ export interface UpdateCompanyUserInput {
   currentPassword?: string;
   newPassword?: string;
   formFields?: CustomerFormFieldsInput;
+  extraFields?: CompanyUserExtraFieldsInput;
 }
 
 // The result's `errors` carries business validation failures (returned with a 200

--- a/apps/storefront/src/shared/service/bc/graphql/accountSetting.ts
+++ b/apps/storefront/src/shared/service/bc/graphql/accountSetting.ts
@@ -258,6 +258,7 @@ export interface UpdateCustomerResponse {
     customer?: {
       updateCustomer?: {
         customer?: Customer;
+        errors?: Array<{ __typename?: string; message?: string }>;
       };
     };
   };
@@ -279,6 +280,14 @@ const updateCustomerMutation = (
         company
         phoneNumber: phone
         email
+      }
+      errors {
+        __typename
+        ... on Error { message }
+        ... on CustomerDoesNotExistError { message }
+        ... on CustomerNotLoggedInError { message }
+        ... on EmailAlreadyInUseError { message }
+        ... on UnexpectedUpdateCustomerError { message }
       }
     }
   }

--- a/apps/storefront/src/types/accountSetting.ts
+++ b/apps/storefront/src/types/accountSetting.ts
@@ -30,6 +30,8 @@ export interface Fields {
 interface BcFormFieldsProps {
   name: string;
   value: any;
+  fieldType?: string;
+  fieldEntityId?: number;
 }
 
 export interface ParamProps {

--- a/apps/storefront/src/types/accountSetting.ts
+++ b/apps/storefront/src/types/accountSetting.ts
@@ -32,6 +32,9 @@ interface BcFormFieldsProps {
   value: any;
   fieldType?: string;
   fieldEntityId?: number;
+  // The react-hook-form registered field name (Fields['name']), carried through so an
+  // unsendable field can be traced back to the control that should show the error.
+  formName?: string;
 }
 
 export interface ParamProps {

--- a/apps/storefront/src/types/accountSetting.ts
+++ b/apps/storefront/src/types/accountSetting.ts
@@ -35,6 +35,9 @@ interface BcFormFieldsProps {
   // The react-hook-form registered field name (Fields['name']), carried through so an
   // unsendable field can be traced back to the control that should show the error.
   formName?: string;
+  // Carried through from Fields['required'] so a required field is resent even when
+  // unchanged — BC revalidates every required custom field on each update call.
+  required?: boolean;
 }
 
 export interface ParamProps {


### PR DESCRIPTION


Jira: [B2B-4938](https://bigcommercecloud.atlassian.net/browse/B2B-4938)

**What/Why?**

Migrates account-settings updates from the legacy name-based b2b middleware mutations to the native BC Storefront GraphQL mutations, behind the PROJECT-7920.use_bc_account_settings flag:

- BC customers → customer.updateCustomer; B2B company users → company.updateCompanyUser.
- Form fields are sent as entityId-keyed typed groups. The fielconfig field_<id> fieldId; choice/checkbox option ids come fromsite.settings.formFields.customer.
- Only changed custom fields are sent (normalized comparison), d now clears it.
- reCaptcha token wiring is required for customer.updateCustomer and is shared via a new useStorefrontCaptcha hook (also adopted by ForgotPassword).
- Flag off → unchanged legacy path.

**Rollout/Rollback**

Gated by the PROJECT-7920.use_bc_account_settings LaunchDarkly e flag; roll back by disabling it (falls straight back to thelegacy middleware path). Code-only change, no data migrations.

**Testing**                                                                                                                                              
- Unit + integration tests added/updated (utils.test.ts, index.test.tsx) — 41 utils + 5 SF-GQL integration tests covering both native paths, change  detection, clearing, and entityId resolution. Full suite green;
- Manual (flag on): BC customer and B2B company user — edited scalar fields, custom text/number fields, and password; confirmed the updateCustomer / updateCompanyUser payloads carry the expected formFields keyed
- Manual (flag off): confirmed the legacy updateBCAccountSettings / updateB2BAccountSettings path is unchanged.
                                            
**Known limitation**: choice/checkbox custom fields require site.settings.formFields.customer, which currently returns empty through the b2b proxy; such edits surface an error rather than saving silently.


Before

https://github.com/user-attachments/assets/99d9ce0c-01f5-4012-bfaf-152e9c48c350

After
includes, b2b, b2c, junior buyer, senior buyer, super admin, masquerading tests

https://github.com/user-attachments/assets/3a7a2d88-397b-4b66-a953-aed09e292262



[B2B-4938]: https://bigcommercecloud.atlassian.net/browse/B2B-4938?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes how customer profile, passwords, and custom fields are saved (including reCaptcha-gated mutations) across BC and B2B users; rollout is flag-gated but the native path is security- and data-sensitive.
> 
> **Overview**
> When **`PROJECT-7920.use_bc_account_settings`** is on, account-settings saves no longer go through the legacy B2B middleware **`updateBCAccountSettings` / `updateB2BAccountSettings`** path. BC customers use **`customer.updateCustomer`** (with optional reCaptcha v2) and **`customer.changePassword`** for password changes; B2B company users use **`company.updateCompanyUser`**.
> 
> Custom fields are built as **entityId-keyed typed `formFields`** (and name-keyed **`extraFields`** for contact-group B2B fields), using **`field_<id>`** parsing and **`site.settings.formFields.customer`** definitions for choice/checkbox option ids. Only **changed** custom fields are sent (with required fields resent for BC revalidation); values that cannot be represented (cleared numbers/dates, unmapped choices) surface **`fieldCannotBeSaved`** instead of silently dropping edits.
> 
> Save logic moves into **`useAccountSettingsSubmit`**; reCaptcha config loading is centralized in **`useStorefrontCaptcha`** (also used by **Forgot Password**). Init/submit helpers adjust date defaults and scalar payload shape for the native path vs legacy flag-off behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6414b0f34e9a6a4d05ae3ee9a8c5597c06fd1bfb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->