### PR TITLE
fix(login): B2B-5343 restrict storefront login to BigCommerce platform only

### DIFF
--- a/apps/storefront/src/hooks/useFeatureFlag.test.ts
+++ b/apps/storefront/src/hooks/useFeatureFlag.test.ts
@@ -1,52 +1,122 @@
 import { buildGlobalStateWith } from 'tests/storeStateBuilders';
 import { renderHookWithProviders } from 'tests/utils/hook-test-utils';
-import { it } from 'vitest';
 
 import type { FeatureFlagKey } from '@/utils/featureFlags';
 
-import { useFeatureFlag } from './useFeatureFlag';
+import {
+  shouldApplyFeatureFlagOnBigCommerce,
+  useFeatureFlag,
+  useShouldApplyFeatureFlagOnBigCommerce,
+} from './useFeatureFlag';
+
+const platformMock = vi.hoisted(() => ({ isBigCommercePlatform: vi.fn(() => true) }));
+
+vi.mock('@/utils/basicConfig', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/utils/basicConfig')>()),
+  isBigCommercePlatform: platformMock.isBigCommercePlatform,
+}));
 
 const TEST_FEATURE_FLAG_KEY = 'B2B-1234.test_feature_flag' as FeatureFlagKey;
 
-it('returns true when the requested flag is enabled', () => {
-  const preloadedState = {
-    global: buildGlobalStateWith({
-      featureFlags: {
-        [TEST_FEATURE_FLAG_KEY]: true,
-      },
-    }),
-  };
+describe('useFeatureFlag', () => {
+  it('returns true when the requested flag is enabled', () => {
+    const preloadedState = {
+      global: buildGlobalStateWith({
+        featureFlags: {
+          [TEST_FEATURE_FLAG_KEY]: true,
+        },
+      }),
+    };
 
-  const { result } = renderHookWithProviders(() => useFeatureFlag(TEST_FEATURE_FLAG_KEY), {
-    preloadedState,
+    const { result } = renderHookWithProviders(() => useFeatureFlag(TEST_FEATURE_FLAG_KEY), {
+      preloadedState,
+    });
+    expect(result.result.current).toBe(true);
   });
-  expect(result.result.current).toBe(true);
+
+  it('defaults to false when the flag key is missing', () => {
+    const preloadedState = {
+      global: buildGlobalStateWith({
+        featureFlags: {},
+      }),
+    };
+
+    const { result } = renderHookWithProviders(() => useFeatureFlag(TEST_FEATURE_FLAG_KEY), {
+      preloadedState,
+    });
+    expect(result.result.current).toBe(false);
+  });
+
+  it('returns false when the flag is explicitly false', () => {
+    const preloadedState = {
+      global: buildGlobalStateWith({
+        featureFlags: {
+          [TEST_FEATURE_FLAG_KEY]: false,
+        },
+      }),
+    };
+
+    const { result } = renderHookWithProviders(() => useFeatureFlag(TEST_FEATURE_FLAG_KEY), {
+      preloadedState,
+    });
+    expect(result.result.current).toBe(false);
+  });
 });
 
-it('defaults to false when the flag key is missing', () => {
-  const preloadedState = {
-    global: buildGlobalStateWith({
-      featureFlags: {},
-    }),
-  };
-
-  const { result } = renderHookWithProviders(() => useFeatureFlag(TEST_FEATURE_FLAG_KEY), {
-    preloadedState,
+describe('shouldApplyFeatureFlagOnBigCommerce', () => {
+  beforeEach(() => {
+    platformMock.isBigCommercePlatform.mockReturnValue(true);
   });
-  expect(result.result.current).toBe(false);
+
+  it('returns true when the flag is on and the platform is Stencil', () => {
+    expect(
+      shouldApplyFeatureFlagOnBigCommerce({ [TEST_FEATURE_FLAG_KEY]: true }, TEST_FEATURE_FLAG_KEY),
+    ).toBe(true);
+  });
+
+  it('returns false when the platform is not bigcommerce even when the flag is on', () => {
+    platformMock.isBigCommercePlatform.mockReturnValue(false);
+
+    expect(
+      shouldApplyFeatureFlagOnBigCommerce({ [TEST_FEATURE_FLAG_KEY]: true }, TEST_FEATURE_FLAG_KEY),
+    ).toBe(false);
+  });
 });
 
-it('returns false when the flag is explicitly false', () => {
-  const preloadedState = {
-    global: buildGlobalStateWith({
-      featureFlags: {
-        [TEST_FEATURE_FLAG_KEY]: false,
-      },
-    }),
-  };
-
-  const { result } = renderHookWithProviders(() => useFeatureFlag(TEST_FEATURE_FLAG_KEY), {
-    preloadedState,
+describe('useShouldApplyFeatureFlagOnBigCommerce', () => {
+  beforeEach(() => {
+    platformMock.isBigCommercePlatform.mockReturnValue(true);
   });
-  expect(result.result.current).toBe(false);
+
+  it('returns true when the flag is on and the platform is Stencil', () => {
+    const { result } = renderHookWithProviders(
+      () => useShouldApplyFeatureFlagOnBigCommerce(TEST_FEATURE_FLAG_KEY),
+      {
+        preloadedState: {
+          global: buildGlobalStateWith({
+            featureFlags: { [TEST_FEATURE_FLAG_KEY]: true },
+          }),
+        },
+      },
+    );
+
+    expect(result.result.current).toBe(true);
+  });
+
+  it('returns false when the platform is not bigcommerce even when the flag is on', () => {
+    platformMock.isBigCommercePlatform.mockReturnValue(false);
+
+    const { result } = renderHookWithProviders(
+      () => useShouldApplyFeatureFlagOnBigCommerce(TEST_FEATURE_FLAG_KEY),
+      {
+        preloadedState: {
+          global: buildGlobalStateWith({
+            featureFlags: { [TEST_FEATURE_FLAG_KEY]: true },
+          }),
+        },
+      },
+    );
+
+    expect(result.result.current).toBe(false);
+  });
 });

--- a/apps/storefront/src/hooks/useFeatureFlag.ts
+++ b/apps/storefront/src/hooks/useFeatureFlag.ts
@@ -1,8 +1,21 @@
 import { useAppSelector } from '@/store';
-import type { FeatureFlagKey } from '@/utils/featureFlags';
+import { isBigCommercePlatform } from '@/utils/basicConfig';
+import type { FeatureFlagKey, FeatureFlags } from '@/utils/featureFlags';
 
 /**
  * Returns whether a single storefront feature flag is enabled (true / false).
  */
 export const useFeatureFlag = (flagKey: FeatureFlagKey): boolean =>
   useAppSelector(({ global }) => global.featureFlags[flagKey] ?? false);
+
+/**
+ * LD may enable a flag for all stores; these helpers gate whether the feature
+ * is actually applied (Stencil only — headless stays on legacy flows).
+ */
+export const useShouldApplyFeatureFlagOnBigCommerce = (flagKey: FeatureFlagKey): boolean =>
+  useFeatureFlag(flagKey) && isBigCommercePlatform();
+
+export const shouldApplyFeatureFlagOnBigCommerce = (
+  featureFlags: FeatureFlags,
+  flagKey: FeatureFlagKey,
+): boolean => (featureFlags[flagKey] ?? false) && isBigCommercePlatform();

--- a/apps/storefront/src/pages/Login/index.test.tsx
+++ b/apps/storefront/src/pages/Login/index.test.tsx
@@ -28,6 +28,13 @@ vi.mock('./useLogout', () => ({
 
 vi.mock('@/utils/loginInfo');
 
+const platformMock = vi.hoisted(() => ({ isBigCommercePlatform: vi.fn(() => true) }));
+
+vi.mock('@/utils/basicConfig', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/utils/basicConfig')>()),
+  isBigCommercePlatform: platformMock.isBigCommercePlatform,
+}));
+
 // The BC-first login flow logs failures via b2bLogger (console.error), which
 // fails the suite under CI's fail-on-console rule — mock it out.
 vi.mock('@/utils/b3Logger');
@@ -51,6 +58,7 @@ const renderLoginPage = (options: Parameters<typeof renderWithProviders>[1] = {}
 
 describe('LoginPage', () => {
   beforeEach(() => {
+    platformMock.isBigCommercePlatform.mockReturnValue(true);
     vi.spyOn(snackbar, 'error');
   });
 
@@ -335,6 +343,43 @@ describe('LoginPage', () => {
         return utils;
       })();
     };
+
+    it('falls back to the legacy B2B login mutation when the platform is not bigcommerce even if the flag is on', async () => {
+      platformMock.isBigCommercePlatform.mockReturnValue(false);
+
+      server.use(
+        graphql.mutation('Login', () =>
+          HttpResponse.json({
+            data: {
+              login: {
+                result: {
+                  storefrontLoginToken: '456',
+                  token: '123',
+                  permissions: [{ code: '1', permissionLevel: 1 }],
+                },
+              },
+            },
+          }),
+        ),
+
+        // If the test passes without hitting this URL, it means the legacy B2B login mutation was used.
+        http.get(CURRENT_JWT_URL, () => {
+          throw new Error('current.jwt must not be requested when the platform is not bigcommerce');
+        }),
+      );
+
+      vi.mocked(getCurrentCustomerInfo).mockResolvedValue({
+        userType: 5,
+        role: 2,
+        companyRoleName: 'Junior Buyer',
+      });
+
+      const { navigation } = await renderBcFirstLoginAndSubmit();
+
+      await waitFor(() => {
+        expect(navigation).toHaveBeenCalledWith(expect.stringContaining('/shoppingLists'));
+      });
+    });
 
     it('stops at BC login and shows the incorrect-account error when credentials are invalid', async () => {
       // BC returns invalid-credentials as HTTP 200 with a populated `errors` array.

--- a/apps/storefront/src/pages/Login/index.tsx
+++ b/apps/storefront/src/pages/Login/index.tsx
@@ -6,7 +6,7 @@ import { B3Card } from '@/components/B3Card';
 import B3Spin from '@/components/spin/B3Spin';
 import { CHECKOUT_URL } from '@/constants';
 import { dispatchEvent } from '@/hooks/useB2BCallback';
-import { useFeatureFlag } from '@/hooks/useFeatureFlag';
+import { useShouldApplyFeatureFlagOnBigCommerce } from '@/hooks/useFeatureFlag';
 import { useMobile } from '@/hooks/useMobile';
 import { useB3Lang } from '@/lib/lang';
 import { CustomStyleContext } from '@/shared/customStyleButton';
@@ -52,7 +52,9 @@ function Login(props: PageProps) {
 
   const isLoggedIn = useAppSelector(isLoggedInSelector);
 
-  const useBcLoginAndAuthorisation = useFeatureFlag('PROJECT-7920.use_bc_login_and_authorisation');
+  const isBcLoginAndAuthorisation = useShouldApplyFeatureFlagOnBigCommerce(
+    'PROJECT-7920.use_bc_login_and_authorisation',
+  );
 
   const quoteDetailToCheckoutUrl = useAppSelector(
     ({ quoteInfo }) => quoteInfo.quoteDetailToCheckoutUrl,
@@ -208,7 +210,7 @@ function Login(props: PageProps) {
     await finishLoginAndNavigate(B2BToken);
   };
 
-  // Legacy flow (useBcLoginAndAuthorisation = false): the B2B login mutation
+  // Legacy flow (isBcLoginAndAuthorisation = false): the B2B login mutation
   // returns the B2B token and a storefront login token in a single call.
   const loginWithLegacyB2BMutation = async (data: LoginConfig) => {
     const { token, storefrontLoginToken, errors } = await performB2BLogin(data);
@@ -251,7 +253,7 @@ function Login(props: PageProps) {
         return;
       }
 
-      if (useBcLoginAndAuthorisation) {
+      if (isBcLoginAndAuthorisation) {
         await loginWithBcAuthorization(data.email, bcErrors);
       } else {
         await loginWithLegacyB2BMutation(data);
@@ -261,7 +263,7 @@ function Login(props: PageProps) {
         snackbar.error(b3Lang(COMPANY_STATUS_MAPPINGS[error.reason]));
         await logout({ showLogoutBanner: false });
       } else if (
-        useBcLoginAndAuthorisation &&
+        isBcLoginAndAuthorisation &&
         error instanceof Error &&
         error.message === 'Operation cannot be performed as the storefront channel is not live'
       ) {

--- a/apps/storefront/src/utils/loginInfo.test.ts
+++ b/apps/storefront/src/utils/loginInfo.test.ts
@@ -11,6 +11,13 @@ import { CompanyError } from '@/utils/companyUtils';
 import b2bLogger from './b3Logger';
 import { ensureBcGraphqlToken, getCurrentCustomerInfo } from './loginInfo';
 
+const platformMock = vi.hoisted(() => ({ isBigCommercePlatform: vi.fn(() => true) }));
+
+vi.mock('./basicConfig', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('./basicConfig')>()),
+  isBigCommercePlatform: platformMock.isBigCommercePlatform,
+}));
+
 const { server } = startMockServer();
 
 const BC_AUTH_FLAG = 'PROJECT-7920.use_bc_login_and_authorisation';
@@ -68,6 +75,7 @@ const stubServices = () => {
 
 describe('getCurrentCustomerInfo permissions source', () => {
   beforeEach(() => {
+    platformMock.isBigCommercePlatform.mockReturnValue(true);
     vi.spyOn(store, 'dispatch').mockImplementation(() => undefined as never);
     vi.spyOn(b2bLogger, 'error').mockImplementation(() => undefined);
     stubServices();
@@ -176,6 +184,57 @@ describe('getCurrentCustomerInfo company error during token exchange', () => {
     await expect(getCurrentCustomerInfo()).rejects.toBeInstanceOf(CompanyError);
 
     expect(snackbar.error).not.toHaveBeenCalled();
+  });
+});
+
+describe('getCurrentCustomerInfo when the platform is not bigcommerce', () => {
+  beforeEach(() => {
+    platformMock.isBigCommercePlatform.mockReturnValue(false);
+    vi.spyOn(store, 'dispatch').mockImplementation(() => undefined as never);
+    vi.spyOn(b2bLogger, 'error').mockImplementation(() => undefined);
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    stubServices();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('sources permissions from the customer-info query even when the BC login flag is on', async () => {
+    mockState({ [BC_AUTH_FLAG]: true, [COMBINED_QUERY_FLAG]: true });
+
+    vi.spyOn(b2bService, 'getB2BCompanyUserInfo').mockResolvedValue({
+      customerInfo: {
+        userType: UserTypes.MULTIPLE_B2C,
+        userInfo: { role: CustomerRole.SENIOR_BUYER, id: 456, companyRoleName: 'Senior Buyer' },
+        permissions: QUERY_PERMISSIONS,
+      },
+    } as never);
+
+    await getCurrentCustomerInfo();
+
+    expect(b2bService.getB2BCompanyUserInfo).toHaveBeenCalledWith(false);
+    expect(b2bService.b2bAuthorization).not.toHaveBeenCalled();
+    expect(store.dispatch).toHaveBeenCalledWith(setPermissionModules(QUERY_PERMISSIONS));
+  });
+
+  it('requests legacy auth fields during JWT init even when the BC login flag is on', async () => {
+    vi.spyOn(store, 'getState').mockReturnValue({
+      company: { tokens: { B2BToken: '', currentCustomerJWT: '' } },
+      global: { featureFlags: { [BC_AUTH_FLAG]: true, [COMBINED_QUERY_FLAG]: true } },
+    } as unknown as ReturnType<typeof store.getState>);
+
+    const getB2BTokenSpy = vi.spyOn(b2bService, 'getB2BToken').mockResolvedValue({
+      authorization: {
+        result: { token: 'b2b-token', loginType: 1, permissions: QUERY_PERMISSIONS },
+      },
+    } as never);
+    vi.spyOn(bcService, 'getCurrentCustomerJWT').mockResolvedValue('new-jwt');
+
+    await getCurrentCustomerInfo();
+
+    expect(getB2BTokenSpy).toHaveBeenCalledWith('new-jwt', expect.any(Number), true);
+    expect(store.dispatch).toHaveBeenCalledWith(setPermissionModules(QUERY_PERMISSIONS));
   });
 });
 

--- a/apps/storefront/src/utils/loginInfo.ts
+++ b/apps/storefront/src/utils/loginInfo.ts
@@ -1,3 +1,4 @@
+import { shouldApplyFeatureFlagOnBigCommerce } from '@/hooks/useFeatureFlag';
 import {
   b2bAuthorization,
   endUserMasqueradingCompany,
@@ -216,8 +217,10 @@ const loginWithCurrentCustomerJWT = async () => {
    * getB2BToken which fields to request and only read/dispatch them when the
    * flag is off.
    */
-  const useBcLoginAndAuthorisation =
-    store.getState().global.featureFlags['PROJECT-7920.use_bc_login_and_authorisation'] ?? false;
+  const useBcLoginAndAuthorisation = shouldApplyFeatureFlagOnBigCommerce(
+    store.getState().global.featureFlags,
+    'PROJECT-7920.use_bc_login_and_authorisation',
+  );
 
   const data = await getB2BToken(currentCustomerJWT, channelId, !useBcLoginAndAuthorisation).catch(
     (error) => {
@@ -276,8 +279,10 @@ export const getCurrentCustomerInfo = async (
 
   try {
     const { featureFlags } = store.getState().global;
-    const useBcLoginAndAuthorisation =
-      featureFlags['PROJECT-7920.use_bc_login_and_authorisation'] ?? false;
+    const useBcLoginAndAuthorisation = shouldApplyFeatureFlagOnBigCommerce(
+      featureFlags,
+      'PROJECT-7920.use_bc_login_and_authorisation',
+    );
 
     const data = await getCustomerInfo();
 


### PR DESCRIPTION
Jira: [B2B-5343](https://bigcommercecloud.atlassian.net/browse/B2B-5343)

## What/Why?
From [slack discussion](https://bigcommerce.slack.com/archives/C079AR329M2/p1784532226452349), the unified storefront flow only works when platform is `bigcommerce`. In PR https://github.com/bigcommerce/b2b-buyer-portal/pull/971, we've restricted storefront registerCompany to BigCommerce platform only. So b2b-buyer-portal on a catalyst store falls back to the existing `createB2BCompanyUser` B2B API path.

Same here, we have to restrict the storefront login and authorisation flow to `bigcommerce` platform only.

**Solution**
Introduce platform-aware flag helpers that combine the LD flag and isBigCommercePlatform():

- shouldApplyFeatureFlagOnBigCommerce(featureFlags, flagKey) — pure function for non-React code (loginInfo.ts)

- useShouldApplyFeatureFlagOnBigCommerce(flagKey) — React hook for components (Login/index.tsx)

These return true only when the flag is on and the storefront is Stencil. On headless, the legacy flow are used instead.

## Rollout/Rollback
Revert if needed

## Testing
Test plan

- [x] Unit tests: useFeatureFlag.test.ts, loginInfo.test.ts, Login/index.test.tsx
- [ ] Manual: Catalyst + flag on — login succeeds, nav items visible (not just Account Settings)
- [ ] Manual: Stencil + flag on — BC-first login still works end-to-end
- [ ] Manual: Stencil + flag off — legacy B2B login mutation still works
- [ ] Manual: Refresh while logged in on Catalyst + flag on — permissions persist

[B2B-5343]: https://bigcommercecloud.atlassian.net/browse/B2B-5343?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes authentication and permission loading paths for headless when the BC login flag is on; incorrect gating could break Catalyst login or nav permissions, but scope is limited to one flag and mirrors an existing register flow pattern.
> 
> **Overview**
> The BC-first login and authorisation path (`PROJECT-7920.use_bc_login_and_authorisation`) now runs only when LaunchDarkly has the flag on **and** the storefront is BigCommerce (Stencil). Headless/Catalyst stores keep the legacy B2B login mutation and permission sourcing even if LD enables the flag globally—matching the earlier register-company platform gate.
> 
> **Helpers:** `shouldApplyFeatureFlagOnBigCommerce` (non-React) and `useShouldApplyFeatureFlagOnBigCommerce` (components) combine the flag with `isBigCommercePlatform()`. Login UI and `loginInfo` JWT init / `getCurrentCustomerInfo` use these instead of reading the raw flag.
> 
> **Tests** cover platform-off behavior for login fallback, permissions from the customer-info query, and legacy `getB2BToken` field requests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6fd7bbb20df8738ac49b881f4f07a41e4e31619. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->