### PR TITLE
fix(orders): B2B-4255 do not show orders with no PO number awaiting payment as "Paid in full"

### DIFF
--- a/apps/storefront/src/lib/lang/locales/en.json
+++ b/apps/storefront/src/lib/lang/locales/en.json
@@ -362,6 +362,7 @@
   "orderDetail.summary": "Summary",
   "orderDetail.paidInFull": "Paid in full on {paidDate}",
   "orderDetail.paidWithPo": "PO Submitted on {paidDate}",
+  "orderDetail.awaitingPayment": "Awaiting Payment",
   "orderDetail.payment": "Payment",
   "orderDetail.viewInvoice": "view invoice",
   "orderDetail.printInvoice": "print invoice",

--- a/apps/storefront/src/pages/OrderDetail/components/OrderAction.tsx
+++ b/apps/storefront/src/pages/OrderDetail/components/OrderAction.tsx
@@ -21,6 +21,9 @@ import { OrderDetailsContext, OrderDetailsState } from '../context/OrderDetailsC
 
 import OrderDialog from './OrderDialog';
 
+const AWAITING_PAYMENT_STATUS_ID = 7;
+const AWAITING_PAYMENT_STATUS_VALUE = 'AWAITING_PAYMENT';
+
 const OrderActionContainer = styled('div')(() => ({}));
 
 interface StyledCardActionsProps {
@@ -346,26 +349,27 @@ export function OrderAction(props: OrderActionProps) {
     ipStatus = 0,
     invoiceId,
     poNumber,
+    statusCode,
     customerId,
     companyInfo: { companyId } = {},
   } = detailsData;
 
   const getPaymentMessage = useCallback(() => {
-    let message = '';
-
-    if (!createAt) return message;
-
+    if (!createAt) return '';
     if (poNumber) {
-      message = b3Lang('orderDetail.paidWithPo', {
-        paidDate: displayFormat(createAt, true),
-      });
-    } else {
-      message = b3Lang('orderDetail.paidInFull', {
+      return b3Lang('orderDetail.paidWithPo', {
         paidDate: displayFormat(createAt, true),
       });
     }
-    return message;
-  }, [poNumber, createAt, b3Lang]);
+
+    if (statusCode === AWAITING_PAYMENT_STATUS_ID || statusCode === AWAITING_PAYMENT_STATUS_VALUE) {
+      return b3Lang('orderDetail.awaitingPayment');
+    }
+
+    return b3Lang('orderDetail.paidInFull', {
+      paidDate: displayFormat(createAt, true),
+    });
+  }, [poNumber, statusCode, createAt, b3Lang]);
 
   if (!orderId) {
     return null;

--- a/apps/storefront/src/pages/OrderDetail/components/OrderAction.tsx
+++ b/apps/storefront/src/pages/OrderDetail/components/OrderAction.tsx
@@ -18,11 +18,9 @@ import { b2bPrintInvoice, getPrintInvoiceUrl } from '@/utils/b3PrintInvoice';
 import { snackbar } from '@/utils/b3Tip';
 
 import { OrderDetailsContext, OrderDetailsState } from '../context/OrderDetailsContext';
+import { AWAITING_PAYMENT_STATUS_VALUE } from '../shared/orderStatus';
 
 import OrderDialog from './OrderDialog';
-
-const AWAITING_PAYMENT_STATUS_ID = 7;
-const AWAITING_PAYMENT_STATUS_VALUE = 'AWAITING_PAYMENT';
 
 const OrderActionContainer = styled('div')(() => ({}));
 
@@ -362,7 +360,7 @@ export function OrderAction(props: OrderActionProps) {
       });
     }
 
