### PR TITLE
B2B-5056: restrict storefront registerCompany to BigCommerce platform only

### DIFF
--- a/apps/storefront/src/pages/Registered/RegisterSteps/steps/CompleteStep/index.tsx
+++ b/apps/storefront/src/pages/Registered/RegisterSteps/steps/CompleteStep/index.tsx
@@ -14,7 +14,7 @@ import { getStorefrontToken } from '@/shared/service/b2b/graphql/recaptcha';
 import { RegisterCompanyStatus } from '@/shared/service/bc/graphql/company';
 import { CompanyStatus } from '@/types/company';
 import b2bLogger from '@/utils/b3Logger';
-import { channelId, storeHash } from '@/utils/basicConfig';
+import { channelId, isBigCommercePlatform, storeHash } from '@/utils/basicConfig';
 import { ensureBcGraphqlToken } from '@/utils/loginInfo';
 
 import { RegisteredContext } from '../../../Context';
@@ -288,7 +288,7 @@ export default function CompleteStep(props: CompleteStepProps) {
               createCustomerContext,
             );
 
-            if (isRegisterCompanyFlowEnabled) {
+            if (isRegisterCompanyFlowEnabled && isBigCommercePlatform()) {
               await ensureBcGraphqlToken();
 
               const customerDetails = await loginAndGetBcCustomer(

--- a/apps/storefront/src/pages/Registered/index.catalyst.test.tsx
+++ b/apps/storefront/src/pages/Registered/index.catalyst.test.tsx
@@ -1,0 +1,500 @@
+import {
+  buildCompanyStateWith,
+  buildGlobalStateWith,
+  renderWithProviders,
+  screen,
+  waitFor,
+} from 'tests/test-utils';
+import { when } from 'vitest-when';
+
+import * as b2bService from '@/shared/service/b2b';
+import * as recaptchaModule from '@/shared/service/b2b/graphql/recaptcha';
+import * as bcModule from '@/shared/service/bc';
+import * as companyGraphqlModule from '@/shared/service/bc/graphql/company';
+import { RegisterCompanyStatus } from '@/shared/service/bc/graphql/company';
+import * as bcGraphqlLoginModule from '@/shared/service/bc/graphql/login';
+import * as loginInfoModule from '@/utils/loginInfo';
+import * as storefrontConfigModule from '@/utils/storefrontConfig';
+
+import { RegisteredProvider } from './Context';
+import Registered from '.';
+
+vi.hoisted(() => {
+  window.B3 = {
+    setting: {
+      channel_id: 1,
+      store_hash: 'store-hash',
+      platform: 'catalyst',
+      environment: 'local',
+    },
+  };
+});
+
+const formFields = [
+  {
+    id: '10',
+    formType: 2,
+    fieldFrom: 10,
+    fieldId: 'field_company_name',
+    groupId: 3,
+    groupName: 'Business Details',
+    isRequired: true,
+    visible: true,
+    labelName: 'Company Name',
+    fieldName: 'company_name',
+    fieldType: 'text',
+    valueConfigs: { label: 'Company Name' },
+  },
+  {
+    id: '13',
+    formType: 2,
+    fieldFrom: 10,
+    fieldId: 'field_company_email',
+    groupId: 3,
+    groupName: 'Business Details',
+    isRequired: true,
+    visible: true,
+    labelName: 'Company Email',
+    fieldName: 'company_email',
+    fieldType: 'text',
+    valueConfigs: { label: 'Company Email' },
+  },
+  {
+    id: '14',
+    formType: 2,
+    fieldFrom: 10,
+    fieldId: 'field_company_phone_number',
+    groupId: 3,
+    groupName: 'Business Details',
+    isRequired: true,
+    visible: true,
+    labelName: 'Company Phone Number',
+    fieldName: 'company_phone_number',
+    fieldType: 'text',
+    valueConfigs: { label: 'Company Phone Number' },
+  },
+  {
+    id: '17',
+    formType: 2,
+    fieldFrom: 10,
+    fieldId: 'field_country',
+    groupId: 4,
+    groupName: 'Address',
+    isRequired: true,
+    visible: true,
+    labelName: 'Country',
+    fieldName: 'country',
+    fieldType: 'dropdown',
+    valueConfigs: { label: 'Country', default: null },
+  },
+  {
+    id: '18',
+    formType: 2,
+    fieldFrom: 10,
+    fieldId: 'field_address_1',
+    groupId: 4,
+    groupName: 'Address',
+    isRequired: true,
+    visible: true,
+    labelName: 'Address 1',
+    fieldName: 'address1',
+    fieldType: 'text',
+    valueConfigs: { label: 'Address 1' },
+  },
+  {
+    id: '21',
+    formType: 2,
+    fieldFrom: 10,
+    fieldId: 'field_city',
+    groupId: 4,
+    groupName: 'Address',
+    isRequired: true,
+    visible: true,
+    labelName: 'City',
+    fieldName: 'city',
+    fieldType: 'text',
+    valueConfigs: { label: 'City' },
+  },
+  {
+    id: '22',
+    formType: 2,
+    fieldFrom: 10,
+    fieldId: 'field_state',
+    groupId: 4,
+    groupName: 'Address',
+    isRequired: true,
+    visible: true,
+    labelName: 'State',
+    fieldName: 'state',
+    fieldType: 'dropdown',
+    valueConfigs: { label: 'State' },
+  },
+  {
+    id: '23',
+    formType: 2,
+    fieldFrom: 10,
+    fieldId: 'field_zip_code',
+    groupId: 4,
+    groupName: 'Address',
+    isRequired: true,
+    visible: true,
+    labelName: 'Zip Code',
+    fieldName: 'zip_code',
+    fieldType: 'text',
+    valueConfigs: { label: 'Zip Code' },
+  },
+  {
+    id: '1',
+    formType: 2,
+    fieldFrom: 10,
+    fieldId: 'field_first_name',
+    groupId: 1,
+    groupName: 'Contact Information',
+    isRequired: true,
+    visible: true,
+    labelName: 'First Name',
+    fieldName: 'first_name',
+    fieldType: 'text',
+    valueConfigs: { label: 'First Name' },
+  },
+  {
+    id: '3',
+    formType: 2,
+    fieldFrom: 10,
+    fieldId: 'field_last_name',
+    groupId: 1,
+    groupName: 'Contact Information',
+    isRequired: true,
+    visible: true,
+    labelName: 'Last Name',
+    fieldName: 'last_name',
+    fieldType: 'text',
+    valueConfigs: { label: 'Last Name' },
+  },
+  {
+    id: '5',
+    formType: 2,
+    fieldFrom: 10,
+    fieldId: 'field_email',
+    groupId: 1,
+    groupName: 'Contact Information',
+    isRequired: true,
+    visible: true,
+    labelName: 'Email Address',
+    fieldName: 'email',
+    fieldType: 'text',
+    valueConfigs: { label: 'Email Address' },
+  },
+  {
+    id: '7',
+    formType: 2,
+    fieldFrom: 10,
+    fieldId: 'field_phone_number',
+    groupId: 1,
+    groupName: 'Contact Information',
+    isRequired: false,
+    visible: true,
+    labelName: 'Phone Number',
+    fieldName: 'phone',
+    fieldType: 'text',
+    valueConfigs: { label: 'Phone Number' },
+  },
+  {
+    id: '33',
+    formType: 2,
+    fieldFrom: 10,
+    fieldId: 'field_create_password',
+    groupId: 5,
+    groupName: 'Password',
+    isRequired: true,
+    visible: true,
+    labelName: 'Create Password',
+    fieldName: 'create_password',
+    fieldType: 'password',
+    valueConfigs: {
+      id: 'field_2',
+      name: 'password',
+      type: 'string',
+      label: 'Password',
+      secret: true,
+      default: '',
+      required: true,
+      fieldType: 'password',
+      maxLength: null,
+      requirements: {
+        alpha: '[A-Za-z]',
+        numeric: '[0-9]',
+        minlength: 7,
+        description:
+          'Passwords must be at least 7 characters and contain both alphabetic and numeric characters.',
+      },
+    },
+  },
+  {
+    id: '35',
+    formType: 2,
+    fieldFrom: 10,
+    fieldId: 'field_confirm_password',
+    groupId: 5,
+    groupName: 'Password',
+    isRequired: true,
+    visible: true,
+    labelName: 'Confirm Password',
+    fieldName: 'confirm_password',
+    fieldType: 'password',
+    valueConfigs: {
+      id: 'field_2',
+      name: 'password',
+      type: 'string',
+      label: 'Password',
+      secret: true,
+      default: '',
+      required: true,
+      fieldType: 'password',
+      maxLength: null,
+      requirements: {
+        alpha: '[A-Za-z]',
+        numeric: '[0-9]',
+        minlength: 7,
+        description:
+          'Passwords must be at least 7 characters and contain both alphabetic and numeric characters.',
+      },
+    },
+  },
+];
+
+const mockCountries = {
+  countries: [
+    {
+      countryCode: 'US',
+      countryName: 'United States',
+      id: '1',
+      states: [{ stateName: 'California', stateCode: 'CA' }],
+    },
+  ],
+};
+
+const b2bRegistrationData = {
+  accountType: 'Business account',
+  contactInfo: {
+    'First Name': 'Jane',
+    'Last Name': 'Smith',
+    'Email Address': 'jane.smith@example.com',
+    'Phone Number': '5550001111',
+  },
+  businessDetails: {
+    'Company Name': 'Catalyst Co',
+    'Company Email': 'catalyst.co@example.com',
+    'Company Phone Number': '5550002222',
+  },
+  address: {
+    Country: 'United States',
+    'Address 1': '1 Catalyst St',
+    City: 'San Francisco',
+    State: 'California',
+    'Zip Code': '94105',
+  },
+  password: {
+    'Create Password': 'Password123',
+    'Confirm Password': 'Password123',
+  },
+};
+
+async function completeB2BRegistration(
+  user: ReturnType<typeof renderWithProviders>['user'],
+  data: typeof b2bRegistrationData,
+) {
+  await user.click(screen.getByLabelText(data.accountType));
+
+  await user.type(screen.getByLabelText(/First Name/i), data.contactInfo['First Name']);
+  await user.type(screen.getByLabelText(/Last Name/i), data.contactInfo['Last Name']);
+  await user.type(screen.getByLabelText(/Email Address/i), data.contactInfo['Email Address']);
+  await user.click(screen.getByRole('button', { name: 'Continue' }));
+
+  await user.type(screen.getByLabelText(/Company Name/i), data.businessDetails['Company Name']);
+  await user.type(screen.getByLabelText(/Company Email/i), data.businessDetails['Company Email']);
+  await user.type(
+    screen.getByLabelText(/Company Phone Number/i),
+    data.businessDetails['Company Phone Number'],
+  );
+  await user.click(screen.getByRole('button', { name: 'Continue' }));
+
+  await user.click(screen.getByLabelText(/Country/i));
+  await user.click(screen.getByRole('option', { name: data.address.Country }));
+  await user.type(screen.getByLabelText(/Address 1/i), data.address['Address 1']);
+  await user.type(screen.getByLabelText(/City/i), data.address.City);
+  await user.click(screen.getByRole('combobox', { name: /State/i }));
+  await user.click(screen.getByRole('option', { name: data.address.State }));
+  await user.type(screen.getByLabelText(/Zip Code/i), data.address['Zip Code']);
+  await user.click(screen.getByRole('button', { name: 'Continue' }));
+
+  await user.type(screen.getByLabelText(/Create Password/i), data.password['Create Password']);
+  await user.type(screen.getByLabelText(/Confirm Password/i), data.password['Confirm Password']);
+  await user.click(screen.getByRole('button', { name: /Submit/i }));
+}
+
+const preloadedStateCatalystWithFFOff = {
+  global: buildGlobalStateWith({
+    featureFlags: { 'B2B-4466.use_register_company_flow': false },
+  }),
+};
+
+const preloadedStateCatalystWithFFOn = {
+  global: buildGlobalStateWith({
+    featureFlags: { 'B2B-4466.use_register_company_flow': true },
+  }),
+  company: buildCompanyStateWith({
+    tokens: {
+      bcGraphqlToken: 'prefetched-bc-storefront-token',
+      B2BToken: '',
+      currentCustomerJWT: '',
+    },
+  }),
+};
+
+describe('Registered Page (Catalyst platform)', () => {
+  beforeEach(() => {
+    window.B3.setting.platform = 'catalyst';
+
+    vi.spyOn(b2bService, 'getB2BAccountFormFields').mockResolvedValue({
+      accountFormFields: formFields,
+    });
+    vi.spyOn(b2bService, 'getB2BCountries').mockResolvedValue(mockCountries);
+    vi.spyOn(b2bService, 'checkUserEmail').mockResolvedValue({ isValid: true });
+    vi.spyOn(b2bService, 'checkUserBCEmail').mockResolvedValue({ isValid: true });
+    vi.spyOn(b2bService, 'validateAddressExtraFields').mockResolvedValue({ code: 200 });
+    vi.spyOn(b2bService, 'validateBCCompanyExtraFields').mockResolvedValue({ code: 200 });
+    vi.spyOn(b2bService, 'createBCCompanyUser').mockResolvedValue({
+      customerCreate: { customer: { id: 42, email: 'jane.smith@example.com' } },
+    });
+    vi.spyOn(b2bService, 'createB2BCompanyUser').mockResolvedValue({
+      companyCreate: { company: { companyStatus: 1 } },
+    });
+    vi.spyOn(b2bService, 'sendSubscribersState').mockImplementation(() => Promise.resolve({}));
+    vi.spyOn(b2bService, 'uploadB2BFile').mockResolvedValue({ code: 200, data: { fileSize: '' } });
+    vi.spyOn(companyGraphqlModule, 'registerCompany').mockResolvedValue({
+      data: {
+        company: {
+          registerCompany: { entityId: 1, status: RegisterCompanyStatus.APPROVED, errors: [] },
+        },
+      },
+    });
+    vi.spyOn(bcModule, 'bcLogin').mockResolvedValue({ error: undefined });
+    vi.spyOn(bcGraphqlLoginModule, 'bcLogoutLogin').mockResolvedValue({
+      data: { logout: { result: 'success' } },
+    });
+    vi.spyOn(loginInfoModule, 'ensureBcGraphqlToken').mockImplementation(() => Promise.resolve());
+    vi.spyOn(loginInfoModule, 'getCurrentCustomerInfo').mockResolvedValue({
+      userType: 5,
+      role: 2,
+      companyRoleName: 'Junior Buyer',
+    });
+    vi.spyOn(recaptchaModule, 'getStorefrontToken').mockResolvedValue({
+      isEnabledOnStorefront: false,
+      siteKey: '',
+    });
+    vi.spyOn(storefrontConfigModule, 'getStoreConfigs').mockImplementation(() => Promise.resolve());
+  });
+
+  describe('B2B-4466.use_register_company_flow enabled', () => {
+    it('uses createB2BCompanyUser (B2B API) instead of Storefront registerCompany', async () => {
+      const { user } = renderWithProviders(
+        <RegisteredProvider>
+          <Registered setOpenPage={vi.fn()} />
+        </RegisteredProvider>,
+        { preloadedState: preloadedStateCatalystWithFFOn },
+      );
+
+      await completeB2BRegistration(user, b2bRegistrationData);
+
+      await waitFor(() => {
+        expect(b2bService.createB2BCompanyUser).toHaveBeenCalled();
+      });
+      expect(companyGraphqlModule.registerCompany).not.toHaveBeenCalled();
+    });
+
+    it('does not call bcLogin for token exchange or ensureBcGraphqlToken', async () => {
+      const { user } = renderWithProviders(
+        <RegisteredProvider>
+          <Registered setOpenPage={vi.fn()} />
+        </RegisteredProvider>,
+        { preloadedState: preloadedStateCatalystWithFFOn },
+      );
+
+      await completeB2BRegistration(user, b2bRegistrationData);
+
+      await waitFor(() => {
+        expect(b2bService.createB2BCompanyUser).toHaveBeenCalled();
+      });
+      expect(loginInfoModule.ensureBcGraphqlToken).not.toHaveBeenCalled();
+      expect(bcModule.bcLogin).not.toHaveBeenCalled();
+    });
+
+    it('shows approval success screen when company is auto-approved', async () => {
+      const { user } = renderWithProviders(
+        <RegisteredProvider>
+          <Registered setOpenPage={vi.fn()} />
+        </RegisteredProvider>,
+        {
+          preloadedState: preloadedStateCatalystWithFFOn,
+          initialGlobalContext: { storeName: 'Catalyst Store' },
+        },
+      );
+
+      await completeB2BRegistration(user, b2bRegistrationData);
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(
+            'Thank you for creating your account at Catalyst Store. Your company account application has been approved',
+          ),
+        ).toBeVisible();
+      });
+      expect(b2bService.createB2BCompanyUser).toHaveBeenCalled();
+      expect(companyGraphqlModule.registerCompany).not.toHaveBeenCalled();
+    });
+
+    it('shows pending screen when company registration is not auto-approved', async () => {
+      when(b2bService.createB2BCompanyUser)
+        .calledWith(expect.objectContaining({ customerId: 42 }))
+        .thenResolve({ companyCreate: { company: { companyStatus: 0 } } });
+
+      const { navigation, user } = renderWithProviders(
+        <RegisteredProvider>
+          <Registered setOpenPage={vi.fn()} />
+        </RegisteredProvider>,
+        { preloadedState: preloadedStateCatalystWithFFOn },
+      );
+
+      await completeB2BRegistration(user, b2bRegistrationData);
+
+      await waitFor(() => {
+        expect(screen.getByRole('heading', { name: 'Application submitted' })).toBeVisible();
+      });
+      await user.click(screen.getByRole('button', { name: /Finish|FINISH/i }));
+      await waitFor(() => {
+        expect(navigation).toHaveBeenCalledWith(expect.stringMatching(/login/i));
+      });
+    });
+  });
+
+  describe('B2B-4466.use_register_company_flow disabled', () => {
+    it('uses createB2BCompanyUser (B2B API) and does not call Storefront registerCompany', async () => {
+      const { user } = renderWithProviders(
+        <RegisteredProvider>
+          <Registered setOpenPage={vi.fn()} />
+        </RegisteredProvider>,
+        { preloadedState: preloadedStateCatalystWithFFOff },
+      );
+
+      await completeB2BRegistration(user, b2bRegistrationData);
+
+      await waitFor(() => {
+        expect(b2bService.createB2BCompanyUser).toHaveBeenCalled();
+      });
+      expect(companyGraphqlModule.registerCompany).not.toHaveBeenCalled();
+      expect(loginInfoModule.ensureBcGraphqlToken).not.toHaveBeenCalled();
+      expect(bcModule.bcLogin).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
Jira: [B2B-5056](https://bigcommercecloud.atlassian.net/browse/B2B-5056)

## What/Why?

The `B2B-4466.use_register_company_flow` flag gates company registration via the BC Storefront GraphQL `registerCompany` mutation. This mutation requires an authenticated storefront session obtained from `/customer/current.jwt`, a Stencil-only endpoint that does not exist on Catalyst.

On Catalyst, there is no Current Customer API, so the session exchange cannot happen and `registerCompany` fails with an authentication error. The fix adds `isBigCommercePlatform()` to the flag check in `CompleteStep`, so Catalyst falls back to the existing `createB2BCompanyUser` B2B API path, which does not require a storefront session.

## Rollout/Rollback

Gated behind the existing `B2B-4466.use_register_company_flow` feature flag. No new flag required. Rolling back is a flag disable or a revert of this one-line change.

## Testing

New test file `index.catalyst.test.tsx` covers:
- FF on + Catalyst: `createB2BCompanyUser` is called, `registerCompany` is not called, `bcLogin` and `ensureBcGraphqlToken` are not invoked
- FF on + Catalyst: auto-approval success screen renders correctly
- FF on + Catalyst: pending approval screen renders and navigates to login
- FF off + Catalyst: same fallback behaviour, `registerCompany` not called

Run locally:
```
cd apps/storefront
yarn test src/pages/Registered/index.catalyst.test.tsx
```
For Catalyst
<img width="1494" height="637" alt="Screenshot 2026-07-21 at 1 36 46 pm" src="https://github.com/user-attachments/assets/b9395eb2-7795-40f1-887e-af463c1fca1c" />


[B2B-5056]: https://bigcommercecloud.atlassian.net/browse/B2B-5056?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single conditional change in registration completion with existing fallback path; behavior on BigCommerce Stencil is unchanged when the flag is on.
> 
> **Overview**
> **Catalyst B2B registration** no longer attempts the Storefront GraphQL `registerCompany` path when `B2B-4466.use_register_company_flow` is on. `CompleteStep` now requires **both** that flag and `isBigCommercePlatform()` before running `ensureBcGraphqlToken`, BC login, and `registerCompany`; on Catalyst it keeps using the B2B API via `createCompany` / `createB2BCompanyUser`.
> 
> Adds **`index.catalyst.test.tsx`** to lock in Catalyst behavior: B2B company creation is used, Storefront `registerCompany` and session helpers are not called, and approval vs pending success flows are covered with the flag on or off.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c775d01f2da0127aa02a676221b24af6c9fe9a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->