### PR TITLE
feat(orders): BACK-534 Render backorder information for my orders and company orders pages.

### DIFF
--- a/apps/storefront/src/components/B3ProductList.tsx
+++ b/apps/storefront/src/components/B3ProductList.tsx
@@ -11,6 +11,7 @@ import type { CatalogQuickVariantSku } from '@/shared/service/b2b/graphql/produc
 import { useAppSelector } from '@/store';
 import { currencyFormat, ordersCurrencyFormat } from '@/utils/b3CurrencyFormat';
 import { getDisplayPrice, judgmentBuyerProduct } from '@/utils/b3Product/b3Product';
+import type { BackorderDisplayFields } from '@/utils/backorderDisplayFromInventory';
 import {
   getCatalogProductRowDisplayState,
   productRequiresChooseOptionsBeforeAdd,
@@ -168,6 +169,7 @@ interface ProductProps<T extends ProductItem = ProductItem> {
   catalogInventoryBySku?: Record<string, CatalogQuickVariantSku>;
   showAvailableToSellHelper?: boolean;
   formatOnlyAvailable?: (availableToSell: number) => string;
+  backorderFieldsForProduct?: (product: T & ProductItem) => BackorderDisplayFields | null;
 }
 
 function getProductVariantSku(product: ProductItem): string {
@@ -197,6 +199,7 @@ export function B3ProductList<T extends ProductItem>(props: ProductProps<T>) {
     catalogInventoryBySku,
     showAvailableToSellHelper = false,
     formatOnlyAvailable = () => '',
+    backorderFieldsForProduct,
   } = props;
 
   const [list, setList] = useState<ProductItem[]>([]);
@@ -269,13 +272,14 @@ export function B3ProductList<T extends ProductItem>(props: ProductProps<T>) {
   }, [products]);
 
   const itemStyle = isMobile ? mobileItemStyle : defaultItemStyle;
+  const backorderLayoutEnabled = catalogBackorderUiEnabled || Boolean(backorderFieldsForProduct);
   const {
     qtyColumn: desktopQtyColumnStyle,
     qtyColumnSx: desktopQtyColumnExtraSx,
     numericColumn: desktopNumericColumnStyle,
     productColumnPadding: desktopProductColumnPadding,
     productColumnSx: desktopProductColumnSx,
-  } = getBackorderLayoutStyles(catalogBackorderUiEnabled && !isMobile, isMobile, itemStyle);
+  } = getBackorderLayoutStyles(backorderLayoutEnabled && !isMobile, isMobile, itemStyle);
 
   const showTypePrice = (newMoney: string | number, product: CustomFieldItems): string | number => {
     if (type === 'quote') {
@@ -381,14 +385,32 @@ export function B3ProductList<T extends ProductItem>(props: ProductProps<T>) {
         const inventoryRow = productRequiresChooseOptionsBeforeAdd(product)
           ? undefined
           : catalogInventoryBySku?.[variantSku.toUpperCase()];
-        const { qtyHelperText, backorderFields } = getCatalogProductRowDisplayState({
-          qty: Number(quantity) || 0,
-          productHelperText: product.helperText,
-          showAvailableToSellHelper,
-          inventoryRow,
-          backorderUiEnabled: catalogBackorderUiEnabled,
-          formatOnlyAvailable,
-        });
+        const { qtyHelperText, backorderFields: catalogBackorderFields } =
+          getCatalogProductRowDisplayState({
+            qty: Number(quantity) || 0,
+            productHelperText: product.helperText,
+            showAvailableToSellHelper,
+            inventoryRow,
+            backorderUiEnabled: catalogBackorderUiEnabled,
+            formatOnlyAvailable,
+          });
+        const backorderFields = backorderFieldsForProduct?.(product) ?? catalogBackorderFields;
+
+        const quantityLabel = (
+          <>
+            {isMobile && <span>Qty: </span>}
+            {quantity}
+          </>
+        );
+
+        const backorderMessageElement = backorderFields && (
+          <BackorderMessage
+            totalOnHand={backorderFields.totalOnHand}
+            quantityBackordered={backorderFields.quantityBackordered}
+            backorderMessage={backorderFields.backorderMessage}
+            visible
+          />
+        );
 
         const getDisplayPrice = (priceValue: number, preFormatted?: string) => {
           if (preFormatted) return showTypePrice(preFormatted, product);
@@ -542,7 +564,7 @@ export function B3ProductList<T extends ProductItem>(props: ProductProps<T>) {
                   : {}),
               }}
             >
-              {quantityEditable ? (
+              {quantityEditable && (
                 <Box
                   sx={{
                     display: 'flex',
@@ -573,7 +595,7 @@ export function B3ProductList<T extends ProductItem>(props: ProductProps<T>) {
                     error={Boolean(qtyHelperText)}
                     helperText={qtyHelperText || undefined}
                   />
-                  {backorderFields && (
+                  {backorderMessageElement && (
                     <Box
                       sx={{
                         mt: 1,
@@ -584,21 +606,34 @@ export function B3ProductList<T extends ProductItem>(props: ProductProps<T>) {
                         alignSelf: quantityStackItemsAlignment,
                       }}
                     >
-                      <BackorderMessage
-                        totalOnHand={backorderFields.totalOnHand}
-                        quantityBackordered={backorderFields.quantityBackordered}
-                        backorderMessage={backorderFields.backorderMessage}
-                        visible
-                      />
+                      {backorderMessageElement}
                     </Box>
                   )}
                 </Box>
-              ) : (
-                <>
-                  {isMobile && <span>Qty: </span>}
-                  {quantity}
-                </>
               )}
+              {!quantityEditable && backorderFields && (
+                <Box
+                  sx={{
+                    display: 'flex',
+                    flexDirection: 'column',
+                    alignItems: quantityStackItemsAlignment,
+                    width: '100%',
+                  }}
+                >
+                  <Box>{quantityLabel}</Box>
+                  <Box
+                    sx={{
+                      mt: 1,
+                      width: '100%',
+                      textAlign,
+                      alignSelf: quantityStackItemsAlignment,
+                    }}
+                  >
+                    {backorderMessageElement}
+                  </Box>
+                </Box>
+              )}
+              {!quantityEditable && !backorderFields && quantityLabel}
             </FlexItem>
 
             {renderPrice(totalText, totalPrice, discountedTotalPrice, safeFormattedTotal)}

--- a/apps/storefront/src/pages/OrderDetail/components/OrderAction.tsx
+++ b/apps/storefront/src/pages/OrderDetail/components/OrderAction.tsx
@@ -5,6 +5,7 @@ import { Box, Card, CardContent, Divider, Typography } from '@mui/material';
 import throttle from 'lodash-es/throttle';
 
 import CustomButton from '@/components/button/CustomButton';
+import { useBackorderStorefrontMessaging } from '@/hooks/useBackorderStorefrontMessaging';
 import { useB3Lang } from '@/lib/lang';
 import HierarchyDialog from '@/pages/CompanyHierarchy/components/HierarchyDialog';
 import { GlobalContext } from '@/shared/global';
@@ -93,6 +94,7 @@ interface OrderCardProps {
   isCurrentCompany: boolean;
   switchCompanyId: number | string | undefined;
   currencyCode?: string;
+  shippingExpectationMessage?: string;
 }
 
 interface DialogData {
@@ -117,6 +119,7 @@ function OrderCard(props: OrderCardProps) {
     isCurrentCompany,
     switchCompanyId,
     currencyCode,
+    shippingExpectationMessage,
   } = props;
   const displayAsNegativeNumber = ['coupon', 'discountAmount'];
   const b3Lang = useB3Lang();
@@ -229,6 +232,12 @@ function OrderCard(props: OrderCardProps) {
             <p>{formatValue(infoValue[index])}</p>
           )}
         </ItemContainer>
+
+        {symbol[key] === 'shipping' && shippingExpectationMessage && (
+          <Typography variant="body2" sx={{ color: '#616161', margin: '0 0 12px' }}>
+            {shippingExpectationMessage}
+          </Typography>
+        )}
       </Fragment>
     ));
   }
@@ -319,6 +328,7 @@ interface OrderData {
   subtitle: string;
   buttons: Buttons[];
   infos: Infos | string;
+  shippingExpectationMessage?: string;
 }
 
 export function OrderAction(props: OrderActionProps) {
@@ -350,7 +360,17 @@ export function OrderAction(props: OrderActionProps) {
     statusCode,
     customerId,
     companyInfo: { companyId } = {},
+    shippingExpectationMessage: rawShippingExpectationMessage = '',
   } = detailsData;
+
+  const { isBackorderMessagingContextEnabled } = useBackorderStorefrontMessaging();
+  const { showDefaultShippingExpectationPrompt } = useAppSelector(
+    ({ global }) => global.backorderDisplaySettings,
+  );
+  const shippingExpectationMessage =
+    isBackorderMessagingContextEnabled && showDefaultShippingExpectationPrompt
+      ? rawShippingExpectationMessage
+      : '';
 
   const getPaymentMessage = useCallback(() => {
     if (!createAt) return '';
@@ -493,6 +513,7 @@ export function OrderAction(props: OrderActionProps) {
         info: priceData || {},
         symbol: priceSymbol || {},
       },
+      shippingExpectationMessage: shippingExpectationMessage || undefined,
     },
     {
       header: b3Lang('orderDetail.payment'),

--- a/apps/storefront/src/pages/OrderDetail/components/OrderShipping.tsx
+++ b/apps/storefront/src/pages/OrderDetail/components/OrderShipping.tsx
@@ -5,11 +5,14 @@ import { format } from 'date-fns/format';
 import { getTracking } from 'ts-tracking-number';
 
 import { B3ProductList } from '@/components/B3ProductList';
+import { useBackorderStorefrontMessaging } from '@/hooks/useBackorderStorefrontMessaging';
 import { useMobile } from '@/hooks/useMobile';
 import { useB3Lang } from '@/lib/lang';
+import type { BackorderDisplayFields } from '@/utils/backorderDisplayFromInventory';
 
-import { OrderShippedItem, OrderShippingsItem } from '../../../types';
+import { OrderProductItem, OrderShippedItem, OrderShippingsItem } from '../../../types';
 import { OrderDetailsContext } from '../context/OrderDetailsContext';
+import { getRemainingBackorderedQuantity } from '../shared/getRemainingBackorderedQuantity';
 
 const ShipmentTitle = styled('span')(() => ({
   fontWeight: 'bold',
@@ -28,6 +31,27 @@ export function OrderShipping({ isCurrentCompany }: OrderShippingProps) {
   const [isMobile] = useMobile();
 
   const b3Lang = useB3Lang();
+
+  const { isBackorderMessagingContextEnabled, hasAnyBackorderDisplay } =
+    useBackorderStorefrontMessaging();
+  const showOrderBackorder = isBackorderMessagingContextEnabled && hasAnyBackorderDisplay;
+
+  const backorderFieldsForProduct = (product: OrderProductItem): BackorderDisplayFields | null => {
+    const { quantity = 0, quantity_shipped: quantityShipped = 0, backorderMessage } = product;
+
+    const quantityBackordered = getRemainingBackorderedQuantity(product);
+    if (quantityBackordered <= 0) {
+      return null;
+    }
+
+    const remainingUnshipped = Math.max(0, quantity - quantityShipped);
+
+    return {
+      totalOnHand: Math.max(0, remainingUnshipped - quantityBackordered),
+      quantityBackordered,
+      backorderMessage: backorderMessage ?? undefined,
+    };
+  };
 
   const [shippingsDetail, setShippingsDetail] = useState<OrderShippingsItem[]>([]);
 
@@ -194,6 +218,9 @@ export function OrderShipping({ isCurrentCompany }: OrderShippingProps) {
                   totalText="Total"
                   canToProduct={isCurrentCompany}
                   textAlign={isMobile ? 'left' : 'right'}
+                  backorderFieldsForProduct={
+                    showOrderBackorder ? backorderFieldsForProduct : undefined
+                  }
                 />
               </Fragment>
             ) : null}

--- a/apps/storefront/src/pages/OrderDetail/context/OrderDetailsContext.tsx
+++ b/apps/storefront/src/pages/OrderDetail/context/OrderDetailsContext.tsx
@@ -40,6 +40,7 @@ export interface OrderDetailsState {
   customerId?: number;
   digitalProducts?: OrderProductItem[];
   billingAddress?: Address;
+  shippingExpectationMessage?: string;
 }
 interface OrderDetailsAction {
   type: string;

--- a/apps/storefront/src/pages/OrderDetail/index.test.tsx
+++ b/apps/storefront/src/pages/OrderDetail/index.test.tsx
@@ -373,6 +373,12 @@ const buildVariantInfoResponseWith = builder<VariantInfoResponse>(() => ({
 
 beforeEach(() => {
   set(window, 'b2b.callbacks.dispatchEvent', vi.fn());
+
+  server.use(
+    graphql.query('GetOrderBackorderHistory', () =>
+      HttpResponse.json({ data: { site: { order: null } } }),
+    ),
+  );
 });
 
 describe('when a personal customer visits an order', () => {
@@ -3471,6 +3477,763 @@ describe('when a personal customer visits an order', () => {
       expect(
         within(dialog).queryByText('will be backordered', { exact: false }),
       ).not.toBeInTheDocument();
+    });
+  });
+
+  describe('when the order has backordered items', () => {
+    const backorderPreloadedState = {
+      company: buildCompanyStateWith({
+        customer: {
+          role: CustomerRole.B2C,
+        },
+      }),
+      storeInfo: buildStoreInfoStateWith({ timeFormat: { display: 'j F Y' } }),
+      global: buildGlobalStateWith({
+        backorderEnabled: true,
+        backorderDisplaySettings: {
+          showQuantityOnBackorder: true,
+          showQuantityOnHand: true,
+          showBackorderMessage: true,
+          showDefaultShippingExpectationPrompt: true,
+          defaultShippingExpectationPrompt: '',
+        },
+        featureFlags: {
+          'BACK-134.backorders_phase_1_1_control_messaging_on_storefront': true,
+        },
+      }),
+    };
+
+    const buildBackorderHistoryResponse = (
+      lineItems: Array<{
+        entityId: number;
+        backorderedQuantity: number;
+        backorderMessage?: string;
+      }>,
+      backorderShippingExpectationMessage: string | null = null,
+    ) => ({
+      data: {
+        site: {
+          order: {
+            entityId: 1,
+            backorderShippingExpectationMessage,
+            consignments: {
+              shipping: {
+                edges: [
+                  {
+                    node: {
+                      lineItems: {
+                        edges: lineItems.map((item) => ({ node: item })),
+                      },
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        },
+      },
+    });
+
+    it('shows backorder details on unshipped items and the shipping-expectation message directly under Shipping', async () => {
+      const address = buildShippingAddressWith('WHATEVER_VALUES');
+
+      const pickleKit = buildProductWith({
+        id: 501,
+        order_address_id: address.id,
+        name: 'Pickle Kit',
+        sku: 'PK',
+        quantity: 5,
+        quantity_shipped: 0,
+        product_options: [],
+        type: 'physical',
+      });
+
+      server.use(
+        graphql.query('GetCustomerOrderStatuses', () =>
+          HttpResponse.json(buildCustomerOrderStatusesWith('WHATEVER_VALUES')),
+        ),
+        graphql.query('AddressConfig', () =>
+          HttpResponse.json(buildAddressConfigResponseWith('WHATEVER_VALUES')),
+        ),
+        graphql.query('GetCustomerOrder', () =>
+          HttpResponse.json(
+            buildCustomerOrderResponseWith({
+              data: {
+                customerOrder: {
+                  shippingAddress: [address],
+                  products: [pickleKit],
+                },
+              },
+            }),
+          ),
+        ),
+        graphql.query('GetOrderBackorderHistory', () =>
+          HttpResponse.json(
+            buildBackorderHistoryResponse(
+              [
+                {
+                  entityId: 501,
+                  backorderedQuantity: 1,
+                  backorderMessage: 'Backorders Schmackorders',
+                },
+              ],
+              "We'll ship your in-stock items right away.",
+            ),
+          ),
+        ),
+      );
+
+      renderWithProviders(<OrderDetails />, { preloadedState: backorderPreloadedState });
+
+      await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+      expect(await screen.findByText('4 ready to ship')).toBeVisible();
+      expect(screen.getByText('1 will be backordered')).toBeVisible();
+      expect(screen.getByText('Backorders Schmackorders')).toBeVisible();
+
+      const summaryHeading = screen.getByRole('heading', { name: 'Summary' });
+      const summaryCard = summaryHeading.closest('.MuiCard-root') as HTMLElement;
+
+      expect(
+        within(summaryCard).getByText("We'll ship your in-stock items right away."),
+      ).toBeVisible();
+
+      const cardText = summaryCard.textContent || '';
+      const shippingIndex = cardText.indexOf('Shipping');
+      const messageIndex = cardText.indexOf("We'll ship your in-stock items right away.");
+      const grandTotalIndex = cardText.indexOf('Grand total');
+
+      expect(shippingIndex).toBeLessThan(messageIndex);
+      expect(messageIndex).toBeLessThan(grandTotalIndex);
+    });
+
+    it('shows the same backorder details when the order is reached via Company Orders', async () => {
+      const address = buildShippingAddressWith('WHATEVER_VALUES');
+
+      const pickleKit = buildProductWith({
+        id: 502,
+        order_address_id: address.id,
+        name: 'Pickle Kit',
+        sku: 'PK',
+        quantity: 5,
+        quantity_shipped: 0,
+        product_options: [],
+        type: 'physical',
+      });
+
+      server.use(
+        graphql.query('GetCustomerOrderStatuses', () =>
+          HttpResponse.json(buildCustomerOrderStatusesWith('WHATEVER_VALUES')),
+        ),
+        graphql.query('AddressConfig', () =>
+          HttpResponse.json(buildAddressConfigResponseWith('WHATEVER_VALUES')),
+        ),
+        graphql.query('GetCustomerOrder', () =>
+          HttpResponse.json(
+            buildCustomerOrderResponseWith({
+              data: {
+                customerOrder: {
+                  shippingAddress: [address],
+                  products: [pickleKit],
+                },
+              },
+            }),
+          ),
+        ),
+        graphql.query('GetOrderBackorderHistory', () =>
+          HttpResponse.json(
+            buildBackorderHistoryResponse([
+              {
+                entityId: 502,
+                backorderedQuantity: 1,
+                backorderMessage: 'Backorders Schmackorders',
+              },
+            ]),
+          ),
+        ),
+      );
+
+      renderWithProviders(<OrderDetails />, {
+        preloadedState: backorderPreloadedState,
+        initialEntries: [{ state: { isCompanyOrder: true } }],
+      });
+
+      await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+      expect(await screen.findByText('4 ready to ship')).toBeVisible();
+      expect(screen.getByText('1 will be backordered')).toBeVisible();
+      expect(screen.getByText('Backorders Schmackorders')).toBeVisible();
+    });
+
+    it('hides the shipping-expectation message when disabled, even when other backorder information is set to show and backorders exist', async () => {
+      const address = buildShippingAddressWith('WHATEVER_VALUES');
+
+      const pickleKit = buildProductWith({
+        id: 511,
+        order_address_id: address.id,
+        name: 'Pickle Kit',
+        sku: 'PK',
+        quantity: 5,
+        quantity_shipped: 0,
+        product_options: [],
+        type: 'physical',
+      });
+
+      server.use(
+        graphql.query('GetCustomerOrderStatuses', () =>
+          HttpResponse.json(buildCustomerOrderStatusesWith('WHATEVER_VALUES')),
+        ),
+        graphql.query('AddressConfig', () =>
+          HttpResponse.json(buildAddressConfigResponseWith('WHATEVER_VALUES')),
+        ),
+        graphql.query('GetCustomerOrder', () =>
+          HttpResponse.json(
+            buildCustomerOrderResponseWith({
+              data: {
+                customerOrder: {
+                  shippingAddress: [address],
+                  products: [pickleKit],
+                },
+              },
+            }),
+          ),
+        ),
+        graphql.query('GetOrderBackorderHistory', () =>
+          HttpResponse.json(
+            buildBackorderHistoryResponse(
+              [
+                {
+                  entityId: 511,
+                  backorderedQuantity: 1,
+                  backorderMessage: 'Backorders Schmackorders',
+                },
+              ],
+              "We'll ship your in-stock items right away.",
+            ),
+          ),
+        ),
+      );
+
+      renderWithProviders(<OrderDetails />, {
+        preloadedState: {
+          ...backorderPreloadedState,
+          global: buildGlobalStateWith({
+            ...backorderPreloadedState.global,
+            backorderDisplaySettings: {
+              ...backorderPreloadedState.global.backorderDisplaySettings,
+              showDefaultShippingExpectationPrompt: false,
+            },
+          }),
+        },
+      });
+
+      await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+      expect(await screen.findByText('4 ready to ship')).toBeVisible();
+      expect(screen.getByText('1 will be backordered')).toBeVisible();
+      expect(
+        screen.queryByText("We'll ship your in-stock items right away."),
+      ).not.toBeInTheDocument();
+    });
+
+    it('displays distinct backorder figures for two separate lines sharing the same SKU', async () => {
+      const address = buildShippingAddressWith('WHATEVER_VALUES');
+
+      const lineOne = buildProductWith({
+        id: 601,
+        order_address_id: address.id,
+        name: 'Widget',
+        sku: 'DUPE-SKU',
+        quantity: 10,
+        quantity_shipped: 0,
+        product_options: [],
+        type: 'physical',
+      });
+
+      const lineTwo = buildProductWith({
+        id: 602,
+        order_address_id: address.id,
+        name: 'Widget',
+        sku: 'DUPE-SKU',
+        quantity: 4,
+        quantity_shipped: 0,
+        product_options: [],
+        type: 'physical',
+      });
+
+      server.use(
+        graphql.query('GetCustomerOrderStatuses', () =>
+          HttpResponse.json(buildCustomerOrderStatusesWith('WHATEVER_VALUES')),
+        ),
+        graphql.query('AddressConfig', () =>
+          HttpResponse.json(buildAddressConfigResponseWith('WHATEVER_VALUES')),
+        ),
+        graphql.query('GetCustomerOrder', () =>
+          HttpResponse.json(
+            buildCustomerOrderResponseWith({
+              data: {
+                customerOrder: {
+                  shippingAddress: [address],
+                  products: [lineOne, lineTwo],
+                },
+              },
+            }),
+          ),
+        ),
+        graphql.query('GetOrderBackorderHistory', () =>
+          HttpResponse.json(
+            buildBackorderHistoryResponse([
+              { entityId: 601, backorderedQuantity: 3, backorderMessage: 'Line one message' },
+              { entityId: 602, backorderedQuantity: 1, backorderMessage: 'Line two message' },
+            ]),
+          ),
+        ),
+      );
+
+      renderWithProviders(<OrderDetails />, { preloadedState: backorderPreloadedState });
+
+      await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+      expect(await screen.findByText('7 ready to ship')).toBeVisible();
+      expect(screen.getByText('3 will be backordered')).toBeVisible();
+      expect(screen.getByText('Line one message')).toBeVisible();
+
+      expect(screen.getByText('3 ready to ship')).toBeVisible();
+      expect(screen.getByText('1 will be backordered')).toBeVisible();
+      expect(screen.getByText('Line two message')).toBeVisible();
+    });
+
+    it('does not fetch backorder history when backorder messaging is disabled', async () => {
+      const address = buildShippingAddressWith('WHATEVER_VALUES');
+      const product = buildProductWith({
+        id: 701,
+        order_address_id: address.id,
+        quantity: 5,
+        quantity_shipped: 0,
+        product_options: [],
+        type: 'physical',
+      });
+
+      const historyHandler = vi.fn();
+
+      server.use(
+        graphql.query('GetCustomerOrderStatuses', () =>
+          HttpResponse.json(buildCustomerOrderStatusesWith('WHATEVER_VALUES')),
+        ),
+        graphql.query('AddressConfig', () =>
+          HttpResponse.json(buildAddressConfigResponseWith('WHATEVER_VALUES')),
+        ),
+        graphql.query('GetCustomerOrder', () =>
+          HttpResponse.json(
+            buildCustomerOrderResponseWith({
+              data: { customerOrder: { shippingAddress: [address], products: [product] } },
+            }),
+          ),
+        ),
+        graphql.query('GetOrderBackorderHistory', () => {
+          historyHandler();
+          return HttpResponse.json(buildBackorderHistoryResponse([]));
+        }),
+      );
+
+      renderWithProviders(<OrderDetails />, { preloadedState });
+
+      await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+      expect(historyHandler).not.toHaveBeenCalled();
+    });
+
+    it('renders the order normally when the backorder history request fails', async () => {
+      const address = buildShippingAddressWith('WHATEVER_VALUES');
+      const product = buildProductWith({
+        id: 801,
+        order_address_id: address.id,
+        name: 'Resilient Product',
+        quantity: 5,
+        quantity_shipped: 0,
+        product_options: [],
+        type: 'physical',
+      });
+
+      server.use(
+        graphql.query('GetCustomerOrderStatuses', () =>
+          HttpResponse.json(buildCustomerOrderStatusesWith('WHATEVER_VALUES')),
+        ),
+        graphql.query('AddressConfig', () =>
+          HttpResponse.json(buildAddressConfigResponseWith('WHATEVER_VALUES')),
+        ),
+        graphql.query('GetCustomerOrder', () =>
+          HttpResponse.json(
+            buildCustomerOrderResponseWith({
+              data: {
+                customerOrder: {
+                  shippingAddress: [address],
+                  products: [product],
+                },
+              },
+            }),
+          ),
+        ),
+        graphql.query('GetOrderBackorderHistory', () => HttpResponse.error()),
+      );
+
+      renderWithProviders(<OrderDetails />, { preloadedState: backorderPreloadedState });
+
+      await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+      expect(await screen.findByText('Resilient Product')).toBeVisible();
+      expect(screen.queryByText('will be backordered', { exact: false })).not.toBeInTheDocument();
+    });
+
+    it('shows only the remaining backordered count once part of the backordered units have shipped', async () => {
+      const address = buildShippingAddressWith('WHATEVER_VALUES');
+
+      const partiallyShippedProduct = buildProductWith({
+        id: 1001,
+        order_address_id: address.id,
+        name: 'Partially Shipped',
+        quantity: 4,
+        quantity_shipped: 2,
+        product_options: [],
+        type: 'physical',
+      });
+
+      server.use(
+        graphql.query('GetCustomerOrderStatuses', () =>
+          HttpResponse.json(buildCustomerOrderStatusesWith('WHATEVER_VALUES')),
+        ),
+        graphql.query('AddressConfig', () =>
+          HttpResponse.json(buildAddressConfigResponseWith('WHATEVER_VALUES')),
+        ),
+        graphql.query('GetCustomerOrder', () =>
+          HttpResponse.json(
+            buildCustomerOrderResponseWith({
+              data: {
+                customerOrder: {
+                  shippingAddress: [address],
+                  products: [partiallyShippedProduct],
+                },
+              },
+            }),
+          ),
+        ),
+        graphql.query('GetOrderBackorderHistory', () =>
+          HttpResponse.json(
+            buildBackorderHistoryResponse([
+              {
+                entityId: 1001,
+                backorderedQuantity: 3,
+                backorderMessage: 'Backorders Schmackorders',
+              },
+            ]),
+          ),
+        ),
+      );
+
+      renderWithProviders(<OrderDetails />, { preloadedState: backorderPreloadedState });
+
+      await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+      expect(await screen.findByText('Partially Shipped')).toBeVisible();
+      expect(screen.getByText('2 will be backordered')).toBeVisible();
+      expect(screen.queryByText('ready to ship', { exact: false })).not.toBeInTheDocument();
+    });
+
+    it('hides the backorder blob once all backordered units have shipped', async () => {
+      const address = buildShippingAddressWith('WHATEVER_VALUES');
+
+      const fullyShippedProduct = buildProductWith({
+        id: 1002,
+        order_address_id: address.id,
+        name: 'Fully Shipped',
+        quantity: 5,
+        quantity_shipped: 5,
+        product_options: [],
+        type: 'physical',
+      });
+
+      const shipment = buildShipmentWith({
+        id: 1,
+        order_address_id: address.id,
+        items: [{ quantity: 5, order_product_id: fullyShippedProduct.id }],
+      });
+
+      server.use(
+        graphql.query('GetCustomerOrderStatuses', () =>
+          HttpResponse.json(buildCustomerOrderStatusesWith('WHATEVER_VALUES')),
+        ),
+        graphql.query('AddressConfig', () =>
+          HttpResponse.json(buildAddressConfigResponseWith('WHATEVER_VALUES')),
+        ),
+        graphql.query('GetCustomerOrder', () =>
+          HttpResponse.json(
+            buildCustomerOrderResponseWith({
+              data: {
+                customerOrder: {
+                  shipments: [shipment],
+                  shippingAddress: [address],
+                  products: [fullyShippedProduct],
+                },
+              },
+            }),
+          ),
+        ),
+        graphql.query('GetOrderBackorderHistory', () =>
+          HttpResponse.json(
+            buildBackorderHistoryResponse([
+              { entityId: 1002, backorderedQuantity: 2, backorderMessage: 'Should not show' },
+            ]),
+          ),
+        ),
+      );
+
+      renderWithProviders(<OrderDetails />, { preloadedState: backorderPreloadedState });
+
+      await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+      expect(await screen.findByText('Fully Shipped')).toBeVisible();
+      expect(screen.queryByText('Should not show')).not.toBeInTheDocument();
+      expect(screen.queryByText('will be backordered', { exact: false })).not.toBeInTheDocument();
+    });
+
+    it('never shows backorder info in the shipped section, even for a line that also has a remaining backorder in Not shipped yet', async () => {
+      const address = buildShippingAddressWith('WHATEVER_VALUES');
+
+      const partiallyShippedProduct = buildProductWith({
+        id: 1003,
+        order_address_id: address.id,
+        name: 'Pickle Kit',
+        quantity: 5,
+        quantity_shipped: 4,
+        product_options: [],
+        type: 'physical',
+      });
+
+      const shipment = buildShipmentWith({
+        id: 1,
+        order_address_id: address.id,
+        items: [{ quantity: 4, order_product_id: partiallyShippedProduct.id }],
+      });
+
+      server.use(
+        graphql.query('GetCustomerOrderStatuses', () =>
+          HttpResponse.json(buildCustomerOrderStatusesWith('WHATEVER_VALUES')),
+        ),
+        graphql.query('AddressConfig', () =>
+          HttpResponse.json(buildAddressConfigResponseWith('WHATEVER_VALUES')),
+        ),
+        graphql.query('GetCustomerOrder', () =>
+          HttpResponse.json(
+            buildCustomerOrderResponseWith({
+              data: {
+                customerOrder: {
+                  shipments: [shipment],
+                  shippingAddress: [address],
+                  products: [partiallyShippedProduct],
+                },
+              },
+            }),
+          ),
+        ),
+        graphql.query('GetOrderBackorderHistory', () =>
+          HttpResponse.json(
+            buildBackorderHistoryResponse([
+              {
+                entityId: 1003,
+                backorderedQuantity: 1,
+                backorderMessage: 'Backorders Schmackorders',
+              },
+            ]),
+          ),
+        ),
+      );
+
+      renderWithProviders(<OrderDetails />, { preloadedState: backorderPreloadedState });
+
+      await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+      expect(await screen.findByText('Not shipped yet')).toBeVisible();
+      expect(screen.getAllByText('1 will be backordered')).toHaveLength(1);
+      expect(screen.getAllByText('Backorders Schmackorders')).toHaveLength(1);
+    });
+
+    it('hides the order-level shipping-expectation message once every backordered unit has been shipped', async () => {
+      const address = buildShippingAddressWith('WHATEVER_VALUES');
+
+      const fullyShippedProduct = buildProductWith({
+        id: 1004,
+        order_address_id: address.id,
+        name: 'Fully Shipped Order',
+        quantity: 5,
+        quantity_shipped: 5,
+        product_options: [],
+        type: 'physical',
+      });
+
+      const shipment = buildShipmentWith({
+        id: 1,
+        order_address_id: address.id,
+        items: [{ quantity: 5, order_product_id: fullyShippedProduct.id }],
+      });
+
+      server.use(
+        graphql.query('GetCustomerOrderStatuses', () =>
+          HttpResponse.json(buildCustomerOrderStatusesWith('WHATEVER_VALUES')),
+        ),
+        graphql.query('AddressConfig', () =>
+          HttpResponse.json(buildAddressConfigResponseWith('WHATEVER_VALUES')),
+        ),
+        graphql.query('GetCustomerOrder', () =>
+          HttpResponse.json(
+            buildCustomerOrderResponseWith({
+              data: {
+                customerOrder: {
+                  shipments: [shipment],
+                  shippingAddress: [address],
+                  products: [fullyShippedProduct],
+                },
+              },
+            }),
+          ),
+        ),
+        graphql.query('GetOrderBackorderHistory', () =>
+          HttpResponse.json(
+            buildBackorderHistoryResponse(
+              [{ entityId: 1004, backorderedQuantity: 2, backorderMessage: 'Should not show' }],
+              "We'll ship your in-stock items right away.",
+            ),
+          ),
+        ),
+      );
+
+      renderWithProviders(<OrderDetails />, { preloadedState: backorderPreloadedState });
+
+      await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+      expect(await screen.findByText('Fully Shipped Order')).toBeVisible();
+      expect(
+        screen.queryByText("We'll ship your in-stock items right away."),
+      ).not.toBeInTheDocument();
+    });
+
+    it('clears a stale shipping-expectation message when navigating to an order whose backorder history fetch fails', async () => {
+      vi.mocked(useParams).mockReturnValue({ id: '1' });
+
+      const address = buildShippingAddressWith('WHATEVER_VALUES');
+
+      const orderOneProduct = buildProductWith({
+        id: 601,
+        order_address_id: address.id,
+        name: 'Order One Product',
+        quantity: 5,
+        quantity_shipped: 0,
+        product_options: [],
+        type: 'physical',
+      });
+
+      const orderTwoProduct = buildProductWith({
+        id: 602,
+        order_address_id: address.id,
+        name: 'Order Two Product',
+        quantity: 5,
+        quantity_shipped: 0,
+        product_options: [],
+        type: 'physical',
+      });
+
+      server.use(
+        graphql.query('GetCustomerOrderStatuses', () =>
+          HttpResponse.json(buildCustomerOrderStatusesWith('WHATEVER_VALUES')),
+        ),
+        graphql.query('AddressConfig', () =>
+          HttpResponse.json(buildAddressConfigResponseWith('WHATEVER_VALUES')),
+        ),
+        graphql.query('GetCustomerOrder', ({ query }) => {
+          if (!query.includes('id: 2')) {
+            return HttpResponse.json(
+              buildCustomerOrderResponseWith({
+                data: {
+                  customerOrder: {
+                    id: '1',
+                    shippingAddress: [address],
+                    products: [orderOneProduct],
+                  },
+                },
+              }),
+            );
+          }
+
+          return HttpResponse.json(
+            buildCustomerOrderResponseWith({
+              data: {
+                customerOrder: {
+                  id: '2',
+                  shippingAddress: [address],
+                  products: [orderTwoProduct],
+                },
+              },
+            }),
+          );
+        }),
+        graphql.query('GetCustomerOrders', () =>
+          HttpResponse.json(
+            buildGetCustomerOrdersWith({
+              data: {
+                customerOrders: {
+                  edges: [
+                    buildCustomerOrderNodeWith({ node: { orderId: '1' } }),
+                    buildCustomerOrderNodeWith({ node: { orderId: '2' } }),
+                  ],
+                  totalCount: 2,
+                },
+              },
+            }),
+          ),
+        ),
+        graphql.query('GetOrderBackorderHistory', ({ variables }) => {
+          if (variables.entityId === 1) {
+            return HttpResponse.json(
+              buildBackorderHistoryResponse(
+                [
+                  {
+                    entityId: 601,
+                    backorderedQuantity: 1,
+                    backorderMessage: 'Backorders Schmackorders',
+                  },
+                ],
+                'Order one shipping message',
+              ),
+            );
+          }
+
+          return HttpResponse.error();
+        }),
+      );
+
+      renderWithProviders(<OrderDetails />, {
+        preloadedState: backorderPreloadedState,
+        initialEntries: [
+          {
+            state: {
+              isCompanyOrder: false,
+              currentIndex: 0,
+              totalCount: 2,
+            },
+          },
+        ],
+      });
+
+      await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+      expect(await screen.findByText('Order one shipping message')).toBeVisible();
+
+      const navigation = await screen.findByRole('navigation', { name: 'Order 1 of 2' });
+      const [, next] = within(navigation).getAllByRole('button');
+
+      await userEvent.click(next);
+
+      expect(await screen.findByText('Order Two Product')).toBeVisible();
+      expect(screen.queryByText('Order one shipping message')).not.toBeInTheDocument();
     });
   });
 });

--- a/apps/storefront/src/pages/OrderDetail/index.tsx
+++ b/apps/storefront/src/pages/OrderDetail/index.tsx
@@ -5,6 +5,7 @@ import { Box, Grid, Stack, Typography } from '@mui/material';
 
 import { b3HexToRgb, getContrastColor } from '@/components/outSideComponents/utils/b3CustomStyles';
 import B3Spin from '@/components/spin/B3Spin';
+import { useBackorderStorefrontMessaging } from '@/hooks/useBackorderStorefrontMessaging';
 import { useFeatureFlag } from '@/hooks/useFeatureFlag';
 import { useMobile } from '@/hooks/useMobile';
 import { useB3Lang } from '@/lib/lang';
@@ -18,7 +19,7 @@ import {
   getOrderStatusType,
 } from '@/shared/service/b2b';
 import type { Order as UnifiedOrder } from '@/shared/service/bc/graphql/orders';
-import { getOrderDetail } from '@/shared/service/bc/graphql/orders';
+import { getOrderBackorderHistory, getOrderDetail } from '@/shared/service/bc/graphql/orders';
 import { isB2BUserSelector, useAppSelector } from '@/store';
 import { AddressConfigItem, CustomerRole, OrderProductItem, OrderStatusItem } from '@/types';
 import b2bLogger from '@/utils/b3Logger';
@@ -33,6 +34,7 @@ import { OrderBilling } from './components/OrderBilling';
 import { OrderHistory } from './components/OrderHistory';
 import { OrderShipping } from './components/OrderShipping';
 import { OrderDetailsContext, OrderDetailsProvider } from './context/OrderDetailsContext';
+import { applyOrderBackorderHistory } from './shared/applyOrderBackorderHistory';
 import convertB2BOrderDetails from './shared/B2BOrderData';
 import { convertOrderDetail } from './shared/convertOrderDetail';
 
@@ -63,6 +65,7 @@ function OrderDetail() {
   const b3Lang = useB3Lang();
 
   const isUnifiedOrders = useFeatureFlag('B2B-4613.buyer_portal_unified_sf_gql_orders');
+  const { isBackorderMessagingContextEnabled } = useBackorderStorefrontMessaging();
 
   const {
     state: { addressConfig },
@@ -102,8 +105,10 @@ function OrderDetail() {
 
   useEffect(() => {
     if (isUnifiedOrders || !orderId) {
-      return;
+      return undefined;
     }
+
+    let isCurrentRequest = true;
 
     const fetchLegacyOrderDetails = async () => {
       const id = parseInt(orderId, 10);
@@ -116,7 +121,7 @@ function OrderDetail() {
       try {
         const order = isB2BUser ? await getB2BOrderDetails(id) : await getBCOrderDetails(id);
 
-        if (order) {
+        if (order && isCurrentRequest) {
           const { products, companyInfo } = order;
 
           const newOrder = {
@@ -132,27 +137,58 @@ function OrderDetail() {
           setIsCurrentCompany(Number(companyInfo.companyId) === Number(currentCompanyId));
 
           const data = convertB2BOrderDetails(newOrder, b3Lang);
-          dispatch({
-            type: 'all',
-            payload: data,
-          });
-          setPreOrderId(orderId);
+
+          let payload: ReturnType<typeof applyOrderBackorderHistory> = {
+            ...data,
+            shippingExpectationMessage: undefined,
+          };
+          if (isBackorderMessagingContextEnabled) {
+            try {
+              const backorderHistory = await getOrderBackorderHistory({ entityId: id });
+              payload = applyOrderBackorderHistory(data, backorderHistory);
+            } catch (err) {
+              b2bLogger.error(err);
+            }
+          }
+
+          if (isCurrentRequest) {
+            dispatch({
+              type: 'all',
+              payload,
+            });
+            setPreOrderId(orderId);
+          }
         }
       } catch (err) {
-        if (err === 'order does not exist') {
+        if (err === 'order does not exist' && isCurrentRequest) {
           setTimeout(() => {
             window.location.hash = `/orderDetail/${preOrderId}`;
           }, 1000);
         }
       } finally {
-        setIsRequestLoading(false);
+        if (isCurrentRequest) {
+          setIsRequestLoading(false);
+        }
       }
     };
 
     fetchLegacyOrderDetails();
-    // Disabling rule since dispatch does not need to be in the dep array and b3Lang has rendering errors
+
+    return () => {
+      isCurrentRequest = false;
+    };
+    // dispatch is stable and b3Lang has rendering errors, so both are omitted.
+    // preOrderId is only read in the failed-navigation fallback; including it would
+    // re-run this effect after setPreOrderId on a successful load, refetching the order.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isB2BUser, isUnifiedOrders, orderId, preOrderId, selectCompanyHierarchyId, currentCompanyId]);
+  }, [
+    isB2BUser,
+    isUnifiedOrders,
+    orderId,
+    selectCompanyHierarchyId,
+    currentCompanyId,
+    isBackorderMessagingContextEnabled,
+  ]);
 
   useEffect(() => {
     if (!isUnifiedOrders || !orderId) {

--- a/apps/storefront/src/pages/OrderDetail/shared/applyOrderBackorderHistory.test.ts
+++ b/apps/storefront/src/pages/OrderDetail/shared/applyOrderBackorderHistory.test.ts
@@ -1,0 +1,306 @@
+import { builder } from 'tests/test-utils';
+
+import { OrderBackorderHistory } from '@/shared/service/bc/graphql/orders';
+import {
+  Address,
+  CompanyInfoTypes,
+  OrderProductItem,
+  OrderShippedItem,
+  OrderShippingsItem,
+} from '@/types';
+
+import { applyOrderBackorderHistory } from './applyOrderBackorderHistory';
+import convertB2BOrderDetails from './B2BOrderData';
+
+type ConvertedOrderData = ReturnType<typeof convertB2BOrderDetails>;
+
+const buildProductWith = builder<OrderProductItem>(() => ({
+  base_price: '10.00',
+  base_total: '10.00',
+  brand: '',
+  configurable_fields: '',
+  cost_price_ex_tax: '0',
+  cost_price_inc_tax: '0',
+  cost_price_tax: '0',
+  id: 1,
+  imageUrl: '',
+  is_bundled_product: false,
+  is_refunded: false,
+  name: 'Product',
+  name_customer: 'Product',
+  name_merchant: 'Product',
+  optionList: [],
+  option_set_id: 0,
+  order_address_id: 1,
+  order_id: 1,
+  parent_order_product_id: 0,
+  price_ex_tax: '10.00',
+  price_inc_tax: '10.00',
+  price_tax: '0',
+  product_id: 1,
+  product_options: [],
+  quantity: 5,
+  quantity_refunded: 0,
+  quantity_shipped: 0,
+  refund_amount: '0',
+  return_id: 0,
+  sku: 'SKU-1',
+  total_ex_tax: '10.00',
+  total_inc_tax: '10.00',
+  total_tax: '0',
+  type: 'physical',
+  variant_id: 1,
+  wrapping_cost_ex_tax: '0',
+  wrapping_cost_inc_tax: '0',
+  wrapping_cost_tax: '0',
+  wrapping_id: 0,
+  wrapping_message: '',
+  wrapping_name: '',
+}));
+
+const buildAddressWith = builder<Address>(() => ({
+  city: '',
+  company: '',
+  country: '',
+  country_iso2: '',
+  email: '',
+  first_name: '',
+  last_name: '',
+  phone: '',
+  state: '',
+  street_1: '',
+  street_2: '',
+  zip: '',
+}));
+
+const buildShippedItemWith = builder<OrderShippedItem>(() => ({
+  ...buildAddressWith('WHATEVER_VALUES'),
+  billing_address: buildAddressWith('WHATEVER_VALUES'),
+  comments: '',
+  customer_id: 1,
+  date_created: '',
+  id: 1,
+  items: [],
+  merchant_shipping_cost: '0',
+  order_address_id: 1,
+  order_id: 1,
+  shipping_address: buildAddressWith('WHATEVER_VALUES'),
+  shipping_method: '',
+  shipping_provider_display_name: '',
+  tracking_carrier: '',
+  tracking_link: '',
+  tracking_number: '',
+  itemsInfo: [],
+}));
+
+const buildShippingWith = builder<OrderShippingsItem>(() => ({
+  ...buildAddressWith('WHATEVER_VALUES'),
+  base_cost: '0',
+  base_handling_cost: '0',
+  cost_ex_tax: '0',
+  cost_inc_tax: '0',
+  cost_tax: '0',
+  cost_tax_class_id: 0,
+  handling_cost_ex_tax: '0',
+  handling_cost_inc_tax: '0',
+  handling_cost_tax: '0',
+  handling_cost_tax_class_id: 0,
+  id: 1,
+  items_shipped: 0,
+  items_total: 0,
+  order_id: 1,
+  shipping_method: '',
+  shipping_quotes: '',
+  shipping_zone_id: 0,
+  shipping_zone_name: '',
+  shipmentItems: [],
+  notShip: { itemsInfo: [] },
+}));
+
+const buildOrderDataWith = builder<ConvertedOrderData>(() => ({
+  shippings: [],
+  billings: [],
+  digitalProducts: [],
+  billingAddress: buildAddressWith('WHATEVER_VALUES'),
+  history: [],
+  poNumber: '',
+  status: '',
+  statusCode: 0,
+  currencyCode: 'USD',
+  currency: '$',
+  money: {
+    currency_location: 'left',
+    currency_token: '$',
+    decimal_token: '.',
+    thousands_token: ',',
+    decimal_places: 2,
+    currency_exchange_rate: '1.0',
+  },
+  orderSummary: { createAt: '', name: '', priceData: {}, priceSymbol: {} },
+  payment: {
+    updatedAt: '',
+    billingAddress: buildAddressWith('WHATEVER_VALUES'),
+    paymentMethod: '',
+    dateCreateAt: '',
+  },
+  orderComments: '',
+  products: [],
+  orderId: 1,
+  customStatus: '',
+  ipStatus: 0,
+  invoiceId: 0,
+  canReturn: false,
+  createdEmail: '',
+  orderIsDigital: false,
+  companyInfo: {} as CompanyInfoTypes,
+}));
+
+const buildHistoryWith = builder<OrderBackorderHistory>(() => ({
+  shippingExpectationMessage: undefined,
+  lineItems: [],
+}));
+
+describe('applyOrderBackorderHistory', () => {
+  it('returns the data unchanged (but explicitly clears any stale message) when there is no history', () => {
+    const data = buildOrderDataWith({ products: [buildProductWith({ id: 1 })] });
+
+    const result = applyOrderBackorderHistory(data, null);
+
+    expect(result).toEqual(data);
+    // Explicit undefined, not merely absent — the context reducer's shallow merge only clears a
+    // stale message from a previously viewed order if the key is actually present in the payload.
+    expect(Object.prototype.hasOwnProperty.call(result, 'shippingExpectationMessage')).toBe(true);
+    expect(result.shippingExpectationMessage).toBeUndefined();
+  });
+
+  it('returns the data unchanged (but explicitly clears any stale message) when the history has no backordered line items, even if a shipping-expectation message is present', () => {
+    const data = buildOrderDataWith({ products: [buildProductWith({ id: 1 })] });
+    const history = buildHistoryWith({
+      shippingExpectationMessage: 'Ships separately',
+      lineItems: [],
+    });
+
+    const result = applyOrderBackorderHistory(data, history);
+
+    expect(result).toEqual(data);
+    expect(Object.prototype.hasOwnProperty.call(result, 'shippingExpectationMessage')).toBe(true);
+    expect(result.shippingExpectationMessage).toBeUndefined();
+  });
+
+  it('clears a stale shipping-expectation message left in context state by a previously viewed order', () => {
+    // OrderDetailsContext's reducer does `{ ...state, ...action.payload }` and stays mounted across
+    // order-to-order navigation (same route, different :id) — so a message from a prior order with
+    // backorders must be explicitly cleared here, not merely omitted, or it lingers for this one.
+    const previousState = {
+      shippingExpectationMessage: 'Ships separately (from a previous order)',
+    };
+    const data = buildOrderDataWith({ products: [buildProductWith({ id: 1 })] });
+
+    const payload = applyOrderBackorderHistory(data, null);
+    const nextState = { ...previousState, ...payload };
+
+    expect(nextState.shippingExpectationMessage).toBeUndefined();
+  });
+
+  it('merges quantityBackordered/backorderMessage by entityId across products, digitalProducts, shipped and unshipped lines, leaving unmatched lines untouched', () => {
+    const matchedProduct = buildProductWith({ id: 501, sku: 'PK' });
+    const matchedDigitalProduct = buildProductWith({ id: 502, sku: 'DL', type: 'digital' });
+    const matchedShippedProduct = buildProductWith({ id: 503, sku: 'SH' });
+    const matchedUnshippedProduct = buildProductWith({ id: 504, sku: 'NS' });
+    const unmatchedProduct = buildProductWith({ id: 999, sku: 'OTHER' });
+
+    const data = buildOrderDataWith({
+      products: [matchedProduct, unmatchedProduct],
+      digitalProducts: [matchedDigitalProduct],
+      shippings: [
+        buildShippingWith({
+          shipmentItems: [buildShippedItemWith({ itemsInfo: [matchedShippedProduct] })],
+          notShip: { itemsInfo: [matchedUnshippedProduct] },
+        }),
+      ],
+    });
+
+    const history = buildHistoryWith({
+      lineItems: [
+        { entityId: 501, quantityBackordered: 1, backorderMessage: 'Backordered A' },
+        { entityId: 502, quantityBackordered: 2, backorderMessage: 'Backordered B' },
+        { entityId: 503, quantityBackordered: 3, backorderMessage: 'Backordered C' },
+        { entityId: 504, quantityBackordered: 4, backorderMessage: 'Backordered D' },
+      ],
+    });
+
+    const result = applyOrderBackorderHistory(data, history);
+
+    expect(result.products[0]).toMatchObject({
+      quantityBackordered: 1,
+      backorderMessage: 'Backordered A',
+    });
+    expect(result.digitalProducts[0]).toMatchObject({
+      quantityBackordered: 2,
+      backorderMessage: 'Backordered B',
+    });
+    expect(result.shippings[0].shipmentItems[0].itemsInfo[0]).toMatchObject({
+      quantityBackordered: 3,
+      backorderMessage: 'Backordered C',
+    });
+    expect(result.shippings[0].notShip.itemsInfo[0]).toMatchObject({
+      quantityBackordered: 4,
+      backorderMessage: 'Backordered D',
+    });
+
+    expect(result.products[1].quantityBackordered).toBeUndefined();
+  });
+
+  it('sets the order-level shipping-expectation message when at least one line still has a remaining backorder', () => {
+    const outstandingProduct = buildProductWith({ id: 1, quantity: 5, quantity_shipped: 0 });
+    const data = buildOrderDataWith({
+      products: [outstandingProduct],
+      shippings: [buildShippingWith({ notShip: { itemsInfo: [outstandingProduct] } })],
+    });
+    const history = buildHistoryWith({
+      shippingExpectationMessage: 'Ships separately',
+      lineItems: [{ entityId: 1, quantityBackordered: 1, backorderMessage: null }],
+    });
+
+    const result = applyOrderBackorderHistory(data, history);
+
+    expect(result.shippingExpectationMessage).toBe('Ships separately');
+  });
+
+  it('normalizes a null shipping-expectation message to undefined', () => {
+    const outstandingProduct = buildProductWith({ id: 1, quantity: 5, quantity_shipped: 0 });
+    const data = buildOrderDataWith({
+      products: [outstandingProduct],
+      shippings: [buildShippingWith({ notShip: { itemsInfo: [outstandingProduct] } })],
+    });
+    const history = buildHistoryWith({
+      shippingExpectationMessage: null,
+      lineItems: [{ entityId: 1, quantityBackordered: 1, backorderMessage: null }],
+    });
+
+    const result = applyOrderBackorderHistory(data, history);
+
+    expect(result.shippingExpectationMessage).toBeUndefined();
+  });
+
+  it('drops the order-level shipping-expectation message when no more backordered items remain unshipped', () => {
+    const fullyShippedProduct = buildProductWith({ id: 1, quantity: 5, quantity_shipped: 5 });
+    const data = buildOrderDataWith({
+      products: [fullyShippedProduct],
+      shippings: [
+        buildShippingWith({
+          shipmentItems: [buildShippedItemWith({ itemsInfo: [fullyShippedProduct] })],
+          notShip: { itemsInfo: [] },
+        }),
+      ],
+    });
+    const history = buildHistoryWith({
+      shippingExpectationMessage: 'Ships separately',
+      lineItems: [{ entityId: 1, quantityBackordered: 1, backorderMessage: null }],
+    });
+
+    const result = applyOrderBackorderHistory(data, history);
+
+    expect(result.shippingExpectationMessage).toBeUndefined();
+  });
+});

--- a/apps/storefront/src/pages/OrderDetail/shared/applyOrderBackorderHistory.ts
+++ b/apps/storefront/src/pages/OrderDetail/shared/applyOrderBackorderHistory.ts
@@ -1,0 +1,63 @@
+import { OrderBackorderHistory } from '@/shared/service/bc/graphql/orders';
+import { OrderProductItem } from '@/types';
+
+import convertB2BOrderDetails from './B2BOrderData';
+import { getRemainingBackorderedQuantity } from './getRemainingBackorderedQuantity';
+
+type ConvertedOrderData = ReturnType<typeof convertB2BOrderDetails>;
+
+function applyToProduct(
+  product: OrderProductItem,
+  byEntityId: Map<number, OrderBackorderHistory['lineItems'][number]>,
+): OrderProductItem {
+  const match = byEntityId.get(product.id);
+  if (!match) {
+    return product;
+  }
+
+  return {
+    ...product,
+    quantityBackordered: match.quantityBackordered,
+    backorderMessage: match.backorderMessage,
+  };
+}
+
+export function applyOrderBackorderHistory(
+  data: ConvertedOrderData,
+  history: OrderBackorderHistory | null,
+): ConvertedOrderData & { shippingExpectationMessage?: string } {
+  if (!history || history.lineItems.length === 0) {
+    // Explicit undefined (not simply omitting the key) so the context reducer's shallow merge
+    // clears a stale message left over from a previously viewed order with backorders.
+    return { ...data, shippingExpectationMessage: undefined };
+  }
+
+  const byEntityId = new Map(history.lineItems.map((item) => [item.entityId, item]));
+
+  const shippings = data.shippings.map((shipping) => ({
+    ...shipping,
+    shipmentItems: shipping.shipmentItems.map((shipment) => ({
+      ...shipment,
+      itemsInfo: shipment.itemsInfo.map((product) => applyToProduct(product, byEntityId)),
+    })),
+    notShip: {
+      itemsInfo: shipping.notShip.itemsInfo.map((product) => applyToProduct(product, byEntityId)),
+    },
+  }));
+
+  // The order-level message is only relevant while something is still actually outstanding —
+  // a line's raw history figure doesn't shrink as it ships, so re-check what's left.
+  const hasRemainingBackorder = shippings.some((shipping) =>
+    shipping.notShip.itemsInfo.some((product) => getRemainingBackorderedQuantity(product) > 0),
+  );
+
+  return {
+    ...data,
+    products: data.products.map((product) => applyToProduct(product, byEntityId)),
+    digitalProducts: data.digitalProducts.map((product) => applyToProduct(product, byEntityId)),
+    shippings,
+    shippingExpectationMessage: hasRemainingBackorder
+      ? (history.shippingExpectationMessage ?? undefined)
+      : undefined,
+  };
+}

--- a/apps/storefront/src/pages/OrderDetail/shared/getRemainingBackorderedQuantity.test.ts
+++ b/apps/storefront/src/pages/OrderDetail/shared/getRemainingBackorderedQuantity.test.ts
@@ -1,0 +1,97 @@
+import { builder } from 'tests/test-utils';
+
+import { OrderProductItem } from '@/types';
+
+import { getRemainingBackorderedQuantity } from './getRemainingBackorderedQuantity';
+
+const buildProductWith = builder<OrderProductItem>(() => ({
+  base_price: '10.00',
+  base_total: '10.00',
+  brand: '',
+  configurable_fields: '',
+  cost_price_ex_tax: '0',
+  cost_price_inc_tax: '0',
+  cost_price_tax: '0',
+  id: 1,
+  imageUrl: '',
+  is_bundled_product: false,
+  is_refunded: false,
+  name: 'Product',
+  name_customer: 'Product',
+  name_merchant: 'Product',
+  optionList: [],
+  option_set_id: 0,
+  order_address_id: 1,
+  order_id: 1,
+  parent_order_product_id: 0,
+  price_ex_tax: '10.00',
+  price_inc_tax: '10.00',
+  price_tax: '0',
+  product_id: 1,
+  product_options: [],
+  quantity: 5,
+  quantity_refunded: 0,
+  quantity_shipped: 0,
+  refund_amount: '0',
+  return_id: 0,
+  sku: 'SKU-1',
+  total_ex_tax: '10.00',
+  total_inc_tax: '10.00',
+  total_tax: '0',
+  type: 'physical',
+  variant_id: 1,
+  wrapping_cost_ex_tax: '0',
+  wrapping_cost_inc_tax: '0',
+  wrapping_cost_tax: '0',
+  wrapping_id: 0,
+  wrapping_message: '',
+  wrapping_name: '',
+}));
+
+describe('getRemainingBackorderedQuantity', () => {
+  it('returns the full backordered quantity when nothing has been shipped', () => {
+    const product = buildProductWith({ quantity: 5, quantity_shipped: 0, quantityBackordered: 2 });
+
+    expect(getRemainingBackorderedQuantity(product)).toBe(2);
+  });
+
+  it('still returns the full backordered quantity while shipped units are within the ready-to-ship portion', () => {
+    const product = buildProductWith({ quantity: 5, quantity_shipped: 3, quantityBackordered: 2 });
+
+    expect(getRemainingBackorderedQuantity(product)).toBe(2);
+  });
+
+  it('reduces the remaining count once shipped units cut into the backordered pool', () => {
+    const product = buildProductWith({ quantity: 4, quantity_shipped: 2, quantityBackordered: 3 });
+
+    expect(getRemainingBackorderedQuantity(product)).toBe(2);
+  });
+
+  it('returns 0 once the line is fully shipped', () => {
+    const product = buildProductWith({ quantity: 5, quantity_shipped: 5, quantityBackordered: 2 });
+
+    expect(getRemainingBackorderedQuantity(product)).toBe(0);
+  });
+
+  it('does not go negative when shipped exceeds the ordered quantity', () => {
+    const product = buildProductWith({ quantity: 5, quantity_shipped: 7, quantityBackordered: 2 });
+
+    expect(getRemainingBackorderedQuantity(product)).toBe(0);
+  });
+
+  it('returns 0 when there is no backordered quantity at all', () => {
+    const product = buildProductWith({ quantity: 5, quantity_shipped: 0, quantityBackordered: 0 });
+
+    expect(getRemainingBackorderedQuantity(product)).toBe(0);
+  });
+
+  it('defaults to 0 when quantityBackordered is undefined', () => {
+    const product = buildProductWith({
+      quantity: 5,
+      quantity_shipped: 0,
+      quantityBackordered: undefined,
+    });
+
+    expect(getRemainingBackorderedQuantity(product)).toBe(0);
+  });
+});

--- a/apps/storefront/src/pages/OrderDetail/shared/getRemainingBackorderedQuantity.ts
+++ b/apps/storefront/src/pages/OrderDetail/shared/getRemainingBackorderedQuantity.ts
@@ -1,0 +1,8 @@
+import { OrderProductItem } from '@/types';
+
+export function getRemainingBackorderedQuantity(product: OrderProductItem): number {
+  const { quantityBackordered = 0, quantity = 0, quantity_shipped: quantityShipped = 0 } = product;
+  const remainingUnshipped = Math.max(0, quantity - quantityShipped);
+
+  return Math.min(quantityBackordered, remainingUnshipped);
+}

--- a/apps/storefront/src/shared/service/bc/graphql/orders.ts
+++ b/apps/storefront/src/shared/service/bc/graphql/orders.ts
@@ -763,6 +763,101 @@ export async function getOrderDetail(variables: {
   });
 }
 
+const GET_ORDER_BACKORDER_HISTORY = `query GetOrderBackorderHistory($entityId: Int!) {
+  site {
+    order(filter: { entityId: $entityId }) {
+      entityId
+      backorderShippingExpectationMessage
+      consignments {
+        shipping {
+          edges {
+            node {
+              lineItems {
+                edges {
+                  node {
+                    entityId
+                    backorderedQuantity
+                    backorderMessage
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}`;
+
+// entityId (orderProductId), not sku: The same SKU can appear on more than one line in an order (split shipments etc.).
+export interface OrderBackorderLineItem {
+  entityId: number;
+  quantityBackordered: number;
+  backorderMessage?: string | null;
+}
+
+export interface OrderBackorderHistory {
+  shippingExpectationMessage?: string | null;
+  lineItems: OrderBackorderLineItem[];
+}
+
+interface GetOrderBackorderHistoryResponse {
+  data?: {
+    site?: {
+      order?: {
+        entityId: number;
+        backorderShippingExpectationMessage?: string | null;
+        consignments?: {
+          shipping?: {
+            edges: Array<{
+              node: {
+                lineItems: {
+                  edges: Array<{
+                    node: {
+                      entityId: number;
+                      backorderedQuantity?: number;
+                      backorderMessage?: string | null;
+                    };
+                  }>;
+                };
+              };
+            }>;
+          };
+        };
+      } | null;
+    };
+  };
+}
+
+export async function getOrderBackorderHistory(variables: {
+  entityId: number;
+}): Promise<OrderBackorderHistory | null> {
+  const response = await storefrontGQLRequest<GetOrderBackorderHistoryResponse>({
+    query: GET_ORDER_BACKORDER_HISTORY,
+    variables,
+  });
+
+  const order = response.data?.site?.order;
+  if (!order) {
+    return null;
+  }
+
+  const shippingEdges = order.consignments?.shipping?.edges ?? [];
+  const lineItems = shippingEdges
+    .flatMap((edge) => edge.node.lineItems.edges.map(({ node }) => node))
+    .filter((node) => (node.backorderedQuantity ?? 0) > 0)
+    .map((node) => ({
+      entityId: node.entityId,
+      quantityBackordered: node.backorderedQuantity ?? 0,
+      backorderMessage: node.backorderMessage,
+    }));
+
+  return {
+    shippingExpectationMessage: order.backorderShippingExpectationMessage,
+    lineItems,
+  };
+}
+
 /** Customers who have placed orders within a company. */
 export async function getCustomersWithOrders(variables: {
   filters?: CustomerWithOrdersFiltersInput;

--- a/apps/storefront/src/types/orderDetail.ts
+++ b/apps/storefront/src/types/orderDetail.ts
@@ -71,6 +71,8 @@ export interface OrderProductItem {
   formattedPrice?: string;
   /** Pre-formatted line total from SF GQL subTotalSalePrice.formattedV2 (server-authoritative). */
   formattedTotal?: string;
+  quantityBackordered?: number;
+  backorderMessage?: string | null;
 }
 
 export interface EditableProductItem extends OrderProductItem {


### PR DESCRIPTION
Jira: [BACK-534](https://bigcommercecloud.atlassian.net/browse/BACK-534)

## What/Why?
Display backorder information on the my orders and comapny orders pages when an order has backorders.

## Rollout/Rollback
Revert this PR is there are issues.

## Testing
Given the following inventory information:
<img width="1477" height="886" alt="productsShowInventory" src="https://github.com/user-attachments/assets/94046347-fe55-45ff-8fc7-edeadf3916fd" />

When **no** backorder are present in the order:
Display is the same across quote and inventory:
Quote:
<img width="1457" height="877" alt="quoteNoBO" src="https://github.com/user-attachments/assets/325f1c2e-dfee-4ad4-bfd5-b7534758f835" />

Orders:
<img width="1459" height="890" alt="orderNoBO" src="https://github.com/user-attachments/assets/f8a4113b-b823-4e46-819b-cfd7c6cc0781" />

When backorders **are** present in the order:
Display is the same across quote and inventory:
Quote:
<img width="1454" height="890" alt="quoteBO" src="https://github.com/user-attachments/assets/f309e44e-8fee-4504-9631-290f26e68a49" />

Orders:
<img width="1468" height="884" alt="orderBO" src="https://github.com/user-attachments/assets/7c123333-fa78-4b0c-b3a6-b50dccc25adb" />

When an order is partially shipped the inventory return is updated to reflect to what is left for backordering:
<img width="1473" height="871" alt="shippedChangesTheBODisplay" src="https://github.com/user-attachments/assets/26c14eea-28bb-4748-85d4-a1b26d9562ab" />

When an order is fully shipped the backorder information no longer displays as there is nothing to display and the shipping expectation message also goes away.
<img width="1500" height="894" alt="fullyShipped" src="https://github.com/user-attachments/assets/abf1d3cc-2f29-41b0-8401-171f3a422588" />

This also covers the Company Orders page:
<img width="1489" height="889" alt="Screenshot 2026-07-22 at 1 15 55 pm" src="https://github.com/user-attachments/assets/95626f1c-43c1-4155-926d-604188b3401f" />

ping @bigcommerce/team-b2b @animesh1987 

[BACK-534]: https://bigcommercecloud.atlassian.net/browse/BACK-534?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a second GraphQL fetch on order detail and merges backorder data into order state; failures are handled gracefully but incorrect entity-id matching or stale message clearing could show wrong messaging.
> 
> **Overview**
> Adds **backorder messaging** on order detail (My Orders and Company Orders) when storefront backorder controls and display settings allow it.
> 
> Order load now optionally calls **`GetOrderBackorderHistory`**, merges line-level `quantityBackordered` / `backorderMessage` by **order product entity id** (not SKU), and derives a **shipping expectation** note for the Summary card only while unshipped backorder remains. Partial shipments reduce displayed backorder counts; fully shipped lines and orders hide backorder UI and clear stale messages when navigating between orders.
> 
> **`B3ProductList`** accepts an optional `backorderFieldsForProduct` override so order “Not shipped yet” rows can show `BackorderMessage` without catalog inventory. **`OrderShipping`** supplies those fields from remaining backorder math; shipped sections stay without backorder blobs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c098e9f18ecfa799d11f29cfdb5785f9c76d695. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->