-    if (statusCode === AWAITING_PAYMENT_STATUS_ID || statusCode === AWAITING_PAYMENT_STATUS_VALUE) {
+    if (statusCode === AWAITING_PAYMENT_STATUS_VALUE) {
       return b3Lang('orderDetail.awaitingPayment');
     }
 

--- a/apps/storefront/src/pages/OrderDetail/index.test.tsx
+++ b/apps/storefront/src/pages/OrderDetail/index.test.tsx
@@ -172,6 +172,7 @@ const buildCustomerOrderResponseWith = builder<GetCustomerOrder>(() => ({
       shippingAddress: [buildShippingAddressWith('WHATEVER_VALUES')],
       coupons: [],
       status: faker.word.noun(),
+      statusId: faker.number.int(),
       paymentMethod: faker.lorem.sentence(3),
       shipments: false,
       billingAddress: {
@@ -427,6 +428,41 @@ describe('when a personal customer visits an order', () => {
 
     expect(await screen.findByRole('heading', { name: /Order #6696/ })).toBeVisible();
     expect(screen.getByText('Pending')).toBeVisible();
+  });
+
+  it('labels an order awaiting payment with no PO as awaiting payment', async () => {
+    vi.mocked(useParams).mockReturnValue({ id: '6696' });
+
+    server.use(
+      graphql.query('GetCustomerOrderStatuses', () =>
+        HttpResponse.json(buildCustomerOrderStatusesWith('WHATEVER_VALUES')),
+      ),
+      graphql.query('AddressConfig', () =>
+        HttpResponse.json(buildAddressConfigResponseWith('WHATEVER_VALUES')),
+      ),
+      graphql.query('GetCustomerOrder', () =>
+        HttpResponse.json(
+          buildCustomerOrderResponseWith({
+            data: {
+              customerOrder: {
+                status: 'Pending',
+                statusId: 7,
+                poNumber: '',
+              },
+            },
+          }),
+        ),
+      ),
+    );
+
+    renderWithProviders(<OrderDetails />, { preloadedState });
+
+    await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+    const paymentBox = screen.getByRole('heading', { name: 'Payment' }).parentElement!;
+    expect(within(paymentBox).getByText('Awaiting Payment')).toBeVisible();
+    expect(within(paymentBox).queryByText(/Paid in full/)).not.toBeInTheDocument();
+    expect(within(paymentBox).queryByText(/PO Submitted/)).not.toBeInTheDocument();
   });
 
   it('can navigate back to the orders listing page', async () => {

--- a/apps/storefront/src/pages/OrderDetail/index.unified.test.tsx
+++ b/apps/storefront/src/pages/OrderDetail/index.unified.test.tsx
@@ -1238,6 +1238,42 @@ describe('Order detail path with unified SF GQL flag ON', () => {
       expect(screen.getByRole('heading', { name: 'Payment' })).toBeVisible();
       expect(screen.getByText(/PO Submitted/)).toBeVisible();
     });
+
+    it('labels an order awaiting payment with no PO as awaiting payment', async () => {
+      const awaitingPaymentOrder = buildUnifiedOrderWith({
+        entityId: 6696,
+        reference: null,
+        orderedAt: { utc: '2026-05-01T12:00:00Z' },
+        status: { value: 'AWAITING_PAYMENT', label: 'Awaiting Payment' },
+        payments: [{ description: 'Cash on delivery' }],
+      });
+
+      server.use(
+        graphql.query('GetOrderDetail', () =>
+          HttpResponse.json(
+            buildOrderDetailResponseWith({ data: { site: { order: awaitingPaymentOrder } } }),
+          ),
+        ),
+        graphql.query('GetCustomerOrderStatuses', () =>
+          HttpResponse.json(buildCustomerOrderStatusesWith('WHATEVER_VALUES')),
+        ),
+        graphql.query('AddressConfig', () =>
+          HttpResponse.json(buildAddressConfigResponseWith('WHATEVER_VALUES')),
+        ),
+      );
+
+      renderWithProviders(<OrderDetails />, {
+        preloadedState,
+        initialEntries: [{ state: { isCompanyOrder: false } }],
+      });
+
+      await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+      const paymentBox = screen.getByRole('heading', { name: 'Payment' }).parentElement!;
+      expect(within(paymentBox).getByText('Awaiting Payment')).toBeVisible();
+      expect(within(paymentBox).queryByText(/Paid in full/)).not.toBeInTheDocument();
+      expect(within(paymentBox).queryByText(/PO Submitted/)).not.toBeInTheDocument();
+    });
   });
 
   describe('when there are order history events', () => {

--- a/apps/storefront/src/pages/OrderDetail/shared/B2BOrderData.ts
+++ b/apps/storefront/src/pages/OrderDetail/shared/B2BOrderData.ts
@@ -10,6 +10,8 @@ import {
   OrderSummary,
 } from '../../../types';
 
+import { normaliseLegacyStatusCode } from './orderStatus';
+
 interface CouponInfo {
   [key: string]: string;
 }
@@ -209,7 +211,7 @@ const convertB2BOrderDetails = (data: B2BOrderData, b3Lang: LangFormatFunction) 
   history: data.orderHistoryEvent || [],
   poNumber: data.poNumber || '',
   status: data.status,
-  statusCode: data.statusId,
+  statusCode: normaliseLegacyStatusCode(data.statusId),
   currencyCode: data.currencyCode,
   currency: data.money?.currency_token || '$',
   money: data.money,

--- a/apps/storefront/src/pages/OrderDetail/shared/convertOrderDetail.ts
+++ b/apps/storefront/src/pages/OrderDetail/shared/convertOrderDetail.ts
@@ -449,6 +449,7 @@ export function convertOrderDetail(
   OrderDetailsState,
   | 'orderId'
   | 'status'
+  | 'statusCode'
   | 'customStatus'
   | 'poNumber'
   | 'currencyCode'
@@ -489,6 +490,7 @@ export function convertOrderDetail(
   return {
     orderId: order.entityId,
     status: order.status.label,
+    statusCode: order.status.value ?? '',
     customStatus: '',
     poNumber: order.poNumber ?? '',
     currencyCode: order.totalIncTax.currencyCode,

--- a/apps/storefront/src/pages/OrderDetail/shared/orderStatus.test.ts
+++ b/apps/storefront/src/pages/OrderDetail/shared/orderStatus.test.ts
@@ -1,0 +1,11 @@
+import { AWAITING_PAYMENT_STATUS_VALUE, normaliseLegacyStatusCode } from './orderStatus';
+
+describe('normaliseLegacyStatusCode', () => {
+  it('maps the legacy awaiting-payment statusId to the unified status value', () => {
+    expect(normaliseLegacyStatusCode(7)).toBe(AWAITING_PAYMENT_STATUS_VALUE);
+  });
+
+  it('passes through statusIds that have no mapping', () => {
+    expect(normaliseLegacyStatusCode(2)).toBe(2);
+  });
+});

--- a/apps/storefront/src/pages/OrderDetail/shared/orderStatus.ts
+++ b/apps/storefront/src/pages/OrderDetail/shared/orderStatus.ts
@@ -1,0 +1,8 @@
+export const AWAITING_PAYMENT_STATUS_VALUE = 'AWAITING_PAYMENT';
+
+const LEGACY_STATUS_ID_TO_VALUE: Record<number, string> = {
+  7: AWAITING_PAYMENT_STATUS_VALUE,
+};
+
+export const normaliseLegacyStatusCode = (statusId: number): string | number =>
+  LEGACY_STATUS_ID_TO_VALUE[statusId] ?? statusId;

--- a/apps/storefront/src/shared/service/b2b/graphql/orders.ts
+++ b/apps/storefront/src/shared/service/b2b/graphql/orders.ts
@@ -211,6 +211,7 @@ export interface GetCustomerOrder {
       paymentMethod: string;
 
       status: string;
+      statusId: number;
 
       totalTax: number;
       totalExTax: number;


### PR DESCRIPTION
Jira: [B2B-4255](https://bigcommercecloud.atlassian.net/browse/B2B-4255)

## What/Why?
Orders awaiting payment without an associated PO number were incorrectly labelled as "Paid in full".

## Rollout/Rollback
Merge/revert

## Testing
Test provided in `apps/storefront/src/pages/OrderDetail/index.unified.test.tsx`.

### Before
Order awaiting payment shows "Paid in full"
<img width="1705" height="1020" alt="Screenshot 2026-07-16 at 2 42 47 pm" src="https://github.com/user-attachments/assets/4d5323fe-4d73-45c3-a372-4f7c541ff118" />


### After
Without PO
<img width="1699" height="1000" alt="Screenshot 2026-07-16 at 11 38 52 am" src="https://github.com/user-attachments/assets/c9d34e5d-9a57-4812-8071-8f5d52f2659d" />

With PO
<img width="1706" height="1073" alt="Screenshot 2026-07-16 at 11 40 00 am" src="https://github.com/user-attachments/assets/1e80c6e0-677f-4cc2-9dc1-29fdf9b37bcf" />

[B2B-4255]: https://bigcommercecloud.atlassian.net/browse/B2B-4255?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI copy and display logic only on order detail payment; PO and paid-in-full paths are unchanged aside from the new status branch.
> 
> **Overview**
> Fixes incorrect **"Paid in full"** copy on the order detail **Payment** card when an order has no PO and is still awaiting payment.
> 
> `getPaymentMessage` in `OrderAction` now checks order status before defaulting to paid: PO orders still show **PO Submitted**, awaiting-payment orders show the new **`orderDetail.awaitingPayment`** string, and other orders keep **Paid in full**. Awaiting payment is detected via status id `7` or value `AWAITING_PAYMENT` (legacy and unified flows).
> 
> Unified order conversion now exposes `statusCode` from `order.status.value`; the customer-order GraphQL type adds `statusId` (legacy already maps it into `statusCode`). Tests cover both legacy and unified order detail rendering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82f33977d80fbd5d9bec7043ab0ed5066271e51d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->