### PR TITLE
fix(invoices): B2B-4553 Block buyers to pay invoice with different currencies

### DIFF
--- a/apps/storefront/src/components/table/B3PaginationTable.tsx
+++ b/apps/storefront/src/components/table/B3PaginationTable.tsx
@@ -295,6 +295,7 @@ function PaginationTable<GetRequestListParams, Row extends object>(
       getList,
       getCacheList,
       refresh,
+      setSelectCheckbox,
     }),
     [getList, getCacheList, getSelectedValue, refresh],
   );

--- a/apps/storefront/src/components/table/B3PaginationTable.tsx
+++ b/apps/storefront/src/components/table/B3PaginationTable.tsx
@@ -295,7 +295,6 @@ function PaginationTable<GetRequestListParams, Row extends object>(
       getList,
       getCacheList,
       refresh,
-      setSelectCheckbox,
     }),
     [getList, getCacheList, getSelectedValue, refresh],
   );

--- a/apps/storefront/src/lib/lang/locales/en.json
+++ b/apps/storefront/src/lib/lang/locales/en.json
@@ -190,6 +190,7 @@
   "invoice.invoiceItemCardHeader.amountDue": "Amount due",
   "invoice.invoiceItemCardHeader.amountToPay": "Amount to pay",
   "invoice.footer.invalidNameError": "The payment amount entered has an invalid value.",
+  "invoice.footer.differentCurrencyError": "You cannot pay multiple invoices in different currencies",
   "invoice.footer.invoiceSelected": "{invoices} invoices selected",
   "invoice.footer.totalPayment": "Total payment: {total}",
   "invoice.footer.payInvoices": "Pay invoices",

--- a/apps/storefront/src/lib/lang/locales/en.json
+++ b/apps/storefront/src/lib/lang/locales/en.json
@@ -190,7 +190,7 @@
   "invoice.invoiceItemCardHeader.amountDue": "Amount due",
   "invoice.invoiceItemCardHeader.amountToPay": "Amount to pay",
   "invoice.footer.invalidNameError": "The payment amount entered has an invalid value.",
-  "invoice.footer.differentCurrencyError": "You cannot pay multiple invoices in different currencies",
+  "invoice.footer.differentCurrencyError": "Cannot pay invoices in mixed currencies",
   "invoice.footer.invoiceSelected": "{invoices} invoices selected",
   "invoice.footer.totalPayment": "Total payment: {total}",
   "invoice.footer.payInvoices": "Pay invoices",

--- a/apps/storefront/src/pages/Invoice/InvoiceItemCard.tsx
+++ b/apps/storefront/src/pages/Invoice/InvoiceItemCard.tsx
@@ -6,11 +6,11 @@ import { Box, Card, CardContent, InputAdornment, TextField, Typography } from '@
 import { TableColumnItem } from '@/components/table/B3Table';
 import { useB3Lang } from '@/lib/lang';
 import { InvoiceList, InvoiceListNode } from '@/types/invoice';
-import { currencyFormat } from '@/utils/b3CurrencyFormat';
 import { displayFormat } from '@/utils/b3DateFormat';
 
 import B3Pulldown from './components/B3Pulldown';
 import InvoiceStatus from './components/InvoiceStatus';
