### PR TITLE
feat(orders): BACK-660 Render backorder prompt for reorder/add to shopping list

### DIFF
--- a/apps/storefront/src/pages/OrderDetail/components/OrderCheckboxProduct.tsx
+++ b/apps/storefront/src/pages/OrderDetail/components/OrderCheckboxProduct.tsx
@@ -5,13 +5,19 @@ import BackorderMessage from '@/components/BackorderMessage';
 import { PRODUCT_DEFAULT_IMAGE } from '@/constants';
 import { useMobile } from '@/hooks/useMobile';
 import { useB3Lang } from '@/lib/lang';
-import type { CatalogQuickVariantSku } from '@/shared/service/b2b/graphql/product';
+import type { CatalogQuickVariantSku, ProductSearch } from '@/shared/service/b2b/graphql/product';
 import { currencyFormat } from '@/utils/b3CurrencyFormat';
 import { snackbar } from '@/utils/b3Tip';
-import { getCatalogProductRowDisplayState } from '@/utils/catalogBackorderDisplay';
+import type { BackorderDisplayFields } from '@/utils/backorderDisplayFromInventory';
+import {
+  getCatalogBackorderFieldsForPicklistProduct,
+  getCatalogProductRowDisplayState,
+  type PicklistSelection,
+} from '@/utils/catalogBackorderDisplay';
 
 import { EditableProductItem, OrderProductOption } from '../../../types';
 import { formatCurrency } from '../shared/convertOrderDetail';
