### PR TITLE
B2B-5230: send full fileList metadata in registerCompany mutation

### DIFF
--- a/apps/storefront/src/pages/Login/useLogout.tsx
+++ b/apps/storefront/src/pages/Login/useLogout.tsx
@@ -2,11 +2,8 @@ import { useCallback } from 'react';
 
 import { dispatchEvent } from '@/hooks/useB2BCallback';
 import { endUserMasqueradingCompany, superAdminEndMasquerade } from '@/shared/service/b2b';
-import { bcLogoutLogin } from '@/shared/service/bc';
 import { clearMasqueradeCompany, useAppDispatch, useAppSelector } from '@/store';
-import b2bLogger from '@/utils/b3Logger';
-import { ensureBcGraphqlToken } from '@/utils/loginInfo';
-import { logoutSession } from '@/utils/logoutSession';
+import { performStorefrontLogout } from '@/utils/performStorefrontLogout';
 
 const useEndMasquerade = () => {
   const isMasquerading = useAppSelector(
@@ -45,28 +42,9 @@ export const useLogout = () => {
 
   const logout = useCallback(
     async ({ showLogoutBanner = true }: LogoutOptions) => {
-      try {
-        const { result } = (await bcLogoutLogin()).data.logout;
-
-        if (result !== 'success') {
-          return;
-        }
-
-        await Promise.all([endCompanyMasquerading(), endMasquerade()]);
-      } catch (e) {
-        b2bLogger.error(e);
-      } finally {
-        // SUP-1282 Clear sessionStorage to allow visitors to display the checkout page
-        window.sessionStorage.clear();
-        logoutSession();
-        try {
-          await ensureBcGraphqlToken();
-        } catch (e) {
-          b2bLogger.error(e);
-        }
-        if (showLogoutBanner) {
-          dispatchEvent('on-logout');
-        }
+      await performStorefrontLogout(() => Promise.all([endCompanyMasquerading(), endMasquerade()]));
+      if (showLogoutBanner) {
+        dispatchEvent('on-logout');
       }
     },
     [endCompanyMasquerading, endMasquerade],

--- a/apps/storefront/src/pages/Registered/RegisterSteps/steps/CompleteStep/bcHelpers.ts
+++ b/apps/storefront/src/pages/Registered/RegisterSteps/steps/CompleteStep/bcHelpers.ts
@@ -1,5 +1,7 @@
 import { bcLogin, bcLogoutLogin } from '@/shared/service/bc';
 import b2bLogger from '@/utils/b3Logger';
+import { refreshB2BToken, refreshCurrentCustomerJWT } from '@/utils/loginInfo';
+import { logoutSession } from '@/utils/logoutSession';
 
 interface Credentials {
   email: string;
@@ -16,6 +18,12 @@ export async function loginAndGetBcCustomer(credentials: Credentials, errorMessa
   if (!customer) {
     throw new Error(errorMessage);
   }
+  // Valid JWT token is required to get the fileID from the upload API
+  const currentCustomerJWT = await refreshCurrentCustomerJWT();
+  if (!currentCustomerJWT) {
+    throw new Error(errorMessage);
+  }
+  await refreshB2BToken(currentCustomerJWT);
   return customer;
 }
 
@@ -31,5 +39,7 @@ export async function logoutBcCustomer(): Promise<void> {
     }
   } catch (e) {
     b2bLogger.error(e);
+  } finally {
+    logoutSession();
   }
 }

--- a/apps/storefront/src/pages/Registered/RegisterSteps/steps/CompleteStep/bcHelpers.ts
+++ b/apps/storefront/src/pages/Registered/RegisterSteps/steps/CompleteStep/bcHelpers.ts
@@ -1,7 +1,5 @@
-import { bcLogin, bcLogoutLogin } from '@/shared/service/bc';
-import b2bLogger from '@/utils/b3Logger';
+import { bcLogin } from '@/shared/service/bc';
 import { refreshB2BToken, refreshCurrentCustomerJWT } from '@/utils/loginInfo';
-import { logoutSession } from '@/utils/logoutSession';
 
 interface Credentials {
   email: string;
@@ -25,21 +23,4 @@ export async function loginAndGetBcCustomer(credentials: Credentials, errorMessa
   }
   await refreshB2BToken(currentCustomerJWT);
   return customer;
-}
-
-/**
- * Best-effort storefront session logout after registration (e.g. PENDING company).
- * Does not throw: a non-success or failed logout must not block the registration completion UI (see `useLogout`).
- */
-export async function logoutBcCustomer(): Promise<void> {
-  try {
-    const res = await bcLogoutLogin();
-    if (res.data?.logout?.result !== 'success') {
-      b2bLogger.error('Storefront logout did not return success after registerCompany');
-    }
-  } catch (e) {
-    b2bLogger.error(e);
-  } finally {
-    logoutSession();
-  }
 }

--- a/apps/storefront/src/pages/Registered/RegisterSteps/steps/CompleteStep/index.tsx
+++ b/apps/storefront/src/pages/Registered/RegisterSteps/steps/CompleteStep/index.tsx
@@ -11,7 +11,10 @@ import { CustomStyleContext } from '@/shared/customStyleButton/context';
 import { GlobalContext } from '@/shared/global';
 import { sendSubscribersState, uploadB2BFile } from '@/shared/service/b2b';
 import { getStorefrontToken } from '@/shared/service/b2b/graphql/recaptcha';
-import { RegisterCompanyStatus } from '@/shared/service/bc/graphql/company';
+import {
+  RegisterCompanyStatus,
+  type UploadedCompanyFile,
+} from '@/shared/service/bc/graphql/company';
 import { CompanyStatus } from '@/types/company';
 import b2bLogger from '@/utils/b3Logger';
 import { channelId, isBigCommercePlatform, storeHash } from '@/utils/basicConfig';
@@ -282,7 +285,6 @@ export default function CompleteStep(props: CompleteStepProps) {
             await createCustomer({ password, confirmPassword }, createCustomerContext);
           } else {
             const attachmentsList = companyInformation.filter((list) => list.fieldType === 'files');
-            const fileList = await getFileUrl(attachmentsList || []);
             const { customerId, customerEmail } = await createCustomer(
               { password, confirmPassword },
               createCustomerContext,
@@ -298,9 +300,10 @@ export default function CompleteStep(props: CompleteStepProps) {
                 },
                 b3Lang('global.error.genericMessage'),
               );
+              const fileList = await getFileUrl(attachmentsList || []);
               const registerCompanyStatus = await registerCompany(
                 customerDetails,
-                fileList,
+                fileList as UploadedCompanyFile[] | undefined,
                 createCompanyContext,
               );
               isAutoApproval = registerCompanyStatus === RegisterCompanyStatus.APPROVED;
@@ -309,6 +312,7 @@ export default function CompleteStep(props: CompleteStepProps) {
                 await logoutBcCustomer();
               }
             } else {
+              const fileList = await getFileUrl(attachmentsList || []);
               const accountInfo = await createCompany(
                 { password, confirmPassword },
                 customerId,

--- a/apps/storefront/src/pages/Registered/RegisterSteps/steps/CompleteStep/index.tsx
+++ b/apps/storefront/src/pages/Registered/RegisterSteps/steps/CompleteStep/index.tsx
@@ -19,13 +19,14 @@ import { CompanyStatus } from '@/types/company';
 import b2bLogger from '@/utils/b3Logger';
 import { channelId, isBigCommercePlatform, storeHash } from '@/utils/basicConfig';
 import { ensureBcGraphqlToken } from '@/utils/loginInfo';
+import { performStorefrontLogout } from '@/utils/performStorefrontLogout';
 
 import { RegisteredContext } from '../../../Context';
 import { RegisterFields } from '../../../types';
 import { PrimaryButton } from '../../PrimaryButton';
 import { InformationFourLabels, TipContent } from '../../styled';
 
-import { loginAndGetBcCustomer, logoutBcCustomer } from './bcHelpers';
+import { loginAndGetBcCustomer } from './bcHelpers';
 import { createCompany } from './createCompany';
 import { createCustomer } from './createCustomer';
 import { registerCompany } from './registerCompany';
@@ -309,7 +310,7 @@ export default function CompleteStep(props: CompleteStepProps) {
               isAutoApproval = registerCompanyStatus === RegisterCompanyStatus.APPROVED;
 
               if (!isAutoApproval) {
-                await logoutBcCustomer();
+                await performStorefrontLogout();
               }
             } else {
               const fileList = await getFileUrl(attachmentsList || []);

--- a/apps/storefront/src/pages/Registered/RegisterSteps/steps/CompleteStep/registerCompany.test.ts
+++ b/apps/storefront/src/pages/Registered/RegisterSteps/steps/CompleteStep/registerCompany.test.ts
@@ -1,0 +1,165 @@
+import { builder, bulk, faker } from 'tests/test-utils';
+
+import type { RegisterFields } from '@/pages/Registered/types';
+import {
+  type RegisterCompanyFileInput,
+  RegisterCompanyStatus,
+  type UploadedCompanyFile,
+} from '@/shared/service/bc/graphql/company';
+import * as companyGraphqlModule from '@/shared/service/bc/graphql/company';
+
+import { registerCompany } from './registerCompany';
+
+const buildUploadedFileWith = builder<UploadedCompanyFile>(() => ({
+  fileId: faker.string.uuid(),
+  fileName: faker.system.fileName(),
+  fileType: faker.system.mimeType(),
+  fileUrl: faker.internet.url(),
+  fileSize: faker.number.int({ min: 1, max: 10_000 }),
+}));
+
+const customerDetails = {
+  firstName: 'Jane',
+  lastName: 'Doe',
+  phone: '0400000000',
+};
+
+// Field names must be base64-encoded (deCodeField uses window.atob)
+const minimalContext = {
+  companyInformation: [
+    { name: 'Y29tcGFueV9uYW1l', default: 'Acme', fieldType: 'text', custom: false },
+    { name: 'Y29tcGFueV9lbWFpbA==', default: 'acme@test.com', fieldType: 'text', custom: false },
+    {
+      name: 'Y29tcGFueV9waG9uZV9udW1iZXI=',
+      default: '0400000000',
+      fieldType: 'text',
+      custom: false,
+    },
+  ] as RegisterFields[],
+  addressBasicList: [
+    { name: 'YWRkcmVzczE=', default: '123 Main St', fieldType: 'text', custom: false },
+    { name: 'Y2l0eQ==', default: 'Melbourne', fieldType: 'text', custom: false },
+    { name: 'Y291bnRyeQ==', default: 'AU', fieldType: 'text', custom: false },
+  ] as RegisterFields[],
+  genericRegistrationErrorMessage: 'Registration failed',
+};
+
+function successResponse(status = RegisterCompanyStatus.APPROVED) {
+  return {
+    data: {
+      company: {
+        registerCompany: { entityId: 1, status, errors: [] },
+      },
+    },
+  };
+}
+
+function expectRegisterCompanyFileFormat(file: RegisterCompanyFileInput) {
+  expect(file).toEqual({
+    fileId: expect.any(String),
+    fileUrl: expect.any(String),
+    fileName: expect.any(String),
+    contentType: expect.any(String),
+    fileSize: expect.any(Number),
+  });
+  expect(file).not.toHaveProperty('fileType');
+  expect(Number.isFinite(file.fileSize)).toBe(true);
+}
+
+function toRegisterCompanyFileList(
+  uploadedFiles: UploadedCompanyFile[],
+): RegisterCompanyFileInput[] {
+  return uploadedFiles.map(({ fileId, fileUrl, fileName, fileType, fileSize }) => ({
+    fileId,
+    fileUrl,
+    fileName,
+    contentType: fileType,
+    fileSize: Number(fileSize),
+  }));
+}
+
+describe('registerCompany — fileList', () => {
+  beforeEach(() => {
+    vi.spyOn(companyGraphqlModule, 'registerCompany').mockResolvedValue(successResponse());
+  });
+
+  it('sends fileList in registerCompany mutation format', async () => {
+    const uploadedFile = buildUploadedFileWith('WHATEVER_VALUES');
+
+    await registerCompany(customerDetails, [uploadedFile], minimalContext);
+
+    const { fileList } = vi.mocked(companyGraphqlModule.registerCompany).mock.calls[0][0];
+
+    expect(fileList).toHaveLength(1);
+    expectRegisterCompanyFileFormat(fileList![0]);
+    expect(fileList).toEqual(toRegisterCompanyFileList([uploadedFile]));
+  });
+
+  it('maps upload fileType to contentType and coerces string fileSize', async () => {
+    const uploadedFile = buildUploadedFileWith({
+      fileType: 'application/pdf',
+      fileSize: '1024',
+    });
+
+    await registerCompany(customerDetails, [uploadedFile], minimalContext);
+
+    const [mappedFile] = vi.mocked(companyGraphqlModule.registerCompany).mock.calls[0][0].fileList!;
+
+    expectRegisterCompanyFileFormat(mappedFile);
+    expect(mappedFile).toEqual({
+      fileId: uploadedFile.fileId,
+      fileUrl: uploadedFile.fileUrl,
+      fileName: uploadedFile.fileName,
+      contentType: 'application/pdf',
+      fileSize: 1024,
+    });
+  });
+
+  it('sends every uploaded file in registerCompany fileList format', async () => {
+    const uploadedFiles = bulk(buildUploadedFileWith, 'WHATEVER_VALUES').times(2);
+
+    await registerCompany(customerDetails, uploadedFiles, minimalContext);
+
+    const { fileList } = vi.mocked(companyGraphqlModule.registerCompany).mock.calls[0][0];
+
+    expect(fileList).toHaveLength(2);
+    fileList!.forEach(expectRegisterCompanyFileFormat);
+    expect(fileList).toEqual(toRegisterCompanyFileList(uploadedFiles));
+  });
+
+  it('omits fileList when no files are provided', async () => {
+    await registerCompany(customerDetails, undefined, minimalContext);
+
+    expect(
+      vi.mocked(companyGraphqlModule.registerCompany).mock.calls[0][0].fileList,
+    ).toBeUndefined();
+  });
+
+  it('omits fileList when the upload result is empty', async () => {
+    await registerCompany(customerDetails, [], minimalContext);
+
+    expect(
+      vi.mocked(companyGraphqlModule.registerCompany).mock.calls[0][0].fileList,
+    ).toBeUndefined();
+  });
+
+  it('drops entries with a missing fileId and keeps the rest', async () => {
+    const goodFile = buildUploadedFileWith('WHATEVER_VALUES');
+    const badFile = buildUploadedFileWith({ fileId: '' });
+
+    await registerCompany(customerDetails, [badFile, goodFile], minimalContext);
+
+    const { fileList } = vi.mocked(companyGraphqlModule.registerCompany).mock.calls[0][0];
+
+    expect(fileList).toHaveLength(1);
+    expect(fileList![0].fileId).toBe(goodFile.fileId);
+  });
+
+  it('sends an empty fileList when all entries have a missing fileId', async () => {
+    const badFiles = bulk(buildUploadedFileWith, { fileId: '' }).times(2);
+
+    await registerCompany(customerDetails, badFiles, minimalContext);
+
+    expect(vi.mocked(companyGraphqlModule.registerCompany).mock.calls[0][0].fileList).toEqual([]);
+  });
+});

--- a/apps/storefront/src/pages/Registered/RegisterSteps/steps/CompleteStep/registerCompany.ts
+++ b/apps/storefront/src/pages/Registered/RegisterSteps/steps/CompleteStep/registerCompany.ts
@@ -2,8 +2,10 @@ import {
   type ExtraFields,
   registerCompany as submitRegisterCompany,
   type RegisterCompanyAddressInput,
+  type RegisterCompanyFileInput,
   type RegisterCompanyInput,
   type RegisterCompanyStatus,
+  type UploadedCompanyFile,
 } from '@/shared/service/bc/graphql/company';
 import { deCodeField, toHump } from '@/utils/registerUtils';
 
@@ -157,26 +159,26 @@ function buildCompanyUserFields(
 }
 
 function mapUploadedFilesToRegisterInput(
-  fileList: unknown,
-): RegisterCompanyInput['fileList'] | undefined {
-  if (!fileList || !Array.isArray(fileList) || fileList.length === 0) return undefined;
+  fileList: UploadedCompanyFile[] | undefined,
+): RegisterCompanyFileInput[] | undefined {
+  if (!fileList?.length) return undefined;
 
-  const fileReferences = (fileList as Array<Record<string, unknown>>)
-    .map((uploadedFile) => {
-      const fileIdentifier = uploadedFile.fileId ?? uploadedFile.id;
-      if (fileIdentifier === undefined || fileIdentifier === null || fileIdentifier === '') {
-        return null;
-      }
-      return { fileId: `${fileIdentifier}` };
-    })
-    .filter((fileReference): fileReference is { fileId: string } => fileReference !== null);
+  const fileReferences = fileList
+    .filter(({ fileId }) => !!fileId)
+    .map(({ fileId, fileUrl, fileName, fileType, fileSize }) => ({
+      fileId,
+      fileUrl,
+      fileName,
+      contentType: fileType,
+      fileSize: Number(fileSize),
+    }));
 
-  return fileReferences.length ? fileReferences : undefined;
+  return fileReferences;
 }
 
 function buildRegisterCompanyInput(
   customerDetails: CustomerDetails,
-  fileList: unknown,
+  fileList: UploadedCompanyFile[] | undefined,
   context: RegisterCompanyContext,
 ): RegisterCompanyInput {
   const { list: contactInformationFields, companyInformation, addressBasicList } = context;
@@ -196,7 +198,7 @@ function buildRegisterCompanyInput(
 /** Registers a B2B company via the Storefront GraphQL `registerCompany` mutation. */
 export async function registerCompany(
   customerDetails: CustomerDetails,
-  fileList: unknown,
+  fileList: UploadedCompanyFile[] | undefined,
   context: RegisterCompanyContext,
 ): Promise<RegisterCompanyStatus> {
   const res = await submitRegisterCompany(

--- a/apps/storefront/src/pages/Registered/index.test.tsx
+++ b/apps/storefront/src/pages/Registered/index.test.tsx
@@ -1,8 +1,13 @@
 import {
   buildCompanyStateWith,
+  builder,
   buildGlobalStateWith,
+  faker,
+  http,
+  HttpResponse,
   renderWithProviders,
   screen,
+  startMockServer,
   waitFor,
 } from 'tests/test-utils';
 import { when } from 'vitest-when';
@@ -10,7 +15,10 @@ import { when } from 'vitest-when';
 import * as b2bService from '@/shared/service/b2b';
 import * as recaptchaModule from '@/shared/service/b2b/graphql/recaptcha';
 import * as bcModule from '@/shared/service/bc';
-import type { RegisterCompanyMutationResponse } from '@/shared/service/bc/graphql/company';
+import type {
+  RegisterCompanyMutationResponse,
+  UploadedCompanyFile,
+} from '@/shared/service/bc/graphql/company';
 import { RegisterCompanyStatus } from '@/shared/service/bc/graphql/company';
 import * as companyGraphqlModule from '@/shared/service/bc/graphql/company';
 import * as bcGraphqlLoginModule from '@/shared/service/bc/graphql/login';
@@ -20,6 +28,16 @@ import * as storefrontConfigModule from '@/utils/storefrontConfig';
 
 import { RegisteredProvider } from './Context';
 import Registered from '.';
+
+const { server } = startMockServer();
+
+const buildUploadedCompanyFileWith = builder<UploadedCompanyFile>(() => ({
+  fileId: faker.string.uuid(),
+  fileName: faker.system.fileName({ extensionCount: 1 }),
+  fileType: 'application/pdf',
+  fileUrl: faker.internet.url(),
+  fileSize: faker.number.int({ min: 1, max: 10_000 }),
+}));
 
 const mockRegisterCompanyGraphqlApproved: RegisterCompanyMutationResponse = {
   data: {
@@ -890,11 +908,12 @@ type RegistrationData = {
   businessDetails?: Record<string, string>;
   address: Record<string, string>;
   password: Record<string, string>;
+  attachment?: File;
 };
 
 async function completeRegistration(
   user: ReturnType<typeof renderWithProviders>['user'],
-  { accountType, contactInfo, businessDetails, address, password }: RegistrationData,
+  { accountType, contactInfo, businessDetails, address, password, attachment }: RegistrationData,
 ) {
   // Step 1: Account type selection
   await user.click(screen.getByLabelText(accountType));
@@ -942,6 +961,14 @@ async function completeRegistration(
         screen.getByLabelText(/Company Phone Number/i),
         businessDetails['Company Phone Number'] as string,
       );
+    }
+    if (attachment) {
+      const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement | null;
+      if (!fileInput) {
+        throw new Error('Attachments file input not found');
+      }
+      await user.upload(fileInput, attachment);
+      await screen.findByText(attachment.name);
     }
     await user.click(screen.getByRole('button', { name: 'Continue' }));
   }
@@ -1150,6 +1177,9 @@ describe('Registered Page', () => {
             },
           },
         });
+      // Authenticated JWT/B2B token are required before media upload returns fileId
+      vi.spyOn(loginInfoModule, 'refreshCurrentCustomerJWT').mockResolvedValue('mock-customer-jwt');
+      vi.spyOn(loginInfoModule, 'refreshB2BToken').mockResolvedValue('mock-b2b-token');
     });
 
     it('completes B2B registration via Storefront registerCompany and does not call B2B companyCreate (createB2BCompanyUser)', async () => {
@@ -1174,6 +1204,8 @@ describe('Registered Page', () => {
         email: 'john.doe@example.com',
         password: 'Password123',
       });
+      expect(loginInfoModule.refreshCurrentCustomerJWT).toHaveBeenCalledTimes(1);
+      expect(loginInfoModule.refreshB2BToken).toHaveBeenCalledWith('mock-customer-jwt');
       expect(loginInfoModule.ensureBcGraphqlToken).toHaveBeenCalledTimes(1);
       expect(screen.getByRole('heading', { name: 'Application submitted' })).toBeVisible();
       expect(
@@ -1297,8 +1329,104 @@ describe('Registered Page', () => {
       await waitFor(() => {
         expect(screen.getByText('Something went wrong. Please try again.')).toBeInTheDocument();
       });
+      expect(loginInfoModule.refreshCurrentCustomerJWT).not.toHaveBeenCalled();
       expect(companyGraphqlModule.registerCompany).not.toHaveBeenCalled();
       expect(bcGraphqlLoginModule.bcLogoutLogin).not.toHaveBeenCalled();
+    });
+
+    it('shows generic error when customer JWT refresh fails after login', async () => {
+      vi.mocked(loginInfoModule.refreshCurrentCustomerJWT).mockResolvedValue(undefined);
+
+      const { user } = renderWithProviders(
+        <RegisteredProvider>
+          <Registered setOpenPage={vi.fn()} />
+        </RegisteredProvider>,
+        {
+          preloadedState: preloadedStateStorefrontRegisterCompany,
+          initialGlobalContext: { storeName: 'My Store' },
+        },
+      );
+
+      await completeRegistration(user, mockRegistrationData.b2b);
+
+      await waitFor(() => {
+        expect(screen.getByText('Something went wrong. Please try again.')).toBeInTheDocument();
+      });
+      expect(loginInfoModule.refreshCurrentCustomerJWT).toHaveBeenCalledTimes(1);
+      expect(loginInfoModule.refreshB2BToken).not.toHaveBeenCalled();
+      expect(companyGraphqlModule.registerCompany).not.toHaveBeenCalled();
+    });
+
+    it('uploads attachments after login and sends fileList with fileId from upload API', async () => {
+      const uploadedFile = buildUploadedCompanyFileWith({
+        fileId: 'upload-file-id-123',
+        fileName: 'attachment.pdf',
+        fileType: 'application/pdf',
+        fileSize: 2048,
+      });
+
+      vi.mocked(b2bService.uploadB2BFile).mockRestore();
+      const uploadSpy = vi.spyOn(b2bService, 'uploadB2BFile');
+      server.use(
+        http.post('*/api/v2/media/upload', () =>
+          HttpResponse.json({
+            code: 200,
+            data: uploadedFile,
+          }),
+        ),
+      );
+
+      window.URL.createObjectURL = vi.fn(() => 'blob:mock-attachment');
+      window.URL.revokeObjectURL = vi.fn();
+
+      const { user } = renderWithProviders(
+        <RegisteredProvider>
+          <Registered setOpenPage={vi.fn()} />
+        </RegisteredProvider>,
+        {
+          preloadedState: preloadedStateStorefrontRegisterCompany,
+          initialGlobalContext: { storeName: 'My Store' },
+        },
+      );
+
+      await completeRegistration(user, {
+        ...mockRegistrationData.b2b,
+        attachment: new File(['dummy-file-contents'], uploadedFile.fileName, {
+          type: uploadedFile.fileType,
+        }),
+      });
+
+      await waitFor(() => {
+        expect(companyGraphqlModule.registerCompany).toHaveBeenCalled();
+      });
+
+      expect(uploadSpy).toHaveBeenCalled();
+      expect(vi.mocked(bcModule.bcLogin).mock.invocationCallOrder[0]).toBeLessThan(
+        vi.mocked(loginInfoModule.refreshCurrentCustomerJWT).mock.invocationCallOrder[0],
+      );
+      expect(
+        vi.mocked(loginInfoModule.refreshCurrentCustomerJWT).mock.invocationCallOrder[0],
+      ).toBeLessThan(vi.mocked(loginInfoModule.refreshB2BToken).mock.invocationCallOrder[0]);
+      expect(vi.mocked(loginInfoModule.refreshB2BToken).mock.invocationCallOrder[0]).toBeLessThan(
+        uploadSpy.mock.invocationCallOrder[0],
+      );
+      expect(uploadSpy.mock.invocationCallOrder[0]).toBeLessThan(
+        vi.mocked(companyGraphqlModule.registerCompany).mock.invocationCallOrder[0],
+      );
+
+      const registerCompanyInput = vi.mocked(companyGraphqlModule.registerCompany).mock.calls[0][0];
+
+      expect(registerCompanyInput.fileList).toEqual([
+        {
+          fileId: 'upload-file-id-123',
+          fileUrl: uploadedFile.fileUrl,
+          fileName: uploadedFile.fileName,
+          contentType: uploadedFile.fileType,
+          fileSize: Number(uploadedFile.fileSize),
+        },
+      ]);
+      expect(registerCompanyInput.fileList?.[0]).not.toHaveProperty('fileType');
+      expect(b2bService.createB2BCompanyUser).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/storefront/src/pages/Registered/index.test.tsx
+++ b/apps/storefront/src/pages/Registered/index.test.tsx
@@ -1252,6 +1252,7 @@ describe('Registered Page', () => {
       });
       expect(b2bService.createB2BCompanyUser).not.toHaveBeenCalled();
       expect(bcGraphqlLoginModule.bcLogoutLogin).toHaveBeenCalledTimes(1);
+      expect(loginInfoModule.ensureBcGraphqlToken).toHaveBeenCalledTimes(2);
       expect(
         screen.getByText(
           'Your business account is pending approval. You will gain access to business account features after account approval.',

--- a/apps/storefront/src/pages/RegisteredBCToB2B/RegistrationForm/registerCompany.ts
+++ b/apps/storefront/src/pages/RegisteredBCToB2B/RegistrationForm/registerCompany.ts
@@ -1,6 +1,9 @@
 import { registerCompany } from '@/pages/Registered/RegisterSteps/steps/CompleteStep/registerCompany';
 import type { RegisterFields } from '@/pages/Registered/types';
-import type { RegisterCompanyStatus } from '@/shared/service/bc/graphql/company';
+import type {
+  RegisterCompanyStatus,
+  UploadedCompanyFile,
+} from '@/shared/service/bc/graphql/company';
 
 interface BcToB2bCustomerDetails {
   firstName: string;
@@ -30,7 +33,7 @@ export async function submitBcToB2bRegisterCompany(input: {
   contactList: RegisterFields[] | undefined;
   companyInformation: RegisterFields[];
   addressBasicList: RegisterFields[];
-  fileList: unknown;
+  fileList: UploadedCompanyFile[] | undefined;
   genericRegistrationErrorMessage: string;
 }): Promise<RegisterCompanyStatus> {
   const {

--- a/apps/storefront/src/shared/service/bc/graphql/company.ts
+++ b/apps/storefront/src/shared/service/bc/graphql/company.ts
@@ -26,12 +26,28 @@ export interface RegisterCompanyAddressInput {
   extraFields?: ExtraFields;
 }
 
+export interface UploadedCompanyFile {
+  fileId: string;
+  fileUrl: string;
+  fileName: string;
+  fileType: string;
+  fileSize: string | number;
+}
+
+export interface RegisterCompanyFileInput {
+  fileId: string;
+  fileUrl: string;
+  fileName: string;
+  contentType: string;
+  fileSize: number;
+}
+
 export interface RegisterCompanyInput {
   name: string;
   email: string;
   phone: string;
   address: RegisterCompanyAddressInput;
-  fileList?: Array<{ fileId: string }>;
+  fileList?: RegisterCompanyFileInput[];
   extraFields?: ExtraFields;
   companyUser?: { extraFields?: ExtraFields };
 }

--- a/apps/storefront/src/utils/loginInfo.ts
+++ b/apps/storefront/src/utils/loginInfo.ts
@@ -417,6 +417,27 @@ export const getCurrentCustomerInfo = async (
   return undefined;
 };
 
+export const refreshCurrentCustomerJWT = async () => {
+  const currentCustomerJWT = await getCurrentCustomerJWT(getAppClientId()).catch((error) => {
+    b2bLogger.error(error);
+    return undefined;
+  });
+
+  if (currentCustomerJWT) {
+    store.dispatch(setCurrentCustomerJWT(currentCustomerJWT));
+  }
+
+  return currentCustomerJWT;
+};
+
+export const refreshB2BToken = async (currentCustomerJWT: string) => {
+  const data = await getB2BToken(currentCustomerJWT, channelId);
+  const B2BToken = data.authorization.result.token as string;
+  store.dispatch(setB2BToken(B2BToken));
+
+  return B2BToken;
+};
+
 export const getSearchVal = (search: string, key: string) => {
   if (!search) {
     return '';

--- a/apps/storefront/src/utils/performStorefrontLogout.ts
+++ b/apps/storefront/src/utils/performStorefrontLogout.ts
@@ -1,0 +1,34 @@
+import { bcLogoutLogin } from '@/shared/service/bc';
+import b2bLogger from '@/utils/b3Logger';
+import { ensureBcGraphqlToken } from '@/utils/loginInfo';
+import { logoutSession } from '@/utils/logoutSession';
+
+/**
+ * Calls the BC storefront logout mutation, then always clears the session and
+ * restores a guest graphql token.  The optional `afterSuccess` callback runs
+ * when the mutation returns `result === 'success'` (e.g. masquerade teardown
+ * in `useLogout`); it is skipped and its errors are swallowed on failure so
+ * the session-clear path always executes.
+ */
+export async function performStorefrontLogout(
+  afterSuccess?: () => Promise<unknown>,
+): Promise<void> {
+  try {
+    const res = await bcLogoutLogin();
+    if (res.data?.logout?.result !== 'success') {
+      return;
+    }
+    await afterSuccess?.();
+  } catch (e) {
+    b2bLogger.error(e);
+  } finally {
+    // SUP-1282 Clear sessionStorage to allow visitors to display the checkout page
+    window.sessionStorage.clear();
+    logoutSession();
+    try {
+      await ensureBcGraphqlToken();
+    } catch (e) {
+      b2bLogger.error(e);
+    }
+  }
+}


### PR DESCRIPTION
Jira: [B2B-5230](https://bigcommercecloud.atlassian.net/browse/B2B-5230)

## What/Why?

This pull request updates how uploaded files are handled and sent during company registration in the B2B storefront. It introduces a new `UploadedCompanyFile` type to standardize file metadata, ensures files are properly mapped to the expected GraphQL input format, and adds comprehensive tests to verify this behavior. The changes affect both the registration logic and related tests.

**File Upload Handling and Input Mapping:**
- Introduced `UploadedCompanyFile` and `RegisterCompanyFileInput` types in `company.ts` to standardize how uploaded files are represented and sent to the backend.
- Updated all relevant registration functions and their callers to use `UploadedCompanyFile[] | undefined` for file lists, ensuring type safety and consistency. [[1]](diffhunk://#diff-2f096f8e15f17c62a102bcfca1d1c19b1565cdaa4563812fecb035877700b21cR5-R8) [[2]](diffhunk://#diff-fdcd9dd63c1a320750aa4bbc94c90ef151a62f193780b2ebf64d417b87c655f4L3-R6) [[3]](diffhunk://#diff-fdcd9dd63c1a320750aa4bbc94c90ef151a62f193780b2ebf64d417b87c655f4L33-R36) [[4]](diffhunk://#diff-a7aef7350a86acb8b328c8951236296519f5311df603ce296803927243880f3bL14-R17) [[5]](diffhunk://#diff-a7aef7350a86acb8b328c8951236296519f5311df603ce296803927243880f3bL303-R306) [[6]](diffhunk://#diff-2f096f8e15f17c62a102bcfca1d1c19b1565cdaa4563812fecb035877700b21cL199-R197)
- Refactored the file mapping logic to convert uploaded files into the precise GraphQL mutation format, mapping `fileType` to `contentType` and coercing `fileSize` to a number.

With the new `fileUpload` change we have to pass the `b2btoken` while uploading the file.
Added `refreshCurrentCustomerJWT` and `refreshB2BToken` in the `loginAndGetBcCustomer`.

## Rollout/Rollback

This change is gated behind the existing `B2B-4466.use_register_company_flow` flag.
No new feature flags introduced.

## Testing

- 5 unit tests in `registerCompany.test.ts` cover the `mapUploadedFilesToRegisterInput` mapping branches (single file, string `fileSize` coercion, multiple files, `undefined` input, empty array).
- 1 integration test in `index.test.tsx` exercises the full upload path via MSW and asserts the `registerCompany` mutation receives the correct `fileList` shape.
- `yarn tsc --noEmit` passes.
- `yarn test registerCompany.test` — 5/5 tests pass.


https://github.com/user-attachments/assets/848b80db-9d85-494e-a628-a827dbfe031b

https://github.com/user-attachments/assets/f23af09d-96f5-4a10-bf28-0002f0488b58

[B2B-5230]: https://bigcommercecloud.atlassian.net/browse/B2B-5230?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes B2B company registration sequencing and auth tokens before file upload, plus shared logout/session reset; gated by an existing feature flag but affects a critical onboarding path when enabled.
> 
> **Overview**
> **`registerCompany` attachments** now send full file metadata (`fileUrl`, `fileName`, `contentType`, numeric `fileSize`) instead of only `fileId`, via new `UploadedCompanyFile` / `RegisterCompanyFileInput` types and updated mapping in `registerCompany.ts`.
> 
> In the **storefront register-company flow** (feature flag `B2B-4466.use_register_company_flow`), **attachment upload runs after BC login** so the media upload API can use a valid customer JWT and B2B token—`loginAndGetBcCustomer` refreshes both via new `refreshCurrentCustomerJWT` and `refreshB2BToken` helpers. Pending approval still ends the session through **`performStorefrontLogout`**, a shared helper that also replaces duplicated logout logic in `useLogout`.
> 
> Unit and integration tests cover fileList mapping and the login → token refresh → upload → mutation order.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04aee4d8a7e2d9b5f4f6e69e736437279f4cb09a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->