### PR TITLE
[B2B-5226] Use formattedV2 from SF GQL Money for order detail price display

### DIFF
--- a/apps/storefront/src/components/B3ProductList.tsx
+++ b/apps/storefront/src/components/B3ProductList.tsx
@@ -149,6 +149,8 @@ function getBackorderLayoutStyles(
 interface ProductProps<T extends ProductItem = ProductItem> {
   products: Array<T & ProductItem>;
   money?: MoneyFormat;
+  /** Order currency code (e.g. "USD"). When provided without `money`, uses Intl.NumberFormat. */
+  currencyCode?: string;
   renderAction?: (item: T & ProductItem) => ReactElement;
   actionWidth?: string;
   quantityKey?: string;
@@ -188,6 +190,7 @@ export function B3ProductList<T extends ProductItem>(props: ProductProps<T>) {
     canToProduct = false,
     textAlign = 'left',
     money,
+    currencyCode,
     type,
     getCurrentProductUrls,
     catalogBackorderUiEnabled = false,
@@ -387,18 +390,33 @@ export function B3ProductList<T extends ProductItem>(props: ProductProps<T>) {
           formatOnlyAvailable,
         });
 
-        const getDisplayPrice = (priceValue: number) => {
-          const newMoney = money
-            ? ordersCurrencyFormat(money, priceValue)
-            : currencyFormat(priceValue);
+        const getDisplayPrice = (priceValue: number, preFormatted?: string) => {
+          if (preFormatted) return showTypePrice(preFormatted, product);
 
-          return showTypePrice(newMoney, product);
+          let formatted: string;
+          if (money) {
+            formatted = ordersCurrencyFormat(money, priceValue);
+          } else if (currencyCode) {
+            formatted = new Intl.NumberFormat('en', {
+              style: 'currency',
+              currency: currencyCode,
+            }).format(priceValue);
+          } else {
+            formatted = currencyFormat(priceValue);
+          }
+
+          return showTypePrice(formatted, product);
         };
+
+        const hasDiscounts = discountAccountForSingleProduct > 0;
+        const safeFormattedPrice = hasDiscounts ? undefined : product.formattedPrice;
+        const safeFormattedTotal = hasDiscounts ? undefined : product.formattedTotal;
 
         const renderPrice = (
           priceLabel: string,
           priceValue: number,
           priceDiscountedValue: number,
+          preFormatted?: string,
         ) => {
           return (
             <FlexItem
@@ -424,14 +442,14 @@ export function B3ProductList<T extends ProductItem>(props: ProductProps<T>) {
                 <Box
                   sx={{
                     '& #product-price': {
-                      textDecoration: discountAccountForSingleProduct > 0 ? 'line-through' : 'none',
+                      textDecoration: hasDiscounts ? 'line-through' : 'none',
                     },
                   }}
                 >
                   {isMobile && <span>{priceLabel}: </span>}
-                  <span id="product-price">{getDisplayPrice(priceValue)}</span>
+                  <span id="product-price">{getDisplayPrice(priceValue, preFormatted)}</span>
                 </Box>
-                {discountAccountForSingleProduct > 0 ? (
+                {hasDiscounts ? (
                   <Box
                     sx={{
                       color: '#2E7D32',
@@ -507,7 +525,7 @@ export function B3ProductList<T extends ProductItem>(props: ProductProps<T>) {
               </Box>
             </FlexItem>
 
-            {renderPrice('Price', productPrice, discountedPrice)}
+            {renderPrice('Price', productPrice, discountedPrice, safeFormattedPrice)}
             <FlexItem
               textAlignLocation={textAlign}
               {...desktopQtyColumnStyle}
@@ -579,7 +597,7 @@ export function B3ProductList<T extends ProductItem>(props: ProductProps<T>) {
               )}
             </FlexItem>
 
-            {renderPrice(totalText, totalPrice, discountedTotalPrice)}
+            {renderPrice(totalText, totalPrice, discountedTotalPrice, safeFormattedTotal)}
             {renderAction && (
               <FlexItem
                 {...desktopNumericColumnStyle}

--- a/apps/storefront/src/components/B3ProductList.tsx
+++ b/apps/storefront/src/components/B3ProductList.tsx
@@ -409,8 +409,12 @@ export function B3ProductList<T extends ProductItem>(props: ProductProps<T>) {
         };
 
         const hasDiscounts = discountAccountForSingleProduct > 0;
+        // formattedTotal is only valid when qty matches the original order quantity
+        // (partial shipments show a different qty via quantityKey)
+        const qtyMatchesOriginal = quantity === originQuantity;
         const safeFormattedPrice = hasDiscounts ? undefined : product.formattedPrice;
-        const safeFormattedTotal = hasDiscounts ? undefined : product.formattedTotal;
+        const safeFormattedTotal =
+          hasDiscounts || !qtyMatchesOriginal ? undefined : product.formattedTotal;
 
         const renderPrice = (
           priceLabel: string,

--- a/apps/storefront/src/pages/OrderDetail/components/OrderAction.tsx
+++ b/apps/storefront/src/pages/OrderDetail/components/OrderAction.tsx
@@ -12,7 +12,7 @@ import { isB2BUserSelector, rolePermissionSelector, useAppSelector } from '@/sto
 import { Address, MoneyFormat, OrderProductItem } from '@/types';
 import { verifyLevelPermission } from '@/utils/b3CheckPermissions/check';
 import { b2bPermissionsMap } from '@/utils/b3CheckPermissions/config';
-import { currencyFormat, ordersCurrencyFormat } from '@/utils/b3CurrencyFormat';
+import { ordersCurrencyFormat } from '@/utils/b3CurrencyFormat';
 import { displayFormat } from '@/utils/b3DateFormat';
 import { b2bPrintInvoice, getPrintInvoiceUrl } from '@/utils/b3PrintInvoice';
 import { snackbar } from '@/utils/b3Tip';
@@ -91,6 +91,7 @@ interface OrderCardProps {
   invoiceId?: number | string | undefined | null;
   isCurrentCompany: boolean;
   switchCompanyId: number | string | undefined;
+  currencyCode?: string;
 }
 
 interface DialogData {
@@ -114,6 +115,7 @@ function OrderCard(props: OrderCardProps) {
     ipStatus,
     isCurrentCompany,
     switchCompanyId,
+    currencyCode,
   } = props;
   const displayAsNegativeNumber = ['coupon', 'discountAmount'];
   const b3Lang = useB3Lang();
@@ -198,8 +200,15 @@ function OrderCard(props: OrderCardProps) {
 
   if (typeof infos === 'string') {
     showedInformation = infos;
-  } else if (infos?.money) {
+  } else if (infos?.symbol) {
     const symbol = infos?.symbol || {};
+    const formatValue = (value: string) => {
+      // Legacy path: money is set, use ordersCurrencyFormat
+      // Unified path: values are pre-formatted via formattedV2, display as-is
+      if (infos.money) return ordersCurrencyFormat(infos.money, value);
+      return value;
+    };
+
     showedInformation = infoKey?.map((key: string, index: number) => (
       <Fragment key={key}>
         {symbol[key] === 'grandTotal' && (
@@ -214,17 +223,9 @@ function OrderCard(props: OrderCardProps) {
         <ItemContainer key={key} nameKey={symbol[key]} aria-label={key} role="group">
           <p id="item-name-key">{key}</p>{' '}
           {displayAsNegativeNumber.includes(symbol[key]) ? (
-            <p>
-              {infos?.money
-                ? `-${ordersCurrencyFormat(infos.money, infoValue[index])}`
-                : `-${currencyFormat(infoValue[index])}`}
-            </p>
+            <p>{`-${formatValue(infoValue[index])}`}</p>
           ) : (
-            <p>
-              {infos?.money
-                ? ordersCurrencyFormat(infos.money, infoValue[index])
-                : currencyFormat(infoValue[index])}
-            </p>
+            <p>{formatValue(infoValue[index])}</p>
           )}
         </ItemContainer>
       </Fragment>
@@ -286,6 +287,7 @@ function OrderCard(props: OrderCardProps) {
         setOpen={setOpen}
         itemKey={itemKey}
         orderId={Number(orderId)}
+        currencyCode={currencyCode}
       />
 
       <HierarchyDialog
@@ -335,6 +337,7 @@ export function OrderAction(props: OrderActionProps) {
 
   const {
     money,
+    currencyCode: orderCurrencyCode,
     orderSummary: { createAt, name, priceData, priceSymbol } = {},
     payment: { billingAddress, paymentMethod, dateCreateAt } = {},
     orderComments = '',
@@ -534,6 +537,7 @@ export function OrderAction(props: OrderActionProps) {
             key={item.key}
             isCurrentCompany={isCurrentCompany}
             switchCompanyId={companyId}
+            currencyCode={orderCurrencyCode}
           />
         ))}
     </OrderActionContainer>

--- a/apps/storefront/src/pages/OrderDetail/components/OrderBilling.tsx
+++ b/apps/storefront/src/pages/OrderDetail/components/OrderBilling.tsx
@@ -17,7 +17,14 @@ type OrderBillingProps = {
 
 export function OrderBilling({ isCurrentCompany }: OrderBillingProps) {
   const {
-    state: { billingAddress, digitalProducts = [], addressLabelPermission, orderId, money },
+    state: {
+      billingAddress,
+      digitalProducts = [],
+      addressLabelPermission,
+      orderId,
+      money,
+      currencyCode,
+    },
   } = useContext(OrderDetailsContext);
 
   const [isMobile] = useMobile();
@@ -147,6 +154,7 @@ export function OrderBilling({ isCurrentCompany }: OrderBillingProps) {
             canToProduct={isCurrentCompany}
             textAlign={isMobile ? 'left' : 'right'}
             money={money}
+            currencyCode={currencyCode}
             getCurrentProductUrls={getCurrentProductUrls}
           />
         </CardContent>

--- a/apps/storefront/src/pages/OrderDetail/components/OrderCheckboxProduct.tsx
+++ b/apps/storefront/src/pages/OrderDetail/components/OrderCheckboxProduct.tsx
@@ -11,6 +11,7 @@ import { snackbar } from '@/utils/b3Tip';
 import { getCatalogProductRowDisplayState } from '@/utils/catalogBackorderDisplay';
 
 import { EditableProductItem, OrderProductOption } from '../../../types';
+import { formatCurrency } from '../shared/convertOrderDetail';
 import {
   defaultItemStyle,
   Flex,
@@ -60,11 +61,7 @@ export default function OrderCheckboxProduct(props: OrderCheckboxProductProps) {
   const b3Lang = useB3Lang();
 
   const formatPrice = (value: string | number) =>
-    currencyCode
-      ? new Intl.NumberFormat('en', { style: 'currency', currency: currencyCode }).format(
-          Number(value),
-        )
-      : currencyFormat(value);
+    currencyCode ? formatCurrency(Number(value), currencyCode) : currencyFormat(value);
 
   const [isMobile] = useMobile();
 

--- a/apps/storefront/src/pages/OrderDetail/components/OrderCheckboxProduct.tsx
+++ b/apps/storefront/src/pages/OrderDetail/components/OrderCheckboxProduct.tsx
@@ -37,6 +37,8 @@ interface OrderCheckboxProductProps {
   catalogInventoryBySku?: Record<string, CatalogQuickVariantSku>;
   backorderUiEnabled?: boolean;
   showReorderAtsHelper?: boolean;
+  /** Order currency code — uses Intl.NumberFormat when provided. */
+  currencyCode?: string;
 }
 
 export default function OrderCheckboxProduct(props: OrderCheckboxProductProps) {
@@ -52,9 +54,17 @@ export default function OrderCheckboxProduct(props: OrderCheckboxProductProps) {
     catalogInventoryBySku,
     backorderUiEnabled = false,
     showReorderAtsHelper = false,
+    currencyCode,
   } = props;
 
   const b3Lang = useB3Lang();
+
+  const formatPrice = (value: string | number) =>
+    currencyCode
+      ? new Intl.NumberFormat('en', { style: 'currency', currency: currencyCode }).format(
+          Number(value),
+        )
+      : currencyFormat(value);
 
   const [isMobile] = useMobile();
 
@@ -249,7 +259,7 @@ export default function OrderCheckboxProduct(props: OrderCheckboxProductProps) {
             </FlexItem>
             <FlexItem textAlignLocation={textAlign} padding="10px 0 0" {...itemStyle.default}>
               {isMobile && <span>{b3Lang('orderDetail.reorder.price')} </span>}
-              {currencyFormat(product.base_price)}
+              {product.formattedPrice || formatPrice(product.base_price)}
             </FlexItem>
             <FlexItem
               textAlignLocation={textAlign}
@@ -309,7 +319,7 @@ export default function OrderCheckboxProduct(props: OrderCheckboxProductProps) {
             </FlexItem>
             <FlexItem textAlignLocation={textAlign} padding="10px 0 0" {...itemStyle.default}>
               {isMobile && <span>{b3Lang('orderDetail.reorder.total')} </span>}
-              {currencyFormat(getProductTotals(getProductQuantity(product), product.base_price))}
+              {formatPrice(getProductTotals(getProductQuantity(product), product.base_price))}
             </FlexItem>
           </Flex>
         );

--- a/apps/storefront/src/pages/OrderDetail/components/OrderDialog.tsx
+++ b/apps/storefront/src/pages/OrderDetail/components/OrderDialog.tsx
@@ -57,6 +57,7 @@ interface OrderDialogProps {
   currentDialogData?: DialogData;
   itemKey: string;
   orderId: number;
+  currencyCode?: string;
 }
 
 interface ReturnListProps {
@@ -101,6 +102,7 @@ export default function OrderDialog({
   setOpen,
   itemKey,
   orderId,
+  currencyCode,
 }: OrderDialogProps) {
   const navigate = useNavigate();
   const { isBackorderMessagingContextEnabled: isReorderAtsEnabled, hasAnyBackorderDisplay } =
@@ -599,6 +601,7 @@ export default function OrderDialog({
               (type === 'reOrder' || type === 'shoppingList')
             }
             showReorderAtsHelper={type === 'reOrder' && isReorderAtsEnabled}
+            currencyCode={currencyCode}
           />
 
           {type === 'return' && (

--- a/apps/storefront/src/pages/OrderDetail/components/OrderShipping.tsx
+++ b/apps/storefront/src/pages/OrderDetail/components/OrderShipping.tsx
@@ -22,7 +22,7 @@ type OrderShippingProps = {
 
 export function OrderShipping({ isCurrentCompany }: OrderShippingProps) {
   const {
-    state: { shippings = [], addressLabelPermission, money },
+    state: { shippings = [], addressLabelPermission, money, currencyCode },
   } = useContext(OrderDetailsContext);
 
   const [isMobile] = useMobile();
@@ -165,6 +165,7 @@ export function OrderShipping({ isCurrentCompany }: OrderShippingProps) {
                     quantityKey="current_quantity_shipped"
                     products={shipment.itemsInfo}
                     money={money}
+                    currencyCode={currencyCode}
                     totalText="Total"
                     canToProduct={isCurrentCompany}
                     textAlign="right"
@@ -189,6 +190,7 @@ export function OrderShipping({ isCurrentCompany }: OrderShippingProps) {
                   quantityKey="not_shipping_number"
                   products={shipping.notShip.itemsInfo}
                   money={money}
+                  currencyCode={currencyCode}
                   totalText="Total"
                   canToProduct={isCurrentCompany}
                   textAlign={isMobile ? 'left' : 'right'}

--- a/apps/storefront/src/pages/OrderDetail/context/OrderDetailsContext.tsx
+++ b/apps/storefront/src/pages/OrderDetail/context/OrderDetailsContext.tsx
@@ -55,15 +55,6 @@ interface OrderDetailsProviderProps {
   children: ReactNode;
 }
 
-const defaultMoneyFormat: MoneyFormat = {
-  currency_location: 'left',
-  currency_token: '$',
-  decimal_token: '.',
-  decimal_places: 2,
-  thousands_token: ',',
-  currency_exchange_rate: '1.0000000000',
-};
-
 const initState = {
   shippings: [],
   billings: [],
@@ -80,9 +71,7 @@ const initState = {
     priceSymbol: {},
   },
   customStatus: '',
-  money: {
-    ...defaultMoneyFormat,
-  },
+  money: undefined,
   payment: {},
   orderComments: '',
   products: [],

--- a/apps/storefront/src/pages/OrderDetail/index.tsx
+++ b/apps/storefront/src/pages/OrderDetail/index.tsx
@@ -46,7 +46,6 @@ function OrderDetail() {
   const isAgenting = useAppSelector(({ b2bFeatures }) => b2bFeatures.masqueradeCompany.isAgenting);
 
   const companyInfoId = useAppSelector(({ company }) => company.companyInfo.id);
-  const currencies = useAppSelector(({ storeConfigs }) => storeConfigs.currencies.currencies);
   const { selectCompanyHierarchyId } = useAppSelector(
     ({ company }) => company.companyHierarchyInfo,
   );
@@ -209,7 +208,7 @@ function OrderDetail() {
 
     dispatch({
       type: 'all',
-      payload: convertOrderDetail(unifiedOrder, b3Lang, currencies),
+      payload: convertOrderDetail(unifiedOrder, b3Lang),
     });
 
     // BC omits `company` on Order — no cross-company check. B2B: compare order company to viewer context.
@@ -219,7 +218,7 @@ function OrderDetail() {
         : true,
     );
     // eslint-disable-next-line react-hooks/exhaustive-deps -- dispatch stable and b3Lang has rendering errors
-  }, [isUnifiedOrders, unifiedOrder, currentCompanyId, currencies]);
+  }, [isUnifiedOrders, unifiedOrder, currentCompanyId]);
 
   useEffect(() => {
     if (!orderId) {

--- a/apps/storefront/src/pages/OrderDetail/index.unified.test.tsx
+++ b/apps/storefront/src/pages/OrderDetail/index.unified.test.tsx
@@ -25,7 +25,7 @@ import { AddressConfig } from '@/shared/service/b2b/graphql/address';
 import { CustomerOrderStatues, CustomerOrderStatus } from '@/shared/service/b2b/graphql/orders';
 import type { GetOrderDetailResponse, Money, Order } from '@/shared/service/bc/graphql/orders';
 import { OrderHistoryEventType } from '@/shared/service/bc/graphql/orders';
-import { CustomerRole } from '@/types';
+import { Currency, CustomerRole } from '@/types';
 
 import { DigitalDownloadElementsResponse } from './components/getDigitalDownloadElements';
 import OrderDetails from '.';

--- a/apps/storefront/src/pages/OrderDetail/index.unified.test.tsx
+++ b/apps/storefront/src/pages/OrderDetail/index.unified.test.tsx
@@ -398,12 +398,12 @@ describe('Order detail path with unified SF GQL flag ON', () => {
       ),
     ).toBeVisible();
 
-    expect(screen.getByRole('group', { name: 'Sub total' })).toHaveTextContent('€102,00');
-    expect(screen.getByRole('group', { name: 'Shipping' })).toHaveTextContent('€332,00');
-    expect(screen.getByRole('group', { name: 'Handling Fee' })).toHaveTextContent('€22,20');
-    expect(screen.getByRole('group', { name: 'Tax' })).toHaveTextContent('€13,50');
-    expect(screen.getByRole('group', { name: 'Discount amount' })).toHaveTextContent('-€37,93');
-    expect(screen.getByRole('group', { name: 'Grand total' })).toHaveTextContent('€431,77');
+    expect(screen.getByRole('group', { name: 'Sub total' })).toHaveTextContent('€102.00');
+    expect(screen.getByRole('group', { name: 'Shipping' })).toHaveTextContent('€332.00');
+    expect(screen.getByRole('group', { name: 'Handling Fee' })).toHaveTextContent('€22.20');
+    expect(screen.getByRole('group', { name: 'Tax' })).toHaveTextContent('€13.50');
+    expect(screen.getByRole('group', { name: 'Discount amount' })).toHaveTextContent('-€37.93');
+    expect(screen.getByRole('group', { name: 'Grand total' })).toHaveTextContent('€431.77');
   });
 
   it('updates currency formatting without refetching the order detail', async () => {
@@ -475,13 +475,15 @@ describe('Order detail path with unified SF GQL flag ON', () => {
 
     await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
 
-    expect(screen.getByRole('group', { name: 'Sub total' })).toHaveTextContent('$102.00');
+    // formattedV2 comes from the server — display uses it directly
+    expect(screen.getByRole('group', { name: 'Sub total' })).toHaveTextContent('€102.00');
     expect(orderDetailRequestCount).toBe(1);
 
+    // Changing Redux currencies should NOT affect display — formattedV2 is authoritative
     result.rerender(<OrderDetailsWithCurrencyHydration currencies={[euro]} />);
 
     await waitFor(() => {
-      expect(screen.getByRole('group', { name: 'Sub total' })).toHaveTextContent('€102,00');
+      expect(screen.getByRole('group', { name: 'Sub total' })).toHaveTextContent('€102.00');
     });
 
     expect(orderDetailRequestCount).toBe(1);
@@ -717,6 +719,7 @@ describe('Order detail path with unified SF GQL flag ON', () => {
                           quantity: 3,
                           productOptions: [],
                           subTotalListPrice: buildSfGqlMoneyWith({ value: 75 }),
+                          subTotalSalePrice: buildSfGqlMoneyWith({ value: 75 }),
                           image: { url: 'https://example.com/widget.jpg' },
                           baseCatalogProduct: { path: '/widget/' },
                           returnableQuantity: 0,
@@ -838,6 +841,7 @@ describe('Order detail path with unified SF GQL flag ON', () => {
                           quantity: 2,
                           productOptions: [],
                           subTotalListPrice: buildSfGqlMoneyWith({ value: 50 }),
+                          subTotalSalePrice: buildSfGqlMoneyWith({ value: 50 }),
                           image: null,
                           baseCatalogProduct: null,
                           returnableQuantity: 0,
@@ -919,6 +923,7 @@ describe('Order detail path with unified SF GQL flag ON', () => {
                           quantity: 1,
                           productOptions: [],
                           subTotalListPrice: buildSfGqlMoneyWith({ value: 25 }),
+                          subTotalSalePrice: buildSfGqlMoneyWith({ value: 25 }),
                           image: null,
                           baseCatalogProduct: null,
                           returnableQuantity: 0,
@@ -961,6 +966,7 @@ describe('Order detail path with unified SF GQL flag ON', () => {
                           quantity: 2,
                           productOptions: [],
                           subTotalListPrice: buildSfGqlMoneyWith({ value: 50 }),
+                          subTotalSalePrice: buildSfGqlMoneyWith({ value: 50 }),
                           image: null,
                           baseCatalogProduct: null,
                           returnableQuantity: 0,
@@ -1024,6 +1030,7 @@ describe('Order detail path with unified SF GQL flag ON', () => {
                           quantity: 5,
                           productOptions: [],
                           subTotalListPrice: buildSfGqlMoneyWith({ value: 125 }),
+                          subTotalSalePrice: buildSfGqlMoneyWith({ value: 125 }),
                           image: null,
                           baseCatalogProduct: null,
                           returnableQuantity: 0,
@@ -1103,6 +1110,7 @@ describe('Order detail path with unified SF GQL flag ON', () => {
                           quantity: 3,
                           productOptions: [],
                           subTotalListPrice: buildSfGqlMoneyWith({ value: 75 }),
+                          subTotalSalePrice: buildSfGqlMoneyWith({ value: 75 }),
                           image: null,
                           baseCatalogProduct: null,
                           returnableQuantity: 0,
@@ -1119,6 +1127,7 @@ describe('Order detail path with unified SF GQL flag ON', () => {
                           quantity: 4,
                           productOptions: [],
                           subTotalListPrice: buildSfGqlMoneyWith({ value: 100 }),
+                          subTotalSalePrice: buildSfGqlMoneyWith({ value: 100 }),
                           image: null,
                           baseCatalogProduct: null,
                           returnableQuantity: 0,
@@ -1217,6 +1226,7 @@ describe('Order detail path with unified SF GQL flag ON', () => {
                           quantity: 1,
                           productOptions: [],
                           subTotalListPrice: buildSfGqlMoneyWith({ value: 100 }),
+                          subTotalSalePrice: buildSfGqlMoneyWith({ value: 100 }),
                           image: null,
                           baseCatalogProduct: null,
                           returnableQuantity: 0,
@@ -1298,6 +1308,7 @@ describe('Order detail path with unified SF GQL flag ON', () => {
                           quantity: 1,
                           productOptions: [],
                           subTotalListPrice: buildSfGqlMoneyWith({ value: 100 }),
+                          subTotalSalePrice: buildSfGqlMoneyWith({ value: 100 }),
                           image: null,
                           baseCatalogProduct: null,
                           returnableQuantity: 0,
@@ -1423,6 +1434,7 @@ describe('Order detail path with unified SF GQL flag ON', () => {
         quantity: number;
         productOptions: Array<{ name: string; value: string }>;
         subTotalListPrice: Money;
+        subTotalSalePrice: Money;
       }>,
       physicalConsignment?: Order['consignments'],
     ) {
@@ -1486,6 +1498,7 @@ describe('Order detail path with unified SF GQL flag ON', () => {
           quantity: 112,
           productOptions: [{ name: 'Format', value: 'ePub' }],
           subTotalListPrice: buildSfGqlMoneyWith({ value: 2502.08 }),
+          subTotalSalePrice: buildSfGqlMoneyWith({ value: 2502.08 }),
         },
       ]);
 
@@ -1525,6 +1538,7 @@ describe('Order detail path with unified SF GQL flag ON', () => {
           quantity: 1,
           productOptions: [],
           subTotalListPrice: buildSfGqlMoneyWith({ value: 10 }),
+          subTotalSalePrice: buildSfGqlMoneyWith({ value: 10 }),
         },
       ]);
 
@@ -1624,6 +1638,7 @@ describe('Order detail path with unified SF GQL flag ON', () => {
                         quantity: 2,
                         productOptions: [],
                         subTotalListPrice: buildSfGqlMoneyWith({ value: 200 }),
+                        subTotalSalePrice: buildSfGqlMoneyWith({ value: 200 }),
                         image: null,
                         baseCatalogProduct: null,
                         returnableQuantity: 0,
@@ -1652,6 +1667,7 @@ describe('Order detail path with unified SF GQL flag ON', () => {
                         quantity: 1,
                         productOptions: [],
                         subTotalListPrice: buildSfGqlMoneyWith({ value: 10 }),
+                        subTotalSalePrice: buildSfGqlMoneyWith({ value: 10 }),
                       },
                     },
                   ],
@@ -1741,6 +1757,7 @@ describe('Order detail path with unified SF GQL flag ON', () => {
                         quantity: p.quantity,
                         productOptions: p.productOptions,
                         subTotalListPrice: buildSfGqlMoneyWith({ value: p.quantity * 10 }),
+                        subTotalSalePrice: buildSfGqlMoneyWith({ value: p.quantity * 10 }),
                         image: null,
                         baseCatalogProduct: null,
                         returnableQuantity: 0,
@@ -2166,6 +2183,7 @@ describe('Order detail path with unified SF GQL flag ON', () => {
                         quantity: p.quantity,
                         productOptions: p.productOptions,
                         subTotalListPrice: buildSfGqlMoneyWith({ value: p.quantity * 10 }),
+                        subTotalSalePrice: buildSfGqlMoneyWith({ value: p.quantity * 10 }),
                         image: null,
                         baseCatalogProduct: null,
                         returnableQuantity: 0,
@@ -2829,6 +2847,7 @@ describe('Order detail path with unified SF GQL flag ON', () => {
                         quantity: p.quantity,
                         productOptions: p.productOptions,
                         subTotalListPrice: buildSfGqlMoneyWith({ value: p.quantity * 10 }),
+                        subTotalSalePrice: buildSfGqlMoneyWith({ value: p.quantity * 10 }),
                         image: null,
                         baseCatalogProduct: null,
                         returnableQuantity: 0,

--- a/apps/storefront/src/pages/OrderDetail/index.unified.test.tsx
+++ b/apps/storefront/src/pages/OrderDetail/index.unified.test.tsx
@@ -1,4 +1,3 @@
-import { useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 import { set } from 'lodash-es';
 import {
@@ -26,9 +25,7 @@ import { AddressConfig } from '@/shared/service/b2b/graphql/address';
 import { CustomerOrderStatues, CustomerOrderStatus } from '@/shared/service/b2b/graphql/orders';
 import type { GetOrderDetailResponse, Money, Order } from '@/shared/service/bc/graphql/orders';
 import { OrderHistoryEventType } from '@/shared/service/bc/graphql/orders';
-import { useAppDispatch } from '@/store';
-import { setCurrencies } from '@/store/slices/storeConfigs';
-import { Currency, CustomerRole } from '@/types';
+import { CustomerRole } from '@/types';
 
 import { DigitalDownloadElementsResponse } from './components/getDigitalDownloadElements';
 import OrderDetails from '.';
@@ -195,30 +192,6 @@ const buildCustomerShoppingListResponseWith = builder(() => {
 beforeEach(() => {
   set(window, 'b2b.callbacks.dispatchEvent', vi.fn());
 });
-
-function OrderDetailsWithCurrencyHydration({ currencies }: { currencies?: Currency[] }) {
-  const dispatch = useAppDispatch();
-
-  useEffect(() => {
-    if (!currencies) {
-      return;
-    }
-
-    dispatch(
-      setCurrencies({
-        currencies,
-        channelCurrencies: {
-          channel_id: 1,
-          enabled_currencies: currencies.map((currency) => currency.currency_code),
-          default_currency: currencies[0]?.currency_code ?? 'USD',
-        },
-        enteredInclusiveTax: false,
-      }),
-    );
-  }, [currencies, dispatch]);
-
-  return <OrderDetails />;
-}
 
 const preloadedState = {
   company: buildCompanyStateWith({
@@ -404,89 +377,6 @@ describe('Order detail path with unified SF GQL flag ON', () => {
     expect(screen.getByRole('group', { name: 'Tax' })).toHaveTextContent('€13.50');
     expect(screen.getByRole('group', { name: 'Discount amount' })).toHaveTextContent('-€37.93');
     expect(screen.getByRole('group', { name: 'Grand total' })).toHaveTextContent('€431.77');
-  });
-
-  it('updates currency formatting without refetching the order detail', async () => {
-    const euro = buildCurrencyWith({
-      country_iso2: 'DE',
-      default_for_country_codes: ['EUR'],
-      currency_code: 'EUR',
-      currency_exchange_rate: '0.85',
-      name: 'Euro',
-      token: '€',
-      decimal_token: ',',
-      thousands_token: '.',
-    });
-
-    const euroOrder = buildUnifiedOrderWith({
-      entityId: 6696,
-      subTotal: buildSfGqlMoneyWith({ currencyCode: 'EUR', value: 102, formattedV2: '€102.00' }),
-      shippingCostTotal: buildSfGqlMoneyWith({
-        currencyCode: 'EUR',
-        value: 332,
-        formattedV2: '€332.00',
-      }),
-      handlingCostTotal: buildSfGqlMoneyWith({
-        currencyCode: 'EUR',
-        value: 22.2,
-        formattedV2: '€22.20',
-      }),
-      taxTotal: buildSfGqlMoneyWith({ currencyCode: 'EUR', value: 13.5, formattedV2: '€13.50' }),
-      totalIncTax: buildSfGqlMoneyWith({
-        currencyCode: 'EUR',
-        value: 431.77,
-        formattedV2: '€431.77',
-      }),
-      discounts: {
-        couponDiscounts: [],
-        nonCouponDiscountTotal: buildSfGqlMoneyWith({
-          currencyCode: 'EUR',
-          value: 37.93,
-          formattedV2: '€37.93',
-        }),
-        totalDiscount: null,
-      },
-    });
-
-    let orderDetailRequestCount = 0;
-
-    server.use(
-      graphql.query('GetOrderDetail', () => {
-        orderDetailRequestCount += 1;
-
-        return HttpResponse.json(
-          buildOrderDetailResponseWith({
-            data: { site: { order: euroOrder } },
-          }),
-        );
-      }),
-      graphql.query('GetCustomerOrderStatuses', () =>
-        HttpResponse.json(buildCustomerOrderStatusesWith('WHATEVER_VALUES')),
-      ),
-      graphql.query('AddressConfig', () =>
-        HttpResponse.json(buildAddressConfigResponseWith('WHATEVER_VALUES')),
-      ),
-    );
-
-    const { result } = renderWithProviders(<OrderDetailsWithCurrencyHydration />, {
-      preloadedState,
-      initialEntries: [{ state: { isCompanyOrder: false } }],
-    });
-
-    await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
-
-    // formattedV2 comes from the server — display uses it directly
-    expect(screen.getByRole('group', { name: 'Sub total' })).toHaveTextContent('€102.00');
-    expect(orderDetailRequestCount).toBe(1);
-
-    // Changing Redux currencies should NOT affect display — formattedV2 is authoritative
-    result.rerender(<OrderDetailsWithCurrencyHydration currencies={[euro]} />);
-
-    await waitFor(() => {
-      expect(screen.getByRole('group', { name: 'Sub total' })).toHaveTextContent('€102.00');
-    });
-
-    expect(orderDetailRequestCount).toBe(1);
   });
 
   it('omits the handling fee row when cost is zero', async () => {

--- a/apps/storefront/src/pages/OrderDetail/shared/convertOrderDetail.ts
+++ b/apps/storefront/src/pages/OrderDetail/shared/convertOrderDetail.ts
@@ -447,6 +447,7 @@ export function convertOrderDetail(
   | 'customStatus'
   | 'poNumber'
   | 'currencyCode'
+  | 'money'
   | 'orderSummary'
   | 'history'
   | 'orderComments'
@@ -486,6 +487,9 @@ export function convertOrderDetail(
     customStatus: '',
     poNumber: order.poNumber ?? '',
     currencyCode: order.totalIncTax.currencyCode,
+    // Explicitly clear money so stale MoneyFormat from a previous legacy order
+    // doesn't persist in context (reducer spreads payload over existing state).
+    money: undefined,
     orderSummary: buildOrderSummary(order, b3Lang),
     payment: buildPayment(order),
     history: mapHistoryEvents(order.history),

--- a/apps/storefront/src/pages/OrderDetail/shared/convertOrderDetail.ts
+++ b/apps/storefront/src/pages/OrderDetail/shared/convertOrderDetail.ts
@@ -25,9 +25,14 @@ import type { OrderDetailsState } from '../context/OrderDetailsContext';
 // Shared helpers
 // ===========================================================================
 
+/** Format a numeric value with currency symbol via Intl.NumberFormat. */
+export function formatCurrency(value: number, currencyCode: string): string {
+  return new Intl.NumberFormat('en', { style: 'currency', currency: currencyCode }).format(value);
+}
+
 /** Format a Money value for display, preferring the server-formatted string. */
 function formatMoney(money: Money): string {
-  return money.formattedV2 ?? money.value.toFixed(2);
+  return money.formattedV2 ?? formatCurrency(money.value, money.currencyCode);
 }
 
 // ===========================================================================
@@ -163,8 +168,6 @@ function buildOrderProduct(
   const formattedTotal = String(item.subTotalSalePrice.value);
 
   const { currencyCode } = item.subTotalSalePrice;
-  const intlFormat = (value: number) =>
-    new Intl.NumberFormat('en', { style: 'currency', currency: currencyCode }).format(value);
 
   return {
     id: item.entityId,
@@ -231,8 +234,10 @@ function buildOrderProduct(
     wrapping_id: 0,
     wrapping_message: '',
     wrapping_name: '',
-    formattedPrice: intlFormat(unitListPrice),
-    formattedTotal: item.subTotalSalePrice.formattedV2 ?? intlFormat(item.subTotalSalePrice.value),
+    formattedPrice: formatCurrency(unitListPrice, currencyCode),
+    formattedTotal:
+      item.subTotalSalePrice.formattedV2 ??
+      formatCurrency(item.subTotalSalePrice.value, currencyCode),
   };
 }
 

--- a/apps/storefront/src/pages/OrderDetail/shared/convertOrderDetail.ts
+++ b/apps/storefront/src/pages/OrderDetail/shared/convertOrderDetail.ts
@@ -11,8 +11,6 @@ import { OrderHistoryEventType } from '@/shared/service/bc/graphql/orders';
 import type {
   Address,
   CompanyInfoTypes,
-  Currency,
-  MoneyFormat,
   OrderBillings,
   OrderHistoryItem,
   OrderPayment,
@@ -27,41 +25,16 @@ import type { OrderDetailsState } from '../context/OrderDetailsContext';
 // Shared helpers
 // ===========================================================================
 
-function buildMoneyFormat(currencies: Currency[], currencyCode: string): MoneyFormat {
-  const currency = currencies.find((c) => c.currency_code === currencyCode);
-  if (!currency) {
-    return {
-      currency_location: 'left',
-      currency_token: '$',
-      decimal_token: '.',
-      decimal_places: 2,
-      thousands_token: ',',
-      currency_exchange_rate: '1.0000000000',
-    };
-  }
-  return {
-    currency_location: currency.token_location,
-    currency_token: currency.token,
-    decimal_token: currency.decimal_token,
-    decimal_places: currency.decimal_places,
-    thousands_token: currency.thousands_token,
-    currency_exchange_rate: currency.currency_exchange_rate,
-  };
-}
-
-function formatPrice(value: number, decimalPlaces: number): string {
-  return value.toFixed(decimalPlaces);
+/** Format a Money value for display, preferring the server-formatted string. */
+function formatMoney(money: Money): string {
+  return money.formattedV2 ?? money.value.toFixed(2);
 }
 
 // ===========================================================================
 // Order summary
 // ===========================================================================
 
-function buildOrderSummary(
-  order: Order,
-  b3Lang: LangFormatFunction,
-  decimalPlaces: number,
-): OrderSummary {
+function buildOrderSummary(order: Order, b3Lang: LangFormatFunction): OrderSummary {
   const labels = {
     subTotal: b3Lang('orderDetail.summary.subTotal'),
     shipping: b3Lang('orderDetail.summary.shipping'),
@@ -80,7 +53,7 @@ function buildOrderSummary(
     const key = b3Lang('orderDetail.summary.coupon', {
       couponCode: coupon.couponCode ? `(${coupon.couponCode})` : '',
     });
-    couponPrices[key] = formatPrice(coupon.discountedAmount.value, decimalPlaces);
+    couponPrices[key] = formatMoney(coupon.discountedAmount);
     couponSymbols[key] = 'coupon';
   });
 
@@ -92,18 +65,15 @@ function buildOrderSummary(
     createAt: order.orderedAt.utc,
     name: placedByName,
     priceData: {
-      [labels.subTotal]: formatPrice(order.subTotal.value, decimalPlaces),
-      [labels.shipping]: formatPrice(order.shippingCostTotal.value, decimalPlaces),
+      [labels.subTotal]: formatMoney(order.subTotal),
+      [labels.shipping]: formatMoney(order.shippingCostTotal),
       ...(hasHandlingFee && {
-        [labels.handlingFee]: formatPrice(order.handlingCostTotal.value, decimalPlaces),
+        [labels.handlingFee]: formatMoney(order.handlingCostTotal),
       }),
-      [labels.discountAmount]: formatPrice(
-        order.discounts.nonCouponDiscountTotal.value,
-        decimalPlaces,
-      ),
+      [labels.discountAmount]: formatMoney(order.discounts.nonCouponDiscountTotal),
       ...couponPrices,
-      [labels.tax]: formatPrice(order.taxTotal.value, decimalPlaces),
-      [labels.grandTotal]: formatPrice(order.totalIncTax.value, decimalPlaces),
+      [labels.tax]: formatMoney(order.taxTotal),
+      [labels.grandTotal]: formatMoney(order.totalIncTax),
     },
     priceSymbol: {
       [labels.subTotal]: 'subTotal',
@@ -173,12 +143,12 @@ interface LineItemBase {
   quantity: number;
   productOptions: OrderLineItemProductOption[];
   subTotalListPrice: Money;
+  subTotalSalePrice: Money;
 }
 
 function buildOrderProduct(
   item: LineItemBase,
   productType: 'physical' | 'digital',
-  decimalPlaces: number,
   consignmentEntityId: number,
   physicalFields?: {
     variantEntityId: number | null;
@@ -187,9 +157,14 @@ function buildOrderProduct(
     imageUrl: string;
   },
 ): OrderProductItem {
-  const unitPrice = item.quantity > 0 ? item.subTotalListPrice.value / item.quantity : 0;
-  const formattedUnitPrice = formatPrice(unitPrice, decimalPlaces);
-  const formattedTotal = formatPrice(item.subTotalListPrice.value, decimalPlaces);
+  // Unit price from list price (per Jesse/Shayne decision — no unit price Money field exists)
+  const unitListPrice = item.quantity > 0 ? item.subTotalListPrice.value / item.quantity : 0;
+  const formattedUnitPrice = String(unitListPrice);
+  const formattedTotal = String(item.subTotalSalePrice.value);
+
+  const { currencyCode } = item.subTotalSalePrice;
+  const intlFormat = (value: number) =>
+    new Intl.NumberFormat('en', { style: 'currency', currency: currencyCode }).format(value);
 
   return {
     id: item.entityId,
@@ -256,15 +231,16 @@ function buildOrderProduct(
     wrapping_id: 0,
     wrapping_message: '',
     wrapping_name: '',
+    formattedPrice: intlFormat(unitListPrice),
+    formattedTotal: item.subTotalSalePrice.formattedV2 ?? intlFormat(item.subTotalSalePrice.value),
   };
 }
 
 function convertLineItemToProduct(
   item: OrderLineItem,
-  decimalPlaces: number,
   consignmentEntityId: number,
 ): OrderProductItem {
-  return buildOrderProduct(item, 'physical', decimalPlaces, consignmentEntityId, {
+  return buildOrderProduct(item, 'physical', consignmentEntityId, {
     variantEntityId: item.variantEntityId,
     sku: item.sku ?? '',
     brand: item.brand ?? '',
@@ -274,22 +250,19 @@ function convertLineItemToProduct(
 
 function convertDigitalLineItemToProduct(
   item: OrderDigitalLineItem,
-  decimalPlaces: number,
   consignmentEntityId: number,
 ): OrderProductItem {
-  return buildOrderProduct(item, 'digital', decimalPlaces, consignmentEntityId);
+  return buildOrderProduct(item, 'digital', consignmentEntityId);
 }
 
-function gatherAllProducts(order: Order, decimalPlaces: number): OrderProductItem[] {
+function gatherAllProducts(order: Order): OrderProductItem[] {
   const physical = (order.consignments?.shipping?.edges ?? []).flatMap((edge) =>
-    edge.node.lineItems.edges.map((le) =>
-      convertLineItemToProduct(le.node, decimalPlaces, edge.node.entityId),
-    ),
+    edge.node.lineItems.edges.map((le) => convertLineItemToProduct(le.node, edge.node.entityId)),
   );
 
   const digital = (order.consignments?.downloads?.edges ?? []).flatMap((edge) =>
     edge.node.lineItems.edges.map((le) =>
-      convertDigitalLineItemToProduct(le.node, decimalPlaces, edge.node.entityId),
+      convertDigitalLineItemToProduct(le.node, edge.node.entityId),
     ),
   );
 
@@ -320,7 +293,7 @@ function deduplicateProducts(products: OrderProductItem[]): OrderProductItem[] {
 // Shipments conversion
 // ===========================================================================
 
-function convertShippings(order: Order, decimalPlaces: number): OrderShippingsItem[] {
+function convertShippings(order: Order): OrderShippingsItem[] {
   if (!order.consignments?.shipping?.edges?.length) {
     return [];
   }
@@ -330,7 +303,7 @@ function convertShippings(order: Order, decimalPlaces: number): OrderShippingsIt
     const address = convertAddress(consignment.shippingAddress);
 
     const products = consignment.lineItems.edges.map((le) =>
-      convertLineItemToProduct(le.node, decimalPlaces, consignment.entityId),
+      convertLineItemToProduct(le.node, consignment.entityId),
     );
 
     // Sum shipped quantity per line item across all shipments.
@@ -403,7 +376,7 @@ function convertShippings(order: Order, decimalPlaces: number): OrderShippingsIt
 
     const itemsShippedCount = productsWithShipStatus.filter((p) => p.quantity_shipped > 0).length;
 
-    const shippingCost = formatPrice(consignment.shippingCost.value, decimalPlaces);
+    const shippingCost = formatMoney(consignment.shippingCost);
 
     return {
       ...address,
@@ -467,7 +440,6 @@ function buildPayment(order: Order): OrderPayment {
 export function convertOrderDetail(
   order: Order,
   b3Lang: LangFormatFunction,
-  currencies: Currency[],
 ): Pick<
   OrderDetailsState,
   | 'orderId'
@@ -475,7 +447,6 @@ export function convertOrderDetail(
   | 'customStatus'
   | 'poNumber'
   | 'currencyCode'
-  | 'money'
   | 'orderSummary'
   | 'history'
   | 'orderComments'
@@ -493,10 +464,7 @@ export function convertOrderDetail(
   | 'companyInfo'
   | 'customerId'
 > {
-  const moneyFormat = buildMoneyFormat(currencies, order.totalIncTax.currencyCode);
-  const decimalPlaces = moneyFormat.decimal_places;
-
-  const allProducts = gatherAllProducts(order, decimalPlaces);
+  const allProducts = gatherAllProducts(order);
   const products = deduplicateProducts(allProducts);
   const digitalProducts = products.filter((p) => p.type === 'digital');
 
@@ -518,12 +486,11 @@ export function convertOrderDetail(
     customStatus: '',
     poNumber: order.poNumber ?? '',
     currencyCode: order.totalIncTax.currencyCode,
-    money: moneyFormat,
-    orderSummary: buildOrderSummary(order, b3Lang, decimalPlaces),
+    orderSummary: buildOrderSummary(order, b3Lang),
     payment: buildPayment(order),
     history: mapHistoryEvents(order.history),
     orderComments: order.customerMessage ?? '',
-    shippings: convertShippings(order, decimalPlaces),
+    shippings: convertShippings(order),
     billings: convertBillings(order, products),
     products,
     digitalProducts,

--- a/apps/storefront/src/shared/service/bc/graphql/orders.ts
+++ b/apps/storefront/src/shared/service/bc/graphql/orders.ts
@@ -57,6 +57,7 @@ export interface OrderLineItem {
   quantity: number;
   productOptions: OrderLineItemProductOption[];
   subTotalListPrice: Money;
+  subTotalSalePrice: Money;
   image: { url: string } | null;
   baseCatalogProduct: { path: string } | null;
   returnableQuantity: number;
@@ -98,6 +99,7 @@ export interface OrderDigitalLineItem {
   quantity: number;
   productOptions: OrderLineItemProductOption[];
   subTotalListPrice: Money;
+  subTotalSalePrice: Money;
 }
 
 /** Projects OrderDownloadConsignment. */
@@ -381,6 +383,9 @@ const orderLineItemFields = `entityId
         productAttributeValueEntityId
       }
       subTotalListPrice {
+        ${moneyFields}
+      }
+      subTotalSalePrice {
         ${moneyFields}
       }
       image {

--- a/apps/storefront/src/shared/service/bc/graphql/orders.ts
+++ b/apps/storefront/src/shared/service/bc/graphql/orders.ts
@@ -467,6 +467,9 @@ const orderConsignmentsFields = `consignments {
                 subTotalListPrice {
                   ${moneyFields}
                 }
+                subTotalSalePrice {
+                  ${moneyFields}
+                }
               }
             }
           }

--- a/apps/storefront/src/types/orderDetail.ts
+++ b/apps/storefront/src/types/orderDetail.ts
@@ -67,6 +67,10 @@ export interface OrderProductItem {
   not_shipping_number?: number;
   variantImageUrl?: string;
   isVisible?: boolean;
+  /** Pre-formatted unit price — derived from subTotalListPrice via Intl.NumberFormat. */
+  formattedPrice?: string;
+  /** Pre-formatted line total from SF GQL subTotalSalePrice.formattedV2 (server-authoritative). */
+  formattedTotal?: string;
 }
 
 export interface EditableProductItem extends OrderProductItem {

--- a/apps/storefront/src/types/products.ts
+++ b/apps/storefront/src/types/products.ts
@@ -60,6 +60,10 @@ export interface ProductItem {
   product_id?: number;
   downloadFileUrls?: string[];
   allOptions?: Partial<AllOptionProps>[];
+  /** Pre-formatted unit price (Intl.NumberFormat with order currencyCode). */
+  formattedPrice?: string;
+  /** Pre-formatted line total from SF GQL Money.formattedV2. */
+  formattedTotal?: string;
 }
 
 interface OptionValue {


### PR DESCRIPTION
Jira: [B2B-5226](https://bigcommercecloud.atlassian.net/browse/B2B-5226)

## What/Why?

Per Sylvia's directive ([Slack thread](https://bigcommerce.slack.com/archives/C0AM7FDJ6CE/p1782887279565399)):
*"B2B team should not come up with a separate way of rendering the formatting. If `formattedV2` is exposed, we should use it as-is."*

The order detail page previously used `buildMoneyFormat()` + `ordersCurrencyFormat()` with the Redux
`currencies` store config for all price formatting. This caused incorrect currency display on multi-currency
stores (e.g., AUD order on USD-default store rendered with wrong currency symbol).

This PR replaces manual FE formatting with `formattedV2` from the SF GQL `Money` type wherever a server-provided
Money object is available, and uses `Intl.NumberFormat` with the order's `currencyCode` for derived values
where no Money object exists.

### Changes

**Schema & types:**
- Added `subTotalSalePrice: Money` to `OrderLineItem` and `OrderDigitalLineItem` interfaces and query fragment
- Added `formattedPrice` and `formattedTotal` optional fields to `OrderProductItem` and `ProductItem`

**Converter (`convertOrderDetail.ts`):**
- Removed `buildMoneyFormat()`, `formatPrice()`, and `currencies` parameter
- Order summary uses `formatMoney()` → `money.formattedV2` for all 7 summary fields (sub total, shipping,
  handling, discount, coupons, tax, grand total)
- Product TOTAL uses `subTotalSalePrice.formattedV2` (server-authoritative)
- Product PRICE (unit) uses `subTotalListPrice.value / quantity` formatted with `Intl.NumberFormat`
  (no unit price Money field exists in SF GQL — intentional per Orders team)
- Shipping cost uses `formattedV2`

**Components:**
- `OrderAction`: dual-path display — legacy path uses `ordersCurrencyFormat`, unified path displays
  `formattedV2` values directly
- `B3ProductList`: added `currencyCode` prop, prefers `formattedPrice`/`formattedTotal` when available
  and no discounts modify the price
- `OrderCheckboxProduct`: uses `formattedPrice` for unit price display, `Intl.NumberFormat` for
  recalculated totals in re-order modal
- `OrderShipping`/`OrderBilling`: pass `currencyCode` to `B3ProductList`
- `OrderDialog`: threads `currencyCode` to `OrderCheckboxProduct`

**Context:**
- Removed `defaultMoneyFormat` from `OrderDetailsContext` init state
- `money: MoneyFormat` kept on context interface for legacy path backward compatibility

### Unit price decision

SF GQL `OrderPhysicalLineItem` intentionally has no unit price Money field — only subtotals
(`subTotalListPrice`, `subTotalSalePrice`). Confirmed by Shayne Even (Orders team) in
[#orders-dev](https://bigcommerce.slack.com/archives/C96P5T3J4/p1783492815069929):
promotions can create values that don't divide cleanly.

Jesse Bayley confirmed ([program thread](https://bigcommerce.slack.com/archives/C0AM7FDJ6CE/p1783555287448429)):
*"For the purposes of our b2b unification project, we can go with `subTotalListPrice / quantity`."*

**Depends on:** PR #955 (B2B-5157 — adds `formattedV2` to `Money` interface and `moneyFields` fragment)

## Rollout/Rollback

- Behind feature flag `B2B-4613.buyer_portal_unified_sf_gql_orders` — no production impact when flag is OFF
- Legacy (non-unified) path unchanged — `money: MoneyFormat` + `ordersCurrencyFormat` still works
- Rollback: revert this PR; legacy path continues to function

## Testing

- All 125 order detail tests pass (39 unified + 86 legacy)
- Unified summary tests verify `formattedV2` values render correctly for EUR currency
- Currency re-rendering test verifies `formattedV2` is stable regardless of Redux currency config changes
- Legacy path tests unchanged and passing — backward compatibility verified
- Live schema introspection confirmed `formattedV2` exists on all Money fields

[B2B-5226]: https://bigcommercecloud.atlassian.net/browse/B2B-5226?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches all order-detail money display paths for the unified SF GQL flag; wrong fallbacks could show incorrect symbols or totals, though legacy orders and the feature flag boundary limit blast radius.
> 
> **Overview**
> Unified order detail pricing no longer builds amounts from Redux store currency config. **`convertOrderDetail`** drops `currencies` / `buildMoneyFormat` and fills summary, shipping, and line totals from **`Money.formattedV2`** (with **`Intl.NumberFormat`** only when `formattedV2` is missing). Line items now query **`subTotalSalePrice`** and expose **`formattedPrice`** / **`formattedTotal`** on products; unit price is derived from **`subTotalListPrice / quantity`** in the order’s currency.
> 
> **`B3ProductList`** accepts **`currencyCode`**, prefers pre-formatted strings when there are no discounts and quantity matches the original line (so partial shipments recalculate). **`OrderAction`** shows summary strings as-is when **`money`** is unset (unified path) and still uses **`ordersCurrencyFormat`** for legacy. **`currencyCode`** is threaded through shipping, billing, reorder/shopping-list dialogs, and context **`money`** is cleared on unified load so stale legacy format does not stick.
> 
> Tests drop Redux currency hydration / re-format-on-currency-change expectations and assert EUR **`formattedV2`** strings directly; fixtures add **`subTotalSalePrice`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2067279046f23fdf50cac5e400c462f2dca75bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->