### PR TITLE
B2B-5213: Translated SKU markup fix

### DIFF
--- a/apps/storefront/src/hooks/dom/getPdpSku.test.ts
+++ b/apps/storefront/src/hooks/dom/getPdpSku.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+
+import { getPdpSku } from './getPdpSku';
+
+describe('getPdpSku', () => {
+  it('reads translated SKU markup as text when B2B-3474 is enabled', () => {
+    const element = document.createElement('span');
+    element.innerHTML = '<font dir="auto"><font dir="auto">81006564</font></font>';
+
+    expect(getPdpSku(element, true)).toBe('81006564');
+  });
+
+  it('preserves legacy SKU markup when B2B-3474 is disabled', () => {
+    const element = document.createElement('span');
+    element.innerHTML = '<font dir="auto">81006564</font>';
+
+    expect(getPdpSku(element, false)).toBe('<font dir="auto">81006564</font>');
+  });
+
+  it('decodes special characters when B2B-3474 is enabled', () => {
+    const element = document.createElement('span');
+    element.innerHTML = 'A&amp;B';
+
+    expect(getPdpSku(element, true)).toBe('A&B');
+  });
+
+  it('returns an empty string when the SKU element is absent', () => {
+    expect(getPdpSku(null, true)).toBe('');
+  });
+});

--- a/apps/storefront/src/hooks/dom/getPdpSku.ts
+++ b/apps/storefront/src/hooks/dom/getPdpSku.ts
@@ -1,0 +1,5 @@
+export const getPdpSku = (skuElement: Element | null, useTextContent: boolean): string => {
+  const value = useTextContent ? skuElement?.textContent : skuElement?.innerHTML;
+
+  return (value ?? '').trim();
+};

