### PR TITLE
fix(quotes): B2B-2219 show actual sender name for buyer portal quote messages

### DIFF
--- a/apps/storefront/src/constants/featureFlags.ts
+++ b/apps/storefront/src/constants/featureFlags.ts
@@ -1,0 +1,9 @@
+/**
+ * Temporary local flags for behaviour that will eventually move behind a real
+ * feature-flag service. Keep this file limited to simple `boolean` toggles.
+ *
+ * - `SHOW_USER_NAME` — B2B-2219: render the logged-in user's own name on their
+ *   quote messages instead of the quote's contact name. Flip to `false` to
+ *   revert to the previous behaviour if an issue surfaces.
+ */
+export const SHOW_USER_NAME = true;

--- a/apps/storefront/src/constants/featureFlags.ts
+++ b/apps/storefront/src/constants/featureFlags.ts
@@ -1,9 +1,0 @@
-/**
- * Temporary local flags for behaviour that will eventually move behind a real
- * feature-flag service. Keep this file limited to simple `boolean` toggles.
- *
- * - `SHOW_USER_NAME` — B2B-2219: render the logged-in user's own name on their
- *   quote messages instead of the quote's contact name. Flip to `false` to
- *   revert to the previous behaviour if an issue surfaces.
- */
-export const SHOW_USER_NAME = true;

--- a/apps/storefront/src/pages/QuoteDetail/index.test.tsx
+++ b/apps/storefront/src/pages/QuoteDetail/index.test.tsx
@@ -1,5 +1,6 @@
 import { useParams } from 'react-router-dom';
 import {
+  buildB2BFeaturesStateWith,
   buildCompanyStateWith,
   builder,
   buildGlobalStateWith,
@@ -21,7 +22,7 @@ import { when } from 'vitest-when';
 
 import { B2BProducts, ProductSearch } from '@/shared/service/b2b/graphql/product';
 import { B2BQuoteDetail, QuoteExtraFieldsConfig } from '@/shared/service/b2b/graphql/quote';
-import { CompanyStatus, UserTypes } from '@/types';
+import { CompanyStatus, CustomerRole, UserTypes } from '@/types';
 
 import QuoteDetail from './index';
 
@@ -1704,5 +1705,84 @@ describe('when the user is a B2B customer', () => {
       const summary = screen.getByTestId('quote-summary');
       expect(within(summary).getByText('€200.00')).toBeInTheDocument();
     });
+  });
+});
+
+describe('B2B-2219 buyer-side quote message sender name while a sales rep is agenting', () => {
+  const agentingSalesRep = buildCompanyStateWith({
+    companyInfo: { status: CompanyStatus.APPROVED },
+    customer: {
+      userType: UserTypes.MULTIPLE_B2C,
+      role: CustomerRole.SUPER_ADMIN,
+      firstName: 'Sam',
+      lastName: 'Rep',
+    },
+  });
+
+  const quoteWithBuyerMessage = buildQuoteWith({
+    data: {
+      quote: {
+        id: '272989',
+        trackingHistory: [
+          {
+            date: getUnixTime(new Date('1 January 2025')),
+            read: true,
+            role: 'Contact: Quote Owner',
+            message: 'Hi, I need help with this quote',
+          },
+        ],
+      },
+    },
+  });
+
+  const preloadedStateFor = (isAgenting: boolean) => ({
+    company: agentingSalesRep,
+    storeInfo: buildStoreInfoStateWith('WHATEVER_VALUES'),
+    global: buildGlobalStateWith({
+      backorderEnabled: false,
+      featureFlags: {
+        'B2B-2219.fix_buyer_portal_quote_message_sender_name': true,
+      },
+    }),
+    b2bFeatures: buildB2BFeaturesStateWith({
+      masqueradeCompany: {
+        id: isAgenting ? 1 : 0,
+        isAgenting,
+        companyName: isAgenting ? 'Acme Inc' : '',
+        customerGroupId: 0,
+      },
+    }),
+  });
+
+  beforeEach(() => {
+    server.use(
+      graphql.query('GetQuoteInfoB2B', () => HttpResponse.json(quoteWithBuyerMessage)),
+      graphql.query('SearchProducts', () =>
+        HttpResponse.json(buildProductSearchResponseWith('WHATEVER_VALUES')),
+      ),
+      graphql.query('getQuoteExtraFields', () =>
+        HttpResponse.json(buildQuoteExtraFieldsWith('WHATEVER_VALUES')),
+      ),
+    );
+
+    vitest.mocked(useParams).mockReturnValue({ id: '272989' });
+  });
+
+  it("keeps the quote contact's label instead of the rep's own name while agenting", async () => {
+    renderWithProviders(<QuoteDetail />, { preloadedState: preloadedStateFor(true) });
+
+    await userEvent.click(await screen.findByText('Message'));
+
+    expect(await screen.findByText('Contact: Quote Owner')).toBeVisible();
+    expect(screen.queryByText('Sam Rep')).toBeNull();
+  });
+
+  it("shows the rep's own name on their own buyer-side messages when not agenting", async () => {
+    renderWithProviders(<QuoteDetail />, { preloadedState: preloadedStateFor(false) });
+
+    await userEvent.click(await screen.findByText('Message'));
+
+    expect(await screen.findByText('Sam Rep')).toBeVisible();
+    expect(screen.queryByText('Contact: Quote Owner')).toBeNull();
   });
 });

