### PR TITLE
feat(orders): BACK-658 Render backorder prompt for picklist items in …

### DIFF
--- a/apps/storefront/src/pages/QuickOrder/components/ChooseOptionsDialog.tsx
+++ b/apps/storefront/src/pages/QuickOrder/components/ChooseOptionsDialog.tsx
@@ -16,6 +16,7 @@ import isEqual from 'lodash-es/isEqual';
 import { B3CustomForm } from '@/components/B3CustomForm';
 import B3Dialog from '@/components/B3Dialog';
 import BackorderMessage from '@/components/BackorderMessage';
+import PicklistBackorderMessages from '@/components/PicklistBackorderMessages';
 import B3Spin from '@/components/spin/B3Spin';
 import { PRODUCT_DEFAULT_IMAGE } from '@/constants';
 import { useCatalogChooseOptionsBackorderDisplay } from '@/hooks/useCatalogChooseOptionsBackorderDisplay';
@@ -29,6 +30,11 @@ import { calculateProductListPrice, getBCPrice } from '@/utils/b3Product/b3Produ
 import { getOptionRequestData, getProductOptionsFields } from '@/utils/b3Product/shared/config';
 import { snackbar } from '@/utils/b3Tip';
 import { Base64 } from '@/utils/base64';
+import {
+  catalogListHasPicklistBackorderedItemsForDisplay,
+  getProductDetailsForPicklistSelections,
+} from '@/utils/catalogBackorderDisplay';
+import { parseAttributeOptionId } from '@/utils/parseAttributeOptionId';
 
 const Flex = styled('div')({
   display: 'flex',
@@ -121,11 +127,12 @@ export default function ChooseOptionsDialog(props: ChooseOptionsDialogProps) {
 
   const isShowPrice = !product?.isPriceHidden;
 
-  const { qtyHelperText, backorderFields } = useCatalogChooseOptionsBackorderDisplay({
-    product,
-    variantInfo,
-    quantity,
-  });
+  const { qtyHelperText, backorderFields, backorderUiEnabled } =
+    useCatalogChooseOptionsBackorderDisplay({
+      product,
+      variantInfo,
+      quantity,
+    });
 
   const setChooseOptionsForm = async (product: ShoppingListProductItem) => {
     try {
@@ -362,6 +369,24 @@ export default function ChooseOptionsDialog(props: ChooseOptionsDialogProps) {
     [formFields],
   );
 
+  const picklistSelections =
+    backorderUiEnabled && product?.modifiers?.length
+      ? getProductDetailsForPicklistSelections({
+          optionSelections: getOptionList(formValues).flatMap(({ optionId, optionValue }) => {
+            const parsedOptionId = parseAttributeOptionId(optionId);
+            return parsedOptionId === null
+              ? []
+              : [{ option_id: parsedOptionId, value_id: Number(optionValue) }];
+          }),
+          productsSearch: { modifiers: product.modifiers },
+        })
+      : [];
+
+  const hasPicklistBackorderToDisplay = catalogListHasPicklistBackorderedItemsForDisplay(
+    [{ qty: Number(quantity) || 0, selections: picklistSelections }],
+    additionalProducts,
+  );
+
   useEffect(() => {
     if (cache?.current && isEqual(cache?.current, formValues)) {
       return;
@@ -568,7 +593,7 @@ export default function ChooseOptionsDialog(props: ChooseOptionsDialogProps) {
                         fullWidth
                         error={Boolean(qtyHelperText)}
                       />
-                      {(qtyHelperText || backorderFields) && (
+                      {(qtyHelperText || backorderFields || hasPicklistBackorderToDisplay) && (
                         <Box
                           sx={{
                             width: 'max-content',
@@ -594,6 +619,13 @@ export default function ChooseOptionsDialog(props: ChooseOptionsDialogProps) {
                               visible
                             />
                           )}
+                          <PicklistBackorderMessages
+                            selections={picklistSelections}
+                            picklistProductsById={additionalProducts}
+                            qty={Number(quantity) || 0}
+                            visible
+                            backorderUiEnabled={backorderUiEnabled}
+                          />
                         </Box>
                       )}
                     </Box>

--- a/apps/storefront/src/pages/QuickOrder/index.quickpad.test.tsx
+++ b/apps/storefront/src/pages/QuickOrder/index.quickpad.test.tsx
@@ -750,4 +750,337 @@ describe('when backorder messaging is enabled', () => {
     expect(within(chooseOptionsDialog).queryByText('Lead time: 2-4 weeks')).not.toBeInTheDocument();
     expect(within(chooseOptionsDialog).queryByText('10 available')).not.toBeInTheDocument();
   });
+
+  it('shows the selected picklist child backorder in choose options', async () => {
+    renderWithProviders(<QuickOrderPad />, { preloadedState: backorderPreloadedState });
+
+    const productId = 9100;
+    const modifierId = 70;
+    const pickOptionId = 300;
+    const childProductId = 9200;
+
+    const pickleFestModifier = {
+      id: modifierId,
+      type: 'product_list',
+      display_name: 'PickleFest',
+      required: false,
+      option_values: [
+        {
+          id: pickOptionId,
+          label: 'Mining Pick',
+          is_default: true,
+          value_data: { product_id: childProductId },
+        },
+      ],
+    };
+
+    const baseVariant = buildVariantWith({
+      product_id: productId,
+      sku: 'PK',
+      purchasing_disabled: false,
+      option_values: [],
+      bc_calculated_price: {
+        tax_exclusive: 22,
+        tax_inclusive: 22,
+        as_entered: 22,
+        entered_inclusive: false,
+      },
+    });
+
+    const childProduct = buildSearchProductWith({
+      id: childProductId,
+      name: 'Mining Pick',
+      inventoryTracking: 'product',
+      availableToSell: 100,
+      unlimitedBackorder: false,
+      totalOnHand: 2,
+      backorderMessage: 'Lead time: 2-4 weeks',
+      variants: [],
+    });
+
+    const searchProducts = vi.fn<(...arg: unknown[]) => SearchProductsResponse>();
+
+    when(searchProducts)
+      .calledWith(stringContainingAll('search: "Pickle Kit"', 'currencyCode: "USD"'))
+      .thenReturn({
+        data: {
+          productsSearch: [
+            buildSearchProductWith({
+              id: productId,
+              name: 'Pickle Kit',
+              sku: 'PK',
+              inventoryTracking: 'simple',
+              optionsV3: [],
+              modifiers: [pickleFestModifier],
+              isPriceHidden: false,
+              orderQuantityMinimum: 0,
+              orderQuantityMaximum: 0,
+              inventoryLevel: 100,
+              variants: [baseVariant],
+            }),
+          ],
+        },
+      });
+
+    when(searchProducts)
+      .calledWith(stringContainingAll(`productIds: [${childProductId}]`))
+      .thenReturn({ data: { productsSearch: [childProduct] } });
+
+    const getPriceProducts = vi.fn<(...arg: unknown[]) => PriceProductsResponse>().mockReturnValue({
+      data: {
+        priceProducts: [buildProductPriceWith({ productId, variantId: baseVariant.variant_id })],
+      },
+    });
+
+    server.use(
+      graphql.query('SearchProducts', ({ query }) => HttpResponse.json(searchProducts(query))),
+      graphql.query('priceProducts', () => HttpResponse.json(getPriceProducts())),
+    );
+
+    const searchBox = screen.getByPlaceholderText('Search products');
+    await userEvent.type(searchBox, 'Pickle Kit');
+    await userEvent.click(screen.getByRole('button', { name: 'Search product' }));
+
+    const listDialog = await screen.findByRole('dialog', { name: 'Quick order pad' });
+    await userEvent.click(within(listDialog).getByRole('button', { name: 'Choose options' }));
+
+    const chooseOptionsDialog = await screen.findByRole('dialog', { name: 'Choose options' });
+    const quantityInput = within(chooseOptionsDialog).getByRole('spinbutton');
+
+    await userEvent.type(quantityInput, '4', {
+      initialSelectionStart: 0,
+      initialSelectionEnd: Infinity,
+    });
+
+    await waitFor(() => {
+      expect(within(chooseOptionsDialog).getByText('PickleFest:')).toBeVisible();
+    });
+    expect(within(chooseOptionsDialog).getByText('2 ready to ship')).toBeVisible();
+    expect(within(chooseOptionsDialog).getByText('2 will be backordered')).toBeVisible();
+    expect(within(chooseOptionsDialog).getByText('Lead time: 2-4 weeks')).toBeVisible();
+  });
+
+  it('hides the picklist child backorder when messaging is disabled', async () => {
+    renderWithProviders(<QuickOrderPad />, { preloadedState });
+
+    const productId = 9300;
+    const modifierId = 71;
+    const pickOptionId = 301;
+    const childProductId = 9400;
+
+    const pickleFestModifier = {
+      id: modifierId,
+      type: 'product_list',
+      display_name: 'PickleFest',
+      required: false,
+      option_values: [
+        {
+          id: pickOptionId,
+          label: 'Mining Pick',
+          is_default: true,
+          value_data: { product_id: childProductId },
+        },
+      ],
+    };
+
+    const baseVariant = buildVariantWith({
+      product_id: productId,
+      sku: 'PK2',
+      purchasing_disabled: false,
+      option_values: [],
+      bc_calculated_price: {
+        tax_exclusive: 22,
+        tax_inclusive: 22,
+        as_entered: 22,
+        entered_inclusive: false,
+      },
+    });
+
+    const childProduct = buildSearchProductWith({
+      id: childProductId,
+      name: 'Mining Pick',
+      inventoryTracking: 'product',
+      availableToSell: 100,
+      unlimitedBackorder: false,
+      totalOnHand: 2,
+      backorderMessage: 'Lead time: 2-4 weeks',
+      variants: [],
+    });
+
+    const searchProducts = vi.fn<(...arg: unknown[]) => SearchProductsResponse>();
+
+    when(searchProducts)
+      .calledWith(stringContainingAll('search: "Pickle Kit"'))
+      .thenReturn({
+        data: {
+          productsSearch: [
+            buildSearchProductWith({
+              id: productId,
+              name: 'Pickle Kit',
+              sku: 'PK2',
+              inventoryTracking: 'simple',
+              optionsV3: [],
+              modifiers: [pickleFestModifier],
+              isPriceHidden: false,
+              orderQuantityMinimum: 0,
+              orderQuantityMaximum: 0,
+              inventoryLevel: 100,
+              variants: [baseVariant],
+            }),
+          ],
+        },
+      });
+
+    when(searchProducts)
+      .calledWith(stringContainingAll(`productIds: [${childProductId}]`))
+      .thenReturn({ data: { productsSearch: [childProduct] } });
+
+    const getPriceProducts = vi.fn<(...arg: unknown[]) => PriceProductsResponse>().mockReturnValue({
+      data: {
+        priceProducts: [buildProductPriceWith({ productId, variantId: baseVariant.variant_id })],
+      },
+    });
+
+    server.use(
+      graphql.query('SearchProducts', ({ query }) => HttpResponse.json(searchProducts(query))),
+      graphql.query('priceProducts', () => HttpResponse.json(getPriceProducts())),
+    );
+
+    const searchBox = screen.getByPlaceholderText('Search products');
+    await userEvent.type(searchBox, 'Pickle Kit');
+    await userEvent.click(screen.getByRole('button', { name: 'Search product' }));
+
+    const listDialog = await screen.findByRole('dialog', { name: 'Quick order pad' });
+    await userEvent.click(within(listDialog).getByRole('button', { name: 'Choose options' }));
+
+    const chooseOptionsDialog = await screen.findByRole('dialog', { name: 'Choose options' });
+    const quantityInput = within(chooseOptionsDialog).getByRole('spinbutton');
+
+    await userEvent.type(quantityInput, '4', {
+      initialSelectionStart: 0,
+      initialSelectionEnd: Infinity,
+    });
+
+    await waitFor(() => {
+      expect(within(chooseOptionsDialog).getByText('PickleFest')).toBeVisible();
+    });
+    expect(within(chooseOptionsDialog).queryByText('PickleFest:')).not.toBeInTheDocument();
+    expect(
+      within(chooseOptionsDialog).queryByText('2 will be backordered'),
+    ).not.toBeInTheDocument();
+    expect(within(chooseOptionsDialog).queryByText('Lead time: 2-4 weeks')).not.toBeInTheDocument();
+  });
+
+  it('renders no picklist backorder block when the selected child is in stock', async () => {
+    renderWithProviders(<QuickOrderPad />, { preloadedState: backorderPreloadedState });
+
+    const productId = 9500;
+    const modifierId = 72;
+    const pickOptionId = 302;
+    const childProductId = 9600;
+
+    const pickleFestModifier = {
+      id: modifierId,
+      type: 'product_list',
+      display_name: 'PickleFest',
+      required: false,
+      option_values: [
+        {
+          id: pickOptionId,
+          label: 'Mining Pick',
+          is_default: true,
+          value_data: { product_id: childProductId },
+        },
+      ],
+    };
+
+    const baseVariant = buildVariantWith({
+      product_id: productId,
+      sku: 'PK3',
+      purchasing_disabled: false,
+      option_values: [],
+      bc_calculated_price: {
+        tax_exclusive: 22,
+        tax_inclusive: 22,
+        as_entered: 22,
+        entered_inclusive: false,
+      },
+    });
+
+    const childProduct = buildSearchProductWith({
+      id: childProductId,
+      name: 'Mining Pick',
+      inventoryTracking: 'product',
+      availableToSell: 100,
+      unlimitedBackorder: false,
+      totalOnHand: 100,
+      backorderMessage: 'Lead time: 2-4 weeks',
+      variants: [],
+    });
+
+    const searchProducts = vi.fn<(...arg: unknown[]) => SearchProductsResponse>();
+    when(searchProducts)
+      .calledWith(stringContainingAll('search: "Pickle Kit"'))
+      .thenReturn({
+        data: {
+          productsSearch: [
+            buildSearchProductWith({
+              id: productId,
+              name: 'Pickle Kit',
+              sku: 'PK3',
+              inventoryTracking: 'simple',
+              optionsV3: [],
+              modifiers: [pickleFestModifier],
+              isPriceHidden: false,
+              orderQuantityMinimum: 0,
+              orderQuantityMaximum: 0,
+              inventoryLevel: 100,
+              variants: [baseVariant],
+            }),
+          ],
+        },
+      });
+    when(searchProducts)
+      .calledWith(stringContainingAll(`productIds: [${childProductId}]`))
+      .thenReturn({ data: { productsSearch: [childProduct] } });
+
+    const getPriceProducts = vi.fn<(...arg: unknown[]) => PriceProductsResponse>().mockReturnValue({
+      data: {
+        priceProducts: [buildProductPriceWith({ productId, variantId: baseVariant.variant_id })],
+      },
+    });
+
+    server.use(
+      graphql.query('SearchProducts', ({ query }) => HttpResponse.json(searchProducts(query))),
+      graphql.query('priceProducts', () => HttpResponse.json(getPriceProducts())),
+    );
+
+    const searchBox = screen.getByPlaceholderText('Search products');
+    await userEvent.type(searchBox, 'Pickle Kit');
+    await userEvent.click(screen.getByRole('button', { name: 'Search product' }));
+
+    const listDialog = await screen.findByRole('dialog', { name: 'Quick order pad' });
+    await userEvent.click(within(listDialog).getByRole('button', { name: 'Choose options' }));
+
+    const chooseOptionsDialog = await screen.findByRole('dialog', { name: 'Choose options' });
+    const quantityInput = within(chooseOptionsDialog).getByRole('spinbutton');
+    await userEvent.type(quantityInput, '4', {
+      initialSelectionStart: 0,
+      initialSelectionEnd: Infinity,
+    });
+
+    // The picklist modifier label still renders in the options form...
+    await waitFor(() => {
+      expect(within(chooseOptionsDialog).getByText('PickleFest')).toBeVisible();
+    });
+    // ...but no backorder block (header or lines) shows for an in-stock child.
+    expect(within(chooseOptionsDialog).queryByText('PickleFest:')).not.toBeInTheDocument();
+    expect(within(chooseOptionsDialog).queryByText('Lead time: 2-4 weeks')).not.toBeInTheDocument();
+    expect(
+      within(chooseOptionsDialog).queryByText('ready to ship', { exact: false }),
+    ).not.toBeInTheDocument();
+    expect(
+      within(chooseOptionsDialog).queryByText('will be backordered', { exact: false }),
+    ).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
Jira: [BACK-658](https://bigcommercecloud.atlassian.net/browse/BACK-658)

## What/Why?
Render backorder prompt for picklist items in the quickorder prompt.

## Rollout/Rollback
Revert this PR if there are issues.

## Testing
Tests pass and additional tests added:

### Before:
Picklist child backorder information is not present when over the onhand threshold.
<img width="1880" height="975" alt="Screenshot 2026-07-15 at 10 33 31 am" src="https://github.com/user-attachments/assets/a2506ea8-9fb1-4ba2-b4af-2456922ddba7" />


### After:
Adding a picklist item results in the backorder information displaying correctly once the thresholds are crossed.
https://github.com/user-attachments/assets/5a4a15d3-624a-4318-bb0e-bacee30a10f4

Parent and child both backordered.
<img width="1889" height="984" alt="Screenshot 2026-07-15 at 10 25 32 am" src="https://github.com/user-attachments/assets/838b6e01-70e8-424f-891d-54eb1fec5959" />

Only parent backordered.
<img width="1854" height="1001" alt="Screenshot 2026-07-15 at 10 27 29 am" src="https://github.com/user-attachments/assets/c2a4a209-bb96-47e3-bf86-8916b885d9c4" />

Only child backordered.
<img width="1883" height="969" alt="Screenshot 2026-07-15 at 10 25 26 am" src="https://github.com/user-attachments/assets/fa127fba-2640-4f98-b65a-50008a62f4b1" />

None backordered.
<img width="1884" height="1000" alt="Screenshot 2026-07-15 at 10 25 42 am" src="https://github.com/user-attachments/assets/536a9a0a-500a-4bb0-8bc9-62ddf332723a" />

ping @animesh1987 @declankirk @bigcommerce/team-b2b 

[BACK-658]: https://bigcommercecloud.atlassian.net/browse/BACK-658?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Storefront-only display logic in Quick Order with feature-flag gating; covered by new integration tests and reuses existing components.
> 
> **Overview**
> Quick Order **Choose options** now surfaces backorder messaging for **product_list** (picklist) child products, alongside the existing parent variant backorder UI.
> 
> The dialog derives picklist selections from the current form values and quantity, uses shared `catalogBackorderDisplay` helpers to decide when to show the block, and renders `PicklistBackorderMessages` next to the quantity field when backorder UI is enabled. The helper area also opens when picklist backorder applies, not only for parent qty/backorder fields.
> 
> Integration tests cover showing child backorder when over on-hand, hiding it when storefront backorder messaging is off, and omitting the block when the selected child is in stock.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b3acc9b97f87b126ee963c33aa1a68ec3c6f739. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->