### PR TITLE
refactor(common): B2B-5056 replace platform string literals with typed helpers

### DIFF
--- a/apps/storefront/src/HeadlessController/getSku.tsx
+++ b/apps/storefront/src/HeadlessController/getSku.tsx
@@ -2,7 +2,7 @@ import { z } from 'zod';
 
 import B3Request from '@/shared/service/request/b3Fetch';
 import { LineItem } from '@/utils/b3Product/b3Product';
-import { platform } from '@/utils/basicConfig';
+import { isBigCommercePlatform } from '@/utils/basicConfig';
 
 const Options = z.array(
   z.object({
@@ -25,7 +25,7 @@ const graphqlRequest: typeof B3Request.graphqlBC | typeof B3Request.graphqlBCPro
   query,
   variables,
 }) => {
-  return platform === 'bigcommerce'
+  return isBigCommercePlatform()
     ? B3Request.graphqlBC({ query, variables })
     : B3Request.graphqlBCProxy({ query, variables });
 };

--- a/apps/storefront/src/constants/index.ts
+++ b/apps/storefront/src/constants/index.ts
@@ -1,3 +1,5 @@
+import { PLATFORM } from './platform';
+
 export const SUPPORT_LANGUAGE = ['en', 'zh', 'fr', 'nl', 'de', 'it', 'es'];
 
 // cspell:disable
@@ -68,7 +70,7 @@ export const BROWSER_LANG = navigator.language.substring(0, 2);
 const {
   setting: { platform, cart_url: cartUrl },
 } = window.B3;
-const CART_FALLBACK_VALUE = platform === 'bigcommerce' ? '/cart.php' : '/cart';
+const CART_FALLBACK_VALUE = platform === PLATFORM.BIGCOMMERCE ? '/cart.php' : '/cart';
 export const CART_URL = cartUrl ?? CART_FALLBACK_VALUE;
 export const CHECKOUT_URL = '/checkout';
 

--- a/apps/storefront/src/constants/platform.ts
+++ b/apps/storefront/src/constants/platform.ts
@@ -1,0 +1,12 @@
+/**
+ * Channel platforms referenced in buyer portal logic.
+ *
+ * - `BIGCOMMERCE` — Stencil storefront (native BC)
+ * - `CATALYST` — BC headless (Catalyst)
+ * - `CUSTOM` — default for other headless integrations (Next, Gatsby, etc.)
+ */
+export const PLATFORM = {
+  BIGCOMMERCE: 'bigcommerce',
+  CATALYST: 'catalyst',
+  CUSTOM: 'custom',
+} as const;

--- a/apps/storefront/src/pages/AccountSetting/index.test.tsx
+++ b/apps/storefront/src/pages/AccountSetting/index.test.tsx
@@ -18,6 +18,7 @@ import AccountSetting from '.';
 vi.mock('@/utils/basicConfig', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@/utils/basicConfig')>()),
   platform: 'catalyst',
+  isCatalystPlatform: () => true,
 }));
 
 const { server } = startMockServer();

--- a/apps/storefront/src/pages/AccountSetting/index.tsx
+++ b/apps/storefront/src/pages/AccountSetting/index.tsx
@@ -28,7 +28,7 @@ import { CustomerRole, UserTypes } from '@/types';
 import { Fields, ParamProps } from '@/types/accountSetting';
 import { B3SStorage } from '@/utils/b3Storage';
 import { snackbar } from '@/utils/b3Tip';
-import { channelId, platform } from '@/utils/basicConfig';
+import { channelId, isCatalystPlatform } from '@/utils/basicConfig';
 import { deCodeField, getAccountFormFields } from '@/utils/registerUtils';
 
 import { getAccountSettingsFields, getPasswordModifiedFields } from './config';
