### PR TITLE
LOCAL-3436: Register all locale bundles in localeLoaders

### DIFF
--- a/apps/storefront/src/lib/lang/locales/index.ts
+++ b/apps/storefront/src/lib/lang/locales/index.ts
@@ -4,10 +4,27 @@ import en from './en.json';
 
 type LocaleMessages = Record<string, string>;
 
-// Filenames use underscores for BCP-47 region tags (fr_FR.json); runtime codes use dashes (fr-FR).
+// Locale bundle filenames match the runtime BCP-47-style locale codes (e.g. es-MX.json for "es-MX").
 const localeLoaders: Record<string, () => Promise<LocaleMessages>> = {
-  fr: () => import('./fr.json').then((m) => m.default),
+  da: () => import('./da.json').then((m) => m.default),
+  de: () => import('./de.json').then((m) => m.default),
   es: () => import('./es.json').then((m) => m.default),
+  'es-419': () => import('./es-419.json').then((m) => m.default),
+  'es-AR': () => import('./es-AR.json').then((m) => m.default),
+  'es-CL': () => import('./es-CL.json').then((m) => m.default),
+  'es-CO': () => import('./es-CO.json').then((m) => m.default),
+  'es-LA': () => import('./es-LA.json').then((m) => m.default),
+  'es-MX': () => import('./es-MX.json').then((m) => m.default),
+  'es-PE': () => import('./es-PE.json').then((m) => m.default),
+  fr: () => import('./fr.json').then((m) => m.default),
+  it: () => import('./it.json').then((m) => m.default),
+  ja: () => import('./ja.json').then((m) => m.default),
+  nl: () => import('./nl.json').then((m) => m.default),
+  no: () => import('./no.json').then((m) => m.default),
+  pl: () => import('./pl.json').then((m) => m.default),
+  pt: () => import('./pt.json').then((m) => m.default),
+  'pt-BR': () => import('./pt-BR.json').then((m) => m.default),
+  sv: () => import('./sv.json').then((m) => m.default),
 };
 
 // Returns true when a static bundle covers the given code — either an exact


### PR DESCRIPTION
Jira: [LOCAL-3436](https://bigcommercecloud.atlassian.net/browse/LOCAL-3436)

## What/Why?
`localeLoaders` in `apps/storefront/src/lib/lang/locales/index.ts` only had entries for `fr` and `es`, even though 17 other locale JSON files already existed in the same directory: `da`, `de`, `es-419`, `es-AR`, `es-CL`, `es-CO`, `es-LA`, `es-MX`, `es-PE`, `it`, `ja`, `nl`, `no`, `pl`, `pt`, `pt-BR`, `sv`.

`isSupportedLocale` and `useLocaleBundle` both resolve locale codes through `localeLoaders`, so any code missing an entry silently fell back to the `en` bundle regardless of the JSON file being present on disk. This adds a loader entry for every existing locale file, following the same `import(...).then((m) => m.default)` pattern already used for `fr`/`es`.

## Rollout/Rollback
Standard deploy, no migrations or flags. Revert the commit to roll back; each new entry is additive and independent, so there is no risk to existing `fr`/`es` behavior.

## Testing
Manual testing: 
<img width="2896" height="1508" alt="image" src="https://github.com/user-attachments/assets/c936820e-6751-4771-a532-14be621ab0e0" />
<img width="2930" height="1574" alt="image" src="https://github.com/user-attachments/assets/5cfae919-2074-4f26-80b0-97d1c16a8ed4" />


[LOCAL-3436]: https://bigcommercecloud.atlassian.net/browse/LOCAL-3436?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