+import { getOrderPicklistSelections } from '../shared/getOrderPicklistSelections';
 import {
   defaultItemStyle,
   Flex,
@@ -40,7 +46,27 @@ interface OrderCheckboxProductProps {
   showReorderAtsHelper?: boolean;
   /** Order currency code — uses Intl.NumberFormat when provided. */
   currencyCode?: string;
+  picklistProductsById?: Record<number, ProductSearch>;
 }
+
+interface PicklistBackorderRow {
+  selection: PicklistSelection;
+  backorderFields: BackorderDisplayFields;
+}
+
+const getPicklistBackorderRows = (
+  selections: PicklistSelection[],
+  qty: number,
+  picklistProductsById: Record<number, ProductSearch>,
+): PicklistBackorderRow[] =>
+  selections.flatMap((selection) => {
+    const backorderFields = getCatalogBackorderFieldsForPicklistProduct(
+      qty,
+      picklistProductsById[selection.productId],
+    );
+
+    return backorderFields ? [{ selection, backorderFields }] : [];
+  });
 
 export default function OrderCheckboxProduct(props: OrderCheckboxProductProps) {
   const {
@@ -56,6 +82,7 @@ export default function OrderCheckboxProduct(props: OrderCheckboxProductProps) {
     backorderUiEnabled = false,
     showReorderAtsHelper = false,
     currencyCode,
+    picklistProductsById = {},
   } = props;
 
   const b3Lang = useB3Lang();
@@ -220,6 +247,12 @@ export default function OrderCheckboxProduct(props: OrderCheckboxProductProps) {
           backorderUiEnabled,
           formatOnlyAvailable: (count) => b3Lang('orderDetail.reorder.onlyAvailable', { count }),
         });
+        const picklistSelections = usesCatalogBackorderInventory
+          ? getOrderPicklistSelections(product, catalogInventoryBySku ?? {})
+          : [];
+        const picklistBackorderRows = backorderUiEnabled
+          ? getPicklistBackorderRows(picklistSelections, qty, picklistProductsById)
+          : [];
 
         return (
           <Flex
@@ -312,6 +345,29 @@ export default function OrderCheckboxProduct(props: OrderCheckboxProductProps) {
                     />
                   </Box>
                 )}
+                {picklistBackorderRows.map(({ selection, backorderFields: selectionFields }) => (
+                  <Box
+                    key={`${selection.modifierId}-${selection.productId}`}
+                    sx={{
+                      mt: 1,
+                      width: '100%',
+                      maxWidth: '100%',
+                      minWidth: 0,
+                      textAlign,
+                      alignSelf: qtyStackAlignItems,
+                    }}
+                  >
+                    <Typography sx={{ color: '#616161', typography: 'body2' }}>
+                      {`${selection.displayName}:`}
+                    </Typography>
+                    <BackorderMessage
+                      totalOnHand={selectionFields.totalOnHand}
+                      quantityBackordered={selectionFields.quantityBackordered}
+                      backorderMessage={selectionFields.backorderMessage}
+                      visible
+                    />
+                  </Box>
+                ))}
               </Box>
             </FlexItem>
             <FlexItem textAlignLocation={textAlign} padding="10px 0 0" {...itemStyle.default}>

--- a/apps/storefront/src/pages/OrderDetail/components/OrderDialog.test.tsx
+++ b/apps/storefront/src/pages/OrderDetail/components/OrderDialog.test.tsx
@@ -1,0 +1,89 @@
+import {
+  buildCompanyStateWith,
+  buildGlobalStateWith,
+  buildStoreInfoStateWith,
+  renderWithProviders,
+  screen,
+  waitFor,
+} from 'tests/test-utils';
+
+import * as b2bService from '@/shared/service/b2b';
+import { CustomerRole, OrderProductItem } from '@/types';
+
+import OrderDialog from './OrderDialog';
+
+const preloadedState = {
+  company: buildCompanyStateWith({ customer: { role: CustomerRole.B2C } }),
+  storeInfo: buildStoreInfoStateWith('WHATEVER_VALUES'),
+  global: buildGlobalStateWith('WHATEVER_VALUES'),
+};
+
+const dialogData = {
+  dialogTitle: 'Re-Order',
+  type: 'reOrder',
+  description: 'Re-order description',
+  confirmText: 'Re-Order',
+};
+
+const visibleProduct = {
+  id: 1,
+  sku: 'SKU-1',
+  name: 'Test product',
+  quantity: 1,
+  base_price: '10.00',
+  product_options: [],
+  isVisible: true,
+} as unknown as OrderProductItem;
+
+const renderDialog = (props: { open: boolean; products: OrderProductItem[] }) => (
+  <OrderDialog
+    open={props.open}
+    products={props.products}
+    type="reOrder"
+    currentDialogData={dialogData}
+    setOpen={vi.fn()}
+    itemKey="order-summary"
+    orderId={123}
+  />
+);
+
+describe('OrderDialog loading state', () => {
+  it('re-enables the confirm button after closing while inventory is still loading', async () => {
+    vi.spyOn(b2bService, 'getVariantInfoBySkus').mockReturnValue(
+      new Promise(() => {}) as unknown as ReturnType<typeof b2bService.getVariantInfoBySkus>,
+    );
+
+    const { result } = renderWithProviders(
+      renderDialog({ open: false, products: [visibleProduct] }),
+      { preloadedState },
+    );
+
+    result.rerender(renderDialog({ open: true, products: [visibleProduct] }));
+    const confirmButton = await screen.findByRole('button', { name: 'Re-Order' });
+    await waitFor(() => expect(confirmButton).toBeDisabled());
+
+    result.rerender(renderDialog({ open: false, products: [visibleProduct] }));
+    result.rerender(renderDialog({ open: true, products: [] }));
+
+    const reopenedButton = await screen.findByRole('button', { name: 'Re-Order' });
+    await waitFor(() => expect(reopenedButton).toBeEnabled());
+  });
+
+  it('re-enables the confirm button when products change to none while inventory is still loading', async () => {
+    vi.spyOn(b2bService, 'getVariantInfoBySkus').mockReturnValue(
+      new Promise(() => {}) as unknown as ReturnType<typeof b2bService.getVariantInfoBySkus>,
+    );
+
+    const { result } = renderWithProviders(
+      renderDialog({ open: true, products: [visibleProduct] }),
+      { preloadedState },
+    );
+
+    const confirmButton = await screen.findByRole('button', { name: 'Re-Order' });
+    await waitFor(() => expect(confirmButton).toBeDisabled());
+
+    result.rerender(renderDialog({ open: true, products: [] }));
+
+    await waitFor(() => expect(confirmButton).toBeEnabled());
+  });
+});

--- a/apps/storefront/src/pages/OrderDetail/components/OrderDialog.tsx
+++ b/apps/storefront/src/pages/OrderDetail/components/OrderDialog.tsx
@@ -14,12 +14,14 @@ import {
   addProductToBcShoppingList,
   addProductToShoppingList,
   getVariantInfoBySkus,
+  searchProducts,
 } from '@/shared/service/b2b';
 import {
   type CatalogQuickVariantSku,
+  type ProductSearch,
   QUOTE_VALIDATION_ERROR_CODES,
 } from '@/shared/service/b2b/graphql/product';
-import { isB2BUserSelector, useAppSelector } from '@/store';
+import { activeCurrencyInfoSelector, isB2BUserSelector, useAppSelector } from '@/store';
 import b2bLogger from '@/utils/b3Logger';
 import { snackbar } from '@/utils/b3Tip';
 import b3TriggerCartNumber from '@/utils/b3TriggerCartNumber';
@@ -32,6 +34,7 @@ import {
 
 import { EditableProductItem, OrderProductItem } from '../../../types';
 import getReturnFormFields from '../shared/config';
+import { getOrderPicklistSelections } from '../shared/getOrderPicklistSelections';
 
 import CreateShoppingList from './CreateShoppingList';
 import OrderCheckboxProduct from './OrderCheckboxProduct';
@@ -75,6 +78,18 @@ const getXsrfToken = (): string | undefined => {
   return decodeURIComponent(token);
 };
 
+const indexVariantRowsBySku = (
+  rows: CatalogQuickVariantSku[],
+): Record<string, CatalogQuickVariantSku> => {
+  const bySku: Record<string, CatalogQuickVariantSku> = {};
+  rows.forEach((row) => {
+    if (row.variantSku) {
+      bySku[row.variantSku.toUpperCase()] = row;
+    }
+  });
+  return bySku;
+};
+
 const validateProducts = async (products: EditableProductItem[]) => {
   return rawValidateProducts(
     products.map((product) => ({
@@ -107,11 +122,21 @@ export default function OrderDialog({
   const navigate = useNavigate();
   const { isBackorderMessagingContextEnabled: isReorderAtsEnabled, hasAnyBackorderDisplay } =
     useBackorderStorefrontMessaging();
+  const backorderUiEnabled =
+    isReorderAtsEnabled &&
+    hasAnyBackorderDisplay &&
+    (type === 'reOrder' || type === 'shoppingList');
   const isB2BUser = useAppSelector(isB2BUserSelector);
+  const { currency_code: activeCurrencyCode } = useAppSelector(activeCurrencyInfoSelector);
+  const companyInfoId = useAppSelector(({ company }) => company.companyInfo.id);
+  const customerGroupId = useAppSelector(({ company }) => company.customer.customerGroupId);
   const [isOpenCreateShopping, setOpenCreateShopping] = useState(false);
   const [openShoppingList, setOpenShoppingList] = useState(false);
   const [editableProducts, setEditableProducts] = useState<EditableProductItem[]>([]);
   const [variantInfoList, setVariantInfoList] = useState<CatalogQuickVariantSku[]>([]);
+  const [picklistProductsById, setPicklistProductsById] = useState<Record<number, ProductSearch>>(
+    {},
+  );
   const [isRequestLoading, setIsRequestLoading] = useState(false);
   const [checkedArr, setCheckedArr] = useState<number[]>([]);
   const [returnArr, setReturnArr] = useState<ReturnListProps[]>([]);
@@ -511,6 +536,8 @@ export default function OrderDialog({
   useEffect(() => {
     if (!open) {
       setVariantInfoList([]);
+      setPicklistProductsById({});
+      setIsRequestLoading(false);
       return () => {};
     }
 
@@ -522,31 +549,83 @@ export default function OrderDialog({
     );
     setCheckedArr([]);
     setVariantInfoList([]);
+    setPicklistProductsById({});
 
     let cancelled = false;
 
     setReorderValidationBanner(false);
 
-    const getVariantInfoByList = async () => {
+    const loadInventory = async () => {
       const visibleProducts = products.filter((item: OrderProductItem) => item?.isVisible);
 
       const visibleSkus = visibleProducts.map((product) => product.sku);
 
-      if (visibleSkus.length === 0) return;
+      if (visibleSkus.length === 0) {
+        setIsRequestLoading(false);
+        return;
+      }
 
-      const { variantSku: nextVariantInfoList = [] } = await getVariantInfoBySkus(visibleSkus);
+      setIsRequestLoading(true);
 
-      if (!cancelled) {
-        setVariantInfoList(nextVariantInfoList);
+      try {
+        const { variantSku: nextVariantInfoList = [] } = await getVariantInfoBySkus(visibleSkus);
+
+        const nextPicklistProductsById: Record<number, ProductSearch> = {};
+        if (backorderUiEnabled) {
+          const variantRowsBySku = indexVariantRowsBySku(nextVariantInfoList);
+
+          const picklistProductIds = [
+            ...new Set(
+              visibleProducts.flatMap((product) =>
+                getOrderPicklistSelections(product, variantRowsBySku).map(
+                  (selection) => selection.productId,
+                ),
+              ),
+            ),
+          ];
+
+          if (picklistProductIds.length > 0) {
+            try {
+              const { productsSearch = [] } = await searchProducts({
+                productIds: picklistProductIds,
+                currencyCode: activeCurrencyCode,
+                companyId: companyInfoId,
+                customerGroupId,
+              });
+              productsSearch.forEach((product: ProductSearch) => {
+                nextPicklistProductsById[Number(product.id)] = product;
+              });
+            } catch (error) {
+              b2bLogger.error(error);
+            }
+          }
+        }
+
+        if (!cancelled) {
+          setVariantInfoList(nextVariantInfoList);
+          setPicklistProductsById(nextPicklistProductsById);
+        }
+      } finally {
+        if (!cancelled) {
+          setIsRequestLoading(false);
+        }
       }
     };
 
-    getVariantInfoByList();
+    loadInventory();
 
     return () => {
       cancelled = true;
     };
-  }, [isB2BUser, open, products]);
+  }, [
+    isB2BUser,
+    open,
+    products,
+    activeCurrencyCode,
+    companyInfoId,
+    customerGroupId,
+    backorderUiEnabled,
+  ]);
 
   const handleProductChange = (products: EditableProductItem[]) => {
     if (type === 'reOrder') {
@@ -595,13 +674,10 @@ export default function OrderDialog({
             textAlign={isMobile ? 'left' : 'right'}
             type={type}
             catalogInventoryBySku={catalogInventoryBySku}
-            backorderUiEnabled={
-              isReorderAtsEnabled &&
-              hasAnyBackorderDisplay &&
-              (type === 'reOrder' || type === 'shoppingList')
-            }
+            backorderUiEnabled={backorderUiEnabled}
             showReorderAtsHelper={type === 'reOrder' && isReorderAtsEnabled}
             currencyCode={currencyCode}
+            picklistProductsById={picklistProductsById}
           />
 
           {type === 'return' && (

--- a/apps/storefront/src/pages/OrderDetail/index.test.tsx
+++ b/apps/storefront/src/pages/OrderDetail/index.test.tsx
@@ -21,6 +21,7 @@ import {
 } from 'tests/test-utils';
 import { when } from 'vitest-when';
 
+import * as b2bService from '@/shared/service/b2b';
 import { AddressConfig } from '@/shared/service/b2b/graphql/address';
 import {
   CustomerOrderNode,
@@ -4234,6 +4235,224 @@ describe('when a personal customer visits an order', () => {
 
       expect(await screen.findByText('Order Two Product')).toBeVisible();
       expect(screen.queryByText('Order one shipping message')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('when the reordered product is a picklist', () => {
+    const parentSku = 'BUNDLE-PARENT';
+    const modifierId = 113;
+    const optionValueId = 98;
+    const picklistProductId = 113000;
+
+    const backorderPreloadedState = {
+      company: buildCompanyStateWith({
+        customer: {
+          role: CustomerRole.B2C,
+        },
+      }),
+      storeInfo: buildStoreInfoStateWith({ timeFormat: { display: 'j F Y' } }),
+      global: buildGlobalStateWith({
+        backorderEnabled: true,
+        backorderDisplaySettings: {
+          showQuantityOnBackorder: true,
+          showQuantityOnHand: true,
+          showBackorderMessage: true,
+          showDefaultShippingExpectationPrompt: false,
+          defaultShippingExpectationPrompt: '',
+        },
+        featureFlags: {
+          'BACK-134.backorders_phase_1_1_control_messaging_on_storefront': true,
+        },
+      }),
+    };
+
+    const childSku = 'BUNDLE-CHILD';
+
+    function buildPicklistOrderProducts() {
+      const parentProduct = {
+        ...buildProductWith({
+          id: 5,
+          name: 'BUNDLE PARENT',
+          sku: parentSku,
+          quantity: 5,
+          product_options: [
+            buildProductOptionWith({
+              value: String(optionValueId),
+              option_id: 33,
+              display_name: 'Bundle option',
+              display_value: 'Bundle child',
+              product_option_id: modifierId,
+            }),
+          ],
+        }),
+        isVisible: true,
+      };
+
+      const childProduct = {
+        ...buildProductWith({
+          id: 6,
+          name: 'Bundle child',
+          sku: childSku,
+          product_id: picklistProductId,
+          quantity: 5,
+        }),
+        isVisible: true,
+        parent_order_product_id: parentProduct.id,
+      };
+
+      const parentVariantInfo = buildVariantInfoWith({
+        variantSku: parentSku,
+        inventoryTracking: 'variant',
+        availableToSell: 100,
+        unlimitedBackorder: false,
+        modifiers: [
+          {
+            id: modifierId,
+            type: 'product_list',
+            display_name: 'Bundle option',
+            option_values: [{ id: optionValueId, value_data: { product_id: picklistProductId } }],
+          },
+        ],
+      });
+
+      const childLineItemVariantInfo = buildVariantInfoWith({
+        variantSku: childSku,
+        productId: String(picklistProductId),
+        inventoryTracking: 'product',
+        availableToSell: 10,
+        unlimitedBackorder: false,
+        totalOnHand: 7,
+        backorderMessage: 'Line-item row message',
+      });
+
+      const childSearchProduct = {
+        id: picklistProductId,
+        inventoryTracking: 'product',
+        availableToSell: 10,
+        unlimitedBackorder: false,
+        totalOnHand: 3,
+        backorderMessage: 'Restocks in 3 weeks',
+        variants: [],
+      };
+
+      return {
+        parentProduct,
+        childProduct,
+        parentVariantInfo,
+        childLineItemVariantInfo,
+        childSearchProduct,
+      };
+    }
+
+    it('shows the picklist child backorder details nested under the parent product', async () => {
+      const {
+        parentProduct,
+        childProduct,
+        parentVariantInfo,
+        childLineItemVariantInfo,
+        childSearchProduct,
+      } = buildPicklistOrderProducts();
+      const searchProductsSpy = vi.spyOn(b2bService, 'searchProducts');
+
+      server.use(
+        graphql.query('GetCustomerOrderStatuses', () =>
+          HttpResponse.json(buildCustomerOrderStatusesWith('WHATEVER_VALUES')),
+        ),
+        graphql.query('AddressConfig', () =>
+          HttpResponse.json(buildAddressConfigResponseWith('WHATEVER_VALUES')),
+        ),
+        graphql.query('GetCustomerOrder', () =>
+          HttpResponse.json(
+            buildCustomerOrderResponseWith({
+              data: { customerOrder: { products: [parentProduct, childProduct] } },
+            }),
+          ),
+        ),
+        graphql.query('GetVariantInfoBySkus', () =>
+          HttpResponse.json(
+            buildVariantInfoResponseWith({
+              data: { variantSku: [parentVariantInfo, childLineItemVariantInfo] },
+            }),
+          ),
+        ),
+        graphql.query('SearchProducts', () =>
+          HttpResponse.json({ data: { productsSearch: [childSearchProduct] } }),
+        ),
+      );
+
+      renderWithProviders(<OrderDetails />, { preloadedState: backorderPreloadedState });
+
+      await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+      await userEvent.click(screen.getByRole('button', { name: 'Re-Order' }));
+
+      const dialog = await screen.findByRole('dialog', { name: 'Re-Order' });
+      const productGroup = within(dialog).getByRole('group', { name: 'BUNDLE PARENT' });
+
+      expect(await within(productGroup).findByText('Bundle option:')).toBeVisible();
+      expect(within(productGroup).getByText('3 ready to ship')).toBeVisible();
+      expect(within(productGroup).getByText('2 will be backordered')).toBeVisible();
+      expect(within(productGroup).getByText('Restocks in 3 weeks')).toBeVisible();
+      expect(searchProductsSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ productIds: [picklistProductId] }),
+      );
+    });
+
+    it('shows the picklist child backorder details nested under the parent product in the add to shopping list dialog', async () => {
+      const {
+        parentProduct,
+        childProduct,
+        parentVariantInfo,
+        childLineItemVariantInfo,
+        childSearchProduct,
+      } = buildPicklistOrderProducts();
+      const searchProductsSpy = vi.spyOn(b2bService, 'searchProducts');
+
+      server.use(
+        graphql.query('GetCustomerOrderStatuses', () =>
+          HttpResponse.json(buildCustomerOrderStatusesWith('WHATEVER_VALUES')),
+        ),
+        graphql.query('AddressConfig', () =>
+          HttpResponse.json(buildAddressConfigResponseWith('WHATEVER_VALUES')),
+        ),
+        graphql.query('GetCustomerOrder', () =>
+          HttpResponse.json(
+            buildCustomerOrderResponseWith({
+              data: { customerOrder: { products: [parentProduct, childProduct] } },
+            }),
+          ),
+        ),
+        graphql.query('GetVariantInfoBySkus', () =>
+          HttpResponse.json(
+            buildVariantInfoResponseWith({
+              data: { variantSku: [parentVariantInfo, childLineItemVariantInfo] },
+            }),
+          ),
+        ),
+        graphql.query('SearchProducts', () =>
+          HttpResponse.json({ data: { productsSearch: [childSearchProduct] } }),
+        ),
+      );
+
+      renderWithProviders(<OrderDetails />, {
+        preloadedState: backorderPreloadedState,
+        initialGlobalContext: { shoppingListEnabled: true },
+      });
+
+      await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+      await userEvent.click(screen.getByRole('button', { name: 'ADD TO SHOPPING LIST' }));
+
+      const dialog = await screen.findByRole('dialog', { name: 'Add to shopping list' });
+      const productGroup = within(dialog).getByRole('group', { name: 'BUNDLE PARENT' });
+
+      expect(await within(productGroup).findByText('Bundle option:')).toBeVisible();
+      expect(within(productGroup).getByText('3 ready to ship')).toBeVisible();
+      expect(within(productGroup).getByText('2 will be backordered')).toBeVisible();
+      expect(within(productGroup).getByText('Restocks in 3 weeks')).toBeVisible();
+      expect(searchProductsSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ productIds: [picklistProductId] }),
+      );
     });
   });
 });

--- a/apps/storefront/src/pages/OrderDetail/shared/getOrderPicklistSelections.test.ts
+++ b/apps/storefront/src/pages/OrderDetail/shared/getOrderPicklistSelections.test.ts
@@ -1,0 +1,149 @@
+import { builder } from 'tests/test-utils';
+
+import type { CatalogQuickVariantSku } from '@/shared/service/b2b/graphql/product';
+import { OrderProductItem, OrderProductOption } from '@/types';
+
+import { getOrderPicklistSelections } from './getOrderPicklistSelections';
+
+const buildProductOptionWith = builder<OrderProductOption>(() => ({
+  display_name: 'Bundle option',
+  display_name_customer: 'Bundle option',
+  display_name_merchant: 'Bundle option',
+  display_style: '',
+  display_value: 'Bundle child',
+  display_value_customer: 'Bundle child',
+  display_value_merchant: 'Bundle child',
+  id: 1,
+  name: 'Bundle option',
+  option_id: 0,
+  order_product_id: 0,
+  product_option_id: 100,
+  type: 'product_list',
+  value: '200',
+}));
+
+const buildProductWith = builder<OrderProductItem>(() => ({
+  base_price: '10.00',
+  base_total: '10.00',
+  brand: '',
+  configurable_fields: '',
+  cost_price_ex_tax: '0',
+  cost_price_inc_tax: '0',
+  cost_price_tax: '0',
+  id: 1,
+  imageUrl: '',
+  is_bundled_product: false,
+  is_refunded: false,
+  name: 'Product',
+  name_customer: 'Product',
+  name_merchant: 'Product',
+  optionList: [],
+  option_set_id: 0,
+  order_address_id: 1,
+  order_id: 1,
+  parent_order_product_id: 0,
+  price_ex_tax: '10.00',
+  price_inc_tax: '10.00',
+  price_tax: '0',
+  product_id: 1,
+  product_options: [],
+  quantity: 5,
+  quantity_refunded: 0,
+  quantity_shipped: 0,
+  refund_amount: '0',
+  return_id: 0,
+  sku: 'BUNDLE-PARENT',
+  total_ex_tax: '10.00',
+  total_inc_tax: '10.00',
+  total_tax: '0',
+  type: 'physical',
+  variant_id: 1,
+  wrapping_cost_ex_tax: '0',
+  wrapping_cost_inc_tax: '0',
+  wrapping_cost_tax: '0',
+  wrapping_id: 0,
+  wrapping_message: '',
+  wrapping_name: '',
+}));
+
+const picklistModifier = {
+  id: 100,
+  type: 'product_list',
+  display_name: 'Bundle option',
+  option_values: [{ id: 200, value_data: { product_id: 555 } }],
+};
+
+const buildInventoryBySku = (
+  modifiers: unknown[],
+  sku = 'BUNDLE-PARENT',
+): Record<string, CatalogQuickVariantSku> => ({ [sku]: { modifiers } });
+
+describe('getOrderPicklistSelections', () => {
+  it('resolves a picklist selection from the product options and the parent modifier', () => {
+    const product = buildProductWith({
+      product_options: [buildProductOptionWith({ product_option_id: 100, value: '200' })],
+    });
+    const inventoryBySku = buildInventoryBySku([picklistModifier]);
+
+    expect(getOrderPicklistSelections(product, inventoryBySku)).toEqual([
+      { modifierId: 100, displayName: 'Bundle option', productId: 555 },
+    ]);
+  });
+
+  it('matches the parent modifier row case-insensitively by sku', () => {
+    const product = buildProductWith({
+      sku: 'bundle-parent',
+      product_options: [buildProductOptionWith({ product_option_id: 100, value: '200' })],
+    });
+    const inventoryBySku = buildInventoryBySku([picklistModifier], 'BUNDLE-PARENT');
+
+    expect(getOrderPicklistSelections(product, inventoryBySku)).toEqual([
+      { modifierId: 100, displayName: 'Bundle option', productId: 555 },
+    ]);
+  });
+
+  it('returns an empty array when the product has no options', () => {
+    const product = buildProductWith({ product_options: [] });
+    const inventoryBySku = buildInventoryBySku([picklistModifier]);
+
+    expect(getOrderPicklistSelections(product, inventoryBySku)).toEqual([]);
+  });
+
+  it('returns an empty array when the product sku has no catalog inventory row', () => {
+    const product = buildProductWith({
+      product_options: [buildProductOptionWith({ product_option_id: 100, value: '200' })],
+    });
+
+    expect(getOrderPicklistSelections(product, {})).toEqual([]);
+  });
+
+  it('returns an empty array when the referenced modifier is not a picklist', () => {
+    const product = buildProductWith({
+      product_options: [buildProductOptionWith({ product_option_id: 100, value: '200' })],
+    });
+    const inventoryBySku = buildInventoryBySku([{ ...picklistModifier, type: 'dropdown' }]);
+
+    expect(getOrderPicklistSelections(product, inventoryBySku)).toEqual([]);
+  });
+
+  it('resolves selections across multiple picklist modifiers', () => {
+    const secondModifier = {
+      id: 101,
+      type: 'product_list',
+      display_name: 'Second option',
+      option_values: [{ id: 201, value_data: { product_id: 556 } }],
+    };
+    const product = buildProductWith({
+      product_options: [
+        buildProductOptionWith({ product_option_id: 100, value: '200' }),
+        buildProductOptionWith({ product_option_id: 101, value: '201' }),
+      ],
+    });
+    const inventoryBySku = buildInventoryBySku([picklistModifier, secondModifier]);
+
+    expect(getOrderPicklistSelections(product, inventoryBySku)).toEqual([
+      { modifierId: 100, displayName: 'Bundle option', productId: 555 },
+      { modifierId: 101, displayName: 'Second option', productId: 556 },
+    ]);
+  });
+});

--- a/apps/storefront/src/pages/OrderDetail/shared/getOrderPicklistSelections.ts
+++ b/apps/storefront/src/pages/OrderDetail/shared/getOrderPicklistSelections.ts
@@ -1,0 +1,27 @@
+import type { CatalogQuickVariantSku } from '@/shared/service/b2b/graphql/product';
+import { OrderProductItem } from '@/types';
+import {
+  getProductDetailsForPicklistSelections,
+  type PicklistSelection,
+} from '@/utils/catalogBackorderDisplay';
+
+export function getOrderPicklistSelections(
+  product: OrderProductItem,
+  catalogInventoryBySku: Record<string, CatalogQuickVariantSku>,
+): PicklistSelection[] {
+  const optionSelections = (product.product_options || []).map((option) => ({
+    option_id: option.product_option_id,
+    value_id: Number(option.value),
+  }));
+
+  if (optionSelections.length === 0) {
+    return [];
+  }
+
+  const modifiers = catalogInventoryBySku[product.sku.toUpperCase()]?.modifiers;
+
+  return getProductDetailsForPicklistSelections({
+    optionSelections,
+    productsSearch: { modifiers },
+  });
+}


### PR DESCRIPTION
Jira: [BACK-660](https://bigcommercecloud.atlassian.net/browse/BACK-660)

## What/Why?
Display backorder prompts for `re-order`/`add to shopping list` modals.

## Rollout/Rollback
Revert this PR if we encounter issues.

## Testing
Tests added/updated.

Note: it is a known/existing thing that a picklist item is merged with an individual purchase of that item and displays as the picklist child's price.
It is also a known/existing thing that the picklist displays as both in the picklist and as an individual item.

Reorder shows fresh inventory stock information:
<img width="1428" height="863" alt="Screenshot 2026-07-27 at 10 45 50 am" src="https://github.com/user-attachments/assets/d258083b-2f72-4d16-9341-df84f96f8944" />

Add to shopping list shows fresh inventory stock information:
<img width="1484" height="870" alt="Screenshot 2026-07-27 at 10 46 01 am" src="https://github.com/user-attachments/assets/da70823b-a6f5-4da7-8daf-02dfecd88c2b" />

Parent and child picklist without other children:
<img width="915" height="559" alt="Screenshot 2026-07-27 at 10 46 23 am" src="https://github.com/user-attachments/assets/a3e3fcc3-217d-494f-aed7-622889c6c87b" />

Still works when no picklists are present:
<img width="1395" height="717" alt="Screenshot 2026-07-27 at 10 58 42 am" src="https://github.com/user-attachments/assets/6bc26895-36c1-4a05-9337-7d49c594f396" />

ping @bigcommerce/team-b2b @animesh1987 @declankirk 

[BACK-660]: https://bigcommercecloud.atlassian.net/browse/BACK-660?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds async inventory and product-search loading to reorder/shopping-list flows and new picklist backorder calculations; mistakes could mislead users on stock or leave actions disabled, but changes are scoped to storefront messaging UI.
> 
> **Overview**
> **Re-order** and **add to shopping list** dialogs now show backorder messaging (ready to ship, backordered qty, restock message) using live catalog inventory, including for **picklist/bundle** parents where child option inventory is shown nested under the parent row.
> 
> `OrderDialog` loads variant info by SKU and, when backorder UI is enabled, resolves picklist selections and calls **`searchProducts`** for those child product IDs. It passes a `picklistProductsById` map into the product list. Dialog inventory loading was tightened so the confirm action is not stuck disabled when the dialog closes, reopens with no products, or the product list clears while a fetch is still in flight.
> 
> `OrderCheckboxProduct` renders per-picklist-option `BackorderMessage` blocks via `getOrderPicklistSelections` and shared catalog backorder helpers. Tests cover picklist nesting, `searchProducts` usage, dialog loading edge cases, and picklist selection resolution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce4aa046df5f2406cbc7e642a01dd7a771540f03. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->