@@ -53,7 +53,7 @@ function useData() {
   const isDisplayUpgradeBanner =
     CustomerRole.B2C === customer.role &&
     [UserTypes.B2C, UserTypes.MULTIPLE_B2C].includes(customer.userType) &&
-    platform === 'catalyst';
+    isCatalystPlatform();
 
   const validateEmailValue = async (emailValue: string) => {
     if (customer.emailAddress === trim(emailValue)) return true;

--- a/apps/storefront/src/pages/Invoice/utils/payment.ts
+++ b/apps/storefront/src/pages/Invoice/utils/payment.ts
@@ -4,6 +4,7 @@ import { getInvoiceCheckoutUrl } from '@/shared/service/b2b';
 import { BcCartData } from '@/types/invoice';
 import { attemptCheckoutLoginAndRedirect } from '@/utils/b3checkout';
 import b2bLogger from '@/utils/b3Logger';
+import { isBigCommercePlatform, isCatalystPlatform } from '@/utils/basicConfig';
 
 const getCheckoutUrlAndCart = async (params: BcCartData) => {
   const {
@@ -32,12 +33,12 @@ export const gotoInvoiceCheckoutUrl = async (
     }
   };
 
-  if (platform === 'bigcommerce') {
+  if (isBigCommercePlatform(platform)) {
     handleStencil();
     return;
   }
 
-  if (platform === 'catalyst') {
+  if (isCatalystPlatform(platform)) {
     window.location.assign(`/checkout?cartId=${cartId}`);
     return;
   }

--- a/apps/storefront/src/pages/Login/index.tsx
+++ b/apps/storefront/src/pages/Login/index.tsx
@@ -19,7 +19,7 @@ import { setB2BToken, setCurrentCustomerJWT } from '@/store/slices/company';
 import { LoginFlagType } from '@/types/login';
 import b2bLogger from '@/utils/b3Logger';
 import { snackbar } from '@/utils/b3Tip';
-import { channelId, platform } from '@/utils/basicConfig';
+import { channelId, isCatalystPlatform } from '@/utils/basicConfig';
 import { isCompanyError } from '@/utils/companyUtils';
 import { getCurrentCustomerInfo } from '@/utils/loginInfo';
 import { isDefaultLoginStylingActive } from '@/utils/preMountLoginMask';
@@ -429,7 +429,7 @@ function Login(props: PageProps) {
 }
 
 export default function LoginPage(props: PageProps) {
-  if (platform === 'catalyst') {
+  if (isCatalystPlatform()) {
     return <CatalystLogin />;
   }
 

--- a/apps/storefront/src/pages/PDP/index.tsx
+++ b/apps/storefront/src/pages/PDP/index.tsx
@@ -6,6 +6,7 @@ import { useB3Lang } from '@/lib/lang';
 import { GlobalContext } from '@/shared/global';
 import { isB2BUserSelector, useAppSelector } from '@/store';
 import { serialize } from '@/utils/b3Serialize';
+import { isBigCommercePlatform } from '@/utils/basicConfig';
 
 import CreateShoppingList from '../OrderDetail/components/CreateShoppingList';
 import OrderShoppingList from '../OrderDetail/components/OrderShoppingList';
@@ -24,7 +25,7 @@ function useData() {
   const isB2BUser = useAppSelector(isB2BUserSelector);
 
   const getShoppingListItem = () => {
-    if (platform !== 'bigcommerce') {
+    if (!isBigCommercePlatform(platform)) {
       return window.b2b.utils.shoppingList.itemFromCurrentPage[0];
     }
 

--- a/apps/storefront/src/pages/Registered/index.tsx
+++ b/apps/storefront/src/pages/Registered/index.tsx
@@ -15,7 +15,7 @@ import { useAppSelector } from '@/store';
 import b2bLogger from '@/utils/b3Logger';
 import { loginJump } from '@/utils/b3Login';
 import { B3SStorage } from '@/utils/b3Storage';
-import { platform } from '@/utils/basicConfig';
+import { isCatalystPlatform } from '@/utils/basicConfig';
 import { getCurrentCustomerInfo } from '@/utils/loginInfo';
 
 import { loginCheckout, LoginConfig } from '../Login/helper';
@@ -112,7 +112,7 @@ function Registered(props: PageProps) {
 
         clearRegisterInfo();
 
-        if (platform === 'catalyst') {
+        if (isCatalystPlatform()) {
           const landingLoginLocation =
             params.get('redirectTo') === 'check-out'
               ? LOGIN_LANDING_LOCATIONS.CHECKOUT

--- a/apps/storefront/src/pages/quote/utils/quoteCheckout.test.ts
+++ b/apps/storefront/src/pages/quote/utils/quoteCheckout.test.ts
@@ -42,6 +42,8 @@ vi.mock('@/utils/basicConfig', () => ({
   channelId: 1,
   disableLogoutButton: false,
   BigCommerceStorefrontAPIBaseURL: 'https://store-test-store.mybigcommerce.com',
+  isBigCommercePlatform: () => true,
+  isCatalystPlatform: () => false,
 }));
 
 vi.mock('@/utils/loginInfo', () => ({

--- a/apps/storefront/src/pages/quote/utils/quoteCheckout.ts
+++ b/apps/storefront/src/pages/quote/utils/quoteCheckout.ts
@@ -8,7 +8,7 @@ import { isLoggedInSelector } from '@/store/selectors';
 import { attemptCheckoutLoginAndRedirect, setQuoteToStorage } from '@/utils/b3checkout';
 import b2bLogger from '@/utils/b3Logger';
 import { snackbar } from '@/utils/b3Tip';
-import { platform } from '@/utils/basicConfig';
+import { isBigCommercePlatform, isCatalystPlatform } from '@/utils/basicConfig';
 import { getSearchVal } from '@/utils/loginInfo';
 
 import { detectQuoteStockChange, QuoteStockSnapshotItem } from './detectQuoteStockChange';
@@ -121,12 +121,12 @@ export const handleQuoteCheckout = async ({
       }
     }
 
-    if (platform === 'bigcommerce') {
+    if (isBigCommercePlatform()) {
       window.location.href = checkoutUrl;
       return;
     }
 
-    if (platform === 'catalyst') {
+    if (isCatalystPlatform()) {
       window.location.href = `/checkout?cartId=${cartId}`;
       return;
     }

--- a/apps/storefront/src/shared/service/b2b/graphql/login.ts
+++ b/apps/storefront/src/shared/service/b2b/graphql/login.ts
@@ -1,4 +1,4 @@
-import { platform } from '@/utils/basicConfig';
+import { isBigCommercePlatform } from '@/utils/basicConfig';
 import { convertObjectOrArrayKeysToCamel } from '@/utils/graphqlDataConvert';
 
 import B3Request from '../../request/b3Fetch';
@@ -17,7 +17,7 @@ const storeFrontToken = `mutation storeFrontToken($storeFrontTokenData: Customer
 }
 `;
 export const getBCGraphqlToken = (data: Partial<ApiTokenConfig>): Promise<string> | undefined => {
-  if (platform !== 'bigcommerce') {
+  if (!isBigCommercePlatform()) {
     return undefined;
   }
   return B3Request.graphqlB2B({

--- a/apps/storefront/src/shared/service/bc/api/login.ts
+++ b/apps/storefront/src/shared/service/bc/api/login.ts
@@ -1,11 +1,14 @@
-import { BigCommerceStorefrontAPIBaseURL, platform } from '../../../../utils/basicConfig';
+import {
+  BigCommerceStorefrontAPIBaseURL,
+  isBigCommercePlatform,
+} from '../../../../utils/basicConfig';
 
 /**
  * This function it's still present due the merchant can logs in as a client and stencil channels trade the current customer jwt to recognize
  * which user log in on the channel
  */
 export const getCurrentCustomerJWT = async (app_client_id: string) => {
-  if (platform !== 'bigcommerce') {
+  if (!isBigCommercePlatform()) {
     return undefined;
   }
   const response = await fetch(
@@ -26,7 +29,7 @@ export const getCurrentCustomerJWT = async (app_client_id: string) => {
  * it makes the stencil channel recognize the user who log in the channel
  */
 export const customerLoginAPI = (storefrontLoginToken: string) => {
-  if (platform !== 'bigcommerce') {
+  if (!isBigCommercePlatform()) {
     return;
   }
   fetch(`${BigCommerceStorefrontAPIBaseURL}/login/token/${storefrontLoginToken}`, {

--- a/apps/storefront/src/shared/service/bc/graphql/cart.ts
+++ b/apps/storefront/src/shared/service/bc/graphql/cart.ts
@@ -2,7 +2,7 @@ import Cookies from 'js-cookie';
 
 import { CreateCartInput, DeleteCartInput } from '@/types/cart';
 import { LineItem } from '@/utils/b3Product/b3Product';
-import { platform } from '@/utils/basicConfig';
+import { isBigCommercePlatform } from '@/utils/basicConfig';
 
 import B3Request from '../../request/b3Fetch';
 
@@ -326,7 +326,7 @@ export interface GetCart {
 }
 
 export const getCart = async (cartId?: string): Promise<GetCart> => {
-  if (platform === 'bigcommerce') {
+  if (isBigCommercePlatform()) {
     const cartInfo = await B3Request.graphqlBC({
       query: getCartInfo,
     });

--- a/apps/storefront/src/shared/service/bc/graphql/client.ts
+++ b/apps/storefront/src/shared/service/bc/graphql/client.ts
@@ -1,4 +1,4 @@
-import { platform } from '@/utils/basicConfig';
+import { isBigCommercePlatform } from '@/utils/basicConfig';
 
 import B3Request from '../../request/b3Fetch';
 
@@ -6,7 +6,5 @@ export function storefrontGQLRequest<T = any>(data: {
   query: string;
   variables?: object;
 }): Promise<T> {
-  return platform === 'bigcommerce'
-    ? B3Request.graphqlBC<T>(data)
-    : B3Request.graphqlBCProxy<T>(data);
+  return isBigCommercePlatform() ? B3Request.graphqlBC<T>(data) : B3Request.graphqlBCProxy<T>(data);
 }

--- a/apps/storefront/src/utils/b2bVerifyBcLoginStatus.ts
+++ b/apps/storefront/src/utils/b2bVerifyBcLoginStatus.ts
@@ -4,14 +4,14 @@ import { store } from '@/store';
 import { CustomerRole } from '@/types';
 import b2bLogger from '@/utils/b3Logger';
 
-import { platform } from './basicConfig';
+import { isBigCommercePlatform } from './basicConfig';
 
 const b2bVerifyBcLoginStatus = async () => {
   let isBcLogin = false;
   const { role } = store.getState().company.customer;
   const { B2BToken } = store.getState().company.tokens;
 
-  if (B2BToken && platform !== 'bigcommerce') return true;
+  if (B2BToken && !isBigCommercePlatform()) return true;
 
   try {
     if (Number(role) !== CustomerRole.GUEST) {

--- a/apps/storefront/src/utils/b3Login.ts
+++ b/apps/storefront/src/utils/b3Login.ts
@@ -3,14 +3,14 @@ import { NavigateFunction } from 'react-router-dom';
 import { LOGIN_LANDING_LOCATIONS } from '@/constants';
 import { store } from '@/store';
 
-import { platform } from './basicConfig';
+import { isCatalystPlatform } from './basicConfig';
 
 export const loginJump = (navigate: NavigateFunction, isClearSession = false) => {
   const {
     global: { loginLandingLocation, recordOpenHash, setOpenPageFn },
   } = store.getState();
   if (loginLandingLocation === LOGIN_LANDING_LOCATIONS.HOME && !recordOpenHash) {
-    if (platform === 'catalyst') {
+    if (isCatalystPlatform()) {
       return false;
     }
 
@@ -30,7 +30,7 @@ export const loginJump = (navigate: NavigateFunction, isClearSession = false) =>
     return false;
   }
   if (loginLandingLocation === LOGIN_LANDING_LOCATIONS.HOME && recordOpenHash) {
-    if (platform === 'catalyst') {
+    if (isCatalystPlatform()) {
       return false;
     }
 

--- a/apps/storefront/src/utils/b3PrintInvoice.test.tsx
+++ b/apps/storefront/src/utils/b3PrintInvoice.test.tsx
@@ -3,14 +3,17 @@ import { vi } from 'vitest';
 import { store } from '@/store';
 
 import { getPrintInvoiceBaseUrl } from './b3PrintInvoice';
-import * as basicConfig from './basicConfig';
 
 const STORE_URL = 'https://store-abc.mybigcommerce.com';
 const STOREFRONT_URL = 'https://my-custom-storefront.com';
 
+const platformMocks = vi.hoisted(() => ({
+  isBigCommercePlatform: vi.fn(() => true),
+}));
+
 vi.mock('./basicConfig', () => ({
-  platform: 'bigcommerce',
   BigCommerceStorefrontAPIBaseURL: 'https://store-abc.mybigcommerce.com',
+  isBigCommercePlatform: platformMocks.isBigCommercePlatform,
 }));
 
 const getStateWithUrls = (urls: string[]) => ({
@@ -23,6 +26,7 @@ const getStateWithUrls = (urls: string[]) => ({
 
 describe('getPrintInvoiceBaseUrl', () => {
   beforeEach(() => {
+    platformMocks.isBigCommercePlatform.mockReturnValue(true);
     vi.spyOn(store, 'getState').mockReturnValue(
       getStateWithUrls([]) as ReturnType<typeof store.getState>,
     );
@@ -30,15 +34,13 @@ describe('getPrintInvoiceBaseUrl', () => {
 
   describe('when platform is bigcommerce (Stencil)', () => {
     it('returns BigCommerceStorefrontAPIBaseURL', () => {
-      (basicConfig as { platform: string }).platform = 'bigcommerce';
-
       expect(getPrintInvoiceBaseUrl()).toBe(STORE_URL);
     });
   });
 
   describe('when platform is not bigcommerce (headless)', () => {
     beforeEach(() => {
-      (basicConfig as { platform: string }).platform = 'catalyst';
+      platformMocks.isBigCommercePlatform.mockReturnValue(false);
     });
 
     it('returns storefront URL when urls contain store URL first and storefront second', () => {

--- a/apps/storefront/src/utils/b3PrintInvoice.tsx
+++ b/apps/storefront/src/utils/b3PrintInvoice.tsx
@@ -1,7 +1,7 @@
 import { store } from '@/store';
 
 import b2bLogger from './b3Logger';
-import { BigCommerceStorefrontAPIBaseURL, platform } from './basicConfig';
+import { BigCommerceStorefrontAPIBaseURL, isBigCommercePlatform } from './basicConfig';
 
 const bindDom = (html: string, domId: string) => {
   let iframeDom = document.getElementById(domId) as HTMLIFrameElement | null;
@@ -28,7 +28,7 @@ const normalizeUrl = (url: string) => url.trim().replace(/\/$/, '');
  * On headless, derives from storeInfo.urls (store URL vs storefront URL) for the current channel.
  */
 export const getPrintInvoiceBaseUrl = (): string => {
-  if (platform === 'bigcommerce') return BigCommerceStorefrontAPIBaseURL;
+  if (isBigCommercePlatform()) return BigCommerceStorefrontAPIBaseURL;
   const { storeInfo } = store.getState().global;
   const storeUrlNormalized = normalizeUrl(BigCommerceStorefrontAPIBaseURL);
   const urls = storeInfo?.urls ?? [];
@@ -46,7 +46,7 @@ export const getPrintInvoiceUrl = (orderId: string) =>
 export const b2bPrintInvoice = async (orderId: string, domId: string) => {
   const url = getPrintInvoiceUrl(orderId);
 
-  if (platform !== 'bigcommerce') {
+  if (!isBigCommercePlatform()) {
     window.open(url);
     return;
   }

--- a/apps/storefront/src/utils/basicConfig.ts
+++ b/apps/storefront/src/utils/basicConfig.ts
@@ -1,12 +1,18 @@
+import { PLATFORM } from '@/constants/platform';
+
 export const {
   store_hash: storeHash,
   channel_id: channelId,
   disable_logout_button: disableLogoutButton,
-  platform = 'custom',
+  platform = PLATFORM.CUSTOM,
 } = window.B3.setting;
 
+export const isBigCommercePlatform = (value: string = platform) => value === PLATFORM.BIGCOMMERCE;
+
+export const isCatalystPlatform = (value: string = platform) => value === PLATFORM.CATALYST;
+
 const generateBcStorefrontAPIBaseUrl = () => {
-  if (platform === 'bigcommerce') return window.origin;
+  if (isBigCommercePlatform()) return window.origin;
   if (channelId === 1) return `https://store-${storeHash}.mybigcommerce.com`;
 
   return `https://store-${storeHash}-${channelId}.mybigcommerce.com`;


### PR DESCRIPTION
Jira: [B2B-5056](https://bigcommercecloud.atlassian.net/browse/B2B-5056)

## What/Why?
<!--
  A description about what this pull request implements and its purpose.
  Try to be detailed and describe any technical details to simplify the job
  of the reviewer and the individual on production support.
-->

- Introduces constants/platform.ts as a single source of truth for the three platform values the app branches on (PLATFORM.BIGCOMMERCE,
  PLATFORM.CATALYST, PLATFORM.CUSTOM)
  - Adds isBigCommercePlatform(value?) and isCatalystPlatform(value?) helpers in basicConfig.ts that default to the embed-script platform when
  called without arguments
  - Replaces all raw platform === 'bigcommerce' / platform === 'catalyst' string comparisons across 13 call sites with the new helpers
  - Updates b3PrintInvoice.test.tsx to mock isBigCommercePlatform as a function (required — the old test mutated the module property directly,
  which stopped working once the code switched to the helper)

## Rollout/Rollback
<!--
Detail how this change will be rolled out. Include reference to any
experiments and how the success will be measured as the experiment is
ramped.

Document rollback procedures. Is rolling back the change as simple as
rolling back an experiment or does it require reverting code? Are there
database migrations that may change our decision to roll forward instead of
back?
-->

Revert this PR

## Testing
<!--
Provide as much information as you can about how you tested and how another
Engineer can test your change. Include screenshots, or test run output
where appropriate.
-->
Updated the related tests.

[B2B-5056]: https://bigcommercecloud.atlassian.net/browse/B2B-5056?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical refactor with no intended behavior change; risk is limited to a mistyped platform check, mitigated by updated tests.
> 
> **Overview**
> Centralizes storefront **platform** values in `constants/platform.ts` (`PLATFORM.BIGCOMMERCE`, `PLATFORM.CATALYST`, `PLATFORM.CUSTOM`) and adds **`isBigCommercePlatform()`** / **`isCatalystPlatform()`** in `basicConfig.ts` (optional override arg, defaulting to embed `window.B3.setting.platform`).
> 
> **Replaces** scattered `platform === 'bigcommerce'` / `'catalyst'` checks across login, registration, checkout (quote/invoice), cart/GraphQL routing, JWT/login APIs, PDP shopping list, cart URL fallback, and print-invoice behavior with those helpers—behavior unchanged, comparisons centralized.
> 
> **Tests** now mock the helpers (e.g. `b3PrintInvoice.test.tsx` uses `vi.fn` on `isBigCommercePlatform` instead of mutating `platform` on the module).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db5ee10481abccbc5f232db291bd349c8c18a832. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->