### PR TITLE
refactor(register): B2B-5401 reduce handleCompleted complexity in CompleteStep

### DIFF
--- a/apps/storefront/src/pages/Registered/RegisterSteps/steps/CompleteStep/createCustomer.ts
+++ b/apps/storefront/src/pages/Registered/RegisterSteps/steps/CompleteStep/createCustomer.ts
@@ -2,7 +2,7 @@ import { createBCCompanyUser } from '@/shared/service/b2b';
 import { channelId, storeHash } from '@/utils/basicConfig';
 import { deCodeField } from '@/utils/registerUtils';
 
-import type { RegisterFields } from '../../../types';
+import { RegisterAccountType, type RegisterFields } from '../../../types';
 
 interface CreateCustomerContext {
   emailMarketingNewsletter?: boolean;
@@ -62,7 +62,7 @@ export function createCustomer(
   bcFields.origin_channel_id = channelId;
   bcFields.channel_ids = [channelId];
 
-  if (accountType === '2') {
+  if (accountType === RegisterAccountType.PERSONAL) {
     const addresses: CustomFieldItems = {};
 
     const getBCAddressField = addressBasicList.filter((field: RegisterFields) => !field.custom);

--- a/apps/storefront/src/pages/Registered/RegisterSteps/steps/CompleteStep/index.tsx
+++ b/apps/storefront/src/pages/Registered/RegisterSteps/steps/CompleteStep/index.tsx
@@ -22,7 +22,7 @@ import { ensureBcGraphqlToken } from '@/utils/loginInfo';
 import { performStorefrontLogout } from '@/utils/performStorefrontLogout';
 
 import { RegisteredContext } from '../../../Context';
-import { RegisterFields } from '../../../types';
+import { RegisterAccountType, RegisterFields } from '../../../types';
 import { PrimaryButton } from '../../PrimaryButton';
 import { InformationFourLabels, TipContent } from '../../styled';
 
@@ -37,6 +37,11 @@ interface CompleteStepProps {
 }
 
 type CompleteStepList = Array<RegisterFields> | undefined;
+
+type PasswordCredentials = {
+  password: string;
+  confirmPassword: string;
+};
 
 export default function CompleteStep(props: CompleteStepProps) {
   const b3Lang = useB3Lang();
@@ -111,16 +116,18 @@ export default function CompleteStep(props: CompleteStepProps) {
     emailMarketingNewsletter,
   } = state;
 
-  const list: CompleteStepList = accountType === '1' ? contactInformation : bcContactInformation;
+  const list: CompleteStepList =
+    accountType === RegisterAccountType.BUSINESS ? contactInformation : bcContactInformation;
   const passwordInfo: CompleteStepList =
-    accountType === '1' ? passwordInformation : bcPasswordInformation;
+    accountType === RegisterAccountType.BUSINESS ? passwordInformation : bcPasswordInformation;
 
   const passwordName = passwordInfo[0]?.groupName || '';
 
   const additionalInfo: CompleteStepList =
-    accountType === '1' ? additionalInformation : bcAdditionalInformation;
+    accountType === RegisterAccountType.BUSINESS ? additionalInformation : bcAdditionalInformation;
 
-  const addressBasicList = accountType === '1' ? addressBasicFields : bcAddressBasicFields;
+  const addressBasicList =
+    accountType === RegisterAccountType.BUSINESS ? addressBasicFields : bcAddressBasicFields;
 
   const createCustomerContext = {
     emailMarketingNewsletter,
@@ -200,7 +207,7 @@ export default function CompleteStep(props: CompleteStepProps) {
   const saveRegisterPassword = (data: CustomFieldItems) => {
     const newPasswordInformation = passwordInformation.map((field: RegisterFields) => {
       const registerField = field;
-      if (accountType === '1') {
+      if (accountType === RegisterAccountType.BUSINESS) {
         registerField.default = data[field.name] ?? field.default;
       }
       return field;
@@ -208,7 +215,7 @@ export default function CompleteStep(props: CompleteStepProps) {
 
     const newBcPasswordInformation = bcPasswordInformation.map((field: RegisterFields) => {
       const registerField = field;
-      if (accountType === '2') {
+      if (accountType === RegisterAccountType.PERSONAL) {
         registerField.default = data[field.name] ?? field.default;
       }
 
@@ -253,17 +260,86 @@ export default function CompleteStep(props: CompleteStepProps) {
     }
   };
 
+  // Personal accounts are always auto-approved
+  const registerPersonalAccount = async (credentials: PasswordCredentials): Promise<boolean> => {
+    await createCustomer(credentials, createCustomerContext);
+
+    return true;
+  };
+
+  const registerViaCompanyFlow = async (
+    customerEmail: string,
+    password: string,
+    attachmentFields: RegisterFields[],
+  ): Promise<boolean> => {
+    await ensureBcGraphqlToken();
+
+    const customerDetails = await loginAndGetBcCustomer(
+      {
+        email: customerEmail,
+        password,
+      },
+      b3Lang('global.error.genericMessage'),
+    );
+    const fileList = await getFileUrl(attachmentFields || []);
+    const registerCompanyStatus = await registerCompany(
+      customerDetails,
+      fileList as UploadedCompanyFile[] | undefined,
+      createCompanyContext,
+    );
+    const isAutoApproval = registerCompanyStatus === RegisterCompanyStatus.APPROVED;
+
+    if (!isAutoApproval) {
+      await performStorefrontLogout();
+    }
+
+    return isAutoApproval;
+  };
+
+  const registerViaLegacyFlow = async (
+    credentials: PasswordCredentials,
+    customerId: number,
+    customerEmail: string,
+    attachmentFields: RegisterFields[],
+  ): Promise<boolean> => {
+    const fileList = await getFileUrl(attachmentFields || []);
+    const accountInfo = await createCompany(
+      credentials,
+      customerId,
+      customerEmail,
+      fileList,
+      createCompanyContext,
+    );
+
+    const companyStatus = accountInfo?.companyCreate?.company?.companyStatus || '';
+
+    return Number(companyStatus) === CompanyStatus.APPROVED;
+  };
+
+  const registerBusinessAccount = async (credentials: PasswordCredentials): Promise<boolean> => {
+    const attachmentFields = companyInformation.filter((field) => field.fieldType === 'files');
+    const { customerId, customerEmail } = await createCustomer(credentials, createCustomerContext);
+
+    if (isRegisterCompanyFlowEnabled && isBigCommercePlatform()) {
+      return registerViaCompanyFlow(customerEmail, credentials.password, attachmentFields);
+    }
+
+    return registerViaLegacyFlow(credentials, customerId, customerEmail, attachmentFields);
+  };
+
+  const validatePasswordsMatch = (password: string, confirmPassword: string): boolean => {
+    if (password === confirmPassword) return true;
+
+    const message = b3Lang('global.registerComplete.passwordMatchPrompt');
+    setError('confirmPassword', { type: 'manual', message });
+    setError('password', { type: 'manual', message });
+
+    return false;
+  };
+
   const handleCompleted = (event: MouseEvent) => {
     handleSubmit(async ({ password, confirmPassword }: CustomFieldItems) => {
-      if (password !== confirmPassword) {
-        setError('confirmPassword', {
-          type: 'manual',
-          message: b3Lang('global.registerComplete.passwordMatchPrompt'),
-        });
-        setError('password', {
-          type: 'manual',
-          message: b3Lang('global.registerComplete.passwordMatchPrompt'),
-        });
+      if (!validatePasswordsMatch(password, confirmPassword)) {
         return;
       }
 
@@ -272,81 +348,29 @@ export default function CompleteStep(props: CompleteStepProps) {
         return;
       }
 
-      if (!isCaptchaMissing) {
-        try {
-          dispatch({
-            type: 'loading',
-            payload: {
-              isLoading: true,
-            },
-          });
+      if (isCaptchaMissing) {
+        return;
+      }
 
-          let isAutoApproval = true;
-          if (accountType === '2') {
-            await createCustomer({ password, confirmPassword }, createCustomerContext);
-          } else {
-            const attachmentsList = companyInformation.filter((list) => list.fieldType === 'files');
-            const { customerId, customerEmail } = await createCustomer(
-              { password, confirmPassword },
-              createCustomerContext,
-            );
+      try {
+        dispatch({ type: 'loading', payload: { isLoading: true } });
 
-            if (isRegisterCompanyFlowEnabled && isBigCommercePlatform()) {
-              await ensureBcGraphqlToken();
+        const isAutoApproval =
+          accountType === RegisterAccountType.PERSONAL
+            ? await registerPersonalAccount({ password, confirmPassword })
+            : await registerBusinessAccount({ password, confirmPassword });
 
-              const customerDetails = await loginAndGetBcCustomer(
-                {
-                  email: customerEmail,
-                  password,
-                },
-                b3Lang('global.error.genericMessage'),
-              );
-              const fileList = await getFileUrl(attachmentsList || []);
-              const registerCompanyStatus = await registerCompany(
-                customerDetails,
-                fileList as UploadedCompanyFile[] | undefined,
-                createCompanyContext,
-              );
-              isAutoApproval = registerCompanyStatus === RegisterCompanyStatus.APPROVED;
-
-              if (!isAutoApproval) {
-                await performStorefrontLogout();
-              }
-            } else {
-              const fileList = await getFileUrl(attachmentsList || []);
-              const accountInfo = await createCompany(
-                { password, confirmPassword },
-                customerId,
-                customerEmail,
-                fileList,
-                createCompanyContext,
-              );
-
-              const companyStatus = accountInfo?.companyCreate?.company?.companyStatus || '';
-              isAutoApproval = Number(companyStatus) === CompanyStatus.APPROVED;
-            }
-          }
-          dispatch({
-            type: 'finishInfo',
-            payload: {
-              submitSuccess: true,
-              isAutoApproval,
-              blockPendingAccountOrderCreation,
-            },
-          });
-          saveRegisterPassword({ password, confirmPassword });
-          await handleSendSubscribersState();
-          handleNext(password);
-        } catch (err: unknown) {
-          setErrorMessage(err instanceof Error ? err.message : String(err));
-        } finally {
-          dispatch({
-            type: 'loading',
-            payload: {
-              isLoading: false,
-            },
-          });
-        }
+        dispatch({
+          type: 'finishInfo',
+          payload: { submitSuccess: true, isAutoApproval, blockPendingAccountOrderCreation },
+        });
+        saveRegisterPassword({ password, confirmPassword });
+        await handleSendSubscribersState();
+        handleNext(password);
+      } catch (err: unknown) {
+        setErrorMessage(err instanceof Error ? err.message : String(err));
+      } finally {
+        dispatch({ type: 'loading', payload: { isLoading: false } });
       }
     })(event);
   };

--- a/apps/storefront/src/pages/Registered/index.test.tsx
+++ b/apps/storefront/src/pages/Registered/index.test.tsx
@@ -906,14 +906,15 @@ type RegistrationData = {
   accountType: string;
   contactInfo: Record<string, string | boolean>;
   businessDetails?: Record<string, string>;
+  /** Files dropped onto the `field_attachments` dropzone in the Business Details step. */
+  attachments?: File[];
   address: Record<string, string>;
   password: Record<string, string>;
-  attachment?: File;
 };
 
 async function completeRegistration(
   user: ReturnType<typeof renderWithProviders>['user'],
-  { accountType, contactInfo, businessDetails, address, password, attachment }: RegistrationData,
+  { accountType, contactInfo, businessDetails, attachments, address, password }: RegistrationData,
 ) {
   // Step 1: Account type selection
   await user.click(screen.getByLabelText(accountType));
@@ -962,13 +963,14 @@ async function completeRegistration(
         businessDetails['Company Phone Number'] as string,
       );
     }
-    if (attachment) {
-      const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement | null;
-      if (!fileInput) {
-        throw new Error('Attachments file input not found');
-      }
-      await user.upload(fileInput, attachment);
-      await screen.findByText(attachment.name);
+    if (attachments?.length) {
+      // The `field_attachments` dropzone renders a bare file input with no accessible name.
+      const fileInput = document.querySelector<HTMLInputElement>('input[type="file"]');
+      if (!fileInput) throw new Error('Expected an attachments file input in Business Details');
+      await user.upload(fileInput, attachments);
+      // The dropzone reads each file asynchronously before it calls `setValue`, so wait for
+      // the previews to render — otherwise Continue can fire before the field is populated.
+      await Promise.all(attachments.map((file) => screen.findByText(file.name)));
     }
     await user.click(screen.getByRole('button', { name: 'Continue' }));
   }
@@ -1133,6 +1135,61 @@ describe('Registered Page', () => {
     });
   });
 
+  it('does not register and flags both password fields when the passwords do not match', async () => {
+    const { user } = renderWithProviders(
+      <RegisteredProvider>
+        <Registered setOpenPage={vi.fn()} />
+      </RegisteredProvider>,
+      { preloadedState: preloadedStateB2bCompanyCreate },
+    );
+
+    await completeRegistration(user, {
+      ...mockRegistrationData.b2c,
+      businessDetails: undefined,
+      password: {
+        'Create Password': 'Password123',
+        'Confirm Password': 'DifferentPassword456',
+      },
+    });
+
+    // The error is set on both `confirmPassword` and `password`, so it renders twice.
+    expect(await screen.findAllByText('Your passwords do not match.')).toHaveLength(2);
+
+    // Submission is aborted before any account is created.
+    expect(b2bService.createBCCompanyUser).not.toHaveBeenCalled();
+    expect(b2bService.createB2BCompanyUser).not.toHaveBeenCalled();
+    expect(companyGraphqlModule.registerCompany).not.toHaveBeenCalled();
+    expect(
+      screen.queryByRole('heading', { name: 'Registration complete!' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('blocks submission with a missing-captcha message when storefront captcha is unsolved', async () => {
+    vi.spyOn(recaptchaModule, 'getStorefrontToken').mockResolvedValue({
+      isEnabledOnStorefront: true,
+      siteKey: 'test-site-key',
+    });
+
+    const { user } = renderWithProviders(
+      <RegisteredProvider>
+        <Registered setOpenPage={vi.fn()} />
+      </RegisteredProvider>,
+      { preloadedState: preloadedStateB2bCompanyCreate },
+    );
+
+    await completeRegistration(user, { ...mockRegistrationData.b2c, businessDetails: undefined });
+
+    expect(
+      await screen.findByText('The captcha you entered is incorrect. Please try again.'),
+    ).toBeVisible();
+
+    // Submission is aborted before any account is created.
+    expect(b2bService.createBCCompanyUser).not.toHaveBeenCalled();
+    expect(
+      screen.queryByRole('heading', { name: 'Registration complete!' }),
+    ).not.toBeInTheDocument();
+  });
+
   it('renders and completes Business (B2B) registration flow with auto approval', async () => {
     const { navigation, user } = renderWithProviders(
       <RegisteredProvider>
@@ -1159,6 +1216,73 @@ describe('Registered Page', () => {
     // Expect /orders because companyAutoApproval.enabled is true (default from CustomStyleContext)
     await waitFor(() => {
       expect(navigation).toHaveBeenCalledWith(expect.stringMatching(/\/orders/i));
+    });
+  });
+
+  describe('company attachments (field_attachments)', () => {
+    const buildAttachment = (name = 'company-registration.pdf') =>
+      new File(['dummy-attachment-content'], name, { type: 'application/pdf' });
+
+    it('uploads attached files and forwards the normalised file list to companyCreate', async () => {
+      vi.spyOn(b2bService, 'uploadB2BFile').mockResolvedValue({
+        code: 200,
+        data: { id: 99, fileName: 'company-registration.pdf', fileSize: 1024 },
+      });
+
+      const { user } = renderWithProviders(
+        <RegisteredProvider>
+          <Registered setOpenPage={vi.fn()} />
+        </RegisteredProvider>,
+        { preloadedState: preloadedStateB2bCompanyCreate },
+      );
+
+      await completeRegistration(user, {
+        ...mockRegistrationData.b2b,
+        attachments: [buildAttachment()],
+      });
+
+      expect(b2bService.uploadB2BFile).toHaveBeenCalledTimes(1);
+      expect(b2bService.uploadB2BFile).toHaveBeenCalledWith({
+        file: expect.objectContaining({ name: 'company-registration.pdf' }),
+        type: 'companyAttachedFile',
+      });
+
+      // `fileSize` is coerced to a string before the list is handed to companyCreate.
+      expect(b2bService.createB2BCompanyUser).toHaveBeenCalledWith(
+        expect.objectContaining({
+          fileList: [{ id: 99, fileName: 'company-registration.pdf', fileSize: '1024' }],
+        }),
+      );
+      expect(screen.getByRole('heading', { name: 'Application submitted' })).toBeVisible();
+    });
+
+    it('does not create the company when an attachment upload fails', async () => {
+      vi.spyOn(b2bService, 'uploadB2BFile').mockResolvedValue({
+        code: 500,
+        data: { errMsg: 'Attachment rejected by storage' },
+      });
+
+      const { user } = renderWithProviders(
+        <RegisteredProvider>
+          <Registered setOpenPage={vi.fn()} />
+        </RegisteredProvider>,
+        { preloadedState: preloadedStateB2bCompanyCreate },
+      );
+
+      await completeRegistration(user, {
+        ...mockRegistrationData.b2b,
+        attachments: [buildAttachment()],
+      });
+
+      expect(await screen.findByText('Attachment rejected by storage')).toBeVisible();
+
+      // Uploads now run after customer creation (B2B-5230), so the customer is already
+      // created by the time the upload fails; only the company-creation step is skipped.
+      expect(b2bService.createBCCompanyUser).toHaveBeenCalledTimes(1);
+      expect(b2bService.createB2BCompanyUser).not.toHaveBeenCalled();
+      expect(
+        screen.queryByRole('heading', { name: 'Application submitted' }),
+      ).not.toBeInTheDocument();
     });
   });
 
@@ -1392,9 +1516,11 @@ describe('Registered Page', () => {
 
       await completeRegistration(user, {
         ...mockRegistrationData.b2b,
-        attachment: new File(['dummy-file-contents'], uploadedFile.fileName, {
-          type: uploadedFile.fileType,
-        }),
+        attachments: [
+          new File(['dummy-file-contents'], uploadedFile.fileName, {
+            type: uploadedFile.fileType,
+          }),
+        ],
       });
 
       await waitFor(() => {

--- a/apps/storefront/src/pages/Registered/types.ts
+++ b/apps/storefront/src/pages/Registered/types.ts
@@ -1,3 +1,8 @@
+export enum RegisterAccountType {
+  BUSINESS = '1',
+  PERSONAL = '2',
+}
+
 export interface RegisterFields extends Record<string, any> {
   name: string;
   label?: string;


### PR DESCRIPTION
Jira: [B2B-5401](https://bigcommercecloud.atlassian.net/browse/B2B-5401)

## What/Why?
Refactor `handleCompleted` in the registration `CompleteStep` to reduce cyclomatic complexity ~13 and nesting depth 5, inlining password validation and all four registration flows.
It is now a short orchestrator delegating to small single-purpose functions.

## Rollout/Rollback
Revert

## Testing

- Added new additional Unit tests
- Added new functional tests https://github.com/bigcommerce/functional-tests/pull/3066
- All 17 existing tests passed:
<img width="1887" height="480" alt="image" src="https://github.com/user-attachments/assets/8f8fd252-2380-4340-9896-1b79ee6b45a9" />


[B2B-5401]: https://bigcommercecloud.atlassian.net/browse/B2B-5401?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Also, manually verified the registration flow working for personal and business accounts and users and company created and visible in Merchant dashboard.





<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Registration submit still drives customer and company creation, login, and file upload; the change is mostly structural but touches critical onboarding paths and B2B-4466 flow branching.
> 
> **Overview**
> Refactors registration **CompleteStep** so `handleCompleted` is a thin orchestrator: password match and captcha guards run first, then personal vs business registration delegates to dedicated helpers.
> 
> **`RegisterAccountType`** (`BUSINESS` / `PERSONAL`) replaces magic `'1'` / `'2'` strings in CompleteStep and `createCustomer` for account-type branching.
> 
> Business registration is split into **`registerBusinessAccount`** (create customer, then company flow vs legacy **`createB2BCompanyUser`**), **`registerViaCompanyFlow`** (login, uploads, storefront **`registerCompany`**, logout when not auto-approved), and **`registerViaLegacyFlow`**. Personal flow uses **`registerPersonalAccount`**, which always treats the account as auto-approved.
> 
> **Tests** add password-mismatch and missing-captcha coverage, multi-file **`attachments`** in the registration helper (with async dropzone waits), and attachment upload success/failure cases for legacy company create.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 984610b46b2688f6e4aed5cf785daf9ee373e8cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->