+import { formatInvoiceBalanceAmount } from './utils/payment';
 
 interface InvoiceItemCardProps {
   item: any;
@@ -22,6 +22,7 @@ interface InvoiceItemCardProps {
   handleOpenHistoryModal: (bool: boolean) => void;
   selectedPay: CustomFieldItems | InvoiceListNode[];
   handleGetCorrespondingCurrency: (code: string) => string;
+  decimalPlaces: number;
   addBottom: boolean;
   isCurrentCompany: boolean;
   invoicePay: boolean;
@@ -45,6 +46,7 @@ export function InvoiceItemCard(props: InvoiceItemCardProps) {
     handleOpenHistoryModal,
     selectedPay = [],
     handleGetCorrespondingCurrency,
+    decimalPlaces,
     addBottom,
     isCurrentCompany,
     invoicePay,
@@ -108,23 +110,12 @@ export function InvoiceItemCard(props: InvoiceItemCardProps) {
     {
       key: 'originalBalance',
       title: b3Lang('invoice.invoiceItemCardHeader.invoiceTotal'),
-      render: () => {
-        const { originalBalance } = item;
-        const originalAmount = Number(originalBalance.value);
-
-        return currencyFormat(originalAmount || 0);
-      },
+      render: () => formatInvoiceBalanceAmount(item.originalBalance, decimalPlaces),
     },
     {
       key: 'openBalance',
       title: b3Lang('invoice.invoiceItemCardHeader.amountDue'),
-      render: () => {
-        const { openBalance } = item;
-
-        const openAmount = Number(openBalance.value);
-
-        return currencyFormat(openAmount || 0);
-      },
+      render: () => formatInvoiceBalanceAmount(item.openBalance, decimalPlaces),
     },
     {
       key: 'openBalanceToPay',

--- a/apps/storefront/src/pages/Invoice/components/InvoiceFooter.tsx
+++ b/apps/storefront/src/pages/Invoice/components/InvoiceFooter.tsx
@@ -42,6 +42,10 @@ function InvoiceFooter(props: InvoiceFooterProps) {
   const hasMixedCurrency = hasMixedInvoiceCurrencies(selectedPay as InvoiceListNode[]);
 
   const handlePay = async () => {
+    if (hasMixedCurrency) {
+      return;
+    }
+
     const lineItems: BcCartDataLineItem[] = [];
     let currency = 'SGD';
 
@@ -84,6 +88,10 @@ function InvoiceFooter(props: InvoiceFooterProps) {
 
   useEffect(() => {
     if (selectedPay.length > 0) {
+      if (hasMixedInvoiceCurrencies(selectedPay as InvoiceListNode[])) {
+        return;
+      }
+
       const handleStatisticsInvoiceAmount = (checkedArr: CustomFieldItems) => {
         let amount = 0;
 

--- a/apps/storefront/src/pages/Invoice/components/InvoiceFooter.tsx
+++ b/apps/storefront/src/pages/Invoice/components/InvoiceFooter.tsx
@@ -9,9 +9,9 @@ import { snackbar } from '@/utils/b3Tip';
 import { handleGetCorrespondingCurrencyToken } from '@/utils/currencyUtils';
 
 import {
-  filterInvoicesBySameCurrency,
   formattingNumericValues,
   gotoInvoiceCheckoutUrl,
+  hasMixedInvoiceCurrencies,
 } from '../utils/payment';
 
 interface InvoiceFooterProps {
@@ -39,7 +39,7 @@ function InvoiceFooter(props: InvoiceFooterProps) {
 
   const { selectedPay, decimalPlaces } = props;
 
-  const { hasMixedCurrency } = filterInvoicesBySameCurrency(selectedPay as InvoiceListNode[]);
+  const hasMixedCurrency = hasMixedInvoiceCurrencies(selectedPay as InvoiceListNode[]);
 
   const handlePay = async () => {
     const lineItems: BcCartDataLineItem[] = [];

--- a/apps/storefront/src/pages/Invoice/components/InvoiceFooter.tsx
+++ b/apps/storefront/src/pages/Invoice/components/InvoiceFooter.tsx
@@ -8,7 +8,11 @@ import { BcCartData, BcCartDataLineItem, InvoiceListNode } from '@/types/invoice
 import { snackbar } from '@/utils/b3Tip';
 import { handleGetCorrespondingCurrencyToken } from '@/utils/currencyUtils';
 
-import { formattingNumericValues, gotoInvoiceCheckoutUrl } from '../utils/payment';
+import {
+  filterInvoicesBySameCurrency,
+  formattingNumericValues,
+  gotoInvoiceCheckoutUrl,
+} from '../utils/payment';
 
 interface InvoiceFooterProps {
   selectedPay: CustomFieldItems;
@@ -34,6 +38,8 @@ function InvoiceFooter(props: InvoiceFooterProps) {
       };
 
   const { selectedPay, decimalPlaces } = props;
+
+  const { hasMixedCurrency } = filterInvoicesBySameCurrency(selectedPay as InvoiceListNode[]);
 
   const handlePay = async () => {
     const lineItems: BcCartDataLineItem[] = [];
@@ -173,12 +179,14 @@ function InvoiceFooter(props: InvoiceFooterProps) {
               sx={{
                 fontSize: '16px',
                 fontWeight: '700',
-                color: '#000000',
+                color: hasMixedCurrency ? 'error.main' : '#000000',
               }}
             >
-              {b3Lang('invoice.footer.totalPayment', {
-                total: `${currentToken}${selectedAccount}`,
-              })}
+              {hasMixedCurrency
+                ? b3Lang('invoice.footer.differentCurrencyError')
+                : b3Lang('invoice.footer.totalPayment', {
+                    total: `${currentToken}${selectedAccount}`,
+                  })}
             </Typography>
             <Box
               sx={{
@@ -190,6 +198,7 @@ function InvoiceFooter(props: InvoiceFooterProps) {
             >
               <Button
                 variant="contained"
+                disabled={hasMixedCurrency}
                 sx={{
                   marginLeft: isMobile ? 0 : '1rem',
                   width: isMobile ? '100%' : 'auto',

--- a/apps/storefront/src/pages/Invoice/index.mobile.test.tsx
+++ b/apps/storefront/src/pages/Invoice/index.mobile.test.tsx
@@ -304,6 +304,75 @@ it('can pay for multiple invoices', async () => {
   });
 });
 
+it('disables the Pay invoices button when selected invoices are in different currencies', async () => {
+  server.use(
+    graphql.query('GetInvoices', () =>
+      HttpResponse.json(
+        buildInvoicesResponseWith({
+          data: {
+            invoices: {
+              edges: [
+                buildInvoiceWith({
+                  node: {
+                    id: '3344',
+                    invoiceNumber: '3344',
+                    status: InvoiceStatusCode.PartiallyPaid,
+                    originalBalance: { code: 'USD', value: 922 },
+                    openBalance: { code: 'USD', value: 433 },
+                    companyInfo: {
+                      companyId: preloadedState.company.companyInfo.id,
+                    },
+                  },
+                }),
+                buildInvoiceWith({
+                  node: {
+                    id: '3345',
+                    invoiceNumber: '3345',
+                    status: InvoiceStatusCode.PartiallyPaid,
+                    originalBalance: { code: 'EUR', value: 444 },
+                    openBalance: { code: 'EUR', value: 232 },
+                    companyInfo: {
+                      companyId: preloadedState.company.companyInfo.id,
+                    },
+                  },
+                }),
+              ],
+            },
+          },
+        }),
+      ),
+    ),
+    graphql.query('GetInvoiceStats', () =>
+      HttpResponse.json(buildInvoiceStatsResponseWith('WHATEVER_VALUES')),
+    ),
+  );
+
+  renderWithProviders(<Invoice />, { preloadedState });
+
+  await waitForElementToBeRemoved(() => screen.queryByText(/loading/i));
+
+  const group3344 = screen.getByRole('group', { name: '3344' });
+  const group3345 = screen.getByRole('group', { name: '3345' });
+
+  await userEvent.click(within(group3344).getByRole('checkbox'));
+
+  expect(screen.getByText('1 invoices selected')).toBeVisible();
+  expect(screen.getByRole('heading', { name: 'Total payment: $433.00' })).toBeVisible();
+  expect(screen.getByRole('button', { name: 'Pay invoices' })).toBeEnabled();
+
+  await userEvent.click(within(group3345).getByRole('checkbox'));
+
+  expect(within(group3345).getByRole('checkbox')).toBeChecked();
+  expect(screen.getByText('2 invoices selected')).toBeVisible();
+  expect(
+    screen.getByRole('heading', {
+      name: 'Cannot pay invoices in mixed currencies',
+    }),
+  ).toBeVisible();
+  expect(screen.queryByText(/Total payment:/)).not.toBeInTheDocument();
+  expect(screen.getByRole('button', { name: 'Pay invoices' })).toBeDisabled();
+});
+
 it('can specify an amount to pay for the invoices', async () => {
   const getCreateCartResponse = vi.fn();
   const getCheckoutLoginResponse = vi.fn();

--- a/apps/storefront/src/pages/Invoice/index.mobile.test.tsx
+++ b/apps/storefront/src/pages/Invoice/index.mobile.test.tsx
@@ -20,6 +20,7 @@ import {
 import { when } from 'vitest-when';
 
 import { permissionLevels } from '@/constants';
+import { defaultCurrenciesState } from '@/store/slices/storeConfigs';
 
 import { InvoiceStatusCode } from './components/InvoiceStatus';
 import { triggerPdfDownload } from './components/triggerPdfDownload';
@@ -212,6 +213,83 @@ it('renders invoice information in the table', async () => {
   expect(within(group).getByText('$433.00')).toBeInTheDocument();
 
   expect(within(group).getByRole('button', { name: 'More actions' })).toBeInTheDocument();
+});
+
+it('displays invoice amounts using the invoice currency when store default differs', async () => {
+  const eurCurrency = {
+    id: '2',
+    is_default: false,
+    last_updated: '2024-01-01',
+    country_iso2: 'DE',
+    default_for_country_codes: [],
+    currency_code: 'EUR',
+    currency_exchange_rate: '1.0000000000',
+    name: 'Euro',
+    token: '€',
+    auto_update: false,
+    decimal_token: '.',
+    decimal_places: 2,
+    enabled: true,
+    is_transactional: true,
+    token_location: 'left' as const,
+    thousands_token: ',',
+  };
+
+  server.use(
+    graphql.query('GetInvoices', () =>
+      HttpResponse.json(
+        buildInvoicesResponseWith({
+          data: {
+            invoices: {
+              edges: [
+                buildInvoiceWith({
+                  node: {
+                    id: '5566',
+                    orderNumber: '5678',
+                    status: InvoiceStatusCode.PartiallyPaid,
+                    originalBalance: { code: 'EUR', value: 444 },
+                    openBalance: { code: 'EUR', value: 232 },
+                    companyInfo: {
+                      companyName: 'Monsters Inc.',
+                    },
+                  },
+                }),
+              ],
+            },
+          },
+        }),
+      ),
+    ),
+    graphql.query('GetInvoiceStats', () =>
+      HttpResponse.json(buildInvoiceStatsResponseWith('WHATEVER_VALUES')),
+    ),
+  );
+
+  renderWithProviders(<Invoice />, {
+    preloadedState: {
+      ...preloadedState,
+      storeConfigs: {
+        currencies: {
+          currencies: [defaultCurrenciesState.currencies[0], eurCurrency],
+          channelCurrencies: {
+            channel_id: 1,
+            enabled_currencies: ['USD', 'EUR'],
+            default_currency: 'USD',
+          },
+          enteredInclusiveTax: false,
+        },
+      },
+    },
+  });
+
+  await waitForElementToBeRemoved(() => screen.queryByText(/loading/i));
+
+  const group = screen.getByRole('group', { name: '5566' });
+
+  expect(within(group).getByText('€444.00')).toBeVisible();
+  expect(within(group).getByText('€232.00')).toBeVisible();
+  expect(within(group).queryByText('$444.00')).not.toBeInTheDocument();
+  expect(within(group).queryByText('$232.00')).not.toBeInTheDocument();
 });
 
 it('can pay for multiple invoices', async () => {

--- a/apps/storefront/src/pages/Invoice/index.test.tsx
+++ b/apps/storefront/src/pages/Invoice/index.test.tsx
@@ -423,6 +423,71 @@ it('blocks selecting invoices that are in different currencies', async () => {
   expect(snackbar.error).toHaveBeenCalled();
 });
 
+it('blocks selecting all invoices when the page contains different currencies', async () => {
+  server.use(
+    graphql.query('GetInvoices', () =>
+      HttpResponse.json(
+        buildInvoicesResponseWith({
+          data: {
+            invoices: {
+              edges: [
+                buildInvoiceWith({
+                  node: {
+                    id: '3344',
+                    invoiceNumber: '3322',
+                    status: InvoiceStatusCode.PartiallyPaid,
+                    originalBalance: { code: 'USD', value: 922 },
+                    openBalance: { code: 'USD', value: 433 },
+                    companyInfo: {
+                      companyId: preloadedState.company.companyInfo.id,
+                    },
+                  },
+                }),
+                buildInvoiceWith({
+                  node: {
+                    id: '3345',
+                    invoiceNumber: '3325',
+                    status: InvoiceStatusCode.PartiallyPaid,
+                    originalBalance: { code: 'EUR', value: 444 },
+                    openBalance: { code: 'EUR', value: 232 },
+                    companyInfo: {
+                      companyId: preloadedState.company.companyInfo.id,
+                    },
+                  },
+                }),
+              ],
+            },
+          },
+        }),
+      ),
+    ),
+    graphql.query('GetInvoiceStats', () =>
+      HttpResponse.json(buildInvoiceStatsResponseWith('WHATEVER_VALUES')),
+    ),
+  );
+
+  renderWithProviders(<Invoice />, { preloadedState });
+
+  await waitForElementToBeRemoved(() => screen.queryByText(/loading/i));
+
+  const table = screen.getByRole('table');
+
+  const columnHeaders = within(table).getAllByRole('columnheader');
+
+  const secondRow = within(table).getByRole('row', { name: /3325/ });
+  const secondRowCells = within(secondRow).getAllByRole('cell');
+
+  // click the "select all" checkbox in the header, which would otherwise
+  // select both the USD and EUR invoices at once
+  await userEvent.click(within(columnHeaders[0]).getByRole('checkbox'));
+
+  // only the reference-currency invoice should end up selected
+  expect(screen.getByText('1 invoices selected')).toBeInTheDocument();
+  expect(screen.getByRole('heading', { name: 'Total payment: $433.00' })).toBeInTheDocument();
+  expect(within(secondRowCells[0]).getByRole('checkbox')).not.toBeChecked();
+  expect(snackbar.error).toHaveBeenCalled();
+});
+
 it('can specify an amount to pay for the invoices', async () => {
   const getCreateCartResponse = vi.fn();
   const getCheckoutLoginResponse = vi.fn();

--- a/apps/storefront/src/pages/Invoice/index.test.tsx
+++ b/apps/storefront/src/pages/Invoice/index.test.tsx
@@ -21,7 +21,6 @@ import {
 import { when } from 'vitest-when';
 
 import { permissionLevels } from '@/constants';
-import { snackbar } from '@/utils/b3Tip';
 
 import { InvoiceStatusCode } from './components/InvoiceStatus';
 import { triggerPdfDownload } from './components/triggerPdfDownload';
@@ -30,9 +29,6 @@ import Invoice from '.';
 const { server } = startMockServer();
 
 vi.mock('./components/triggerPdfDownload');
-vi.mock('@/utils/b3Tip', () => ({
-  snackbar: { error: vi.fn() },
-}));
 
 const buildInvoiceWith = builder(() => ({
   node: {
@@ -353,7 +349,7 @@ it('can pay for multiple invoices', async () => {
   });
 });
 
-it('blocks selecting invoices that are in different currencies', async () => {
+it('disables the Pay invoices button when selected invoices are in different currencies', async () => {
   server.use(
     graphql.query('GetInvoices', () =>
       HttpResponse.json(
@@ -413,17 +409,27 @@ it('blocks selecting invoices that are in different currencies', async () => {
 
   expect(screen.getByText('1 invoices selected')).toBeInTheDocument();
   expect(screen.getByRole('heading', { name: 'Total payment: $433.00' })).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: 'Pay invoices' })).toBeEnabled();
 
-  // attempting to also select the EUR invoice should be blocked
+  // selecting the EUR invoice too is now allowed
   await userEvent.click(within(secondRowCells[0]).getByRole('checkbox'));
 
-  expect(within(secondRowCells[0]).getByRole('checkbox')).not.toBeChecked();
-  expect(screen.getByText('1 invoices selected')).toBeInTheDocument();
-  expect(screen.getByRole('heading', { name: 'Total payment: $433.00' })).toBeInTheDocument();
-  expect(snackbar.error).toHaveBeenCalled();
+  expect(within(secondRowCells[0]).getByRole('checkbox')).toBeChecked();
+  expect(screen.getByText('2 invoices selected')).toBeInTheDocument();
+
+  // the misleading flattened total is replaced with a warning...
+  expect(
+    screen.getByRole('heading', {
+      name: 'You cannot pay multiple invoices in different currencies',
+    }),
+  ).toBeInTheDocument();
+  expect(screen.queryByText(/Total payment:/)).not.toBeInTheDocument();
+
+  // ...and paying is blocked while the selection mixes currencies
+  expect(screen.getByRole('button', { name: 'Pay invoices' })).toBeDisabled();
 });
 
-it('blocks selecting all invoices when the page contains different currencies', async () => {
+it('disables the Pay invoices button when selecting all invoices with different currencies', async () => {
   server.use(
     graphql.query('GetInvoices', () =>
       HttpResponse.json(
@@ -477,15 +483,19 @@ it('blocks selecting all invoices when the page contains different currencies', 
   const secondRow = within(table).getByRole('row', { name: /3325/ });
   const secondRowCells = within(secondRow).getAllByRole('cell');
 
-  // click the "select all" checkbox in the header, which would otherwise
-  // select both the USD and EUR invoices at once
+  // click the "select all" checkbox in the header
   await userEvent.click(within(columnHeaders[0]).getByRole('checkbox'));
 
-  // only the reference-currency invoice should end up selected
-  expect(screen.getByText('1 invoices selected')).toBeInTheDocument();
-  expect(screen.getByRole('heading', { name: 'Total payment: $433.00' })).toBeInTheDocument();
-  expect(within(secondRowCells[0]).getByRole('checkbox')).not.toBeChecked();
-  expect(snackbar.error).toHaveBeenCalled();
+  // both invoices get selected even though currencies differ
+  expect(within(secondRowCells[0]).getByRole('checkbox')).toBeChecked();
+  expect(screen.getByText('2 invoices selected')).toBeInTheDocument();
+
+  expect(
+    screen.getByRole('heading', {
+      name: 'You cannot pay multiple invoices in different currencies',
+    }),
+  ).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: 'Pay invoices' })).toBeDisabled();
 });
 
 it('can specify an amount to pay for the invoices', async () => {

--- a/apps/storefront/src/pages/Invoice/index.test.tsx
+++ b/apps/storefront/src/pages/Invoice/index.test.tsx
@@ -21,6 +21,7 @@ import {
 import { when } from 'vitest-when';
 
 import { permissionLevels } from '@/constants';
+import { defaultCurrenciesState } from '@/store/slices/storeConfigs';
 
 import { InvoiceStatusCode } from './components/InvoiceStatus';
 import { triggerPdfDownload } from './components/triggerPdfDownload';
@@ -246,6 +247,83 @@ it('renders invoice information in the table', async () => {
   expect(within(row).getByRole('button', { name: 'More actions' })).toBeInTheDocument();
 });
 
+it('displays invoice amounts using the invoice currency when store default differs', async () => {
+  const eurCurrency = {
+    id: '2',
+    is_default: false,
+    last_updated: '2024-01-01',
+    country_iso2: 'DE',
+    default_for_country_codes: [],
+    currency_code: 'EUR',
+    currency_exchange_rate: '1.0000000000',
+    name: 'Euro',
+    token: '€',
+    auto_update: false,
+    decimal_token: '.',
+    decimal_places: 2,
+    enabled: true,
+    is_transactional: true,
+    token_location: 'left' as const,
+    thousands_token: ',',
+  };
+
+  server.use(
+    graphql.query('GetInvoices', () =>
+      HttpResponse.json(
+        buildInvoicesResponseWith({
+          data: {
+            invoices: {
+              edges: [
+                buildInvoiceWith({
+                  node: {
+                    invoiceNumber: '7788',
+                    orderNumber: '5678',
+                    status: InvoiceStatusCode.PartiallyPaid,
+                    originalBalance: { code: 'EUR', value: 444 },
+                    openBalance: { code: 'EUR', value: 232 },
+                    companyInfo: {
+                      companyName: 'Monsters Inc.',
+                      companyId: preloadedState.company.companyInfo.id,
+                    },
+                  },
+                }),
+              ],
+            },
+          },
+        }),
+      ),
+    ),
+    graphql.query('GetInvoiceStats', () =>
+      HttpResponse.json(buildInvoiceStatsResponseWith('WHATEVER_VALUES')),
+    ),
+  );
+
+  renderWithProviders(<Invoice />, {
+    preloadedState: {
+      ...preloadedState,
+      storeConfigs: {
+        currencies: {
+          currencies: [defaultCurrenciesState.currencies[0], eurCurrency],
+          channelCurrencies: {
+            channel_id: 1,
+            enabled_currencies: ['USD', 'EUR'],
+            default_currency: 'USD',
+          },
+          enteredInclusiveTax: false,
+        },
+      },
+    },
+  });
+
+  await waitForElementToBeRemoved(() => screen.queryByText(/loading/i));
+
+  const row = screen.getByRole('row', { name: /7788/ });
+  const cells = within(row).getAllByRole('cell');
+
+  expect(cells[7]).toHaveTextContent('€444.00');
+  expect(cells[8]).toHaveTextContent('€232.00');
+});
+
 it('can pay for multiple invoices', async () => {
   const getCreateCartResponse = vi.fn().mockName('getCreateCartResponse');
   const getCheckoutLoginResponse = vi.fn().mockName('getCheckoutLoginResponse');
@@ -397,7 +475,6 @@ it('disables the Pay invoices button when selected invoices are in different cur
   await waitForElementToBeRemoved(() => screen.queryByText(/loading/i));
 
   const table = screen.getByRole('table');
-
   const firstRow = within(table).getByRole('row', { name: /3344/ });
   const firstRowCells = within(firstRow).getAllByRole('cell');
 

--- a/apps/storefront/src/pages/Invoice/index.test.tsx
+++ b/apps/storefront/src/pages/Invoice/index.test.tsx
@@ -421,6 +421,13 @@ it('disables the Pay invoices button when selected invoices are in different cur
   ).toBeVisible();
   expect(screen.queryByText(/Total payment:/)).not.toBeInTheDocument();
   expect(screen.getByRole('button', { name: 'Pay invoices' })).toBeDisabled();
+
+  await userEvent.click(within(secondRowCells[0]).getByRole('checkbox'));
+
+  expect(within(secondRowCells[0]).getByRole('checkbox')).not.toBeChecked();
+  expect(screen.getByText('1 invoices selected')).toBeVisible();
+  expect(screen.getByRole('heading', { name: 'Total payment: $433.00' })).toBeVisible();
+  expect(screen.getByRole('button', { name: 'Pay invoices' })).toBeEnabled();
 });
 
 it('disables the Pay invoices button when selecting all invoices with different currencies', async () => {

--- a/apps/storefront/src/pages/Invoice/index.test.tsx
+++ b/apps/storefront/src/pages/Invoice/index.test.tsx
@@ -360,7 +360,7 @@ it('disables the Pay invoices button when selected invoices are in different cur
                 buildInvoiceWith({
                   node: {
                     id: '3344',
-                    invoiceNumber: '3322',
+                    invoiceNumber: '3344',
                     status: InvoiceStatusCode.PartiallyPaid,
                     originalBalance: { code: 'USD', value: 922 },
                     openBalance: { code: 'USD', value: 433 },
@@ -372,7 +372,7 @@ it('disables the Pay invoices button when selected invoices are in different cur
                 buildInvoiceWith({
                   node: {
                     id: '3345',
-                    invoiceNumber: '3325',
+                    invoiceNumber: '3345',
                     status: InvoiceStatusCode.PartiallyPaid,
                     originalBalance: { code: 'EUR', value: 444 },
                     openBalance: { code: 'EUR', value: 232 },
@@ -398,34 +398,28 @@ it('disables the Pay invoices button when selected invoices are in different cur
 
   const table = screen.getByRole('table');
 
-  const firstRow = within(table).getByRole('row', { name: /3322/ });
+  const firstRow = within(table).getByRole('row', { name: /3344/ });
   const firstRowCells = within(firstRow).getAllByRole('cell');
 
-  const secondRow = within(table).getByRole('row', { name: /3325/ });
+  const secondRow = within(table).getByRole('row', { name: /3345/ });
   const secondRowCells = within(secondRow).getAllByRole('cell');
 
-  // select the USD invoice first
   await userEvent.click(within(firstRowCells[0]).getByRole('checkbox'));
 
-  expect(screen.getByText('1 invoices selected')).toBeInTheDocument();
-  expect(screen.getByRole('heading', { name: 'Total payment: $433.00' })).toBeInTheDocument();
+  expect(screen.getByText('1 invoices selected')).toBeVisible();
+  expect(screen.getByRole('heading', { name: 'Total payment: $433.00' })).toBeVisible();
   expect(screen.getByRole('button', { name: 'Pay invoices' })).toBeEnabled();
 
-  // selecting the EUR invoice too is now allowed
   await userEvent.click(within(secondRowCells[0]).getByRole('checkbox'));
 
   expect(within(secondRowCells[0]).getByRole('checkbox')).toBeChecked();
-  expect(screen.getByText('2 invoices selected')).toBeInTheDocument();
-
-  // the misleading flattened total is replaced with a warning...
+  expect(screen.getByText('2 invoices selected')).toBeVisible();
   expect(
     screen.getByRole('heading', {
-      name: 'You cannot pay multiple invoices in different currencies',
+      name: 'Cannot pay invoices in mixed currencies',
     }),
-  ).toBeInTheDocument();
+  ).toBeVisible();
   expect(screen.queryByText(/Total payment:/)).not.toBeInTheDocument();
-
-  // ...and paying is blocked while the selection mixes currencies
   expect(screen.getByRole('button', { name: 'Pay invoices' })).toBeDisabled();
 });
 
@@ -488,13 +482,13 @@ it('disables the Pay invoices button when selecting all invoices with different 
 
   // both invoices get selected even though currencies differ
   expect(within(secondRowCells[0]).getByRole('checkbox')).toBeChecked();
-  expect(screen.getByText('2 invoices selected')).toBeInTheDocument();
+  expect(screen.getByText('2 invoices selected')).toBeVisible();
 
   expect(
     screen.getByRole('heading', {
-      name: 'You cannot pay multiple invoices in different currencies',
+      name: 'Cannot pay invoices in mixed currencies',
     }),
-  ).toBeInTheDocument();
+  ).toBeVisible();
   expect(screen.getByRole('button', { name: 'Pay invoices' })).toBeDisabled();
 });
 

--- a/apps/storefront/src/pages/Invoice/index.test.tsx
+++ b/apps/storefront/src/pages/Invoice/index.test.tsx
@@ -21,6 +21,7 @@ import {
 import { when } from 'vitest-when';
 
 import { permissionLevels } from '@/constants';
+import { snackbar } from '@/utils/b3Tip';
 
 import { InvoiceStatusCode } from './components/InvoiceStatus';
 import { triggerPdfDownload } from './components/triggerPdfDownload';
@@ -29,6 +30,9 @@ import Invoice from '.';
 const { server } = startMockServer();
 
 vi.mock('./components/triggerPdfDownload');
+vi.mock('@/utils/b3Tip', () => ({
+  snackbar: { error: vi.fn() },
+}));
 
 const buildInvoiceWith = builder(() => ({
   node: {
@@ -347,6 +351,76 @@ it('can pay for multiple invoices', async () => {
   await waitFor(() => {
     expect(window.location.href).toEqual('https://example.com/checkout?cartId=foo-bar');
   });
+});
+
+it('blocks selecting invoices that are in different currencies', async () => {
+  server.use(
+    graphql.query('GetInvoices', () =>
+      HttpResponse.json(
+        buildInvoicesResponseWith({
+          data: {
+            invoices: {
+              edges: [
+                buildInvoiceWith({
+                  node: {
+                    id: '3344',
+                    invoiceNumber: '3322',
+                    status: InvoiceStatusCode.PartiallyPaid,
+                    originalBalance: { code: 'USD', value: 922 },
+                    openBalance: { code: 'USD', value: 433 },
+                    companyInfo: {
+                      companyId: preloadedState.company.companyInfo.id,
+                    },
+                  },
+                }),
+                buildInvoiceWith({
+                  node: {
+                    id: '3345',
+                    invoiceNumber: '3325',
+                    status: InvoiceStatusCode.PartiallyPaid,
+                    originalBalance: { code: 'EUR', value: 444 },
+                    openBalance: { code: 'EUR', value: 232 },
+                    companyInfo: {
+                      companyId: preloadedState.company.companyInfo.id,
+                    },
+                  },
+                }),
+              ],
+            },
+          },
+        }),
+      ),
+    ),
+    graphql.query('GetInvoiceStats', () =>
+      HttpResponse.json(buildInvoiceStatsResponseWith('WHATEVER_VALUES')),
+    ),
+  );
+
+  renderWithProviders(<Invoice />, { preloadedState });
+
+  await waitForElementToBeRemoved(() => screen.queryByText(/loading/i));
+
+  const table = screen.getByRole('table');
+
+  const firstRow = within(table).getByRole('row', { name: /3322/ });
+  const firstRowCells = within(firstRow).getAllByRole('cell');
+
+  const secondRow = within(table).getByRole('row', { name: /3325/ });
+  const secondRowCells = within(secondRow).getAllByRole('cell');
+
+  // select the USD invoice first
+  await userEvent.click(within(firstRowCells[0]).getByRole('checkbox'));
+
+  expect(screen.getByText('1 invoices selected')).toBeInTheDocument();
+  expect(screen.getByRole('heading', { name: 'Total payment: $433.00' })).toBeInTheDocument();
+
+  // attempting to also select the EUR invoice should be blocked
+  await userEvent.click(within(secondRowCells[0]).getByRole('checkbox'));
+
+  expect(within(secondRowCells[0]).getByRole('checkbox')).not.toBeChecked();
+  expect(screen.getByText('1 invoices selected')).toBeInTheDocument();
+  expect(screen.getByRole('heading', { name: 'Total payment: $433.00' })).toBeInTheDocument();
+  expect(snackbar.error).toHaveBeenCalled();
 });
 
 it('can specify an amount to pay for the invoices', async () => {
@@ -1301,6 +1375,8 @@ it('exports selected invoices as CSV', async () => {
                   node: {
                     id: '1441',
                     invoiceNumber: '3322',
+                    openBalance: { code: 'USD', value: 100 },
+                    originalBalance: { code: 'USD', value: 100 },
                     companyInfo: {
                       companyId: preloadedState.company.companyInfo.id,
                       companyName: 'Acme Inc.',
@@ -1311,6 +1387,8 @@ it('exports selected invoices as CSV', async () => {
                   node: {
                     id: '1313',
                     invoiceNumber: '4343',
+                    openBalance: { code: 'USD', value: 200 },
+                    originalBalance: { code: 'USD', value: 200 },
                     companyInfo: {
                       companyId: preloadedState.company.companyInfo.id,
                       companyName: 'Acme Inc.',

--- a/apps/storefront/src/pages/Invoice/index.tsx
+++ b/apps/storefront/src/pages/Invoice/index.tsx
@@ -39,7 +39,7 @@ import InvoiceListType, {
   filterFormConfigsTranslationVariables,
   sortIdArr,
 } from './utils/config';
-import { formattingNumericValues } from './utils/payment';
+import { formatInvoiceBalanceAmount, formattingNumericValues } from './utils/payment';
 import { handlePrintPDF } from './utils/pdf';
 import { InvoiceItemCard } from './InvoiceItemCard';
 
@@ -638,14 +638,8 @@ function Invoice() {
       isSortable: true,
       render: (item: InvoiceList) => {
         const { originalBalance } = item;
-        const originalAmount = formattingNumericValues(
-          Number(originalBalance.value),
-          decimalPlaces,
-        );
 
-        const token = handleGetCorrespondingCurrencyToken(originalBalance.code);
-
-        return `${token}${originalAmount || 0}`;
+        return formatInvoiceBalanceAmount(originalBalance, decimalPlaces);
       },
       width: '10%',
     },
@@ -656,10 +650,7 @@ function Invoice() {
       render: (item: InvoiceList) => {
         const { openBalance } = item;
 
-        const openAmount = formattingNumericValues(Number(openBalance.value), decimalPlaces);
-        const token = handleGetCorrespondingCurrencyToken(openBalance.code);
-
-        return `${token}${openAmount || 0}`;
+        return formatInvoiceBalanceAmount(openBalance, decimalPlaces);
       },
       width: '10%',
     },
@@ -968,6 +959,7 @@ function Invoice() {
               handleOpenHistoryModal={setIsOpenHistory}
               selectedPay={selectedPay}
               handleGetCorrespondingCurrency={handleGetCorrespondingCurrencyToken}
+              decimalPlaces={decimalPlaces}
               addBottom={list.length - 1 === index}
               isCurrentCompany={Number(currentCompanyId) === Number(row.companyInfo.companyId)}
               invoicePay={

--- a/apps/storefront/src/pages/Invoice/index.tsx
+++ b/apps/storefront/src/pages/Invoice/index.tsx
@@ -39,7 +39,7 @@ import InvoiceListType, {
   filterFormConfigsTranslationVariables,
   sortIdArr,
 } from './utils/config';
-import { formattingNumericValues } from './utils/payment';
+import { filterInvoicesBySameCurrency, formattingNumericValues } from './utils/payment';
 import { handlePrintPDF } from './utils/pdf';
 import { InvoiceItemCard } from './InvoiceItemCard';
 
@@ -53,10 +53,11 @@ interface FilterSearchProps {
 
 interface PaginationTableRefProps extends HTMLInputElement {
   getList: () => void;
-  getCacheList: () => void;
+  getCacheList: () => InvoiceListNode[];
   setCacheAllList: (items?: InvoiceList[]) => void;
   setList: (items?: InvoiceListNode[]) => void;
   getSelectedValue: () => void;
+  setSelectCheckbox: (ids: Array<string | number>) => void;
 }
 
 const initFilter = {
@@ -249,20 +250,29 @@ function Invoice() {
     if (selectCheckbox.length > 0) {
       const productList = paginationTableRef.current?.getCacheList() || [];
 
-      const checkedItems = selectCheckbox.map((item: number | string) => {
-        const newItems = productList.find((product: InvoiceListNode) => {
-          const { node } = product;
+      const checkedItems = selectCheckbox
+        .map((item: number | string) => {
+          const newItems = productList.find((product: InvoiceListNode) => {
+            const { node } = product;
 
-          return Number(node.id) === Number(item);
-        });
+            return Number(node.id) === Number(item);
+          });
 
-        return newItems;
-      });
+          return newItems;
+        })
+        .filter((item): item is InvoiceListNode => !!item && !item.node.disableCurrentCheckbox);
 
-      const newEnableItems = checkedItems.filter(
-        (item: InvoiceListNode | undefined) => item && !item.node.disableCurrentCheckbox,
-      );
-      setCheckedArr([...newEnableItems]);
+      const { validInvoices, hasMixedCurrency } = filterInvoicesBySameCurrency(checkedItems);
+
+      if (hasMixedCurrency) {
+        snackbar.error(b3Lang('invoice.footer.differentCurrencyError'));
+        const validIds = validInvoices.map((item) => item.node.id);
+        paginationTableRef.current?.setSelectCheckbox(validIds);
+        setCheckedArr([...validInvoices]);
+        return;
+      }
+
+      setCheckedArr([...checkedItems]);
     } else {
       setCheckedArr([]);
     }

--- a/apps/storefront/src/pages/Invoice/index.tsx
+++ b/apps/storefront/src/pages/Invoice/index.tsx
@@ -39,7 +39,7 @@ import InvoiceListType, {
   filterFormConfigsTranslationVariables,
   sortIdArr,
 } from './utils/config';
-import { filterInvoicesBySameCurrency, formattingNumericValues } from './utils/payment';
+import { formattingNumericValues } from './utils/payment';
 import { handlePrintPDF } from './utils/pdf';
 import { InvoiceItemCard } from './InvoiceItemCard';
 
@@ -53,11 +53,10 @@ interface FilterSearchProps {
 
 interface PaginationTableRefProps extends HTMLInputElement {
   getList: () => void;
-  getCacheList: () => InvoiceListNode[];
+  getCacheList: () => void;
   setCacheAllList: (items?: InvoiceList[]) => void;
   setList: (items?: InvoiceListNode[]) => void;
   getSelectedValue: () => void;
-  setSelectCheckbox: (ids: Array<string | number>) => void;
 }
 
 const initFilter = {
@@ -250,29 +249,20 @@ function Invoice() {
     if (selectCheckbox.length > 0) {
       const productList = paginationTableRef.current?.getCacheList() || [];
 
-      const checkedItems = selectCheckbox
-        .map((item: number | string) => {
-          const newItems = productList.find((product: InvoiceListNode) => {
-            const { node } = product;
+      const checkedItems = selectCheckbox.map((item: number | string) => {
+        const newItems = productList.find((product: InvoiceListNode) => {
+          const { node } = product;
 
-            return Number(node.id) === Number(item);
-          });
+          return Number(node.id) === Number(item);
+        });
 
-          return newItems;
-        })
-        .filter((item): item is InvoiceListNode => !!item && !item.node.disableCurrentCheckbox);
+        return newItems;
+      });
 
-      const { validInvoices, hasMixedCurrency } = filterInvoicesBySameCurrency(checkedItems);
-
-      if (hasMixedCurrency) {
-        snackbar.error(b3Lang('invoice.footer.differentCurrencyError'));
-        const validIds = validInvoices.map((item) => item.node.id);
-        paginationTableRef.current?.setSelectCheckbox(validIds);
-        setCheckedArr([...validInvoices]);
-        return;
-      }
-
-      setCheckedArr([...checkedItems]);
+      const newEnableItems = checkedItems.filter(
+        (item: InvoiceListNode | undefined) => item && !item.node.disableCurrentCheckbox,
+      );
+      setCheckedArr([...newEnableItems]);
     } else {
       setCheckedArr([]);
     }

--- a/apps/storefront/src/pages/Invoice/utils/payment.ts
+++ b/apps/storefront/src/pages/Invoice/utils/payment.ts
@@ -62,18 +62,12 @@ const getInvoiceCurrency = (invoice: InvoiceListNode) => {
   return openBalance?.code || originalBalance.code;
 };
 
-export const filterInvoicesBySameCurrency = (invoices: InvoiceListNode[]) => {
+export const hasMixedInvoiceCurrencies = (invoices: InvoiceListNode[]) => {
   if (invoices.length === 0) {
-    return { validInvoices: [], hasMixedCurrency: false };
+    return false;
   }
 
   const referenceCurrency = getInvoiceCurrency(invoices[0]);
-  const validInvoices = invoices.filter(
-    (invoice) => getInvoiceCurrency(invoice) === referenceCurrency,
-  );
 
-  return {
-    validInvoices,
-    hasMixedCurrency: validInvoices.length < invoices.length,
-  };
+  return invoices.some((invoice) => getInvoiceCurrency(invoice) !== referenceCurrency);
 };

--- a/apps/storefront/src/pages/Invoice/utils/payment.ts
+++ b/apps/storefront/src/pages/Invoice/utils/payment.ts
@@ -5,6 +5,7 @@ import { BcCartData, InvoiceListNode } from '@/types/invoice';
 import { attemptCheckoutLoginAndRedirect } from '@/utils/b3checkout';
 import b2bLogger from '@/utils/b3Logger';
 import { isBigCommercePlatform, isCatalystPlatform } from '@/utils/basicConfig';
+import { handleGetCorrespondingCurrencyToken } from '@/utils/currencyUtils';
 
 const getCheckoutUrlAndCart = async (params: BcCartData) => {
   const {
@@ -53,6 +54,16 @@ export const gotoInvoiceCheckoutUrl = async (
 
 export const formattingNumericValues = (value: number, decimalPlaces: number) =>
   round(Number(value), decimalPlaces).toFixed(decimalPlaces);
+
+export const formatInvoiceBalanceAmount = (
+  balance: { code?: string; value: string | number },
+  decimalPlaces: number,
+) => {
+  const amount = formattingNumericValues(Number(balance.value), decimalPlaces);
+  const token = handleGetCorrespondingCurrencyToken(balance.code || 'USD');
+
+  return `${token}${amount || 0}`;
+};
 
 const getInvoiceCurrency = (invoice: InvoiceListNode) => {
   const {

--- a/apps/storefront/src/pages/Invoice/utils/payment.ts
+++ b/apps/storefront/src/pages/Invoice/utils/payment.ts
@@ -1,7 +1,7 @@
 import round from 'lodash-es/round';
 
 import { getInvoiceCheckoutUrl } from '@/shared/service/b2b';
-import { BcCartData } from '@/types/invoice';
+import { BcCartData, InvoiceListNode } from '@/types/invoice';
 import { attemptCheckoutLoginAndRedirect } from '@/utils/b3checkout';
 import b2bLogger from '@/utils/b3Logger';
 import { isBigCommercePlatform, isCatalystPlatform } from '@/utils/basicConfig';
@@ -53,3 +53,27 @@ export const gotoInvoiceCheckoutUrl = async (
 
 export const formattingNumericValues = (value: number, decimalPlaces: number) =>
   round(Number(value), decimalPlaces).toFixed(decimalPlaces);
+
+const getInvoiceCurrency = (invoice: InvoiceListNode) => {
+  const {
+    node: { openBalance, originalBalance },
+  } = invoice;
+
+  return openBalance?.code || originalBalance.code;
+};
+
+export const filterInvoicesBySameCurrency = (invoices: InvoiceListNode[]) => {
+  if (invoices.length === 0) {
+    return { validInvoices: [], hasMixedCurrency: false };
+  }
+
+  const referenceCurrency = getInvoiceCurrency(invoices[0]);
+  const validInvoices = invoices.filter(
+    (invoice) => getInvoiceCurrency(invoice) === referenceCurrency,
+  );
+
+  return {
+    validInvoices,
+    hasMixedCurrency: validInvoices.length < invoices.length,
+  };
+};


### PR DESCRIPTION
Jira: [B2B-4553](https://bigcommercecloud.atlassian.net/browse/B2B-4553)

## What/Why?
There are three issue/bugs for the invoice list page.
1. As ticket [B2B-4553](https://bigcommercecloud.atlassian.net/browse/B2B-4553) describes, buyers can checkout invoice with different currencies, but the amount is incorrect. Have confirmed with @bc-jessebayley , we are going to block buyers to pay invoice in mixed currencies.
2. In current mobile version, the amount display is incorrect, for example, this invoice is 25 with USD, but displayed with A$25.
<img width="1487" height="726" alt="Screenshot 2026-07-20 at 10 18 21 am" src="https://github.com/user-attachments/assets/1dfd0a87-b197-4209-8648-fa9ba67612fb" />
3. The display of open and overdue is incorrect for both desktop and mobile, we should not directly sum up for in mixed currencies.
<img width="1501" height="675" alt="Screenshot 2026-07-20 at 10 20 23 am" src="https://github.com/user-attachments/assets/f1082bdb-59f8-40dd-ae52-7c3efa3dd7f8" />


This PR is to address issue 1 and 2, selection of mixed-currency invoices is still allowed (e.g. for CSV export); only payment ("PAY INVOICES" button disabled) is blocked.  For the case3, a new ticket to has been created [B2B-5315](https://bigcommercecloud.atlassian.net/browse/B2B-5315) to discuss and handle.

## Rollout/Rollback
Revert this PR if needed

## Testing
**Before**
<img width="1464" height="680" alt="Screenshot 2026-07-20 at 10 23 12 am" src="https://github.com/user-attachments/assets/4e1e71e7-87a6-4a63-94eb-b4a51dd8637a" />

**After**
**Desktop**
1. "PAY INVOICES" button disabled when mixed currencies selected, and able to go checkout page if only single currency invoice selected
https://github.com/user-attachments/assets/d5759fde-fe8c-47c4-b9df-22f163dddf2f

2.  Still can export with mixed currencies invoice selected
https://github.com/user-attachments/assets/6cffed8f-af2a-4f63-a574-b37a84017aea

**Mobile**
https://github.com/user-attachments/assets/5342ce6b-e5c1-423b-8933-7f6fd5bc3002


[B2B-4553]: https://bigcommercecloud.atlassian.net/browse/B2B-4553?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches invoice checkout/payment UX; incorrect currency detection could block valid same-currency batches or still allow bad carts, but scope is limited to the bulk-pay footer with new test coverage.
> 
> **Overview**
> Prevents buyers from starting checkout when **multiple selected invoices use different currencies**.
> 
> Adds `hasMixedInvoiceCurrencies` in invoice payment utils (compares `openBalance` / `originalBalance` codes). **Invoice footer** uses it to disable **Pay invoices**, show the error *"Cannot pay invoices in mixed currencies"* instead of a total, skip summing amounts, and no-op `handlePay`. New copy is in `en.json`.
> 
> Desktop and mobile invoice tests cover mixed-currency selection (including select-all) and recovery when deselecting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af084b7f20bccee6b45845bd45e8c2e8daa47ac8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

[B2B-5315]: https://bigcommercecloud.atlassian.net/browse/B2B-5315?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