--- a/apps/storefront/src/pages/QuoteDetail/index.tsx
+++ b/apps/storefront/src/pages/QuoteDetail/index.tsx
@@ -117,6 +117,8 @@ function useData() {
   const emailAddress = useAppSelector(({ company }) => company.customer.emailAddress);
   const customerGroupId = useAppSelector(({ company }) => company.customer.customerGroupId);
   const role = useAppSelector(({ company }) => company.customer.role);
+  const firstName = useAppSelector(({ company }) => company.customer.firstName);
+  const lastName = useAppSelector(({ company }) => company.customer.lastName);
 
   const isB2BUser = useAppSelector(isB2BUserSelector);
   const { selectCompanyHierarchyId } = useAppSelector(
@@ -183,6 +185,8 @@ function useData() {
     quoteConfig,
     role,
     emailAddress,
+    firstName,
+    lastName,
     isB2BUser,
     selectCompanyHierarchyId,
     isAgenting,
@@ -261,6 +265,8 @@ function QuoteDetail() {
     quoteConfig,
     role,
     emailAddress,
+    firstName,
+    lastName,
     isB2BUser,
     selectCompanyHierarchyId,
     isAgenting,
@@ -976,6 +982,7 @@ function QuoteDetail() {
                 status={quoteDetail.status}
                 isB2BUser={isB2BUser}
                 email={emailAddress || ''}
+                currentUserName={`${firstName} ${lastName}`.trim()}
                 msgs={quoteDetail?.trackingHistory || []}
               />
             </Box>

--- a/apps/storefront/src/pages/QuoteDetail/index.tsx
+++ b/apps/storefront/src/pages/QuoteDetail/index.tsx
@@ -982,7 +982,7 @@ function QuoteDetail() {
                 status={quoteDetail.status}
                 isB2BUser={isB2BUser}
                 email={emailAddress || ''}
-                currentUserName={`${firstName} ${lastName}`.trim()}
+                currentUserName={isAgenting ? undefined : `${firstName} ${lastName}`.trim()}
                 msgs={quoteDetail?.trackingHistory || []}
               />
             </Box>

--- a/apps/storefront/src/pages/QuoteDetail/index.tsx
+++ b/apps/storefront/src/pages/QuoteDetail/index.tsx
@@ -839,6 +839,11 @@ function QuoteDetail() {
     return quoteDetail.currency;
   }, [isCurrencySymbolPlacementFixEnabled, quoteDetail.currency, currenciesMap]);
 
+  const currentUserName = useMemo(
+    () => (isAgenting ? undefined : `${firstName} ${lastName}`.trim()),
+    [isAgenting, firstName, lastName],
+  );
+
   useScrollBar(false);
 
   const { quotePurchasabilityPermission, quoteConvertToOrderPermission } =
@@ -982,7 +987,7 @@ function QuoteDetail() {
                 status={quoteDetail.status}
                 isB2BUser={isB2BUser}
                 email={emailAddress || ''}
-                currentUserName={isAgenting ? undefined : `${firstName} ${lastName}`.trim()}
+                currentUserName={currentUserName}
                 msgs={quoteDetail?.trackingHistory || []}
               />
             </Box>

--- a/apps/storefront/src/pages/quote/components/Message.test.tsx
+++ b/apps/storefront/src/pages/quote/components/Message.test.tsx
@@ -1,0 +1,109 @@
+import { renderWithProviders, screen, userEvent } from 'tests/test-utils';
+import { vi } from 'vitest';
+
+import { updateQuote } from '@/shared/service/b2b';
+
+import Message from './Message';
+
+type MessageComponentProps = Parameters<typeof Message>[0];
+
+vi.mock('@/shared/service/b2b', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/shared/service/b2b')>()),
+  updateQuote: vi.fn(),
+}));
+
+const mockedUpdateQuote = vi.mocked(updateQuote);
+
+const baseProps: Omit<MessageComponentProps, 'msgs' | 'currentUserName'> = {
+  id: 1,
+  status: 0,
+  isB2BUser: false,
+  email: 'buyer@example.com',
+};
+
+const customerMessage = {
+  date: 1_700_000_000,
+  message: 'Hi, I need help with this quote',
+  role: 'Contact: Quote Owner',
+  read: 1,
+};
+
+const salesRepMessage = {
+  date: 1_700_000_010,
+  message: 'Sure, one moment',
+  role: 'Sales rep: Bob Rep',
+  read: 1,
+};
+
+async function renderAndExpand(props: MessageComponentProps) {
+  const view = renderWithProviders(<Message {...props} />);
+  await userEvent.click(screen.getByText('Message'));
+  return view;
+}
+
+describe('Message sender name (B2B-2219)', () => {
+  beforeEach(() => {
+    mockedUpdateQuote.mockResolvedValue({
+      quoteUpdate: { quote: { trackingHistory: [] } },
+    });
+  });
+
+  it("shows the logged-in user's own name instead of the quote contact for the buyer's messages", async () => {
+    await renderAndExpand({
+      ...baseProps,
+      msgs: [customerMessage],
+      currentUserName: 'Jane Buyer',
+    });
+
+    expect(screen.getByText('Jane Buyer')).toBeVisible();
+    expect(screen.queryByText('Contact: Quote Owner')).toBeNull();
+  });
+
+  it('falls back to the original backend-provided label when no current user name is available', async () => {
+    await renderAndExpand({
+      ...baseProps,
+      msgs: [customerMessage],
+      currentUserName: '',
+    });
+
+    expect(screen.getByText('Contact: Quote Owner')).toBeVisible();
+  });
+
+  it('leaves the sales rep label untouched', async () => {
+    await renderAndExpand({
+      ...baseProps,
+      msgs: [customerMessage, salesRepMessage],
+      currentUserName: 'Jane Buyer',
+    });
+
+    expect(screen.getByText('Sales rep: Bob Rep')).toBeVisible();
+  });
+});
+
+describe('Message sender name when SHOW_USER_NAME is disabled', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mockedUpdateQuote.mockResolvedValue({
+      quoteUpdate: { quote: { trackingHistory: [] } },
+    });
+  });
+
+  it('keeps the original backend-provided label even when a current user name is available', async () => {
+    vi.doMock('@/constants/featureFlags', () => ({ SHOW_USER_NAME: false }));
+    const { default: MessageWithFlagDisabled } = await import('./Message');
+
+    renderWithProviders(
+      <MessageWithFlagDisabled
+        {...baseProps}
+        msgs={[customerMessage]}
+        currentUserName="Jane Buyer"
+      />,
+    );
+    await userEvent.click(screen.getByText('Message'));
+
+    expect(screen.getByText('Contact: Quote Owner')).toBeVisible();
+    expect(screen.queryByText('Jane Buyer')).toBeNull();
+
+    vi.doUnmock('@/constants/featureFlags');
+  });
+});

--- a/apps/storefront/src/pages/quote/components/Message.test.tsx
+++ b/apps/storefront/src/pages/quote/components/Message.test.tsx
@@ -1,4 +1,4 @@
-import { renderWithProviders, screen, userEvent } from 'tests/test-utils';
+import { buildGlobalStateWith, renderWithProviders, screen, userEvent } from 'tests/test-utils';
 import { vi } from 'vitest';
 
 import { updateQuote } from '@/shared/service/b2b';
@@ -35,13 +35,26 @@ const salesRepMessage = {
   read: 1,
 };
 
-async function renderAndExpand(props: MessageComponentProps) {
-  const view = renderWithProviders(<Message {...props} />);
+const withSenderNameFlag = (enabled: boolean) => ({
+  preloadedState: {
+    global: buildGlobalStateWith({
+      featureFlags: {
+        'B2B-2219.fix_buyer_portal_quote_message_sender_name': enabled,
+      },
+    }),
+  },
+});
+
+async function renderAndExpand(
+  props: MessageComponentProps,
+  renderOptions?: ReturnType<typeof withSenderNameFlag>,
+) {
+  const view = renderWithProviders(<Message {...props} />, renderOptions);
   await userEvent.click(screen.getByText('Message'));
   return view;
 }
 
-describe('Message sender name (B2B-2219)', () => {
+describe('Message sender name (B2B-2219.fix_buyer_portal_quote_message_sender_name enabled)', () => {
   beforeEach(() => {
     mockedUpdateQuote.mockResolvedValue({
       quoteUpdate: { quote: { trackingHistory: [] } },
@@ -49,61 +62,75 @@ describe('Message sender name (B2B-2219)', () => {
   });
 
   it("shows the logged-in user's own name instead of the quote contact for the buyer's messages", async () => {
-    await renderAndExpand({
-      ...baseProps,
-      msgs: [customerMessage],
-      currentUserName: 'Jane Buyer',
-    });
+    await renderAndExpand(
+      {
+        ...baseProps,
+        msgs: [customerMessage],
+        currentUserName: 'Jane Buyer',
+      },
+      withSenderNameFlag(true),
+    );
 
     expect(screen.getByText('Jane Buyer')).toBeVisible();
     expect(screen.queryByText('Contact: Quote Owner')).toBeNull();
   });
 
   it('falls back to the original backend-provided label when no current user name is available', async () => {
-    await renderAndExpand({
-      ...baseProps,
-      msgs: [customerMessage],
-      currentUserName: '',
-    });
+    await renderAndExpand(
+      {
+        ...baseProps,
+        msgs: [customerMessage],
+        currentUserName: '',
+      },
+      withSenderNameFlag(true),
+    );
 
     expect(screen.getByText('Contact: Quote Owner')).toBeVisible();
   });
 
   it('leaves the sales rep label untouched', async () => {
-    await renderAndExpand({
-      ...baseProps,
-      msgs: [customerMessage, salesRepMessage],
-      currentUserName: 'Jane Buyer',
-    });
+    await renderAndExpand(
+      {
+        ...baseProps,
+        msgs: [customerMessage, salesRepMessage],
+        currentUserName: 'Jane Buyer',
+      },
+      withSenderNameFlag(true),
+    );
 
     expect(screen.getByText('Sales rep: Bob Rep')).toBeVisible();
   });
 });
 
-describe('Message sender name when SHOW_USER_NAME is disabled', () => {
+describe('Message sender name (flag off, including the default/unset state)', () => {
   beforeEach(() => {
-    vi.resetModules();
     mockedUpdateQuote.mockResolvedValue({
       quoteUpdate: { quote: { trackingHistory: [] } },
     });
   });
 
   it('keeps the original backend-provided label even when a current user name is available', async () => {
-    vi.doMock('@/constants/featureFlags', () => ({ SHOW_USER_NAME: false }));
-    const { default: MessageWithFlagDisabled } = await import('./Message');
-
-    renderWithProviders(
-      <MessageWithFlagDisabled
-        {...baseProps}
-        msgs={[customerMessage]}
-        currentUserName="Jane Buyer"
-      />,
+    await renderAndExpand(
+      {
+        ...baseProps,
+        msgs: [customerMessage],
+        currentUserName: 'Jane Buyer',
+      },
+      withSenderNameFlag(false),
     );
-    await userEvent.click(screen.getByText('Message'));
 
     expect(screen.getByText('Contact: Quote Owner')).toBeVisible();
     expect(screen.queryByText('Jane Buyer')).toBeNull();
+  });
 
-    vi.doUnmock('@/constants/featureFlags');
+  it('keeps the original backend-provided label when the flag has never been set (default state)', async () => {
+    await renderAndExpand({
+      ...baseProps,
+      msgs: [customerMessage],
+      currentUserName: 'Jane Buyer',
+    });
+
+    expect(screen.getByText('Contact: Quote Owner')).toBeVisible();
+    expect(screen.queryByText('Jane Buyer')).toBeNull();
   });
 });

--- a/apps/storefront/src/pages/quote/components/Message.tsx
+++ b/apps/storefront/src/pages/quote/components/Message.tsx
@@ -44,18 +44,10 @@ interface CustomerMessageProps {
   msg: MessageProps;
   isEndMessage?: boolean;
   isCustomer?: boolean;
-  currentUserName?: string;
 }
 
-function ChatMessage({ msg, isEndMessage, isCustomer, currentUserName }: CustomerMessageProps) {
+function ChatMessage({ msg, isEndMessage, isCustomer }: CustomerMessageProps) {
   const b3Lang = useB3Lang();
-  const showUserName = useFeatureFlag('B2B-2219.fix_buyer_portal_quote_message_sender_name');
-
-  // B2B-2219: the buyer-side label backend returns is the quote's contact
-  // name, not the actual sender, so prefer the logged-in user's own name
-  // for messages on their side of the thread. Sales-rep labels are untouched.
-  const label =
-    msg?.role && isCustomer && showUserName && currentUserName ? currentUserName : msg?.role;
 
   return (
     <Box
@@ -66,7 +58,7 @@ function ChatMessage({ msg, isEndMessage, isCustomer, currentUserName }: Custome
         paddingTop: '5px',
       }}
     >
-      {label && (
+      {msg?.role && (
         <Box
           sx={{
             height: '14px',
@@ -77,7 +69,7 @@ function ChatMessage({ msg, isEndMessage, isCustomer, currentUserName }: Custome
             color: 'rgba(0, 0, 0, 0.38)',
           }}
         >
-          {label}
+          {msg.role}
         </Box>
       )}
       {msg?.message && (
@@ -145,12 +137,25 @@ function DateMessage({ msg }: DateMessageProps) {
   );
 }
 
+function withResolvedSenderNames(
+  messages: MessageProps[],
+  showUserName: boolean,
+  currentUserName?: string,
+): MessageProps[] {
+  if (!showUserName || !currentUserName) return messages;
+
+  return messages.map((message) =>
+    message.role && message.isCustomer ? { ...message, role: currentUserName } : message,
+  );
+}
+
 function Message({ msgs, id, isB2BUser, email, status, currentUserName }: MsgsProps) {
   const { dispatch: globalDispatch } = useContext(GlobalContext);
 
   const theme = useTheme();
   const primaryColor = theme.palette.primary.main;
   const b3Lang = useB3Lang();
+  const showUserName = useFeatureFlag('B2B-2219.fix_buyer_portal_quote_message_sender_name');
 
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const changeReadRef = useRef(0);
@@ -258,6 +263,11 @@ function Message({ msgs, id, isB2BUser, email, status, currentUserName }: MsgsPr
     // disabling this rule as b3Lang will cause rendering issues
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [primaryColor, read],
+  );
+
+  const displayMessages = useMemo(
+    () => withResolvedSenderNames(messages, showUserName, currentUserName),
+    [messages, showUserName, currentUserName],
   );
 
   useEffect(() => {
@@ -372,13 +382,12 @@ function Message({ msgs, id, isB2BUser, email, status, currentUserName }: MsgsPr
                 },
               }}
             >
-              {messages.map((item: MessageProps, index: number) => (
+              {displayMessages.map((item: MessageProps, index: number) => (
                 <Box key={item.key}>
                   <ChatMessage
                     msg={item}
-                    isEndMessage={index === messages.length - 1}
+                    isEndMessage={index === displayMessages.length - 1}
                     isCustomer={!!item.isCustomer}
-                    currentUserName={currentUserName}
                   />
                   {item.date && <DateMessage msg={item} />}
                 </Box>

--- a/apps/storefront/src/pages/quote/components/Message.tsx
+++ b/apps/storefront/src/pages/quote/components/Message.tsx
@@ -13,7 +13,7 @@ import { format, formatDistanceStrict } from 'date-fns';
 
 import { B3CollapseContainer } from '@/components/B3CollapseContainer';
 import B3Spin from '@/components/spin/B3Spin';
-import { SHOW_USER_NAME } from '@/constants/featureFlags';
+import { useFeatureFlag } from '@/hooks/useFeatureFlag';
 import { useB3Lang } from '@/lib/lang';
 import { GlobalContext } from '@/shared/global';
 import { updateQuote } from '@/shared/service/b2b';
@@ -49,12 +49,13 @@ interface CustomerMessageProps {
 
 function ChatMessage({ msg, isEndMessage, isCustomer, currentUserName }: CustomerMessageProps) {
   const b3Lang = useB3Lang();
+  const showUserName = useFeatureFlag('B2B-2219.fix_buyer_portal_quote_message_sender_name');
 
   // B2B-2219: the buyer-side label backend returns is the quote's contact
   // name, not the actual sender, so prefer the logged-in user's own name
   // for messages on their side of the thread. Sales-rep labels are untouched.
   const label =
-    msg?.role && isCustomer && SHOW_USER_NAME && currentUserName ? currentUserName : msg?.role;
+    msg?.role && isCustomer && showUserName && currentUserName ? currentUserName : msg?.role;
 
   return (
     <Box

--- a/apps/storefront/src/pages/quote/components/Message.tsx
+++ b/apps/storefront/src/pages/quote/components/Message.tsx
@@ -13,6 +13,7 @@ import { format, formatDistanceStrict } from 'date-fns';
 
 import { B3CollapseContainer } from '@/components/B3CollapseContainer';
 import B3Spin from '@/components/spin/B3Spin';
+import { SHOW_USER_NAME } from '@/constants/featureFlags';
 import { useB3Lang } from '@/lib/lang';
 import { GlobalContext } from '@/shared/global';
 import { updateQuote } from '@/shared/service/b2b';
@@ -36,16 +37,25 @@ interface MsgsProps {
   email: string;
   isB2BUser: boolean;
   status: number;
+  currentUserName?: string;
 }
 
 interface CustomerMessageProps {
   msg: MessageProps;
   isEndMessage?: boolean;
   isCustomer?: boolean;
+  currentUserName?: string;
 }
 
-function ChatMessage({ msg, isEndMessage, isCustomer }: CustomerMessageProps) {
+function ChatMessage({ msg, isEndMessage, isCustomer, currentUserName }: CustomerMessageProps) {
   const b3Lang = useB3Lang();
+
+  // B2B-2219: the buyer-side label backend returns is the quote's contact
+  // name, not the actual sender, so prefer the logged-in user's own name
+  // for messages on their side of the thread. Sales-rep labels are untouched.
+  const label =
+    msg?.role && isCustomer && SHOW_USER_NAME && currentUserName ? currentUserName : msg?.role;
+
   return (
     <Box
       sx={{
@@ -55,7 +65,7 @@ function ChatMessage({ msg, isEndMessage, isCustomer }: CustomerMessageProps) {
         paddingTop: '5px',
       }}
     >
-      {msg?.role && (
+      {label && (
         <Box
           sx={{
             height: '14px',
@@ -66,7 +76,7 @@ function ChatMessage({ msg, isEndMessage, isCustomer }: CustomerMessageProps) {
             color: 'rgba(0, 0, 0, 0.38)',
           }}
         >
-          {msg.role}
+          {label}
         </Box>
       )}
       {msg?.message && (
@@ -134,7 +144,7 @@ function DateMessage({ msg }: DateMessageProps) {
   );
 }
 
-function Message({ msgs, id, isB2BUser, email, status }: MsgsProps) {
+function Message({ msgs, id, isB2BUser, email, status, currentUserName }: MsgsProps) {
   const { dispatch: globalDispatch } = useContext(GlobalContext);
 
   const theme = useTheme();
@@ -367,6 +377,7 @@ function Message({ msgs, id, isB2BUser, email, status }: MsgsProps) {
                     msg={item}
                     isEndMessage={index === messages.length - 1}
                     isCustomer={!!item.isCustomer}
+                    currentUserName={currentUserName}
                   />
                   {item.date && <DateMessage msg={item} />}
                 </Box>

--- a/apps/storefront/src/utils/featureFlags.ts
+++ b/apps/storefront/src/utils/featureFlags.ts
@@ -67,6 +67,10 @@ export const featureFlags = [
     key: 'B2B-5309.dedupe_storefront_config_fetch_calls',
     name: 'dedupeStorefrontConfigFetchCalls',
   },
+  {
+    key: 'B2B-2219.fix_buyer_portal_quote_message_sender_name',
+    name: 'fixBuyerPortalQuoteMessageSenderName',
+  },
 ] as const;
 
 export type FeatureFlagKey = (typeof featureFlags)[number]['key'];


### PR DESCRIPTION
Jira: [B2B-2219](https://bigcommercecloud.atlassian.net/browse/B2B-2219)

## What/Why?
<!--
  A description about what this pull request implements and its purpose.
  Try to be detailed and describe any technical details to simplify the job
  of the reviewer and the individual on production support.
-->
The Buyer Portal quote messaging panel (Message.tsx) always rendered whatever label string the backend attached to trackingHistory[].role. For buyer-side messages, that label is the quote's contact name — not the actual sender — so when a company user who isn't the quote's listed contact sent a message, it displayed as coming from the contact instead of them. Quotes 2.0 doesn't have this problem; only the buyer portal messaging panel was affected.


## Rollout/Rollback
<!--
Detail how this change will be rolled out. Include reference to any
experiments and how the success will be measured as the experiment is
ramped.

Document rollback procedures. Is rolling back the change as simple as
rolling back an experiment or does it require reverting code? Are there
database migrations that may change our decision to roll forward instead of
back?
-->
Revert OR guarded by FF
## Testing
<!--
Provide as much information as you can about how you tested and how another
Engineer can test your change. Include screenshots, or test run output
where appropriate.
-->
Added Message.test.tsx (5 unit test cases): 
buyer-side label shows the current user's name when the flag is on; falls back to the original backend label when no user name is available; sales-rep labels are left untouched; and two cases confirming the original (buggy-but-safe) label is preserved when the flag is off or unset.

After SS from local 
<img width="388" height="379" alt="quote-message-after" src="https://github.com/user-attachments/assets/c1938f09-b6fb-400a-8d17-bb615d204e23" />



[B2B-2219]: https://bigcommercecloud.atlassian.net/browse/B2B-2219?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