### PR TITLE
fix(login): B2B-5343 Add back permission for customerInfo endpoint for catalyst store

### DIFF
--- a/apps/storefront/src/shared/service/b2b/graphql/register.ts
+++ b/apps/storefront/src/shared/service/b2b/graphql/register.ts
@@ -1,4 +1,4 @@
-import { channelId, storeHash } from '@/utils/basicConfig';
+import { channelId, isBigCommercePlatform, storeHash } from '@/utils/basicConfig';
 import { convertArrayToGraphql, convertObjectOrArrayKeysToCamel } from '@/utils/graphqlDataConvert';
 
 import B3Request from '../../request/b3Fetch';
@@ -81,11 +81,14 @@ const getAccountFormFields = (type: number) => `query B2BAccountFormFields {
     }
 }`;
 
-const getCustomerInfo = (useBcLoginAndAuthorisation = false) => `{
+const getCustomerInfo = (useBcLoginAndAuthorisation = false) => {
+  const skipPermissions = useBcLoginAndAuthorisation && isBigCommercePlatform();
+
+  return `{
   customerInfo {
     userType,
     ${
-      useBcLoginAndAuthorisation
+      skipPermissions
         ? ''
         : `permissions {
       code
@@ -104,6 +107,7 @@ const getCustomerInfo = (useBcLoginAndAuthorisation = false) => `{
     }
   }
 }`;
+};
 
 const getCountries = () => `query Countries {
   countries(storeHash:"${storeHash}") {

--- a/apps/storefront/src/utils/loginInfo.test.ts
+++ b/apps/storefront/src/utils/loginInfo.test.ts
@@ -6,6 +6,7 @@ import { store } from '@/store';
 import { setBcGraphQLToken, setPermissionModules } from '@/store/slices/company';
 import { CompanyStatus, CustomerRole, UserTypes } from '@/types';
 import { snackbar } from '@/utils/b3Tip';
+import * as basicConfig from '@/utils/basicConfig';
 import { CompanyError } from '@/utils/companyUtils';
 
 import b2bLogger from './b3Logger';
@@ -75,6 +76,26 @@ describe('getCurrentCustomerInfo permissions source', () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+  });
+
+  it('sources permissions from the customer-info query on Catalyst when the BC login flag is on', async () => {
+    vi.spyOn(basicConfig, 'isBigCommercePlatform').mockReturnValue(false);
+
+    mockState({ [BC_AUTH_FLAG]: true, [COMBINED_QUERY_FLAG]: true });
+
+    vi.spyOn(b2bService, 'getB2BCompanyUserInfo').mockResolvedValue({
+      customerInfo: {
+        userType: UserTypes.MULTIPLE_B2C,
+        userInfo: { role: CustomerRole.SENIOR_BUYER, id: 456, companyRoleName: 'Senior Buyer' },
+        permissions: QUERY_PERMISSIONS,
+      },
+    } as never);
+
+    await getCurrentCustomerInfo();
+
+    expect(b2bService.getB2BCompanyUserInfo).toHaveBeenCalledWith(true);
+    expect(b2bService.b2bAuthorization).not.toHaveBeenCalled();
+    expect(store.dispatch).toHaveBeenCalledWith(setPermissionModules(QUERY_PERMISSIONS));
   });
 
   it('sources permissions from b2bAuthorization when the BC login flag is on', async () => {

--- a/apps/storefront/src/utils/loginInfo.ts
+++ b/apps/storefront/src/utils/loginInfo.ts
@@ -35,7 +35,7 @@ import { CompanyStatus, CustomerRole, CustomerRoleName, LoginTypes, UserTypes } 
 
 import b2bLogger from './b3Logger';
 import { B3LStorage, B3SStorage } from './b3Storage';
-import { channelId, storeHash } from './basicConfig';
+import { channelId, isBigCommercePlatform, storeHash } from './basicConfig';
 import { getAccountHierarchyIsEnabled } from './storefrontConfig';
 
 const getLoginTokenInfo = () => {
@@ -378,7 +378,10 @@ export const getCurrentCustomerInfo = async (
       store.dispatch(resetDraftQuoteList());
       store.dispatch(resetDraftQuoteInfo());
 
-      if (useBcLoginAndAuthorisation) {
+      const useBcAuthorizationForPermissions =
+        useBcLoginAndAuthorisation && isBigCommercePlatform();
+
+      if (useBcAuthorizationForPermissions) {
         let { currentCustomerJWT } = store.getState().company.tokens;
         if (!currentCustomerJWT) {
           currentCustomerJWT =


### PR DESCRIPTION
Jira: [B2B-5343](https://bigcommercecloud.atlassian.net/browse/B2B-5343)

## What/Why?
Restores `permissions` on the B2B `customerInfo` GraphQL query for non-BigCommerce platforms, while keeping the BC-first authorization flow unchanged on native BigCommerce storefronts.

## What changed

- **`register.ts`**: Only omit `permissions` from the `customerInfo` query when **both** `PROJECT-7920.use_bc_login_and_authorisation` is enabled **and** the platform is `bigcommerce` (Stencil).
- **`loginInfo.ts`**: Only load permissions from the `b2bAuthorization` mutation on BigCommerce. On Catalyst and other non-bigcommerce platforms, permissions continue to come from `customerInfo`.
- **`loginInfo.test.ts`**: Added coverage for the Catalyst path when the BC login flag is on.

## Why permissions were removed (and why that broke Catalyst)

In PR https://github.com/bigcommerce/b2b-buyer-portal/pull/922 of [B2B-4930](https://bigcommercecloud.atlassian.net/browse/B2B-4930), when `PROJECT-7920.use_bc_login_and_authorisation` was enabled, the `customerInfo` query stopped requesting `permissions` because `bigcommerce` (Stencil) bigcommerce storefronts were updated to load them from the separate `b2bAuthorization` mutation instead.

That change applied to **all platforms**, not just `bigcommerce` (Stencil). Catalyst was unintentionally affected.

## Why putting permissions back fixes Catalyst stores

1. **Catalyst depends on `customerInfo.permissions`**  
   B2B Catalyst consumes the Buyer Portal `customerInfo` GraphQL API directly and uses `permissions { code, permissionLevel }` to decide what B2B features a user can access (orders, quotes, shopping lists, etc.). 

2. **Catalyst does not use the BC-first permission path**  
   On `bigcommerce` (Stencil) platform, permissions can come from `b2bAuthorization` when the flag is on. Catalyst uses a different login flow and does not rely on that mutation for permissions.

3. **Removing permissions left Catalyst with no permission data**  
   With the flag on, `customerInfo` returned no permissions and Catalyst had no fallback source. Users could appear logged in but lose access to B2B functionality that depends on permission checks.

4. **`bigcommerce` (Stencil) behavior is unchanged**  
   On native BC storefronts with the flag on, `customerInfo` still omits permissions and they are still loaded via `b2bAuthorization` — the intended BC-first flow is preserved.

## Behavior after this fix

| Platform | BC login flag | `customerInfo.permissions` | Permission source |
|---|---|---|---|
| `bigcommerce` (Stencil) | Off | Included | `customerInfo` |
| `bigcommerce` (Stencil) | On | Omitted | `b2bAuthorization` |
| Catalyst / other | Off | Included | `customerInfo` |
| Catalyst / other | On | **Included** | `customerInfo` |

## Rollout/Rollback
Revert this PR if needed

## Testing
- [x] On a **Catalyst** store with `PROJECT-7920.use_bc_login_and_authorisation` enabled, verify `customerInfo` returns `permissions { code, permissionLevel }`

<img width="1437" height="750" alt="Screenshot 2026-07-31 at 9 52 24 am" src="https://github.com/user-attachments/assets/17f8e60a-2840-4e70-8767-6ad996d28dc2" />

- [x] Confirm Catalyst B2B features (orders, quotes, shopping lists, etc.) work correctly for B2B users after login. Tested quick order as example here

https://github.com/user-attachments/assets/b9211bd4-025a-40a5-a4ae-e47dd853ff15

- [x] Confirm b2c customer login and permission work as expected

<img width="805" height="577" alt="Screenshot 2026-07-31 at 10 22 30 am" src="https://github.com/user-attachments/assets/286e1aa1-c60d-4be0-97b5-cf0e61bd724b" />

- [x] On a stencil storefront with the flag on, confirm permissions still load via `b2bAuthorization` and B2B features still work

https://github.com/user-attachments/assets/0bbebbe7-7c36-44ee-9f31-d2b30be71825

- [x] Run unit tests: `yarn test src/utils/loginInfo.test.ts`

[B2B-5343]: https://bigcommercecloud.atlassian.net/browse/B2B-5343?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes login-time permission sourcing for Catalyst when the BC login flag is on; incorrect gating could break B2B feature access or regress Stencil’s `b2bAuthorization` path, but scope is narrow and covered by unit tests.
> 
> **Overview**
> Scopes the BC-first permission flow to **native BigCommerce (Stencil)** only, so Catalyst and other platforms again receive and use `permissions` from the `customerInfo` GraphQL query when `PROJECT-7920.use_bc_login_and_authorisation` is enabled.
> 
> **`register.ts`** — Omits `permissions` from the `customerInfo` query only when the BC login flag is on **and** `isBigCommercePlatform()` is true; otherwise the query still requests `permissions { code, permissionLevel }`.
> 
> **`loginInfo.ts`** — Calls `b2bAuthorization` for permissions only under the same combined condition; non-BC platforms continue to dispatch permissions from the `customerInfo` response.
> 
> **`loginInfo.test.ts`** — Adds a test that mocks non-BigCommerce platform and verifies permissions come from `getB2BCompanyUserInfo` without invoking `b2bAuthorization`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4c06a8c27140fbb3841292cdb3ed1d3140cceb9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

[B2B-4930]: https://bigcommercecloud.atlassian.net/browse/B2B-4930?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