### PR TITLE
LOCAL-3323: Replace stored page translations instead of merging

### DIFF
--- a/apps/storefront/src/components/layout/B3RenderRouter.tsx
+++ b/apps/storefront/src/components/layout/B3RenderRouter.tsx
@@ -7,7 +7,7 @@ import { type SetOpenPage } from '@/pages/SetOpenPage';
 import { GlobalContext } from '@/shared/global';
 import { RouteItem } from '@/shared/routeList';
 import { firstLevelRouting, getAllowedRoutes } from '@/shared/routes';
-import { getPageTranslations, useAppDispatch } from '@/store';
+import { getPageTranslations, useAppDispatch, useAppSelector } from '@/store';
 import { channelId } from '@/utils/basicConfig';
 
 import Loading from '../loading/Loading';
@@ -27,6 +27,7 @@ export default function B3RenderRouter(props: B3RenderRouterProps) {
   const location = useLocation();
   const navigate = useNavigate();
   const dispatch = useAppDispatch();
+  const translationVersion = useAppSelector(({ lang }) => lang.translationVersion);
 
   useEffect(() => {
     if (openUrl === '/dashboard') {
@@ -52,8 +53,13 @@ export default function B3RenderRouter(props: B3RenderRouterProps) {
       );
     },
     // ignore dispatch
+    //
+    // translationVersion: when a global refetch bumps the version it also
+    // resets fetchedPages, and on load the dispatch above may already have
+    // been cancelled against the stale persisted fetchedPages. Re-running the
+    // effect refetches the page the user is currently on.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [globalState.multiStorefrontEnabled, location.pathname],
+    [globalState.multiStorefrontEnabled, location.pathname, translationVersion],
   );
 
   return (

--- a/apps/storefront/src/store/appAsyncThunks.ts
+++ b/apps/storefront/src/store/appAsyncThunks.ts
@@ -17,6 +17,7 @@ interface GetGlobalTranslationsParams {
 interface GetGlobalTranslationResponse {
   globalTranslations: Record<string, string>;
   newVersion: number;
+  multiLanguageEnabled: boolean;
 }
 
 interface GetPageTranslationsParams {
@@ -28,7 +29,11 @@ interface GetPageTranslationResponse {
   pageTranslations: Record<string, string>;
   page: string;
   fetchedDependencyPages: string[];
+  multiLanguageEnabled: boolean;
 }
+
+const isMultiLanguageEnabled = (state: RootState) =>
+  state.global.featureFlags['LOCAL-3191.B2B_multi_language'] ?? false;
 
 const REPEATED_PAGES: Partial<Record<string, string>> = {
   'company-orders': 'orders',
@@ -47,14 +52,18 @@ export const getGlobalTranslations = createAppAsyncThunk<
   GetGlobalTranslationsParams
 >(
   'lang/getGlobalTranslations',
-  async ({ channelId, newVersion }, { rejectWithValue }) => {
+  async ({ channelId, newVersion }, { rejectWithValue, getState }) => {
     const { message } = await getTranslation({ channelId, page: 'global' });
 
     if (typeof message === 'string') {
       return rejectWithValue(message);
     }
 
-    return { globalTranslations: message, newVersion };
+    return {
+      globalTranslations: message,
+      newVersion,
+      multiLanguageEnabled: isMultiLanguageEnabled(getState()),
+    };
   },
   {
     condition: ({ newVersion }, { getState }) => {
@@ -105,7 +114,12 @@ export const getPageTranslations = createAppAsyncThunk<
       ...successfulDeps.map((d) => d.translations),
     );
 
-    return { pageTranslations, page, fetchedDependencyPages: successfulDeps.map((d) => d.page) };
+    return {
+      pageTranslations,
+      page,
+      fetchedDependencyPages: successfulDeps.map((d) => d.page),
+      multiLanguageEnabled: isMultiLanguageEnabled(getState()),
+    };
   },
   {
     condition: ({ page: pageKey }, { getState }) => {

--- a/apps/storefront/src/store/appAsyncThunks.ts
+++ b/apps/storefront/src/store/appAsyncThunks.ts
@@ -1,6 +1,7 @@
 import { createAsyncThunk } from '@reduxjs/toolkit';
 
 import getTranslation from '@/shared/service/b2b/api/translation';
+import { getMultiLanguageEnabledCache } from '@/utils/multiLanguageFlagCache';
 
 import type { AppDispatch, RootState } from '.';
 
@@ -32,8 +33,11 @@ interface GetPageTranslationResponse {
   multiLanguageEnabled: boolean;
 }
 
+// Feature flags are populated asynchronously by setStorefrontConfig, after
+// B3StoreContainer has already dispatched getGlobalTranslations, so fall back
+// to the value cached by the previous page load while they are still missing.
 const isMultiLanguageEnabled = (state: RootState) =>
-  state.global.featureFlags['LOCAL-3191.B2B_multi_language'] ?? false;
+  state.global.featureFlags['LOCAL-3191.B2B_multi_language'] ?? getMultiLanguageEnabledCache();
 
 const REPEATED_PAGES: Partial<Record<string, string>> = {
   'company-orders': 'orders',

--- a/apps/storefront/src/store/slices/lang.test.ts
+++ b/apps/storefront/src/store/slices/lang.test.ts
@@ -1,0 +1,151 @@
+import { getGlobalTranslations, getPageTranslations } from '../appAsyncThunks';
+
+import { langSlice, LangState } from './lang';
+
+const { reducer } = langSlice;
+
+const stateWith = (overrides: Partial<LangState>): LangState => ({
+  translations: {},
+  fetchedPages: [],
+  translationVersion: 1,
+  ...overrides,
+});
+
+describe('lang slice translation storage', () => {
+  describe('getGlobalTranslations.fulfilled', () => {
+    const staleState = stateWith({
+      translations: {
+        'global.button.back': '!!=Back',
+        'global.button.next': '!!=Continue',
+        'login.loginText.signInHeader': '!!=Sign in',
+      },
+      fetchedPages: ['global', 'login'],
+    });
+
+    it('replaces the global namespace when multi-language is enabled', () => {
+      // The fetch only fires when the translation version changed, and phrases
+      // the merchant deleted are absent from the response: keeping them around
+      // would serve stale customizations forever. Only global.* is replaced;
+      // other pages are cleaned up when they are refetched (fetchedPages is
+      // reset below, so every page refetches this session).
+      const action = getGlobalTranslations.fulfilled(
+        {
+          globalTranslations: { 'global.button.back': 'NEW_BACK' },
+          newVersion: 2,
+          multiLanguageEnabled: true,
+        },
+        'requestId',
+        { channelId: 1, newVersion: 2 },
+      );
+
+      const state = reducer(staleState, action);
+
+      expect(state.translations).toEqual({
+        'global.button.back': 'NEW_BACK',
+        'login.loginText.signInHeader': '!!=Sign in',
+      });
+      expect(state.translations['global.button.next']).toBeUndefined();
+      expect(state.translationVersion).toBe(2);
+      expect(state.fetchedPages).toEqual(['global']);
+    });
+
+    it('keeps the legacy merge behavior when multi-language is disabled', () => {
+      const action = getGlobalTranslations.fulfilled(
+        {
+          globalTranslations: { 'global.button.back': 'NEW_BACK' },
+          newVersion: 2,
+          multiLanguageEnabled: false,
+        },
+        'requestId',
+        { channelId: 1, newVersion: 2 },
+      );
+
+      const state = reducer(staleState, action);
+
+      expect(state.translations).toEqual({
+        'global.button.back': 'NEW_BACK',
+        'global.button.next': '!!=Continue',
+        'login.loginText.signInHeader': '!!=Sign in',
+      });
+    });
+  });
+
+  describe('getPageTranslations.fulfilled', () => {
+    const staleState = stateWith({
+      translations: {
+        'global.button.back': '!!=Back',
+        'login.button.signIn': '!!=SIGN IN',
+        'login.loginText.signInHeader': '!!=Sign in',
+        'login.loginText.forgotPasswordText': '!!=Forgot your password?',
+        'quoteDraft.button.submit': '!!=Submit',
+      },
+      fetchedPages: ['global'],
+    });
+
+    it('replaces the fetched pages instead of merging when multi-language is enabled', () => {
+      const action = getPageTranslations.fulfilled(
+        {
+          pageTranslations: {
+            'login.button.signIn': '=~SIGN_IN~=',
+            'login.loginText.signInHeader': '==SIGN_IN==',
+          },
+          page: 'login',
+          fetchedDependencyPages: [],
+          multiLanguageEnabled: true,
+        },
+        'requestId',
+        { channelId: 1, page: 'login' },
+      );
+
+      const state = reducer(staleState, action);
+
+      // forgotPasswordText was deleted by the merchant: it must not survive.
+      expect(state.translations).toEqual({
+        'global.button.back': '!!=Back',
+        'login.button.signIn': '=~SIGN_IN~=',
+        'login.loginText.signInHeader': '==SIGN_IN==',
+        'quoteDraft.button.submit': '!!=Submit',
+      });
+      expect(state.fetchedPages).toEqual(['global', 'login']);
+    });
+
+    it('also replaces fetched dependency pages when multi-language is enabled', () => {
+      const action = getPageTranslations.fulfilled(
+        {
+          pageTranslations: { 'quoteDetail.header.title': 'Title:' },
+          page: 'quoteDetail',
+          fetchedDependencyPages: ['quoteDraft'],
+          multiLanguageEnabled: true,
+        },
+        'requestId',
+        { channelId: 1, page: 'quoteDetail' },
+      );
+
+      const state = reducer(staleState, action);
+
+      expect(state.translations['quoteDraft.button.submit']).toBeUndefined();
+      expect(state.translations['quoteDetail.header.title']).toBe('Title:');
+      expect(state.translations['login.loginText.signInHeader']).toBe('!!=Sign in');
+    });
+
+    it('keeps the legacy merge behavior when multi-language is disabled', () => {
+      const action = getPageTranslations.fulfilled(
+        {
+          pageTranslations: { 'login.button.signIn': '=~SIGN_IN~=' },
+          page: 'login',
+          fetchedDependencyPages: [],
+          multiLanguageEnabled: false,
+        },
+        'requestId',
+        { channelId: 1, page: 'login' },
+      );
+
+      const state = reducer(staleState, action);
+
+      expect(state.translations['login.button.signIn']).toBe('=~SIGN_IN~=');
+      expect(state.translations['login.loginText.forgotPasswordText']).toBe(
+        '!!=Forgot your password?',
+      );
+    });
+  });
+});

--- a/apps/storefront/src/store/slices/lang.test.ts
+++ b/apps/storefront/src/store/slices/lang.test.ts
@@ -49,6 +49,20 @@ describe('lang slice translation storage', () => {
       expect(state.fetchedPages).toEqual(['global']);
     });
 
+    it('drops every global phrase when the merchant cleared them all', () => {
+      // Once no global phrase is customised the endpoint answers
+      // {"message": {}}; persisted values must not survive that.
+      const action = getGlobalTranslations.fulfilled(
+        { globalTranslations: {}, newVersion: 2, multiLanguageEnabled: true },
+        'requestId',
+        { channelId: 1, newVersion: 2 },
+      );
+
+      const state = reducer(staleState, action);
+
+      expect(state.translations).toEqual({ 'login.loginText.signInHeader': '!!=Sign in' });
+    });
+
     it('keeps the legacy merge behavior when multi-language is disabled', () => {
       const action = getGlobalTranslations.fulfilled(
         {

--- a/apps/storefront/src/store/slices/lang.ts
+++ b/apps/storefront/src/store/slices/lang.ts
@@ -16,22 +16,57 @@ const initialState: LangState = {
   translationVersion: 0,
 };
 
+// LOCAL-3191.B2B_multi_language: a page response is authoritative for that
+// page's namespace (the key segment before the first dot) - phrases deleted by
+// the merchant are simply absent from it. Merging would keep deleted phrases
+// alive in persisted storage forever, so drop the fetched pages' stored keys
+// before applying the response. Other pages keep their keys until they are
+// refetched themselves.
+const replacePageTranslations = (
+  state: LangState,
+  pages: string[],
+  translations: Record<string, string>,
+) => {
+  Object.keys(state.translations).forEach((key) => {
+    if (pages.includes(key.split('.')[0])) {
+      delete state.translations[key];
+    }
+  });
+  Object.entries(translations).forEach(([key, translation]) => {
+    state.translations[key] = translation;
+  });
+};
+
 export const langSlice = createSlice({
   name: 'lang',
   initialState,
   reducers: {},
   extraReducers(builder) {
     builder.addCase(getGlobalTranslations.fulfilled, (state, { payload }) => {
-      Object.entries(payload.globalTranslations).forEach(([key, translation]) => {
-        state.translations[key] = translation;
-      });
+      if (payload.multiLanguageEnabled) {
+        replacePageTranslations(state, ['global'], payload.globalTranslations);
+      } else {
+        Object.entries(payload.globalTranslations).forEach(([key, translation]) => {
+          state.translations[key] = translation;
+        });
+      }
       state.translationVersion = payload.newVersion;
+      // Resetting fetchedPages forces every other page to refetch this session,
+      // which is when its stale phrases get replaced.
       state.fetchedPages = ['global'];
     });
     builder.addCase(getPageTranslations.fulfilled, (state, { payload }) => {
-      Object.entries(payload.pageTranslations).forEach(([key, translation]) => {
-        state.translations[key] = translation;
-      });
+      if (payload.multiLanguageEnabled) {
+        replacePageTranslations(
+          state,
+          [payload.page, ...payload.fetchedDependencyPages],
+          payload.pageTranslations,
+        );
+      } else {
+        Object.entries(payload.pageTranslations).forEach(([key, translation]) => {
+          state.translations[key] = translation;
+        });
+      }
       state.fetchedPages.push(payload.page, ...payload.fetchedDependencyPages);
     });
   },

--- a/apps/storefront/src/utils/multiLanguageFlagCache.test.ts
+++ b/apps/storefront/src/utils/multiLanguageFlagCache.test.ts
@@ -1,0 +1,37 @@
+import {
+  getMultiLanguageEnabledCache,
+  setMultiLanguageEnabledCache,
+} from './multiLanguageFlagCache';
+
+describe('multi-language feature flag cache', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('defaults to false when nothing has been cached yet', () => {
+    expect(getMultiLanguageEnabledCache()).toBe(false);
+  });
+
+  it('round-trips the cached value', () => {
+    setMultiLanguageEnabledCache(true);
+    expect(getMultiLanguageEnabledCache()).toBe(true);
+
+    setMultiLanguageEnabledCache(false);
+    expect(getMultiLanguageEnabledCache()).toBe(false);
+  });
+
+  it('resolves to false when local storage is unavailable', () => {
+    const getItem = vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new Error('storage disabled');
+    });
+    const setItem = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('storage disabled');
+    });
+
+    expect(() => setMultiLanguageEnabledCache(true)).not.toThrow();
+    expect(getMultiLanguageEnabledCache()).toBe(false);
+
+    getItem.mockRestore();
+    setItem.mockRestore();
+  });
+});

--- a/apps/storefront/src/utils/multiLanguageFlagCache.test.ts
+++ b/apps/storefront/src/utils/multiLanguageFlagCache.test.ts
@@ -24,14 +24,9 @@ describe('multi-language feature flag cache', () => {
     const getItem = vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
       throw new Error('storage disabled');
     });
-    const setItem = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
-      throw new Error('storage disabled');
-    });
 
-    expect(() => setMultiLanguageEnabledCache(true)).not.toThrow();
     expect(getMultiLanguageEnabledCache()).toBe(false);
 
     getItem.mockRestore();
-    setItem.mockRestore();
   });
 });

--- a/apps/storefront/src/utils/multiLanguageFlagCache.ts
+++ b/apps/storefront/src/utils/multiLanguageFlagCache.ts
@@ -19,7 +19,12 @@
 const MULTI_LANGUAGE_STORAGE_KEY = 'b2b-multi-language-enabled';
 
 export const setMultiLanguageEnabledCache = (enabled: boolean) => {
-  localStorage.setItem(MULTI_LANGUAGE_STORAGE_KEY, String(enabled));
+  try {
+    localStorage.setItem(MULTI_LANGUAGE_STORAGE_KEY, String(enabled));
+  } catch {
+    // localStorage can throw (e.g. Safari private mode, storage disabled).
+    // Caching is best-effort here, so a write failure must not break getStoreConfigs.
+  }
 };
 
 export const getMultiLanguageEnabledCache = (): boolean => {

--- a/apps/storefront/src/utils/multiLanguageFlagCache.ts
+++ b/apps/storefront/src/utils/multiLanguageFlagCache.ts
@@ -1,0 +1,35 @@
+/*
+  localStorage bridge for the LOCAL-3191.B2B_multi_language feature flag.
+
+  The flag lives in StoreConfig and is only populated (asynchronously, by
+  setStorefrontConfig) once App's effect has run. B3StoreContainer dispatches
+  getGlobalTranslations from a layout effect well before that, so reading the
+  flag from the store at that point resolves to false on every page load: the
+  global page would always take the legacy merge branch and phrases the
+  merchant deleted would stay in persisted storage forever.
+
+  Caching the resolved value lets the translation thunks read it synchronously.
+  On the very first visit nothing is cached and it resolves to false, which is
+  harmless: persisted storage is empty then, so merging and replacing produce
+  the same result.
+
+  TODO(LOCAL-3191): remove this bridge once the flag is fully rolled out and
+  the legacy merge branch in the lang slice is deleted.
+*/
+const MULTI_LANGUAGE_STORAGE_KEY = 'b2b-multi-language-enabled';
+
+export const setMultiLanguageEnabledCache = (enabled: boolean) => {
+  try {
+    localStorage.setItem(MULTI_LANGUAGE_STORAGE_KEY, String(enabled));
+  } catch {
+    // ignore: persistence is best-effort
+  }
+};
+
+export const getMultiLanguageEnabledCache = (): boolean => {
+  try {
+    return localStorage.getItem(MULTI_LANGUAGE_STORAGE_KEY) === 'true';
+  } catch {
+    return false;
+  }
+};

--- a/apps/storefront/src/utils/multiLanguageFlagCache.ts
+++ b/apps/storefront/src/utils/multiLanguageFlagCache.ts
@@ -19,11 +19,7 @@
 const MULTI_LANGUAGE_STORAGE_KEY = 'b2b-multi-language-enabled';
 
 export const setMultiLanguageEnabledCache = (enabled: boolean) => {
-  try {
-    localStorage.setItem(MULTI_LANGUAGE_STORAGE_KEY, String(enabled));
-  } catch {
-    // ignore: persistence is best-effort
-  }
+  localStorage.setItem(MULTI_LANGUAGE_STORAGE_KEY, String(enabled));
 };
 
 export const getMultiLanguageEnabledCache = (): boolean => {

--- a/apps/storefront/src/utils/storefrontConfig.ts
+++ b/apps/storefront/src/utils/storefrontConfig.ts
@@ -30,6 +30,7 @@ import { setActiveCurrency, setCurrencies } from '@/store/slices/storeConfigs';
 import { B3SStorage } from '@/utils/b3Storage';
 import { channelId } from '@/utils/basicConfig';
 import { FeatureFlagKey, featureFlags } from '@/utils/featureFlags';
+import { setMultiLanguageEnabledCache } from '@/utils/multiLanguageFlagCache';
 import { setNativeLinkInterceptionEnabled } from '@/utils/nativeStorefrontLinks';
 import { setDefaultLoginStylingEnabled } from '@/utils/preMountLoginMask';
 
@@ -311,6 +312,12 @@ const getStoreConfigs = async (dispatch: any, dispatchGlobal: any) => {
   // (see nativeStorefrontLinks.ts for the rest of the caching bridge to remove).
   setNativeLinkInterceptionEnabled(
     store.getState().global.featureFlags['B2B-4912.buyer_portal_native_link_interception'] ?? false,
+  );
+
+  // Same rationale, for the multi-language flag read by the translation thunks:
+  // B3StoreContainer dispatches them before these flags land.
+  setMultiLanguageEnabledCache(
+    store.getState().global.featureFlags['LOCAL-3191.B2B_multi_language'] ?? false,
   );
 
   dispatchGlobal({


### PR DESCRIPTION
Jira: [LOCAL-3323](https://bigcommercecloud.atlassian.net/browse/LOCAL-3323)

## Related PRs

Three PRs ship this change together, all gated on `LOCAL-3191.B2B_multi_language`:

- bigcommerce/b2b-translation-api#68: parses an uploaded file as partial and returns only the strings the merchant actually typed.
- bigcommerce/b2b-edition-api#6790: persists an upload as a replacement instead of a merge, resets the storefront cache, and fixes the duplicate version rows behind the integration 500.

Deploy order does not matter, since all three are inert until the flag is on. Do not enable the flag for a store until all three are out. They were tested together end to end; the shared verification is in the Testing section below.

## What/Why?
We have to pre-translate default channel locale when MultiLanguage for b2b is on. 
For example channel language is set to FR, we should return correct french texts if 
merchant did not make any changes. 

In case merchant uploaded a phrase 
```
VARIABLE,DEFAULT_VALUE,CUSTOM_VALUE
login.button.signIn,Sign In,!--SIGN_IN--!
```
Only this phrase should be custom, and other should be pre-translated by default.

### What?
Backend returns only changed phrases, may return empty list if we do not have translations. In this PR we are using this data correctly and put only this data into the cache (local storage)

For example: merchant translated all phrases in global scope. We put them into the cache (local storage). After merchant translated 1 phrase in global scope (removed the other translations)
When the shopper opens the page, we remove all "global." phrases and store only translated one. 

## Rollout/Rollback

Gated by the `LOCAL-3191.B2B_multi_language` experiment. 
## Testing
FR locale set by default. 

**Regression check.** Experiment disabled, current behavior. Uncustomized phrases are stored and returned as their English defaults.

https://github.com/user-attachments/assets/aaaba0c2-c770-45f3-b5ae-c2ac4bd113c4

**New behavior.** Experiment enabled. Only custom values are stored and returned. Phrases the merchant did not customize fall back to the pre-translated default-locale text.

https://github.com/user-attachments/assets/b687df3a-7275-4a79-90ca-0259f449d00e

[LOCAL-3323]: https://bigcommercecloud.atlassian.net/browse/LOCAL-3323?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