--- a/apps/storefront/src/hooks/dom/useMyQuote.test.tsx
+++ b/apps/storefront/src/hooks/dom/useMyQuote.test.tsx
@@ -11,14 +11,15 @@ import {
 import { renderHookWithProviders } from 'tests/utils/hook-test-utils';
 import { when } from 'vitest-when';
 
-import { B2BProductPurchasableResponse } from '@/shared/service/b2b/graphql/product';
+import * as productService from '@/shared/service/b2b/graphql/product';
 import { GlobalState, initialState } from '@/store';
 
 import { useMyQuote } from './useMyQuote';
 
 const { server } = startMockServer();
 
-type ProductPurchasable = B2BProductPurchasableResponse['data']['productPurchasable'];
+type ProductPurchasable =
+  productService.B2BProductPurchasableResponse['data']['productPurchasable'];
 
 const buildProductPurchasableWith = builder<ProductPurchasable>(() => ({
   availability: faker.helpers.arrayElement(['available', 'disabled']),
@@ -38,6 +39,252 @@ const mockGlobalState: GlobalState = {
 };
 
 describe('when NP&OOS setting is enabled', () => {
+  it('renders the purchasable button for a translated SKU', async () => {
+    const productPurchasableResponse = vi.fn();
+
+    when(productPurchasableResponse)
+      .calledWith(stringContainingAll('productId: 123', 'sku: "81006564"'))
+      .thenReturn(
+        buildProductPurchasableWith({
+          availability: 'available',
+          availableToSell: 5,
+          inventoryLevel: 5,
+          inventoryTracking: 'product',
+          purchasingDisabled: false,
+          unlimitedBackorder: true,
+        }),
+      );
+
+    server.use(
+      graphql.query('GetProductPurchasable', ({ query }) =>
+        HttpResponse.json({ data: { productPurchasable: productPurchasableResponse(query) } }),
+      ),
+    );
+
+    render(<FakeProductDataProvider productId="123" quantity="1" sku="81006564" options={{}} />);
+
+    const skuElement = screen.getByText('81006564');
+    skuElement.innerHTML = '<font dir="auto"><font dir="auto">81006564</font></font>';
+
+    renderHookWithProviders(
+      () =>
+        useMyQuote({
+          setOpenPage: () => {},
+          productQuoteEnabled: true,
+          role: 1,
+          customerId: 1,
+        }),
+      {
+        preloadedState: {
+          global: {
+            ...mockGlobalState,
+            featureFlags: { 'B2B-3474.get_sku_from_pdp_with_text_content': true },
+          },
+        },
+      },
+    );
+
+    await waitFor(() => {
+      expect(productPurchasableResponse).toHaveBeenCalledWith(
+        stringContainingAll('productId: 123', 'sku: "81006564"'),
+      );
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/Add to quote/i)).toBeInTheDocument();
+    });
+  });
+
+  it('does not request purchasability again when translated subtree churn preserves the SKU', async () => {
+    const productPurchasableResponse = vi.fn();
+
+    when(productPurchasableResponse)
+      .calledWith(stringContainingAll('productId: 123', 'sku: "81006564"'))
+      .thenReturn(
+        buildProductPurchasableWith({
+          availability: 'available',
+          availableToSell: 5,
+          inventoryLevel: 5,
+          inventoryTracking: 'product',
+          purchasingDisabled: false,
+          unlimitedBackorder: true,
+        }),
+      );
+
+    server.use(
+      graphql.query('GetProductPurchasable', ({ query }) =>
+        HttpResponse.json({ data: { productPurchasable: productPurchasableResponse(query) } }),
+      ),
+    );
+
+    render(<FakeProductDataProvider productId="123" quantity="1" sku="81006564" options={{}} />);
+
+    const skuElement = screen.getByText('81006564');
+    skuElement.innerHTML = '<font dir="auto"><font dir="auto">81006564</font></font>';
+
+    renderHookWithProviders(
+      () =>
+        useMyQuote({
+          setOpenPage: () => {},
+          productQuoteEnabled: true,
+          role: 1,
+          customerId: 1,
+        }),
+      {
+        preloadedState: {
+          global: {
+            ...mockGlobalState,
+            featureFlags: { 'B2B-3474.get_sku_from_pdp_with_text_content': true },
+          },
+        },
+      },
+    );
+
+    await waitFor(() => {
+      expect(productPurchasableResponse).toHaveBeenCalledWith(
+        stringContainingAll('productId: 123', 'sku: "81006564"'),
+      );
+    });
+    await new Promise((resolve) => {
+      setTimeout(resolve, 0);
+    });
+    const requestCountBeforeSubtreeChurn = productPurchasableResponse.mock.calls.length;
+
+    skuElement.innerHTML = '<font dir="auto"><span>81006564</span></font>';
+    await new Promise((resolve) => {
+      setTimeout(resolve, 0);
+    });
+
+    expect(productPurchasableResponse).toHaveBeenCalledTimes(requestCountBeforeSubtreeChurn);
+  });
+
+  it('requests purchasability with the translated SKU mutation', async () => {
+    const productPurchasableResponse = vi.fn();
+
+    when(productPurchasableResponse)
+      .calledWith(stringContainingAll('productId: 123', 'sku: "81006564"'))
+      .thenReturn(
+        buildProductPurchasableWith({
+          availability: 'available',
+          availableToSell: 5,
+          inventoryLevel: 5,
+          inventoryTracking: 'product',
+          purchasingDisabled: false,
+          unlimitedBackorder: true,
+        }),
+      );
+    when(productPurchasableResponse)
+      .calledWith(stringContainingAll('productId: 123', 'sku: "81006565"'))
+      .thenReturn(
+        buildProductPurchasableWith({
+          availability: 'available',
+          availableToSell: 5,
+          inventoryLevel: 5,
+          inventoryTracking: 'product',
+          purchasingDisabled: false,
+          unlimitedBackorder: true,
+        }),
+      );
+
+    server.use(
+      graphql.query('GetProductPurchasable', ({ query }) =>
+        HttpResponse.json({ data: { productPurchasable: productPurchasableResponse(query) } }),
+      ),
+    );
+
+    render(<FakeProductDataProvider productId="123" quantity="1" sku="81006564" options={{}} />);
+
+    const skuElement = screen.getByText('81006564');
+    skuElement.innerHTML = '<font dir="auto"><font dir="auto">81006564</font></font>';
+
+    renderHookWithProviders(
+      () =>
+        useMyQuote({
+          setOpenPage: () => {},
+          productQuoteEnabled: true,
+          role: 1,
+          customerId: 1,
+        }),
+      {
+        preloadedState: {
+          global: {
+            ...mockGlobalState,
+            featureFlags: { 'B2B-3474.get_sku_from_pdp_with_text_content': true },
+          },
+        },
+      },
+    );
+
+    await waitFor(() => {
+      expect(productPurchasableResponse).toHaveBeenCalledWith(
+        stringContainingAll('productId: 123', 'sku: "81006564"'),
+      );
+    });
+
+    const nestedSkuElement = screen.getByText('81006564');
+    nestedSkuElement.textContent = '81006565';
+
+    await waitFor(() => {
+      expect(productPurchasableResponse).toHaveBeenCalledWith(
+        stringContainingAll('productId: 123', 'sku: "81006565"'),
+      );
+    });
+  });
+
+  it('does not request purchasability for nested translated SKU mutations when B2B-3474 is disabled', async () => {
+    const getProductPurchasable = vi
+      .spyOn(productService, 'getB2BProductPurchasable')
+      .mockResolvedValue({
+        productPurchasable: buildProductPurchasableWith({
+          availability: 'available',
+          availableToSell: 5,
+          inventoryLevel: 5,
+          inventoryTracking: 'product',
+          purchasingDisabled: false,
+          unlimitedBackorder: true,
+        }),
+      });
+
+    render(<FakeProductDataProvider productId="123" quantity="1" sku="81006564" options={{}} />);
+
+    const skuElement = screen.getByText('81006564');
+    skuElement.innerHTML = '<font dir="auto"><font dir="auto">81006564</font></font>';
+
+    renderHookWithProviders(
+      () =>
+        useMyQuote({
+          setOpenPage: () => {},
+          productQuoteEnabled: true,
+          role: 1,
+          customerId: 1,
+        }),
+      {
+        preloadedState: {
+          global: {
+            ...mockGlobalState,
+            featureFlags: { 'B2B-3474.get_sku_from_pdp_with_text_content': false },
+          },
+        },
+      },
+    );
+
+    await waitFor(() => {
+      expect(getProductPurchasable).toHaveBeenCalled();
+    });
+    await new Promise((resolve) => {
+      setTimeout(resolve, 0);
+    });
+    const requestCountBeforeNestedMutation = getProductPurchasable.mock.calls.length;
+
+    const nestedSkuElement = screen.getByText('81006564');
+    nestedSkuElement.textContent = '81006565';
+    await new Promise((resolve) => {
+      setTimeout(resolve, 0);
+    });
+
+    expect(getProductPurchasable).toHaveBeenCalledTimes(requestCountBeforeNestedMutation);
+  });
+
   it('should render add to quote button if product is purchasable', async () => {
     const productPurchasableResponse = vi.fn();
 

--- a/apps/storefront/src/hooks/dom/useMyQuote.ts
+++ b/apps/storefront/src/hooks/dom/useMyQuote.ts
@@ -8,7 +8,6 @@ import {
   splitCustomCssValue,
 } from '@/components/outSideComponents/utils/b3CustomStyles';
 import { ADD_TO_QUOTE_DEFAULT_VALUE, TRANSLATION_ADD_TO_QUOTE_VARIABLE } from '@/constants';
-import { useFeatureFlag } from '@/hooks/useFeatureFlag';
 import config from '@/lib/config';
 import { useB3Lang } from '@/lib/lang';
 import { CustomStyleContext } from '@/shared/customStyleButton';
@@ -58,9 +57,6 @@ export const useMyQuote = ({ setOpenPage, productQuoteEnabled, role }: UseMyQuot
   const b3Lang = useB3Lang();
   const dispatch = useAppDispatch();
   const isBackorderEnabled = useIsBackorderEnabled();
-  const isSkuFromPdpWithTextContentEnabled = useFeatureFlag(
-    'B2B-3474.get_sku_from_pdp_with_text_content',
-  );
 
   const quoteDraftUserId = useAppSelector(({ quoteInfo }) => quoteInfo.draftQuoteInfo.userId);
   const b2bId = useAppSelector(({ company }) => company.customer.b2bId);
@@ -92,7 +88,6 @@ export const useMyQuote = ({ setOpenPage, productQuoteEnabled, role }: UseMyQuot
     isEnableProduct,
     b3Lang,
     isBackorderEnabled,
-    isSkuFromPdpWithTextContentEnabled,
   );
 
   const quoteCallBack = useCallback(

--- a/apps/storefront/src/hooks/dom/useMyQuote.ts
+++ b/apps/storefront/src/hooks/dom/useMyQuote.ts
@@ -8,6 +8,7 @@ import {
   splitCustomCssValue,
 } from '@/components/outSideComponents/utils/b3CustomStyles';
 import { ADD_TO_QUOTE_DEFAULT_VALUE, TRANSLATION_ADD_TO_QUOTE_VARIABLE } from '@/constants';
+import { useFeatureFlag } from '@/hooks/useFeatureFlag';
 import config from '@/lib/config';
 import { useB3Lang } from '@/lib/lang';
 import { CustomStyleContext } from '@/shared/customStyleButton';
@@ -57,6 +58,9 @@ export const useMyQuote = ({ setOpenPage, productQuoteEnabled, role }: UseMyQuot
   const b3Lang = useB3Lang();
   const dispatch = useAppDispatch();
   const isBackorderEnabled = useIsBackorderEnabled();
+  const isSkuFromPdpWithTextContentEnabled = useFeatureFlag(
+    'B2B-3474.get_sku_from_pdp_with_text_content',
+  );
 
   const quoteDraftUserId = useAppSelector(({ quoteInfo }) => quoteInfo.draftQuoteInfo.userId);
   const b2bId = useAppSelector(({ company }) => company.customer.b2bId);
@@ -88,6 +92,7 @@ export const useMyQuote = ({ setOpenPage, productQuoteEnabled, role }: UseMyQuot
     isEnableProduct,
     b3Lang,
     isBackorderEnabled,
+    isSkuFromPdpWithTextContentEnabled,
   );
 
   const quoteCallBack = useCallback(

--- a/apps/storefront/src/hooks/dom/useMyQuote.ts
+++ b/apps/storefront/src/hooks/dom/useMyQuote.ts
@@ -114,7 +114,10 @@ export const useMyQuote = ({ setOpenPage, productQuoteEnabled, role }: UseMyQuot
   }, [role]);
 
   const [openQuickView] = useDomVariation(config['dom.setToQuote'], setCartPermissionsCallback);
-  const [isProductPurchasable] = usePurchasableQuote(openQuickView);
+  const [isProductPurchasable] = usePurchasableQuote(
+    openQuickView,
+    isSkuFromPdpWithTextContentEnabled,
+  );
 
   const cache = useRef<BtnProperties | null>(null);
   const {

--- a/apps/storefront/src/hooks/dom/usePurchasableQuote.ts
+++ b/apps/storefront/src/hooks/dom/usePurchasableQuote.ts
@@ -5,9 +5,7 @@ import { useAppSelector } from '@/store';
 
 import { useIsBackorderEnabled } from '../useIsBackorderEnabled';
 
-interface MyMutationRecord extends MutationRecord {
-  target: HTMLElement;
-}
+import { getPdpSku } from './getPdpSku';
 
 interface ProductInfoProps {
   availability: boolean;
@@ -18,7 +16,10 @@ interface ProductInfoProps {
   unlimitedBackorder?: boolean;
 }
 
-const usePurchasableQuote = (openQuickView: boolean) => {
+const usePurchasableQuote = (
+  openQuickView: boolean,
+  isSkuFromPdpWithTextContentEnabled: boolean,
+) => {
   const [isBuyPurchasable, setBuyPurchasable] = useState<boolean>(true);
   const isBackorderEnabled = useIsBackorderEnabled();
 
@@ -118,21 +119,34 @@ const usePurchasableQuote = (openQuickView: boolean) => {
       isDetailOpen = false;
     }
 
+    let currentSku = getPdpSku(productViewSku, isSkuFromPdpWithTextContentEnabled);
+
     if (productViewSku && isEnableProduct) {
-      const sku = productViewSku.innerHTML.trim();
-      callback(sku, isDetailOpen, true);
+      callback(currentSku, isDetailOpen, true);
     }
 
     const observer = new MutationObserver((mutations: MutationRecord[]) => {
-      let sku = '';
-      mutations.forEach((mutation) => {
-        const myMutation: MyMutationRecord = mutation as MyMutationRecord;
-        if (myMutation.type === 'childList' && myMutation.target.hasAttribute('data-product-sku')) {
-          const newSkuValue = myMutation.target.innerHTML.trim();
-          sku = newSkuValue;
-        }
-      });
-      if (sku) callback(sku, isDetailOpen, false);
+      if (!isSkuFromPdpWithTextContentEnabled) {
+        let sku = '';
+
+        mutations.forEach((mutation) => {
+          const target = mutation.target as HTMLElement;
+
+          if (mutation.type === 'childList' && target.hasAttribute('data-product-sku')) {
+            sku = getPdpSku(target, false);
+          }
+        });
+        if (sku) callback(sku, isDetailOpen, false);
+
+        return;
+      }
+
+      const sku = getPdpSku(productViewSku, true);
+
+      if (sku && sku !== currentSku) {
+        currentSku = sku;
+        callback(sku, isDetailOpen, false);
+      }
     });
 
     const config: MutationObserverInit = { childList: true, subtree: true };
@@ -203,7 +217,12 @@ const usePurchasableQuote = (openQuickView: boolean) => {
       if (observer) observer.disconnect();
       if (qtyDom) qtyDom.removeEventListener('input', handleQuantityChange);
     };
-  }, [openQuickView, isEnableProduct, isOutOfStockPurchaseQuantity]);
+  }, [
+    openQuickView,
+    isEnableProduct,
+    isOutOfStockPurchaseQuantity,
+    isSkuFromPdpWithTextContentEnabled,
+  ]);
 
   return [isBuyPurchasable];
 };

--- a/apps/storefront/src/hooks/dom/utils.test.ts
+++ b/apps/storefront/src/hooks/dom/utils.test.ts
@@ -264,7 +264,7 @@ describe('addProductFromProductPageToQuote', () => {
       )
       .thenReturn(buildProductPriceWith('WHATEVER_VALUES'));
 
-    const { addToQuote } = addProductFromProductPageToQuote(setOpenPage, true, b3Lang, false);
+    const { addToQuote } = addProductFromProductPageToQuote(setOpenPage, true, b3Lang, false, true);
     await addToQuote();
 
     expect(priceProduct).toHaveBeenCalled();
@@ -272,10 +272,49 @@ describe('addProductFromProductPageToQuote', () => {
     expect(globalSnackbar.success).toHaveBeenCalled();
   });
 
+  it('uses legacy SKU markup when B2B-3474 is disabled', async () => {
+    createDOM({
+      productId: 123,
+      qty: 1,
+      sku: '<font dir="auto">81006564</font>',
+    });
+
+    when(searchProduct)
+      .calledWith(expect.stringContaining('productIds: [123]'))
+      .thenReturn(
+        buildSearchB2BProductWith({
+          id: 123,
+          sku: '81006564',
+          name: 'Product Name',
+          variants: [buildProductVariantWith({ sku: '81006564', product_id: 123 })],
+        }),
+      );
+
+    const { addToQuote } = addProductFromProductPageToQuote(
+      setOpenPage,
+      true,
+      b3Lang,
+      false,
+      false,
+    );
+    await addToQuote();
+
+    expect(globalSnackbar.error).toHaveBeenCalledWith('Price error');
+    expect(priceProduct).not.toHaveBeenCalled();
+    expect(addQuoteDraftProduce).not.toHaveBeenCalled();
+    expect(b2bLogger.error).not.toHaveBeenCalled();
+  });
+
   it('shows error when SKU is missing from DOM', async () => {
     createDOM({ productId: 123, qty: 1, sku: '' });
 
-    const { addToQuote } = addProductFromProductPageToQuote(setOpenPage, true, b3Lang, false);
+    const { addToQuote } = addProductFromProductPageToQuote(
+      setOpenPage,
+      true,
+      b3Lang,
+      false,
+      false,
+    );
     await addToQuote();
 
     expect(globalSnackbar.error).toHaveBeenCalledWith('cantAddNoSku');
@@ -296,7 +335,36 @@ describe('addProductFromProductPageToQuote', () => {
         }),
       );
 
-    const { addToQuote } = addProductFromProductPageToQuote(setOpenPage, true, b3Lang, false);
+    const { addToQuote } = addProductFromProductPageToQuote(
+      setOpenPage,
+      true,
+      b3Lang,
+      false,
+      false,
+    );
+    await addToQuote();
+
+    expect(globalSnackbar.error).toHaveBeenCalledWith('Price error');
+    expect(priceProduct).not.toHaveBeenCalled();
+    expect(addQuoteDraftProduce).not.toHaveBeenCalled();
+    expect(b2bLogger.error).not.toHaveBeenCalled();
+  });
+
+  it('shows a price error without throwing when an enabled SKU does not match a variant', async () => {
+    createDOM({ productId: 123, qty: 1, sku: 'DOM-SKU' });
+
+    when(searchProduct)
+      .calledWith(expect.stringContaining('productIds: [123]'))
+      .thenReturn(
+        buildSearchB2BProductWith({
+          id: 123,
+          sku: 'API-SKU',
+          name: 'Product Name',
+          variants: [buildProductVariantWith({ sku: 'API-SKU', product_id: 123 })],
+        }),
+      );
+
+    const { addToQuote } = addProductFromProductPageToQuote(setOpenPage, true, b3Lang, false, true);
     await addToQuote();
 
     expect(globalSnackbar.error).toHaveBeenCalledWith('Price error');
@@ -320,7 +388,13 @@ describe('addProductFromProductPageToQuote', () => {
         }),
       );
 
-    const { addToQuote } = addProductFromProductPageToQuote(setOpenPage, true, b3Lang, false);
+    const { addToQuote } = addProductFromProductPageToQuote(
+      setOpenPage,
+      true,
+      b3Lang,
+      false,
+      false,
+    );
     await addToQuote();
 
     expect(globalSnackbar.error).toHaveBeenCalledWith('Please fill out product options first.');
@@ -349,7 +423,13 @@ describe('addProductFromProductPageToQuote', () => {
       )
       .thenReturn(buildProductPriceWith('WHATEVER_VALUES'));
 
-    const { addToQuote } = addProductFromProductPageToQuote(setOpenPage, true, b3Lang, false);
+    const { addToQuote } = addProductFromProductPageToQuote(
+      setOpenPage,
+      true,
+      b3Lang,
+      false,
+      false,
+    );
     await addToQuote();
 
     expect(globalSnackbar.error).toHaveBeenCalledWith('maximumPurchaseExceed', expect.any(Object));
@@ -363,7 +443,13 @@ describe('addProductFromProductPageToQuote', () => {
 
     createDOM({ productId: 123, qty: 1, sku: 'SKU123' });
 
-    const { addToQuote } = addProductFromProductPageToQuote(setOpenPage, true, b3Lang, false);
+    const { addToQuote } = addProductFromProductPageToQuote(
+      setOpenPage,
+      true,
+      b3Lang,
+      false,
+      false,
+    );
     await addToQuote();
 
     expect(b2bLogger.error).toHaveBeenCalledWith(new Error('test'));
@@ -386,7 +472,13 @@ describe('addProductFromProductPageToQuote', () => {
             }),
           );
 
-        const { addToQuote } = addProductFromProductPageToQuote(setOpenPage, false, b3Lang, false);
+        const { addToQuote } = addProductFromProductPageToQuote(
+          setOpenPage,
+          false,
+          b3Lang,
+          false,
+          false,
+        );
         await addToQuote();
 
         expect(globalSnackbar.error).toHaveBeenCalledWith('unavailable');
@@ -415,6 +507,7 @@ describe('addProductFromProductPageToQuote', () => {
             setOpenPage,
             false,
             b3Lang,
+            false,
             false,
           );
           await addToQuote();
@@ -453,6 +546,7 @@ describe('addProductFromProductPageToQuote', () => {
             false,
             b3Lang,
             false,
+            false,
           );
           await addToQuote();
 
@@ -484,6 +578,7 @@ describe('addProductFromProductPageToQuote', () => {
             setOpenPage,
             false,
             b3Lang,
+            false,
             false,
           );
           await addToQuote();
@@ -522,6 +617,7 @@ describe('addProductFromProductPageToQuote', () => {
             setOpenPage,
             false,
             b3Lang,
+            false,
             false,
           );
           await addToQuote();
@@ -556,7 +652,13 @@ describe('addProductFromProductPageToQuote', () => {
           )
           .thenReturn(buildProductPriceWith('WHATEVER_VALUES'));
 
-        const { addToQuote } = addProductFromProductPageToQuote(setOpenPage, true, b3Lang, false);
+        const { addToQuote } = addProductFromProductPageToQuote(
+          setOpenPage,
+          true,
+          b3Lang,
+          false,
+          false,
+        );
         await addToQuote();
 
         expect(globalSnackbar.success).toHaveBeenCalled();
@@ -589,7 +691,13 @@ describe('addProductFromProductPageToQuote', () => {
             )
             .thenReturn(buildProductPriceWith('WHATEVER_VALUES'));
 
-          const { addToQuote } = addProductFromProductPageToQuote(setOpenPage, true, b3Lang, false);
+          const { addToQuote } = addProductFromProductPageToQuote(
+            setOpenPage,
+            true,
+            b3Lang,
+            false,
+            false,
+          );
           await addToQuote();
 
           expect(addQuoteDraftProduce).toHaveBeenCalled();
@@ -621,7 +729,13 @@ describe('addProductFromProductPageToQuote', () => {
             )
             .thenReturn(buildProductPriceWith('WHATEVER_VALUES'));
 
-          const { addToQuote } = addProductFromProductPageToQuote(setOpenPage, true, b3Lang, false);
+          const { addToQuote } = addProductFromProductPageToQuote(
+            setOpenPage,
+            true,
+            b3Lang,
+            false,
+            false,
+          );
           await addToQuote();
 
           expect(addQuoteDraftProduce).toHaveBeenCalled();
@@ -656,7 +770,13 @@ describe('addProductFromProductPageToQuote', () => {
             )
             .thenReturn(buildProductPriceWith('WHATEVER_VALUES'));
 
-          const { addToQuote } = addProductFromProductPageToQuote(setOpenPage, true, b3Lang, false);
+          const { addToQuote } = addProductFromProductPageToQuote(
+            setOpenPage,
+            true,
+            b3Lang,
+            false,
+            false,
+          );
           await addToQuote();
 
           expect(addQuoteDraftProduce).toHaveBeenCalled();
@@ -689,7 +809,13 @@ describe('addProductFromProductPageToQuote', () => {
             )
             .thenReturn(buildProductPriceWith('WHATEVER_VALUES'));
 
-          const { addToQuote } = addProductFromProductPageToQuote(setOpenPage, true, b3Lang, false);
+          const { addToQuote } = addProductFromProductPageToQuote(
+            setOpenPage,
+            true,
+            b3Lang,
+            false,
+            false,
+          );
           await addToQuote();
 
           expect(addQuoteDraftProduce).toHaveBeenCalled();
@@ -760,7 +886,13 @@ describe('addProductFromProductPageToQuote', () => {
           ],
         });
 
-      const { addToQuote } = addProductFromProductPageToQuote(setOpenPage, false, b3Lang, true);
+      const { addToQuote } = addProductFromProductPageToQuote(
+        setOpenPage,
+        false,
+        b3Lang,
+        true,
+        false,
+      );
       await addToQuote();
 
       expect(globalSnackbar.error).toHaveBeenCalledWith('unavailable');
@@ -806,7 +938,13 @@ describe('addProductFromProductPageToQuote', () => {
           products: [buildValidateProductWith({ responseType: 'WARNING', message: 'test' })],
         });
 
-      const { addToQuote } = addProductFromProductPageToQuote(setOpenPage, false, b3Lang, true);
+      const { addToQuote } = addProductFromProductPageToQuote(
+        setOpenPage,
+        false,
+        b3Lang,
+        true,
+        false,
+      );
       await addToQuote();
 
       expect(addQuoteDraftProduce).toHaveBeenCalled();
@@ -851,7 +989,13 @@ describe('addProductFromProductPageToQuote', () => {
           products: [buildValidateProductWith({ responseType: 'SUCCESS', message: '' })],
         });
 
-      const { addToQuote } = addProductFromProductPageToQuote(setOpenPage, false, b3Lang, true);
+      const { addToQuote } = addProductFromProductPageToQuote(
+        setOpenPage,
+        false,
+        b3Lang,
+        true,
+        false,
+      );
       await addToQuote();
 
       expect(globalSnackbar.success).toHaveBeenCalled();
@@ -899,7 +1043,13 @@ describe('addProductFromProductPageToQuote', () => {
 
       when(getProductOptionList).calledWith(expect.any(Object)).thenReturn([]);
 
-      const { addToQuote } = addProductFromProductPageToQuote(setOpenPage, false, b3Lang, true);
+      const { addToQuote } = addProductFromProductPageToQuote(
+        setOpenPage,
+        false,
+        b3Lang,
+        true,
+        true,
+      );
       await addToQuote();
 
       expect(globalSnackbar.success).toHaveBeenCalledWith('addProductSingular', {

--- a/apps/storefront/src/hooks/dom/utils.test.ts
+++ b/apps/storefront/src/hooks/dom/utils.test.ts
@@ -238,20 +238,71 @@ beforeEach(() => {
 });
 
 describe('addProductFromProductPageToQuote', () => {
+  it('adds a product when storefront translation wraps the SKU in markup', async () => {
+    createDOM({
+      productId: 123,
+      qty: 1,
+      sku: '<font dir="auto" style="vertical-align: inherit;"><font dir="auto" style="vertical-align: inherit;">81006564</font></font>',
+    });
+
+    when(searchProduct)
+      .calledWith(expect.stringContaining('productIds: [123]'))
+      .thenReturn(
+        buildSearchB2BProductWith({
+          id: 123,
+          sku: '81006564',
+          name: 'Product Name',
+          variants: [buildProductVariantWith({ sku: '81006564', product_id: 123 })],
+        }),
+      );
+
+    when(priceProduct)
+      .calledWith(
+        expect.objectContaining({
+          items: [expect.objectContaining({ productId: 123 })],
+        }),
+      )
+      .thenReturn(buildProductPriceWith('WHATEVER_VALUES'));
+
+    const { addToQuote } = addProductFromProductPageToQuote(setOpenPage, true, b3Lang, false);
+    await addToQuote();
+
+    expect(priceProduct).toHaveBeenCalled();
+    expect(addQuoteDraftProduce).toHaveBeenCalled();
+    expect(globalSnackbar.success).toHaveBeenCalled();
+  });
+
   it('shows error when SKU is missing from DOM', async () => {
     createDOM({ productId: 123, qty: 1, sku: '' });
 
-    const { addToQuote } = addProductFromProductPageToQuote(
-      setOpenPage,
-      true,
-      b3Lang,
-      false,
-      false,
-    );
+    const { addToQuote } = addProductFromProductPageToQuote(setOpenPage, true, b3Lang, false);
     await addToQuote();
 
     expect(globalSnackbar.error).toHaveBeenCalledWith('cantAddNoSku');
     expect(addQuoteDraftProduce).not.toHaveBeenCalled();
+  });
+
+  it('shows a price error without throwing when the DOM SKU does not match a variant', async () => {
+    createDOM({ productId: 123, qty: 1, sku: 'DOM-SKU' });
+
+    when(searchProduct)
+      .calledWith(expect.stringContaining('productIds: [123]'))
+      .thenReturn(
+        buildSearchB2BProductWith({
+          id: 123,
+          sku: 'API-SKU',
+          name: 'Product Name',
+          variants: [buildProductVariantWith({ sku: 'API-SKU', product_id: 123 })],
+        }),
+      );
+
+    const { addToQuote } = addProductFromProductPageToQuote(setOpenPage, true, b3Lang, false);
+    await addToQuote();
+
+    expect(globalSnackbar.error).toHaveBeenCalledWith('Price error');
+    expect(priceProduct).not.toHaveBeenCalled();
+    expect(addQuoteDraftProduce).not.toHaveBeenCalled();
+    expect(b2bLogger.error).not.toHaveBeenCalled();
   });
 
   it('shows error when required options are not filled', async () => {
@@ -269,13 +320,7 @@ describe('addProductFromProductPageToQuote', () => {
         }),
       );
 
-    const { addToQuote } = addProductFromProductPageToQuote(
-      setOpenPage,
-      true,
-      b3Lang,
-      false,
-      false,
-    );
+    const { addToQuote } = addProductFromProductPageToQuote(setOpenPage, true, b3Lang, false);
     await addToQuote();
 
     expect(globalSnackbar.error).toHaveBeenCalledWith('Please fill out product options first.');
@@ -304,13 +349,7 @@ describe('addProductFromProductPageToQuote', () => {
       )
       .thenReturn(buildProductPriceWith('WHATEVER_VALUES'));
 
-    const { addToQuote } = addProductFromProductPageToQuote(
-      setOpenPage,
-      true,
-      b3Lang,
-      false,
-      false,
-    );
+    const { addToQuote } = addProductFromProductPageToQuote(setOpenPage, true, b3Lang, false);
     await addToQuote();
 
     expect(globalSnackbar.error).toHaveBeenCalledWith('maximumPurchaseExceed', expect.any(Object));
@@ -324,13 +363,7 @@ describe('addProductFromProductPageToQuote', () => {
 
     createDOM({ productId: 123, qty: 1, sku: 'SKU123' });
 
-    const { addToQuote } = addProductFromProductPageToQuote(
-      setOpenPage,
-      true,
-      b3Lang,
-      false,
-      false,
-    );
+    const { addToQuote } = addProductFromProductPageToQuote(setOpenPage, true, b3Lang, false);
     await addToQuote();
 
     expect(b2bLogger.error).toHaveBeenCalledWith(new Error('test'));
@@ -353,13 +386,7 @@ describe('addProductFromProductPageToQuote', () => {
             }),
           );
 
-        const { addToQuote } = addProductFromProductPageToQuote(
-          setOpenPage,
-          false,
-          b3Lang,
-          false,
-          false,
-        );
+        const { addToQuote } = addProductFromProductPageToQuote(setOpenPage, false, b3Lang, false);
         await addToQuote();
 
         expect(globalSnackbar.error).toHaveBeenCalledWith('unavailable');
@@ -388,7 +415,6 @@ describe('addProductFromProductPageToQuote', () => {
             setOpenPage,
             false,
             b3Lang,
-            false,
             false,
           );
           await addToQuote();
@@ -427,7 +453,6 @@ describe('addProductFromProductPageToQuote', () => {
             false,
             b3Lang,
             false,
-            false,
           );
           await addToQuote();
 
@@ -459,7 +484,6 @@ describe('addProductFromProductPageToQuote', () => {
             setOpenPage,
             false,
             b3Lang,
-            false,
             false,
           );
           await addToQuote();
@@ -498,7 +522,6 @@ describe('addProductFromProductPageToQuote', () => {
             setOpenPage,
             false,
             b3Lang,
-            false,
             false,
           );
           await addToQuote();
@@ -533,13 +556,7 @@ describe('addProductFromProductPageToQuote', () => {
           )
           .thenReturn(buildProductPriceWith('WHATEVER_VALUES'));
 
-        const { addToQuote } = addProductFromProductPageToQuote(
-          setOpenPage,
-          true,
-          b3Lang,
-          false,
-          false,
-        );
+        const { addToQuote } = addProductFromProductPageToQuote(setOpenPage, true, b3Lang, false);
         await addToQuote();
 
         expect(globalSnackbar.success).toHaveBeenCalled();
@@ -572,13 +589,7 @@ describe('addProductFromProductPageToQuote', () => {
             )
             .thenReturn(buildProductPriceWith('WHATEVER_VALUES'));
 
-          const { addToQuote } = addProductFromProductPageToQuote(
-            setOpenPage,
-            true,
-            b3Lang,
-            false,
-            false,
-          );
+          const { addToQuote } = addProductFromProductPageToQuote(setOpenPage, true, b3Lang, false);
           await addToQuote();
 
           expect(addQuoteDraftProduce).toHaveBeenCalled();
@@ -610,13 +621,7 @@ describe('addProductFromProductPageToQuote', () => {
             )
             .thenReturn(buildProductPriceWith('WHATEVER_VALUES'));
 
-          const { addToQuote } = addProductFromProductPageToQuote(
-            setOpenPage,
-            true,
-            b3Lang,
-            false,
-            false,
-          );
+          const { addToQuote } = addProductFromProductPageToQuote(setOpenPage, true, b3Lang, false);
           await addToQuote();
 
           expect(addQuoteDraftProduce).toHaveBeenCalled();
@@ -651,13 +656,7 @@ describe('addProductFromProductPageToQuote', () => {
             )
             .thenReturn(buildProductPriceWith('WHATEVER_VALUES'));
 
-          const { addToQuote } = addProductFromProductPageToQuote(
-            setOpenPage,
-            true,
-            b3Lang,
-            false,
-            false,
-          );
+          const { addToQuote } = addProductFromProductPageToQuote(setOpenPage, true, b3Lang, false);
           await addToQuote();
 
           expect(addQuoteDraftProduce).toHaveBeenCalled();
@@ -690,13 +689,7 @@ describe('addProductFromProductPageToQuote', () => {
             )
             .thenReturn(buildProductPriceWith('WHATEVER_VALUES'));
 
-          const { addToQuote } = addProductFromProductPageToQuote(
-            setOpenPage,
-            true,
-            b3Lang,
-            false,
-            false,
-          );
+          const { addToQuote } = addProductFromProductPageToQuote(setOpenPage, true, b3Lang, false);
           await addToQuote();
 
           expect(addQuoteDraftProduce).toHaveBeenCalled();
@@ -767,13 +760,7 @@ describe('addProductFromProductPageToQuote', () => {
           ],
         });
 
-      const { addToQuote } = addProductFromProductPageToQuote(
-        setOpenPage,
-        false,
-        b3Lang,
-        true,
-        false,
-      );
+      const { addToQuote } = addProductFromProductPageToQuote(setOpenPage, false, b3Lang, true);
       await addToQuote();
 
       expect(globalSnackbar.error).toHaveBeenCalledWith('unavailable');
@@ -819,13 +806,7 @@ describe('addProductFromProductPageToQuote', () => {
           products: [buildValidateProductWith({ responseType: 'WARNING', message: 'test' })],
         });
 
-      const { addToQuote } = addProductFromProductPageToQuote(
-        setOpenPage,
-        false,
-        b3Lang,
-        true,
-        false,
-      );
+      const { addToQuote } = addProductFromProductPageToQuote(setOpenPage, false, b3Lang, true);
       await addToQuote();
 
       expect(addQuoteDraftProduce).toHaveBeenCalled();
@@ -870,20 +851,14 @@ describe('addProductFromProductPageToQuote', () => {
           products: [buildValidateProductWith({ responseType: 'SUCCESS', message: '' })],
         });
 
-      const { addToQuote } = addProductFromProductPageToQuote(
-        setOpenPage,
-        false,
-        b3Lang,
-        true,
-        false,
-      );
+      const { addToQuote } = addProductFromProductPageToQuote(setOpenPage, false, b3Lang, true);
       await addToQuote();
 
       expect(globalSnackbar.success).toHaveBeenCalled();
       expect(addQuoteDraftProduce).toHaveBeenCalled();
     });
 
-    it('correctly retrieves the SKU of a product with special characters and adds it to cart', async () => {
+    it('adds a product with special characters in its SKU to the quote', async () => {
       createDOM({ productId: 123, qty: 1, sku: 'A&B' });
 
       when(searchProduct)
@@ -924,13 +899,7 @@ describe('addProductFromProductPageToQuote', () => {
 
       when(getProductOptionList).calledWith(expect.any(Object)).thenReturn([]);
 
-      const { addToQuote } = addProductFromProductPageToQuote(
-        setOpenPage,
-        false,
-        b3Lang,
-        true,
-        true,
-      );
+      const { addToQuote } = addProductFromProductPageToQuote(setOpenPage, false, b3Lang, true);
       await addToQuote();
 
       expect(globalSnackbar.success).toHaveBeenCalledWith('addProductSingular', {

--- a/apps/storefront/src/hooks/dom/utils.ts
+++ b/apps/storefront/src/hooks/dom/utils.ts
@@ -233,7 +233,6 @@ const addProductFromProductPageToQuote = (
   isEnableProduct: boolean,
   b3Lang: LangFormatFunction,
   isBackorderEnabled: boolean,
-  isSkuFromPdpWithTextContentEnabled: boolean,
 ) => {
   const addToQuote = async (node?: HTMLElement) => {
     try {
@@ -242,9 +241,7 @@ const addProductFromProductPageToQuote = (
       const productId = (productView.querySelector('input[name=product_id]') as CustomFieldItems)
         ?.value;
       const qty = (productView.querySelector('[name="qty[]"]') as CustomFieldItems)?.value ?? 1;
-      const sku = isSkuFromPdpWithTextContentEnabled
-        ? (productView.querySelector('[data-product-sku]')?.textContent ?? '').trim()
-        : (productView.querySelector('[data-product-sku]')?.innerHTML ?? '').trim();
+      const sku = (productView.querySelector('[data-product-sku]')?.textContent ?? '').trim();
       const form = productView.querySelector('form[data-cart-item-add]') as HTMLFormElement;
 
       if (!sku) {
@@ -351,26 +348,29 @@ const addProductFromProductPageToQuote = (
         qty,
       });
 
-      const newProducts: CustomFieldItems = [quoteListitem];
-      const isSuccess = validProductQty(newProducts);
-      if (quoteListitem && isSuccess) {
-        await addQuoteDraftProduce(quoteListitem, qty, optionList || []);
-        globalSnackbar.success(b3Lang('global.notification.addProductSingular'), {
-          action: {
-            onClick: () => gotoQuoteDraft(setOpenPage),
-            label: b3Lang('quoteDraft.notification.openQuote'),
-          },
-        });
-      } else if (!isSuccess) {
+      if (!quoteListitem) {
+        globalSnackbar.error('Price error');
+        return;
+      }
+
+      const isSuccess = validProductQty([quoteListitem]);
+      if (!isSuccess) {
         globalSnackbar.error(b3Lang('global.notification.maximumPurchaseExceed'), {
           action: {
             onClick: () => gotoQuoteDraft(setOpenPage),
             label: b3Lang('quoteDraft.notification.openQuote'),
           },
         });
-      } else {
-        globalSnackbar.error('Price error');
+        return;
       }
+
+      await addQuoteDraftProduce(quoteListitem, qty, optionList || []);
+      globalSnackbar.success(b3Lang('global.notification.addProductSingular'), {
+        action: {
+          onClick: () => gotoQuoteDraft(setOpenPage),
+          label: b3Lang('quoteDraft.notification.openQuote'),
+        },
+      });
     } catch (e) {
       b2bLogger.error(e);
     } finally {

--- a/apps/storefront/src/hooks/dom/utils.ts
+++ b/apps/storefront/src/hooks/dom/utils.ts
@@ -233,6 +233,7 @@ const addProductFromProductPageToQuote = (
   isEnableProduct: boolean,
   b3Lang: LangFormatFunction,
   isBackorderEnabled: boolean,
+  isSkuFromPdpWithTextContentEnabled: boolean,
 ) => {
   const addToQuote = async (node?: HTMLElement) => {
     try {
@@ -241,7 +242,9 @@ const addProductFromProductPageToQuote = (
       const productId = (productView.querySelector('input[name=product_id]') as CustomFieldItems)
         ?.value;
       const qty = (productView.querySelector('[name="qty[]"]') as CustomFieldItems)?.value ?? 1;
-      const sku = (productView.querySelector('[data-product-sku]')?.textContent ?? '').trim();
+      const sku = isSkuFromPdpWithTextContentEnabled
+        ? (productView.querySelector('[data-product-sku]')?.textContent ?? '').trim()
+        : (productView.querySelector('[data-product-sku]')?.innerHTML ?? '').trim();
       const form = productView.querySelector('form[data-cart-item-add]') as HTMLFormElement;
 
       if (!sku) {

--- a/apps/storefront/src/hooks/dom/utils.ts
+++ b/apps/storefront/src/hooks/dom/utils.ts
@@ -26,6 +26,8 @@ import { globalSnackbar } from '@/utils/b3Tip';
 import { getActiveCurrencyInfo } from '@/utils/currencyUtils';
 import { validateProducts } from '@/utils/validateProducts';
 
+import { getPdpSku } from './getPdpSku';
+
 interface DiscountsProps {
   discountedAmount: number;
   id: string;
@@ -242,9 +244,10 @@ const addProductFromProductPageToQuote = (
       const productId = (productView.querySelector('input[name=product_id]') as CustomFieldItems)
         ?.value;
       const qty = (productView.querySelector('[name="qty[]"]') as CustomFieldItems)?.value ?? 1;
-      const sku = isSkuFromPdpWithTextContentEnabled
-        ? (productView.querySelector('[data-product-sku]')?.textContent ?? '').trim()
-        : (productView.querySelector('[data-product-sku]')?.innerHTML ?? '').trim();
+      const sku = getPdpSku(
+        productView.querySelector('[data-product-sku]'),
+        isSkuFromPdpWithTextContentEnabled,
+      );
       const form = productView.querySelector('form[data-cart-item-add]') as HTMLFormElement;
 
       if (!sku) {

--- a/apps/storefront/src/pages/PDP/index.b2b.test.tsx
+++ b/apps/storefront/src/pages/PDP/index.b2b.test.tsx
@@ -279,6 +279,97 @@ describe('stencil', () => {
     expect(window.scrollTo).toHaveBeenCalledWith(0, 0);
   });
 
+  it('can select a variant from a translated SKU when adding to a shopping list', async () => {
+    render(
+      <FakeProductDataProvider
+        productId="123"
+        sku="81006564"
+        quantity="2"
+        options={{ 'attribute[114]': '104' }}
+      />,
+    );
+
+    const skuElement = document.querySelector('[data-product-sku]');
+
+    if (!skuElement) throw new Error('Expected FakeProductDataProvider to render a SKU');
+
+    skuElement.innerHTML = '<font dir="auto"><font dir="auto">81006564</font></font>';
+
+    const addItemsToShoppingList = vi.fn();
+
+    const shoppingList = buildShoppingListNodeWith({
+      node: { id: 992, name: 'Foo Bar Shopping List' },
+    });
+
+    server.use(
+      graphql.query('B2BCustomerShoppingLists', () =>
+        HttpResponse.json(
+          buildShoppingListResponseWith({
+            data: { shoppingLists: { totalCount: 1, edges: [shoppingList] } },
+          }),
+        ),
+      ),
+      graphql.query('SearchProducts', () =>
+        HttpResponse.json({
+          data: {
+            productsSearch: [
+              {
+                variants: [
+                  { variant_id: 222, sku: '81006563' },
+                  { variant_id: 333, sku: '81006564' },
+                ],
+              },
+            ],
+          },
+        }),
+      ),
+      graphql.mutation('AddItemsToShoppingList', ({ variables }) => {
+        addItemsToShoppingList({ variables });
+
+        return HttpResponse.json({
+          data: {
+            shoppingListItemsCreate: {
+              shoppingListsItems: [],
+            },
+          },
+        });
+      }),
+    );
+
+    const shoppingListClickNode = screen.getByRole('link', { name: 'Shopping List Click Node' });
+
+    renderWithProviders(<PDP />, {
+      preloadedState: {
+        ...preloadedState,
+        global: {
+          ...preloadedState.global,
+          featureFlags: {
+            ...preloadedState.global.featureFlags,
+            'B2B-3474.get_sku_from_pdp_with_text_content': true,
+          },
+        },
+      },
+      initialGlobalContext: { shoppingListClickNode },
+    });
+
+    await waitForElementToBeRemoved(() => screen.queryByText(/loading/i));
+
+    await userEvent.click(await screen.findByText('Foo Bar Shopping List'));
+    await userEvent.click(screen.getByText('OK'));
+
+    await waitFor(() => {
+      expect(addItemsToShoppingList).toHaveBeenCalledWith({
+        variables: expect.objectContaining({
+          items: expect.arrayContaining([
+            expect.objectContaining({
+              variantId: 333,
+            }),
+          ]),
+        }),
+      });
+    });
+  });
+
   it('can create a shopping list from the modal and add a product to it', async () => {
     const createShoppingList = vi.fn();
     const getCompanyShoppingLists = vi.fn();

--- a/apps/storefront/src/pages/PDP/index.tsx
+++ b/apps/storefront/src/pages/PDP/index.tsx
@@ -1,6 +1,8 @@
 import { useContext, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
+import { getPdpSku } from '@/hooks/dom/getPdpSku';
+import { useFeatureFlag } from '@/hooks/useFeatureFlag';
 import config from '@/lib/config';
 import { useB3Lang } from '@/lib/lang';
 import { GlobalContext } from '@/shared/global';
@@ -23,6 +25,9 @@ function useData() {
   const platform = useAppSelector(({ global }) => global.storeInfo.platform);
   const setOpenPageFn = useAppSelector(({ global }) => global.setOpenPageFn);
   const isB2BUser = useAppSelector(isB2BUserSelector);
+  const isSkuFromPdpWithTextContentEnabled = useFeatureFlag(
+    'B2B-3474.get_sku_from_pdp_with_text_content',
+  );
 
   const getShoppingListItem = () => {
     if (!isBigCommercePlatform(platform)) {
@@ -39,7 +44,10 @@ function useData() {
 
     const productId = (productView.querySelector('input[name=product_id]') as any)?.value;
     const quantity = (productView.querySelector('[name="qty[]"]') as any)?.value ?? 1;
-    const sku = (productView.querySelector('[data-product-sku]')?.innerHTML ?? '').trim();
+    const sku = getPdpSku(
+      productView.querySelector('[data-product-sku]'),
+      isSkuFromPdpWithTextContentEnabled,
+    );
     const form = productView.querySelector('form[data-cart-item-add]') as HTMLFormElement;
     return {
       productId: Number(productId),

--- a/apps/storefront/src/utils/featureFlags.ts
+++ b/apps/storefront/src/utils/featureFlags.ts
@@ -59,6 +59,10 @@ export const featureFlags = [
     key: 'B2B-4912.buyer_portal_native_link_interception',
     name: 'buyerPortalNativeLinkInterception',
   },
+  {
+    key: 'B2B-3474.get_sku_from_pdp_with_text_content',
+    name: 'getSkuFromPdpWithTextContent',
+  },
 ] as const;
 
 export type FeatureFlagKey = (typeof featureFlags)[number]['key'];

--- a/apps/storefront/src/utils/featureFlags.ts
+++ b/apps/storefront/src/utils/featureFlags.ts
@@ -4,10 +4,6 @@ export const featureFlags = [
     name: 'disableMasqueradingCleanupOnLogin',
   },
   {
-    key: 'B2B-3474.get_sku_from_pdp_with_text_content',
-    name: 'getSkuFromPdpWithTextContent',
-  },
-  {
     key: 'B2B-3978.pass_with_modifiers_to_product_upload',
     name: 'passWithModifiersToProductUpload',
   },

--- a/apps/storefront/src/utils/featureFlags.ts
+++ b/apps/storefront/src/utils/featureFlags.ts
@@ -4,6 +4,10 @@ export const featureFlags = [
     name: 'disableMasqueradingCleanupOnLogin',
   },
   {
+    key: 'B2B-3474.get_sku_from_pdp_with_text_content',
+    name: 'getSkuFromPdpWithTextContent',
+  },
+  {
     key: 'B2B-3978.pass_with_modifiers_to_product_upload',
     name: 'passWithModifiersToProductUpload',
   },
@@ -58,10 +62,6 @@ export const featureFlags = [
   {
     key: 'B2B-4912.buyer_portal_native_link_interception',
     name: 'buyerPortalNativeLinkInterception',
-  },
-  {
-    key: 'B2B-3474.get_sku_from_pdp_with_text_content',
-    name: 'getSkuFromPdpWithTextContent',
   },
 ] as const;
 


### PR DESCRIPTION
Jira: [B2B-5213](https://bigcommercecloud.atlassian.net/browse/B2B-5213)
FeatureFlag: [B2B-3474.get_sku_from_pdp_with_text_content](https://app.launchdarkly.com/projects/default/flags/B2B-3474.get_sku_from_pdp_with_text_content/targeting?env=development&env=integration&env=production&selected-env=production)

## What/Why?
Storefront translation can wrap PDP SKUs in markup, preventing buyers from adding products to a quote. This restores the SKU feature flag: enabled stores read the SKU text content, while disabled stores retain the existing markup behavior.
This is a draft while we confirm why the previous feature flag was not in use and whether it needs any follow-up outside the buyer portal.

During the investigation, I found that the core solution is actually in the codebase, but it's gated by a feature flag. After digging into the feature flag logs, it seems like it was added but never enable. So, I decided to reuse this feature flag as a kill switch to roll out all these changes.

## Rollout/Rollback
Enable the feature flag after confirmation. Revert this change to restore the previous behavior.

## Testing
Before 
<img width="2558" height="1233" alt="Screenshot 2026-07-27 at 1 36 00 pm" src="https://github.com/user-attachments/assets/6191930e-f77e-446f-a63e-1973d04bdc3b" />


After
<img width="2556" height="1291" alt="Screenshot 2026-07-27 at 1 37 39 pm" src="https://github.com/user-attachments/assets/ea99765a-b9f6-4fde-aea1-9cc2be7d2fc2" />


- Added coverage for translated SKU markup and both flag states.
---

> [!NOTE]
> **Medium Risk**
> Touches the PDP add-to-quote path and how pricing/SKU failures are surfaced; mistakes could block quote creation or change error messaging for buyers.
> 
> **Overview**
> **Refactors** the product-page “add to quote” path so a failed price calculation (`getCalculatedProductPrice` returns nothing) shows **Price error** and exits early, max-quantity failures are handled separately, and success only runs after quantity validation passes.
> 
> **Adds** unit tests around PDP SKU handling: translated markup around the SKU (flag on), legacy `innerHTML` behavior when **B2B-3474** is off, and DOM/API SKU mismatches that should surface **Price error** without logging or drafting the quote. One existing special-character SKU test is renamed for clarity.
> 
> **Moves** the `B2B-3474.get_sku_from_pdp_with_text_content` entry to the end of the feature-flag registry (no behavior change in the flag list itself).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 691cdb2723e138b788a2224c1fd1d8f80529d91f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

[B2B-5213]: https://bigcommercecloud.atlassian.net/browse/B2B-5213?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