### PR TITLE
feat(quotes): BACK-821 Implement backorders for picklist children in the add to quote section of draft quotes.

### DIFF
--- a/apps/storefront/src/components/PicklistSelectionBackorderMessage.tsx
+++ b/apps/storefront/src/components/PicklistSelectionBackorderMessage.tsx
@@ -32,7 +32,7 @@ function PicklistSelectionBackorderMessage({
 
   return (
     <Box sx={{ mt: 1, width: '100%' }}>
-      <Typography sx={{ color: '#616161', typography: 'body2' }}>
+      <Typography sx={{ color: '#616161', typography: 'body2', fontWeight: 600 }}>
         {`${selection.displayName}:`}
       </Typography>
       <BackorderMessage

--- a/apps/storefront/src/pages/OrderDetail/components/OrderCheckboxProduct.tsx
+++ b/apps/storefront/src/pages/OrderDetail/components/OrderCheckboxProduct.tsx
@@ -357,7 +357,7 @@ export default function OrderCheckboxProduct(props: OrderCheckboxProductProps) {
                       alignSelf: qtyStackAlignItems,
                     }}
                   >
-                    <Typography sx={{ color: '#616161', typography: 'body2' }}>
+                    <Typography sx={{ color: '#616161', typography: 'body2', fontWeight: 600 }}>
                       {`${selection.displayName}:`}
                     </Typography>
                     <BackorderMessage

--- a/apps/storefront/src/pages/QuickOrder/components/ChooseOptionsDialog.tsx
+++ b/apps/storefront/src/pages/QuickOrder/components/ChooseOptionsDialog.tsx
@@ -34,7 +34,7 @@ import {
   catalogListHasPicklistBackorderedItemsForDisplay,
   getProductDetailsForPicklistSelections,
 } from '@/utils/catalogBackorderDisplay';
-import { parseAttributeOptionId } from '@/utils/parseAttributeOptionId';
+import { getPicklistOptionSelectionsFromForm } from '@/utils/getPicklistOptionSelectionsFromForm';
 
 const Flex = styled('div')({
   display: 'flex',
@@ -372,12 +372,7 @@ export default function ChooseOptionsDialog(props: ChooseOptionsDialogProps) {
   const picklistSelections =
     backorderUiEnabled && product?.modifiers?.length
       ? getProductDetailsForPicklistSelections({
-          optionSelections: getOptionList(formValues).flatMap(({ optionId, optionValue }) => {
-            const parsedOptionId = parseAttributeOptionId(optionId);
-            return parsedOptionId === null
-              ? []
-              : [{ option_id: parsedOptionId, value_id: Number(optionValue) }];
-          }),
+          optionSelections: getPicklistOptionSelectionsFromForm(formFields, formValues),
           productsSearch: { modifiers: product.modifiers },
         })
       : [];

--- a/apps/storefront/src/pages/ShoppingListDetails/components/ChooseOptionsDialog.tsx
+++ b/apps/storefront/src/pages/ShoppingListDetails/components/ChooseOptionsDialog.tsx
@@ -16,6 +16,7 @@ import isEqual from 'lodash-es/isEqual';
 import { B3CustomForm } from '@/components/B3CustomForm';
 import B3Dialog from '@/components/B3Dialog';
 import BackorderMessage from '@/components/BackorderMessage';
+import PicklistBackorderMessages from '@/components/PicklistBackorderMessages';
 import B3Spin from '@/components/spin/B3Spin';
 import { PRODUCT_DEFAULT_IMAGE } from '@/constants';
 import { useBackorderStorefrontMessaging } from '@/hooks/useBackorderStorefrontMessaging';
@@ -35,7 +36,12 @@ import {
 } from '@/utils/b3Product/b3Product';
 import { snackbar } from '@/utils/b3Tip';
 import { Base64 } from '@/utils/base64';
-import { getCatalogInventorySku } from '@/utils/catalogBackorderDisplay';
+import {
+  catalogListHasPicklistBackorderedItemsForDisplay,
+  getCatalogInventorySku,
+  getProductDetailsForPicklistSelections,
+} from '@/utils/catalogBackorderDisplay';
+import { getPicklistOptionSelectionsFromForm } from '@/utils/getPicklistOptionSelectionsFromForm';
 
 import { AllOptionProps, ShoppingListProductItem, SimpleObject, Variant } from '../../../types';
 import {
@@ -444,6 +450,19 @@ export default function ChooseOptionsDialog(props: ChooseOptionsDialogProps) {
     [formFields],
   );
 
+  const picklistSelections =
+    backorderUiEnabled && product?.modifiers?.length
+      ? getProductDetailsForPicklistSelections({
+          optionSelections: getPicklistOptionSelectionsFromForm(formFields, formValues),
+          productsSearch: { modifiers: product.modifiers },
+        })
+      : [];
+
+  const hasPicklistBackorderToDisplay = catalogListHasPicklistBackorderedItemsForDisplay(
+    [{ qty: Number(quantity) || 0, selections: picklistSelections }],
+    additionalProducts,
+  );
+
   useEffect(() => {
     if (cache?.current && isEqual(cache?.current, formValues)) {
       return;
@@ -657,7 +676,7 @@ export default function ChooseOptionsDialog(props: ChooseOptionsDialogProps) {
                         fullWidth
                         error={Boolean(qtyHelperText)}
                       />
-                      {(qtyHelperText || backorderFields) && (
+                      {(qtyHelperText || backorderFields || hasPicklistBackorderToDisplay) && (
                         <Box
                           sx={{
                             width: 'max-content',
@@ -683,6 +702,13 @@ export default function ChooseOptionsDialog(props: ChooseOptionsDialogProps) {
                               visible
                             />
                           )}
+                          <PicklistBackorderMessages
+                            selections={picklistSelections}
+                            picklistProductsById={additionalProducts}
+                            qty={Number(quantity) || 0}
+                            visible
+                            backorderUiEnabled={backorderUiEnabled}
+                          />
                         </Box>
                       )}
                     </Box>

--- a/apps/storefront/src/pages/ShoppingListDetails/index.test.tsx
+++ b/apps/storefront/src/pages/ShoppingListDetails/index.test.tsx
@@ -4517,4 +4517,257 @@ describe('when backorder messaging is enabled in choose options dialog', () => {
       within(chooseOptionsDialog).queryByText('will be backordered', { exact: false }),
     ).not.toBeInTheDocument();
   });
+
+  it('shows the picklist child backorder details when the selected modifier option is backordered', async () => {
+    const modifierId = 70;
+    const optionValueId = 501;
+    const picklistProductId = 70000;
+
+    vitest.mocked(useParams).mockReturnValue({ id: '272989' });
+
+    const listProductEdge = buildShoppingListProductEdgeWith({
+      node: {
+        productName: 'Existing list item',
+        productId: 8000,
+        variantSku: 'LIST-SKU-001',
+        quantity: 1,
+        basePrice: '10.00',
+      },
+    });
+
+    const variant = buildSearchB2BProductVariantWith({
+      variant_id: variantId,
+      product_id: productId,
+      sku: variantSku,
+      purchasing_disabled: false,
+      option_values: [],
+      bc_calculated_price: {
+        tax_exclusive: 50,
+        tax_inclusive: 55,
+        as_entered: 50,
+        entered_inclusive: false,
+      },
+    });
+
+    const searchProduct = buildSearchB2BProductWith({
+      id: productId,
+      name: 'Fog Towel',
+      sku: 'TOWEL-BASE',
+      optionsV3: [],
+      isPriceHidden: false,
+      variants: [variant],
+      modifiers: [
+        {
+          id: modifierId,
+          type: 'product_list',
+          display_name: 'Pickly Picky',
+          option_values: [
+            {
+              id: optionValueId,
+              label: 'Mining Pick',
+              is_default: true,
+              option_id: modifierId,
+              value_data: { product_id: picklistProductId },
+            },
+          ],
+        },
+      ],
+    });
+
+    const picklistChildProduct = buildSearchB2BProductWith({
+      id: picklistProductId,
+      inventoryTracking: 'product',
+      availableToSell: 20,
+      unlimitedBackorder: false,
+      totalOnHand: 1,
+      backorderMessage: 'Backorders Schmackorders',
+      variants: [],
+    });
+
+    const shoppingListResponse = buildShoppingListGraphQLResponseWith({
+      data: {
+        shoppingList: {
+          products: { totalCount: 1, edges: [listProductEdge] },
+          status: 0,
+          grandTotal: '10.00',
+          totalTax: '0',
+        },
+      },
+    });
+
+    server.use(
+      graphql.query('B2BShoppingListDetails', () => HttpResponse.json(shoppingListResponse)),
+      graphql.query('SearchProducts', ({ query }) => {
+        if (/productIds: \[\d/.test(query)) {
+          return HttpResponse.json({ data: { productsSearch: [picklistChildProduct] } });
+        }
+
+        return HttpResponse.json(
+          buildSearchProductsResponseWith({ data: { productsSearch: [searchProduct] } }),
+        );
+      }),
+    );
+
+    renderWithProviders(<ShoppingListDetailsContent setOpenPage={() => {}} />, {
+      preloadedState: backorderPreloadedState,
+    });
+
+    await waitForElementToBeRemoved(() => screen.queryByText(/loading/i));
+
+    const chooseOptionsDialog = await openChooseOptionsDialog();
+    const quantityInput = within(chooseOptionsDialog).getByRole('spinbutton');
+
+    await within(chooseOptionsDialog).findByText('Pickly Picky');
+
+    await userEvent.type(quantityInput, '7', {
+      initialSelectionStart: 0,
+      initialSelectionEnd: Infinity,
+    });
+
+    expect(await within(chooseOptionsDialog).findByText('Pickly Picky:')).toBeVisible();
+    expect(within(chooseOptionsDialog).getByText('1 ready to ship')).toBeVisible();
+    expect(within(chooseOptionsDialog).getByText('6 will be backordered')).toBeVisible();
+    expect(within(chooseOptionsDialog).getByText('Backorders Schmackorders')).toBeVisible();
+  });
+
+  it('updates the picklist backorder information when a different modifier option is selected', async () => {
+    const modifierId = 70;
+    const miningPickOptionValueId = 501;
+    const icePickOptionValueId = 502;
+    const miningPickProductId = 70000;
+    const icePickProductId = 70001;
+
+    vitest.mocked(useParams).mockReturnValue({ id: '272989' });
+
+    const listProductEdge = buildShoppingListProductEdgeWith({
+      node: {
+        productName: 'Existing list item',
+        productId: 8000,
+        variantSku: 'LIST-SKU-001',
+        quantity: 1,
+        basePrice: '10.00',
+      },
+    });
+
+    const variant = buildSearchB2BProductVariantWith({
+      variant_id: variantId,
+      product_id: productId,
+      sku: variantSku,
+      purchasing_disabled: false,
+      option_values: [],
+      bc_calculated_price: {
+        tax_exclusive: 50,
+        tax_inclusive: 55,
+        as_entered: 50,
+        entered_inclusive: false,
+      },
+    });
+
+    const searchProduct = buildSearchB2BProductWith({
+      id: productId,
+      name: 'Fog Towel',
+      sku: 'TOWEL-BASE',
+      optionsV3: [],
+      isPriceHidden: false,
+      variants: [variant],
+      modifiers: [
+        {
+          id: modifierId,
+          type: 'product_list',
+          display_name: 'Pickly Picky',
+          option_values: [
+            {
+              id: miningPickOptionValueId,
+              label: 'Mining Pick',
+              is_default: true,
+              option_id: modifierId,
+              value_data: { product_id: miningPickProductId },
+            },
+            {
+              id: icePickOptionValueId,
+              label: 'Ice Pick',
+              is_default: false,
+              option_id: modifierId,
+              value_data: { product_id: icePickProductId },
+            },
+          ],
+        },
+      ],
+    });
+
+    const miningPickChildProduct = buildSearchB2BProductWith({
+      id: miningPickProductId,
+      inventoryTracking: 'product',
+      availableToSell: 20,
+      unlimitedBackorder: false,
+      totalOnHand: 1,
+      backorderMessage: 'Restocks in 3 weeks',
+      variants: [],
+    });
+
+    const icePickChildProduct = buildSearchB2BProductWith({
+      id: icePickProductId,
+      inventoryTracking: 'product',
+      availableToSell: 20,
+      unlimitedBackorder: false,
+      totalOnHand: 2,
+      backorderMessage: 'Restocks in 6 weeks',
+      variants: [],
+    });
+
+    const shoppingListResponse = buildShoppingListGraphQLResponseWith({
+      data: {
+        shoppingList: {
+          products: { totalCount: 1, edges: [listProductEdge] },
+          status: 0,
+          grandTotal: '10.00',
+          totalTax: '0',
+        },
+      },
+    });
+
+    server.use(
+      graphql.query('B2BShoppingListDetails', () => HttpResponse.json(shoppingListResponse)),
+      graphql.query('SearchProducts', ({ query }) => {
+        if (/productIds: \[\d/.test(query)) {
+          return HttpResponse.json({
+            data: { productsSearch: [miningPickChildProduct, icePickChildProduct] },
+          });
+        }
+
+        return HttpResponse.json(
+          buildSearchProductsResponseWith({ data: { productsSearch: [searchProduct] } }),
+        );
+      }),
+    );
+
+    renderWithProviders(<ShoppingListDetailsContent setOpenPage={() => {}} />, {
+      preloadedState: backorderPreloadedState,
+    });
+
+    await waitForElementToBeRemoved(() => screen.queryByText(/loading/i));
+
+    const chooseOptionsDialog = await openChooseOptionsDialog();
+    const quantityInput = within(chooseOptionsDialog).getByRole('spinbutton');
+
+    await within(chooseOptionsDialog).findByText('Pickly Picky');
+
+    await userEvent.type(quantityInput, '7', {
+      initialSelectionStart: 0,
+      initialSelectionEnd: Infinity,
+    });
+
+    expect(await within(chooseOptionsDialog).findByText('6 will be backordered')).toBeVisible();
+    expect(within(chooseOptionsDialog).getByText('Restocks in 3 weeks')).toBeVisible();
+    expect(within(chooseOptionsDialog).queryByText('Restocks in 6 weeks')).not.toBeInTheDocument();
+
+    await userEvent.click(within(chooseOptionsDialog).getByRole('radio', { name: 'Ice Pick' }));
+
+    expect(await within(chooseOptionsDialog).findByText('Restocks in 6 weeks')).toBeVisible();
+    expect(within(chooseOptionsDialog).getByText('5 will be backordered')).toBeVisible();
+    expect(within(chooseOptionsDialog).queryByText('Restocks in 3 weeks')).not.toBeInTheDocument();
+    expect(
+      within(chooseOptionsDialog).queryByText('6 will be backordered'),
+    ).not.toBeInTheDocument();
+  });
 });

--- a/apps/storefront/src/utils/getPicklistOptionSelectionsFromForm.ts
+++ b/apps/storefront/src/utils/getPicklistOptionSelectionsFromForm.ts
@@ -1,0 +1,20 @@
+import type { FieldValues } from 'react-hook-form';
+
+import { getOptionRequestData } from '@/utils/b3Product/shared/config';
+import { parseAttributeOptionId } from '@/utils/parseAttributeOptionId';
+
+export function getPicklistOptionSelectionsFromForm(
+  formFields: Record<string, unknown>[],
+  formValues: FieldValues,
+): Array<{ option_id: number; value_id: number }> {
+  const optionsData = getOptionRequestData(formFields, {}, formValues);
+
+  return Object.entries(optionsData).flatMap(([optionId, optionValue]) => {
+    const parsedOptionId = parseAttributeOptionId(optionId);
+    if (parsedOptionId === null) {
+      return [];
+    }
+
+    return [{ option_id: parsedOptionId, value_id: Number(optionValue) }];
+  });
+}


### PR DESCRIPTION
Jira: [BACK-821](https://bigcommercecloud.atlassian.net/browse/BACK-821)

## What/Why?
Add backorder information to child products for picklists when the child product is backordered.

## Rollout/Rollback
Revert this Pr if there are issues.

## Testing
Tests added.
Before: 
Backorders for child products in picklist not rendered when adding to quote from the quote draft page.
<img width="1484" height="880" alt="before" src="https://github.com/user-attachments/assets/a30dcc35-18ea-4694-af42-54ee903a042e" />

After:
Both parent and child have backorders, both render information:
<img width="1488" height="896" alt="afterPIcklistAndChildWithBackorders" src="https://github.com/user-attachments/assets/74897a25-5879-4a98-9231-59bda9ca09bf" />

Only parent has backorders, only the parent renders information:
<img width="1432" height="849" alt="afterPicklistParentOnlyBackordered" src="https://github.com/user-attachments/assets/5696af26-308e-4991-af32-7db8c0d1935c" />

Both child has backorders, only the child renders information:
<img width="1455" height="856" alt="afterPickListOnlyChildBackordered" src="https://github.com/user-attachments/assets/ac694730-d991-4e91-91a9-d1b6e3b26f7f" />

Both parent and child do not have any backorders, neither render information:
<img width="1455" height="888" alt="afterPIcklistNeitherParentNorChildAreBackordred" src="https://github.com/user-attachments/assets/3bfed29e-d082-4660-a1fd-7b8fa6d6a2f2" />

ping @bigcommerce/team-b2b @animesh1987 @declankirk 

[BACK-821]: https://bigcommercecloud.atlassian.net/browse/BACK-821?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only storefront changes reusing existing catalog backorder helpers; no checkout or inventory mutation logic.
> 
> **Overview**
> **Choose-options dialogs** now show backorder messaging for **picklist child products** when quantity or modifier selection would backorder the linked SKU, alongside existing parent-product backorder UI.
> 
> The shopping list **ChooseOptionsDialog** (including **draft quote** add-to-quote) wires in the same picklist resolution and **`PicklistBackorderMessages`** used elsewhere, and expands the quantity helper area when any picklist child has backorder to display. Quick order’s dialog switches to a shared **`getPicklistOptionSelectionsFromForm`** helper instead of inline option parsing.
> 
> Picklist modifier labels (e.g. modifier display name before the backorder block) use **semibold** styling in **`PicklistSelectionBackorderMessage`** and order reorder/checkbox rows for consistency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24f4622e11eb1d30ead2b924bf894d17044c2b3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->