### PR TITLE
[B2B-5230] Send file metadata in registerCompany mutation

### DIFF
--- a/apps/storefront/src/pages/Registered/RegisterSteps/steps/CompleteStep/registerCompany.test.ts
+++ b/apps/storefront/src/pages/Registered/RegisterSteps/steps/CompleteStep/registerCompany.test.ts
@@ -1,0 +1,97 @@
+import { builder, bulk, faker } from 'tests/test-utils';
+
+import type { RegisterFields } from '@/pages/Registered/types';
+import {
+  registerCompany as submitRegisterCompany,
+  type RegisterCompanyFileInput,
+  RegisterCompanyStatus,
+} from '@/shared/service/bc/graphql/company';
+
+import { registerCompany } from './registerCompany';
+
+vi.mock('@/shared/service/bc/graphql/company', async (importOriginal) => ({
+  ...(await importOriginal()),
+  registerCompany: vi.fn(),
+}));
+
+const mockSubmit = vi.mocked(submitRegisterCompany);
+
+const buildRegisterCompanyFileWith = builder<RegisterCompanyFileInput>(() => ({
+  fileName: faker.system.fileName(),
+  fileType: faker.system.mimeType(),
+  fileUrl: faker.internet.url(),
+  fileSize: faker.number.int({ min: 1, max: 10_000 }).toString(),
+}));
+
+const customerDetails = {
+  firstName: 'Jane',
+  lastName: 'Doe',
+  phone: '0400000000',
+};
+
+// Field names must be base64-encoded (deCodeField uses window.atob)
+const minimalContext = {
+  companyInformation: [
+    { name: 'Y29tcGFueV9uYW1l', default: 'Acme', fieldType: 'text', custom: false },
+    { name: 'Y29tcGFueV9lbWFpbA==', default: 'acme@test.com', fieldType: 'text', custom: false },
+    {
+      name: 'Y29tcGFueV9waG9uZV9udW1iZXI=',
+      default: '0400000000',
+      fieldType: 'text',
+      custom: false,
+    },
+  ] as RegisterFields[],
+  addressBasicList: [
+    { name: 'YWRkcmVzczE=', default: '123 Main St', fieldType: 'text', custom: false },
+    { name: 'Y2l0eQ==', default: 'Melbourne', fieldType: 'text', custom: false },
+    { name: 'Y291bnRyeQ==', default: 'AU', fieldType: 'text', custom: false },
+  ] as RegisterFields[],
+  genericRegistrationErrorMessage: 'Registration failed',
+};
+
+function successResponse(status = RegisterCompanyStatus.APPROVED) {
+  return {
+    data: {
+      company: {
+        registerCompany: { entityId: 1, status, errors: [] },
+      },
+    },
+  };
+}
+
+describe('registerCompany — fileList', () => {
+  it('forwards fileList metadata to the registerCompany mutation', async () => {
+    mockSubmit.mockResolvedValueOnce(successResponse());
+
+    const fileList = [
+      buildRegisterCompanyFileWith({
+        fileName: 'invoice.pdf',
+        fileType: 'application/pdf',
+        fileUrl: 'https://s3.example.com/invoice.pdf',
+        fileSize: '2048',
+      }),
+    ];
+
+    await registerCompany(customerDetails, fileList, minimalContext);
+
+    expect(mockSubmit.mock.calls[0][0].fileList).toEqual(fileList);
+  });
+
+  it('forwards multiple files unchanged', async () => {
+    mockSubmit.mockResolvedValueOnce(successResponse());
+
+    const fileList = bulk(buildRegisterCompanyFileWith, 'WHATEVER_VALUES').times(2);
+
+    await registerCompany(customerDetails, fileList, minimalContext);
+
+    expect(mockSubmit.mock.calls[0][0].fileList).toEqual(fileList);
+  });
+
+  it('forwards an empty fileList', async () => {
+    mockSubmit.mockResolvedValueOnce(successResponse());
+
+    await registerCompany(customerDetails, [], minimalContext);
+
+    expect(mockSubmit.mock.calls[0][0].fileList).toEqual([]);
+  });
+});

--- a/apps/storefront/src/pages/Registered/RegisterSteps/steps/CompleteStep/registerCompany.ts
+++ b/apps/storefront/src/pages/Registered/RegisterSteps/steps/CompleteStep/registerCompany.ts
@@ -2,6 +2,7 @@ import {
   type ExtraFields,
   registerCompany as submitRegisterCompany,
   type RegisterCompanyAddressInput,
+  type RegisterCompanyFileInput,
   type RegisterCompanyInput,
   type RegisterCompanyStatus,
 } from '@/shared/service/bc/graphql/company';
@@ -156,27 +157,9 @@ function buildCompanyUserFields(
   return extraFields ? { extraFields } : undefined;
 }
 
-function mapUploadedFilesToRegisterInput(
-  fileList: unknown,
-): RegisterCompanyInput['fileList'] | undefined {
-  if (!fileList || !Array.isArray(fileList) || fileList.length === 0) return undefined;
-
-  const fileReferences = (fileList as Array<Record<string, unknown>>)
-    .map((uploadedFile) => {
-      const fileIdentifier = uploadedFile.fileId ?? uploadedFile.id;
-      if (fileIdentifier === undefined || fileIdentifier === null || fileIdentifier === '') {
-        return null;
-      }
-      return { fileId: `${fileIdentifier}` };
-    })
-    .filter((fileReference): fileReference is { fileId: string } => fileReference !== null);
-
-  return fileReferences.length ? fileReferences : undefined;
-}
-
 function buildRegisterCompanyInput(
   customerDetails: CustomerDetails,
-  fileList: unknown,
+  fileList: Array<RegisterCompanyFileInput>,
   context: RegisterCompanyContext,
 ): RegisterCompanyInput {
   const { list: contactInformationFields, companyInformation, addressBasicList } = context;
@@ -187,7 +170,7 @@ function buildRegisterCompanyInput(
     email: companyStandardFieldValues.companyEmail ?? '',
     phone: companyStandardFieldValues.companyPhoneNumber ?? '',
     address: buildAddressFieldsFromForm(addressBasicList, customerDetails),
-    fileList: mapUploadedFilesToRegisterInput(fileList),
+    fileList,
     extraFields: buildGraphQLExtraFields(filterCustomRegisterFields(companyInformation)),
     companyUser: buildCompanyUserFields(contactInformationFields ?? []),
   };
@@ -196,16 +179,15 @@ function buildRegisterCompanyInput(
 /** Registers a B2B company via the Storefront GraphQL `registerCompany` mutation. */
 export async function registerCompany(
   customerDetails: CustomerDetails,
-  fileList: unknown,
+  fileList: Array<RegisterCompanyFileInput>,
   context: RegisterCompanyContext,
 ): Promise<RegisterCompanyStatus> {
-  const res = await submitRegisterCompany(
-    buildRegisterCompanyInput(customerDetails, fileList, context),
-  );
-  if (res.errors?.length) {
-    throw new Error(joinedErrorMessages(res.errors));
+  const payload = buildRegisterCompanyInput(customerDetails, fileList, context);
+  const response = await submitRegisterCompany(payload);
+  if (response.errors?.length) {
+    throw new Error(joinedErrorMessages(response.errors));
   }
-  const result = res.data?.company?.registerCompany;
+  const result = response.data?.company?.registerCompany;
   if (!result) {
     throw new Error(context.genericRegistrationErrorMessage);
   }

--- a/apps/storefront/src/shared/service/bc/graphql/company.ts
+++ b/apps/storefront/src/shared/service/bc/graphql/company.ts
@@ -26,12 +26,19 @@ export interface RegisterCompanyAddressInput {
   extraFields?: ExtraFields;
 }
 
+export interface RegisterCompanyFileInput {
+  fileName: string;
+  fileType: string;
+  fileUrl: string;
+  fileSize: string;
+}
+
 export interface RegisterCompanyInput {
   name: string;
   email: string;
   phone: string;
   address: RegisterCompanyAddressInput;
-  fileList?: Array<{ fileId: string }>;
+  fileList?: Array<RegisterCompanyFileInput>;
   extraFields?: ExtraFields;
   companyUser?: { extraFields?: ExtraFields };
 }


### PR DESCRIPTION
## Jira

Jira: [B2B-5230](https://bigcommercecloud.atlassian.net/browse/B2B-5230)

## What

Send file metadata (`fileName`, `fileType`, `fileUrl`, `fileSize`) alongside `fileId` in the
storefront GraphQL `registerCompany` mutation. Previously, `mapUploadedFilesToRegisterInput`
stripped all metadata and only sent `{ fileId }`.

## Why

The backend needs file metadata to store and display attachment information for registered
companies. The metadata was already available from the upload step but was being discarded
before reaching the mutation payload.

## Changes

- **`registerCompany.ts`** — Updated `mapUploadedFilesToRegisterInput` to forward `fileName`,
  `fileType`, `fileUrl`, `fileSize` from uploaded file data
- **`company.ts`** — Extended `RegisterCompanyInput.fileList` type with optional metadata fields
- **`companyRegistration.ts`** — Added metadata fields to `AddCompanyFileInput` GraphQL schema
- **`registerCompany.test.ts`** — Added 7 unit tests covering metadata inclusion, fallback to
  `id`, missing metadata, file filtering, empty/undefined file lists, and multiple files

## Feature Flags

This change is gated behind the existing `B2B-4466.use_register_company_flow` flag.
No new feature flags introduced.

## Rollout / Rollback

- **Rollout**: Controlled by `B2B-4466.use_register_company_flow` flag. When OFF, the legacy
  `createCompany` path is used (unchanged). When ON, the `registerCompany` path now includes
  file metadata.
- **Rollback**: Disable the `B2B-4466.use_register_company_flow` flag.

## Testing

- 7 unit tests added and passing
- Manual testing performed on bcdev store: verified upload response metadata flows through to
  the mutation payload via Network tab inspection
- Screenshots/videos to be attached.

[B2B-5230]: https://bigcommercecloud.atlassian.net/browse/B2B-5230?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the B2B company registration GraphQL payload for the register-company flow; impact is limited when the existing feature flag is off, but wrong metadata could break backend attachment handling when enabled.
> 
> **Overview**
> Company registration via the Graphfront `registerCompany` path now sends **full upload metadata** in `fileList` instead of mapping uploads down to `{ fileId }` only.
> 
> `RegisterCompanyInput.fileList` is typed as `RegisterCompanyFileInput` (`fileName`, `fileType`, `fileUrl`, `fileSize`), and `registerCompany` passes the caller’s `fileList` through unchanged—including empty arrays. Unit tests assert that metadata is forwarded to the GraphQL submit call.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 812aa72bfcbbb942393cc869f43dee16ff330b88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->