### PR TITLE
B2B-3876: Remove fix_quote_currency_symbol_placement feature flag

### DIFF
--- a/apps/storefront/src/pages/QuoteDetail/index.test.tsx
+++ b/apps/storefront/src/pages/QuoteDetail/index.test.tsx
@@ -1564,7 +1564,7 @@ describe('when the user is a B2B customer', () => {
     });
   });
 
-  describe('fix_quote_currency_symbol_placement feature flag', () => {
+  describe('currency symbol placement', () => {
     const woolSock = buildQuoteProductWith({
       productName: 'Wool Socks',
       quantity: 3,
@@ -1634,33 +1634,13 @@ describe('when the user is a B2B customer', () => {
       vitest.mocked(useParams).mockReturnValue({ id: '272989' });
     });
 
-    it('uses the saved quote currency placement when the flag is disabled', async () => {
+    it('uses the current BC currency placement for quote items and summary', async () => {
       renderWithProviders(<QuoteDetail />, {
         preloadedState: {
           ...preloadedState,
           storeConfigs: storeConfigsWithUpdatedEurPlacement,
           global: buildGlobalStateWith({
             backorderEnabled: false,
-            featureFlags: { 'B2B-3876.fix_quote_currency_symbol_placement': false },
-          }),
-        },
-      });
-
-      const row = (await screen.findByText('Wool Socks')).closest('tr')!;
-      expect(within(row).getByRole('cell', { name: '49.00€' })).toBeInTheDocument();
-
-      const summary = screen.getByTestId('quote-summary');
-      expect(within(summary).getByText('200.00€')).toBeInTheDocument();
-    });
-
-    it('uses the current BC currency placement when the flag is enabled', async () => {
-      renderWithProviders(<QuoteDetail />, {
-        preloadedState: {
-          ...preloadedState,
-          storeConfigs: storeConfigsWithUpdatedEurPlacement,
-          global: buildGlobalStateWith({
-            backorderEnabled: false,
-            featureFlags: { 'B2B-3876.fix_quote_currency_symbol_placement': true },
           }),
         },
       });
@@ -1672,7 +1652,7 @@ describe('when the user is a B2B customer', () => {
       expect(within(summary).getByText('€200.00')).toBeInTheDocument();
     });
 
-    it('places the token on the left when BC config has uppercase token_location LEFT and flag is enabled', async () => {
+    it('places the token on the left when BC config has uppercase token_location LEFT', async () => {
       const eurWithUppercaseLeft = JSON.parse(
         JSON.stringify({ ...eurOnLeftInBcConfig, token_location: 'LEFT' }),
       );
@@ -1693,7 +1673,6 @@ describe('when the user is a B2B customer', () => {
           },
           global: buildGlobalStateWith({
             backorderEnabled: false,
-            featureFlags: { 'B2B-3876.fix_quote_currency_symbol_placement': true },
           }),
         },
       });

--- a/apps/storefront/src/pages/QuoteDetail/index.tsx
+++ b/apps/storefront/src/pages/QuoteDetail/index.tsx
@@ -276,9 +276,6 @@ function QuoteDetail() {
 
   const b3Lang = useB3Lang();
 
-  const isCurrencySymbolPlacementFixEnabled = useFeatureFlag(
-    'B2B-3876.fix_quote_currency_symbol_placement',
-  );
   const isBackorderMessagingEnabled = useFeatureFlag(
     'BACK-134.backorders_phase_1_1_control_messaging_on_storefront',
   );
@@ -826,12 +823,12 @@ function QuoteDetail() {
   }, [quoteDetail]);
 
   const displayCurrency = useMemo(() => {
-    if (isCurrencySymbolPlacementFixEnabled && quoteDetail.currency?.currencyCode) {
+    if (quoteDetail.currency?.currencyCode) {
       const currencySnapshot = currenciesMap[quoteDetail.currency.currencyCode];
       if (currencySnapshot) return currencySnapshot;
     }
     return quoteDetail.currency;
-  }, [isCurrencySymbolPlacementFixEnabled, quoteDetail.currency, currenciesMap]);
+  }, [quoteDetail.currency, currenciesMap]);
 
   useScrollBar(false);
 

--- a/apps/storefront/src/pages/QuotesList/QuoteItemCard.tsx
+++ b/apps/storefront/src/pages/QuotesList/QuoteItemCard.tsx
@@ -26,7 +26,6 @@ interface QuoteItemCardProps {
   goToDetail: (val: ListItem, status: number) => void;
   item: ListItem;
   currenciesMap: Record<string, DisplayCurrency>;
-  isCurrencySymbolPlacementFixEnabled: boolean;
 }
 
 const Flex = styled('div')({
@@ -37,7 +36,7 @@ const Flex = styled('div')({
 });
 
 export function QuoteItemCard(props: QuoteItemCardProps) {
-  const { item, goToDetail, currenciesMap, isCurrencySymbolPlacementFixEnabled } = props;
+  const { item, goToDetail, currenciesMap } = props;
   const theme = useTheme();
   const b3Lang = useB3Lang();
 
@@ -49,15 +48,13 @@ export function QuoteItemCard(props: QuoteItemCardProps) {
       return b3Lang('quoteDraft.quoteSummary.tbd');
     }
     const currencyCode = currency?.currencyCode;
-    const effectiveCurrency =
-      (isCurrencySymbolPlacementFixEnabled && currencyCode && currenciesMap[currencyCode]) ||
-      currency;
+    const effectiveCurrency = (currencyCode && currenciesMap[currencyCode]) || currency;
     return currencyFormatConvert(Number(totalAmount), {
       currency: effectiveCurrency,
       isConversionRate: false,
       useCurrentCurrency: !!effectiveCurrency,
     });
-  }, [item, isCurrencySymbolPlacementFixEnabled, currenciesMap, b3Lang]);
+  }, [item, currenciesMap, b3Lang]);
 
   const columnAllItems: TableColumnItem<ListItem>[] = [
     {

--- a/apps/storefront/src/pages/QuotesList/index.test.tsx
+++ b/apps/storefront/src/pages/QuotesList/index.test.tsx
@@ -1475,7 +1475,7 @@ describe('when the user is a B2C customer', () => {
   });
 });
 
-describe('fix_quote_currency_symbol_placement feature flag', () => {
+describe('currency symbol placement', () => {
   const nonCompany = buildCompanyStateWith({ customer: { b2bId: undefined } });
   const storeInfoWithDateFormat = buildStoreInfoStateWith({ timeFormat: { display: 'j F Y' } });
 
@@ -1533,31 +1533,13 @@ describe('fix_quote_currency_symbol_placement feature flag', () => {
     server.use(graphql.query('GetQuotesList', () => HttpResponse.json(quoteWithEurOnRight)));
   });
 
-  it('uses the saved quote currency placement when the flag is disabled', async () => {
+  it('uses the current BC currency placement for quote subtotals', async () => {
     renderWithProviders(<QuotesList />, {
       preloadedState: {
         company: nonCompany,
         storeInfo: storeInfoWithDateFormat,
         storeConfigs: storeConfigsWithUpdatedEurPlacement,
-        global: buildGlobalStateWith({
-          featureFlags: { 'B2B-3876.fix_quote_currency_symbol_placement': false },
-        }),
-      },
-    });
-
-    const table = await screen.findByRole('table');
-    expect(within(table).getByRole('cell', { name: '100.00€' })).toBeInTheDocument();
-  });
-
-  it('uses the current BC currency placement when the flag is enabled', async () => {
-    renderWithProviders(<QuotesList />, {
-      preloadedState: {
-        company: nonCompany,
-        storeInfo: storeInfoWithDateFormat,
-        storeConfigs: storeConfigsWithUpdatedEurPlacement,
-        global: buildGlobalStateWith({
-          featureFlags: { 'B2B-3876.fix_quote_currency_symbol_placement': true },
-        }),
+        global: buildGlobalStateWith({}),
       },
     });
 
@@ -1565,7 +1547,7 @@ describe('fix_quote_currency_symbol_placement feature flag', () => {
     expect(within(table).getByRole('cell', { name: '€100.00' })).toBeInTheDocument();
   });
 
-  it('places the token on the left when BC config has uppercase token_location LEFT and flag is enabled', async () => {
+  it('places the token on the left when BC config has uppercase token_location LEFT', async () => {
     const eurWithUppercaseLeft = JSON.parse(
       JSON.stringify({ ...eurOnLeftInBcConfig, token_location: 'LEFT' }),
     );
@@ -1585,9 +1567,7 @@ describe('fix_quote_currency_symbol_placement feature flag', () => {
             enteredInclusiveTax: false,
           },
         },
-        global: buildGlobalStateWith({
-          featureFlags: { 'B2B-3876.fix_quote_currency_symbol_placement': true },
-        }),
+        global: buildGlobalStateWith({}),
       },
     });
 

--- a/apps/storefront/src/pages/QuotesList/index.tsx
+++ b/apps/storefront/src/pages/QuotesList/index.tsx
@@ -189,7 +189,6 @@ function useData() {
 
 const useColumnList = (
   currenciesMap: Record<string, DisplayCurrency>,
-  isCurrencySymbolPlacementFixEnabled: boolean,
 ): Array<TableColumnItem<ListItem>> => {
   const b3Lang = useB3Lang();
 
@@ -200,16 +199,14 @@ const useColumnList = (
         return b3Lang('quoteDraft.quoteSummary.tbd');
       }
       const currencyCode = currency?.currencyCode;
-      const effectiveCurrency =
-        (isCurrencySymbolPlacementFixEnabled && currencyCode && currenciesMap[currencyCode]) ||
-        currency;
+      const effectiveCurrency = (currencyCode && currenciesMap[currencyCode]) || currency;
       return currencyFormatConvert(Number(totalAmount), {
         currency: effectiveCurrency,
         isConversionRate: false,
         useCurrentCurrency: !!effectiveCurrency,
       });
     },
-    [isCurrencySymbolPlacementFixEnabled, currenciesMap, b3Lang],
+    [currenciesMap, b3Lang],
   );
 
   return useMemo(
@@ -280,11 +277,8 @@ const useColumnList = (
 function QuotesList() {
   const { getAvailableFilters, draftQuoteListLength, customer, getQuotesList, currenciesMap } =
     useData();
-  const fixQuoteCurrencySymbolPlacement = useFeatureFlag(
-    'B2B-3876.fix_quote_currency_symbol_placement',
-  );
   const isTbdPriceEnabled = useFeatureFlag('B2B-4089.use_tbd_price_on_quotes_list');
-  const columns = useColumnList(currenciesMap, fixQuoteCurrencySymbolPlacement);
+  const columns = useColumnList(currenciesMap);
 
   const initSearch = {
     q: '',
@@ -464,12 +458,7 @@ function QuotesList() {
             isMobile ? b3Lang('quotes.cardsPerPage') : b3Lang('quotes.quotesPerPage')
           }
           renderItem={(row) => (
-            <QuoteItemCard
-              item={row}
-              goToDetail={goToDetail}
-              currenciesMap={currenciesMap}
-              isCurrencySymbolPlacementFixEnabled={fixQuoteCurrencySymbolPlacement}
-            />
+            <QuoteItemCard item={row} goToDetail={goToDetail} currenciesMap={currenciesMap} />
           )}
           onClickRow={(row) => {
             goToDetail(row, Number(row.status));

--- a/apps/storefront/src/pages/quote/components/QuoteDetailSummary.tsx
+++ b/apps/storefront/src/pages/quote/components/QuoteDetailSummary.tsx
@@ -43,9 +43,6 @@ export default function QuoteDetailSummary({
   const isBackorderMessagingEnabled = useFeatureFlag(
     'BACK-134.backorders_phase_1_1_control_messaging_on_storefront',
   );
-  const isCurrencySymbolPlacementFixEnabled = useFeatureFlag(
-    'B2B-3876.fix_quote_currency_symbol_placement',
-  );
   const { showDefaultShippingExpectationPrompt, defaultShippingExpectationPrompt } = useAppSelector(
     ({ global }) => global.backorderDisplaySettings,
   );
@@ -57,9 +54,7 @@ export default function QuoteDetailSummary({
     return showInclusiveTaxPrice ? price + quoteDetailTax : price;
   };
 
-  const effectiveCurrency = isCurrencySymbolPlacementFixEnabled
-    ? (currency ?? quoteDetail.currency)
-    : quoteDetail.currency;
+  const effectiveCurrency = currency ?? quoteDetail.currency;
 
   const priceFormat = (price: number) =>
     currencyFormatConvert(price, {

--- a/apps/storefront/src/pages/quote/components/QuoteDetailTableCard.tsx
+++ b/apps/storefront/src/pages/quote/components/QuoteDetailTableCard.tsx
@@ -4,7 +4,6 @@ import BackorderMessage from '@/components/BackorderMessage';
 import PicklistBackorderMessages from '@/components/PicklistBackorderMessages';
 import { PRODUCT_DEFAULT_IMAGE } from '@/constants';
 import { useBackorderStorefrontMessaging } from '@/hooks/useBackorderStorefrontMessaging';
-import { useFeatureFlag } from '@/hooks/useFeatureFlag';
 import { useB3Lang } from '@/lib/lang';
 import { type ProductSearch } from '@/shared/service/b2b/graphql/product';
 import { useAppSelector } from '@/store';
@@ -53,9 +52,6 @@ function QuoteDetailTableCard(props: QuoteTableCardProps) {
     historyByProductId,
   } = props;
   const b3Lang = useB3Lang();
-  const isCurrencySymbolPlacementFixEnabled = useFeatureFlag(
-    'B2B-3876.fix_quote_currency_symbol_placement',
-  );
   const enteredInclusiveTax = useAppSelector(
     ({ storeConfigs }) => storeConfigs.currencies.enteredInclusiveTax,
   );
@@ -206,7 +202,7 @@ function QuoteDetailTableCard(props: QuoteTableCardProps) {
                 {`${showPrice(
                   currencyFormatConvert(price, {
                     currency,
-                    useCurrentCurrency: isCurrencySymbolPlacementFixEnabled,
+                    useCurrentCurrency: true,
                   }),
                   quoteTableItem,
                 )}`}
@@ -221,7 +217,7 @@ function QuoteDetailTableCard(props: QuoteTableCardProps) {
               {`${showPrice(
                 currencyFormatConvert(offeredPrice, {
                   currency,
-                  useCurrentCurrency: isCurrencySymbolPlacementFixEnabled,
+                  useCurrentCurrency: true,
                 }),
                 quoteTableItem,
               )}`}
@@ -252,7 +248,7 @@ function QuoteDetailTableCard(props: QuoteTableCardProps) {
                 {`${showPrice(
                   currencyFormatConvert(total, {
                     currency,
-                    useCurrentCurrency: isCurrencySymbolPlacementFixEnabled,
+                    useCurrentCurrency: true,
                   }),
                   quoteTableItem,
                 )}`}
@@ -267,7 +263,7 @@ function QuoteDetailTableCard(props: QuoteTableCardProps) {
               {`${showPrice(
                 currencyFormatConvert(totalWithDiscount, {
                   currency,
-                  useCurrentCurrency: isCurrencySymbolPlacementFixEnabled,
+                  useCurrentCurrency: true,
                 }),
                 quoteTableItem,
               )}`}

--- a/apps/storefront/src/utils/featureFlags.ts
+++ b/apps/storefront/src/utils/featureFlags.ts
@@ -36,10 +36,6 @@ export const featureFlags = [
     name: 'b2bMultiLanguage',
   },
   {
-    key: 'B2B-3876.fix_quote_currency_symbol_placement',
-    name: 'fixQuoteCurrencySymbolPlacement',
-  },
-  {
     key: 'PROJECT-7920.use_bc_account_settings',
     name: 'useBcAccountSettings',
   },


### PR DESCRIPTION
Jira: [B2B-3876](https://bigcommercecloud.atlassian.net/browse/B2B-3876)

## What/Why?

Removes the `B2B-3876.fix_quote_currency_symbol_placement` feature flag from the buyer portal. The flag reached 100% production rollout on 2026-05-25 and has been stable for over two months.

The enabled behaviour (resolve currency symbol placement from the current BC store config instead of the stale snapshot saved on the quote) is now always active.

**Files changed:**
- `featureFlags.ts`: Remove flag registration entry
- `QuotesList/index.tsx`, `QuoteItemCard.tsx`: Remove `fixQuoteCurrencySymbolPlacement` flag read; `effectiveCurrency` now always uses `currenciesMap[currencyCode]` when available
- `QuoteDetail/index.tsx`: Remove flag guard in `displayCurrency` memo; always prefers `currenciesMap` snapshot
- `QuoteDetailSummary.tsx`: Remove flag guard; `effectiveCurrency` is always `currency ?? quoteDetail.currency`
- `QuoteDetailTableCard.tsx`: Remove flag guard; `useCurrentCurrency` is always `true`
- `*.test.tsx`: Remove disabled-path test variants (flag=false branches no longer exist)

Consumer PR for the public flag. b2b-edition-api will be cleaned up in a follow-up PR once all consumer PRs merge.

## Rollout/Rollback

No flag evaluation remains. The previously-enabled code path is now permanent. Rolling back requires reverting this PR.

## Testing

- `vitest run src/pages/QuotesList/index.test.tsx src/pages/QuoteDetail/index.test.tsx` — 55 tests pass
- `tsc --noEmit` — no type errors

[B2B-3876]: https://bigcommercecloud.atlassian.net/browse/B2B-3876?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Flag cleanup with behavior matching the already-rolled-out enabled path; only affects quote price display formatting, not checkout or auth.
> 
> **Overview**
> Removes the **`B2B-3876.fix_quote_currency_symbol_placement`** feature flag after full rollout. Quote prices on the **quotes list** and **quote detail** always use **current BigCommerce store currency settings** (via `currenciesMap`) for symbol placement, instead of the currency snapshot stored on the quote.
> 
> **Quote list** and **quote detail** no longer read the flag or pass `isCurrencySymbolPlacementFixEnabled` into cards/columns. **`displayCurrency`** on quote detail always prefers the BC config when a currency code exists. **Quote detail table** formatting always passes `useCurrentCurrency: true`. The flag entry is removed from **`featureFlags.ts`**.
> 
> Tests drop flag-off scenarios and keep coverage for BC placement (including uppercase `token_location`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ffa0d41d19884e20c82fed4206f0eea333cfbfea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->