### PR TITLE
[B2B-5252] Remove unused details field from OrderHistoryEvent

### DIFF
--- a/apps/storefront/src/pages/OrderDetail/index.unified.test.tsx
+++ b/apps/storefront/src/pages/OrderDetail/index.unified.test.tsx
@@ -1355,7 +1355,6 @@ describe('Order detail path with unified SF GQL flag ON', () => {
                         status: 'Pending',
                         source: null,
                         createdBy: null,
-                        details: null,
                         createdAt: '2025-05-01T03:44:00.000Z',
                       },
                       {
@@ -1364,7 +1363,6 @@ describe('Order detail path with unified SF GQL flag ON', () => {
                         status: 'Shipped',
                         source: null,
                         createdBy: null,
-                        details: null,
                         createdAt: '2025-05-04T07:22:00.000Z',
                       },
                     ],

--- a/apps/storefront/src/shared/service/bc/graphql/orders.ts
+++ b/apps/storefront/src/shared/service/bc/graphql/orders.ts
@@ -158,7 +158,6 @@ export interface OrderHistoryEvent {
   status: string;
   source: string | null;
   createdBy: OrderPlacedBy | null;
-  details: Record<string, unknown> | null;
   createdAt: string;
 }
 
@@ -536,7 +535,6 @@ const orderB2BFields = `reference
       lastName
       email
     }
-    details
     createdAt
   }
   quote {


### PR DESCRIPTION
Jira: [B2B-5252](https://bigcommercecloud.atlassian.net/browse/B2B-5252)

## What/Why?

Remove the unused `details` field from the `OrderHistoryEvent` TypeScript interface
and the `orderB2BFields` GraphQL fragment.

Keelan confirmed in [Slack](https://bigcommerce.slack.com/archives/C079AR329M2/p1783491038131569)
(2026-07-08) that `details` is being removed from the unified SF GQL API — it's a JSON blob
that Buyer Portal requests but never renders. Since this field was being newly introduced
(not yet shipped), there is no production impact.

**Changes:**
- Remove `details` from `OrderHistoryEvent` interface in `orders.ts`
- Remove `details` from `orderB2BFields` GraphQL fragment in `orders.ts`
- Remove `details: null` from mock data in `index.unified.test.tsx`

## Rollout/Rollback

All unified orders code is behind feature flag `B2B-4613.buyer_portal_unified_sf_gql_orders`.
No rollout or rollback considerations — this removes an unused field that was never shipped.
Standard revert if needed.

## Testing

- TypeScript compilation passes — no downstream consumers of `details`
- ESLint clean on `orders.ts`
- Verified via grep: no component references `details` on `OrderHistoryEvent`
- Screenshots/videos to be attached.

[B2B-5252]: https://bigcommercecloud.atlassian.net/browse/B2B-5252?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small schema/query cleanup for an unused, unshipped field behind a feature flag; no consumers or UI depend on `details`.
> 
> **Overview**
> Aligns Buyer Portal with the unified storefront GraphQL API by dropping **`details`** from order history events everywhere it was wired but never used.
> 
> **`OrderHistoryEvent`** in `orders.ts` no longer includes `details`, and **`orderB2BFields`** no longer requests `details` on `history` in **`GetOrderDetail`**. Unified order detail test mocks drop `details: null` from history fixtures.
> 
> No UI or runtime behavior change—the field was not rendered and was not yet shipped to production (behind **`B2B-4613.buyer_portal_unified_sf_gql_orders`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45b9dc82936367fc35e3c0ea70973a7acb7afc1a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->