### PR TITLE
B2B-5420: Fix unified orders queries against live SF GQL schema

### DIFF
--- a/apps/storefront/src/pages/CompanyOrderList/unified-company-orders.test.tsx
+++ b/apps/storefront/src/pages/CompanyOrderList/unified-company-orders.test.tsx
@@ -610,14 +610,10 @@ describe('Company Orders — unified SF GQL orders (B2B-4616)', () => {
         );
       });
 
-      it('uses PLACED_BY_Z_TO_A when first activating the Placed by column', async () => {
-        const getOrders = vi
-          .fn()
-          .mockReturnValue(buildCompanyOrdersResponseWith('WHATEVER_VALUES'));
-
+      it('does not allow sorting by the Placed by column (backend support incomplete)', async () => {
         server.use(
-          graphql.query('GetCompanyOrders', ({ variables }) =>
-            HttpResponse.json(getOrders(variables)),
+          graphql.query('GetCompanyOrders', () =>
+            HttpResponse.json(buildCompanyOrdersResponseWith('WHATEVER_VALUES')),
           ),
         );
 
@@ -625,19 +621,9 @@ describe('Company Orders — unified SF GQL orders (B2B-4616)', () => {
 
         await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
 
-        when(getOrders)
-          .calledWith(expect.objectContaining({ sortBy: OrdersSortInput.PLACED_BY_Z_TO_A }))
-          .thenReturn(buildCompanyOrdersResponseWith('WHATEVER_VALUES'));
-
-        await userEvent.click(
-          within(screen.getByRole('columnheader', { name: 'Placed by' })).getByRole('button'),
-        );
-
-        await waitFor(() => {
-          expect(getOrders).toHaveBeenCalledWith(
-            expect.objectContaining({ sortBy: OrdersSortInput.PLACED_BY_Z_TO_A }),
-          );
-        });
+        expect(
+          within(screen.getByRole('columnheader', { name: 'Placed by' })).queryByRole('button'),
+        ).not.toBeInTheDocument();
       });
 
       it('clears cursor variables when sort changes after paging forward', async () => {

--- a/apps/storefront/src/pages/CompanyOrderList/unified-company-orders.test.tsx
+++ b/apps/storefront/src/pages/CompanyOrderList/unified-company-orders.test.tsx
@@ -50,7 +50,7 @@ const buildSfGqlOrderWith = builder<Order>(() => ({
   entityId: faker.number.int({ min: 1000, max: 99999 }),
   orderedAt: { utc: faker.date.past().toISOString() },
   updatedAt: { utc: faker.date.past().toISOString() },
-  status: { value: 'PENDING', label: 'Pending' },
+  status: { value: 'AWAITING_FULFILLMENT', label: 'Awaiting fulfillment' },
   billingAddress: {
     firstName: faker.person.firstName(),
     lastName: faker.person.lastName(),
@@ -87,9 +87,7 @@ const buildSfGqlOrderWith = builder<Order>(() => ({
   company: { entityId: faker.number.int({ min: 1, max: 999 }), name: faker.company.name() },
   placedBy: buildPlacedByWith('WHATEVER_VALUES'),
   history: [],
-  quote: null,
   invoice: null,
-  extraFields: [],
 }));
 
 const buildCompanyOrdersResponseWith = builder<GetCompanyOrdersResponse>(() => {

--- a/apps/storefront/src/pages/MyOrders/unified-orders.test.tsx
+++ b/apps/storefront/src/pages/MyOrders/unified-orders.test.tsx
@@ -524,7 +524,7 @@ describe('My Orders — unified SF GQL orders (B2B-4613)', () => {
             .calledWith(
               expect.objectContaining({
                 filters: expect.objectContaining({
-                  status: 'Pending',
+                  status: 'PENDING',
                   dateRange: { from: '2022-11-15', to: '2022-11-26' },
                 }),
               }),
@@ -595,7 +595,7 @@ describe('My Orders — unified SF GQL orders (B2B-4613)', () => {
           });
         });
 
-        it('resolves custom status label to systemLabel before sending', async () => {
+        it('resolves custom status label to the OrderStatusValue enum before sending', async () => {
           const getOrders = vi
             .fn()
             .mockReturnValue(buildSfGqlCustomerOrdersResponseWith('WHATEVER_VALUES'));
@@ -627,7 +627,7 @@ describe('My Orders — unified SF GQL orders (B2B-4613)', () => {
           when(getOrders)
             .calledWith(
               expect.objectContaining({
-                filters: expect.objectContaining({ status: 'Pending' }),
+                filters: expect.objectContaining({ status: 'PENDING' }),
               }),
             )
             .thenReturn(filteredOrderResponse(66996));
@@ -638,6 +638,59 @@ describe('My Orders — unified SF GQL orders (B2B-4613)', () => {
 
           await userEvent.click(within(dialog).getByRole('combobox', { name: 'Order status' }));
           await userEvent.click(screen.getByRole('option', { name: 'Awaiting' }));
+
+          await userEvent.click(screen.getByRole('button', { name: 'Apply' }));
+
+          await waitFor(() => {
+            expect(screen.getByRole('row', { name: /66996/ })).toBeInTheDocument();
+          });
+        });
+
+        // OrdersFiltersInput.status is an enum on the customer path and [String!] on the
+        // company path. Sending the display-facing system label 400s at coercion.
+        it('sends the OrderStatusValue enum member when a status filter is applied', async () => {
+          const getOrders = vi
+            .fn()
+            .mockReturnValue(buildSfGqlCustomerOrdersResponseWith('WHATEVER_VALUES'));
+
+          server.use(
+            graphql.query('GetCustomerOrderStatuses', () =>
+              HttpResponse.json(
+                buildLegacyOrderStatusesResponseWith({
+                  data: {
+                    bcOrderStatuses: [
+                      buildLegacyOrderStatusWith({
+                        systemLabel: 'Awaiting Fulfillment',
+                        customLabel: 'Being packed',
+                      }),
+                    ],
+                  },
+                }),
+              ),
+            ),
+            graphql.query('GetCustomerOrders', ({ variables }) =>
+              HttpResponse.json(getOrders(variables)),
+            ),
+          );
+
+          renderWithProviders(<MyOrders />, { preloadedState: b2cStateWithFlag(flagOn) });
+
+          await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+          when(getOrders)
+            .calledWith(
+              expect.objectContaining({
+                filters: expect.objectContaining({ status: 'AWAITING_FULFILLMENT' }),
+              }),
+            )
+            .thenReturn(filteredOrderResponse(66996));
+
+          await userEvent.click(screen.getByRole('button', { name: /edit/ }));
+
+          const dialog = await screen.findByRole('dialog', { name: 'Filters' });
+
+          await userEvent.click(within(dialog).getByRole('combobox', { name: 'Order status' }));
+          await userEvent.click(screen.getByRole('option', { name: 'Being packed' }));
 
           await userEvent.click(screen.getByRole('button', { name: 'Apply' }));
 
@@ -713,7 +766,7 @@ describe('My Orders — unified SF GQL orders (B2B-4613)', () => {
             .calledWith(
               expect.objectContaining({
                 filters: expect.objectContaining({
-                  status: 'Pending',
+                  status: 'PENDING',
                   dateRange: { from: '2022-11-15', to: '2022-11-26' },
                 }),
               }),
@@ -784,7 +837,7 @@ describe('My Orders — unified SF GQL orders (B2B-4613)', () => {
           });
         });
 
-        it('resolves custom status label to systemLabel before sending', async () => {
+        it('resolves custom status label to the OrderStatusValue enum before sending', async () => {
           const getOrders = vi
             .fn()
             .mockReturnValue(buildSfGqlCustomerOrdersResponseWith('WHATEVER_VALUES'));
@@ -816,7 +869,7 @@ describe('My Orders — unified SF GQL orders (B2B-4613)', () => {
           when(getOrders)
             .calledWith(
               expect.objectContaining({
-                filters: expect.objectContaining({ status: 'Pending' }),
+                filters: expect.objectContaining({ status: 'PENDING' }),
               }),
             )
             .thenReturn(filteredOrderResponse(66996));

--- a/apps/storefront/src/pages/MyOrders/unified-orders.test.tsx
+++ b/apps/storefront/src/pages/MyOrders/unified-orders.test.tsx
@@ -400,9 +400,11 @@ describe('My Orders — unified SF GQL orders (B2B-4613)', () => {
       expect(capturedVariables).not.toHaveProperty('sortBy');
     });
 
-    // OrdersFiltersInput has no `search`, and the company selector's filter field was
-    // removed. A visible control that cannot filter is worse than no control.
-    it('renders neither the search box nor the company selector on the unified customer path', async () => {
+    // Search is kept visible even though it's a no-op: it's deferred to its own ticket,
+    // not permanently unsupported, so the UI stays unchanged for now (see B2B-5420). The
+    // company-hierarchy selector stays hidden — that field is permanently absent from
+    // OrdersFiltersInput (B2B-5421), so there's no query for it to ever start filtering.
+    it('renders the search box but not the company selector on the unified customer path', async () => {
       server.use(
         graphql.query('GetCustomerOrders', () =>
           HttpResponse.json(buildSfGqlCustomerOrdersResponseWith('WHATEVER_VALUES')),
@@ -422,8 +424,39 @@ describe('My Orders — unified SF GQL orders (B2B-4613)', () => {
       });
 
       expect(await screen.findByRole('table')).toBeInTheDocument();
-      expect(screen.queryByPlaceholderText('Search')).not.toBeInTheDocument();
+      expect(screen.queryByPlaceholderText('Search')).toBeInTheDocument();
       expect(screen.queryByRole('combobox', { name: /compan/i })).not.toBeInTheDocument();
+    });
+
+    // A super admin who isn't currently agenting hits a different branch of
+    // getFilterMoreData's role/agenting checks than CustomerRole.ADMIN does, and that
+    // branch used to leave the "Company" more-filter field visible even though the
+    // customer path's filter state has nowhere to send it — the exact visible-but-inert
+    // defect this fixes for the company more-filter field.
+    it('renders no Company field in more filters for a super admin who is not agenting', async () => {
+      server.use(
+        graphql.query('GetCustomerOrders', () =>
+          HttpResponse.json(buildSfGqlCustomerOrdersResponseWith('WHATEVER_VALUES')),
+        ),
+      );
+
+      renderWithProviders(<MyOrders />, {
+        preloadedState: {
+          ...b2bStateWithFlag(flagOn),
+          company: buildCompanyStateWith({
+            customer: { role: CustomerRole.SUPER_ADMIN, userType: UserTypes.MULTIPLE_B2C },
+            companyInfo: { id: '123', companyName: 'Test Corp', status: CompanyStatus.APPROVED },
+          }),
+        },
+      });
+
+      expect(await screen.findByRole('table')).toBeInTheDocument();
+
+      await userEvent.click(screen.getByRole('button', { name: /edit/ }));
+
+      const dialog = await screen.findByRole('dialog', { name: 'Filters' });
+
+      expect(within(dialog).queryByRole('textbox', { name: /compan/i })).not.toBeInTheDocument();
     });
 
     it("displays the order's own currency via formattedV2, ignoring the store's currency settings", async () => {
@@ -523,36 +556,6 @@ describe('My Orders — unified SF GQL orders (B2B-4613)', () => {
       });
 
       describe('as a B2C customer', () => {
-        it('filters by search input', async () => {
-          const getOrders = vi
-            .fn()
-            .mockReturnValue(buildSfGqlCustomerOrdersResponseWith('WHATEVER_VALUES'));
-
-          server.use(
-            graphql.query('GetCustomerOrders', ({ variables }) =>
-              HttpResponse.json(getOrders(variables)),
-            ),
-          );
-
-          renderWithProviders(<MyOrders />, { preloadedState: b2cStateWithFlag(flagOn) });
-
-          await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
-
-          when(getOrders)
-            .calledWith(
-              expect.objectContaining({
-                filters: expect.objectContaining({ search: '66996' }),
-              }),
-            )
-            .thenReturn(filteredOrderResponse(66996));
-
-          await userEvent.type(screen.getByPlaceholderText(/Search/), '66996');
-
-          await waitFor(() => {
-            expect(screen.getByRole('row', { name: /66996/ })).toBeInTheDocument();
-          });
-        });
-
         it('filters by status and date together', async () => {
           vi.setSystemTime(new Date('21 November 2022'));
 
@@ -765,36 +768,6 @@ describe('My Orders — unified SF GQL orders (B2B-4613)', () => {
       });
 
       describe('as a B2B customer', () => {
-        it('filters by search input', async () => {
-          const getOrders = vi
-            .fn()
-            .mockReturnValue(buildSfGqlCustomerOrdersResponseWith('WHATEVER_VALUES'));
-
-          server.use(
-            graphql.query('GetCustomerOrders', ({ variables }) =>
-              HttpResponse.json(getOrders(variables)),
-            ),
-          );
-
-          renderWithProviders(<MyOrders />, { preloadedState: b2bStateWithFlag(flagOn) });
-
-          await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
-
-          when(getOrders)
-            .calledWith(
-              expect.objectContaining({
-                filters: expect.objectContaining({ search: '66996' }),
-              }),
-            )
-            .thenReturn(filteredOrderResponse(66996));
-
-          await userEvent.type(screen.getByPlaceholderText(/Search/), '66996');
-
-          await waitFor(() => {
-            expect(screen.getByRole('row', { name: /66996/ })).toBeInTheDocument();
-          });
-        });
-
         it('filters by status and date together', async () => {
           vi.setSystemTime(new Date('21 November 2022'));
 
@@ -1090,68 +1063,6 @@ describe('My Orders — unified SF GQL orders (B2B-4613)', () => {
         await userEvent.click(screen.getByRole('button', { name: /previous page/ }));
         await waitFor(() => {
           expect(screen.getByRole('row', { name: /1001/ })).toBeInTheDocument();
-        });
-      });
-
-      it('resets cursor pagination when search filter changes', async () => {
-        const page1Response = buildPagedResponse([{ entityId: 1001 }], {
-          hasNextPage: true,
-          hasPreviousPage: false,
-          startCursor: 'cursor-1001',
-          endCursor: 'cursor-1001',
-        });
-
-        const getOrders = vi.fn().mockReturnValue(page1Response);
-
-        // Page 2
-        when(getOrders)
-          .calledWith(expect.objectContaining({ after: 'cursor-1001' }))
-          .thenReturn(
-            buildPagedResponse([{ entityId: 2001 }], {
-              hasNextPage: false,
-              hasPreviousPage: true,
-              startCursor: 'cursor-2001',
-              endCursor: 'cursor-2001',
-            }),
-          );
-
-        // After search — cursor reset, search filter applied
-        when(getOrders)
-          .calledWith(
-            expect.objectContaining({
-              filters: expect.objectContaining({ search: 'test' }),
-            }),
-          )
-          .thenReturn(
-            buildPagedResponse([{ entityId: 3001 }], {
-              hasNextPage: false,
-              hasPreviousPage: false,
-              startCursor: 'cursor-3001',
-              endCursor: 'cursor-3001',
-            }),
-          );
-
-        server.use(
-          graphql.query('GetCustomerOrders', ({ variables }) =>
-            HttpResponse.json(getOrders(variables)),
-          ),
-        );
-
-        renderWithProviders(<MyOrders />, { preloadedState: b2cStateWithFlag(flagOn) });
-
-        await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
-
-        // Navigate to page 2
-        await userEvent.click(screen.getByRole('button', { name: /next page/ }));
-        await waitFor(() => {
-          expect(screen.getByRole('row', { name: /2001/ })).toBeInTheDocument();
-        });
-
-        // Type in search — should reset pagination back to page 1
-        await userEvent.type(screen.getByPlaceholderText(/Search/), 'test');
-
-        await waitFor(() => {
-          expect(screen.getByRole('row', { name: /3001/ })).toBeInTheDocument();
         });
       });
 

--- a/apps/storefront/src/pages/MyOrders/unified-orders.test.tsx
+++ b/apps/storefront/src/pages/MyOrders/unified-orders.test.tsx
@@ -360,9 +360,6 @@ describe('My Orders — unified SF GQL orders (B2B-4613)', () => {
       expect(headerTexts).toContain('Company');
     });
 
-    // Sorting is not available on customer.orders — the agreed schema puts sortBy on the
-    // company path only, and the upstream endpoint has no sort parameter. A header that
-    // still reports aria-sort tells the user the list sorted when it did not.
     it('renders My Orders column headers as non-sortable when unified orders is enabled', async () => {
       server.use(
         graphql.query('GetCustomerOrders', () =>
@@ -398,10 +395,6 @@ describe('My Orders — unified SF GQL orders (B2B-4613)', () => {
       expect(capturedVariables).not.toHaveProperty('sortBy');
     });
 
-    // Search is kept visible even though it's a no-op: it's deferred to its own ticket,
-    // not permanently unsupported, so the UI stays unchanged for now (see B2B-5420). The
-    // company-hierarchy selector stays hidden — that field is permanently absent from
-    // OrdersFiltersInput (B2B-5421), so there's no query for it to ever start filtering.
     it('renders the search box but not the company selector on the unified customer path', async () => {
       server.use(
         graphql.query('GetCustomerOrders', () =>
@@ -426,11 +419,6 @@ describe('My Orders — unified SF GQL orders (B2B-4613)', () => {
       expect(screen.queryByRole('combobox', { name: /compan/i })).not.toBeInTheDocument();
     });
 
-    // A super admin who isn't currently agenting hits a different branch of
-    // getFilterMoreData's role/agenting checks than CustomerRole.ADMIN does, and that
-    // branch used to leave the "Company" more-filter field visible even though the
-    // customer path's filter state has nowhere to send it — the exact visible-but-inert
-    // defect this fixes for the company more-filter field.
     it('renders no Company field in more filters for a super admin who is not agenting', async () => {
       server.use(
         graphql.query('GetCustomerOrders', () =>
@@ -711,8 +699,6 @@ describe('My Orders — unified SF GQL orders (B2B-4613)', () => {
           });
         });
 
-        // OrdersFiltersInput.status is an enum on the customer path and [String!] on the
-        // company path. Sending the display-facing system label 400s at coercion.
         it('sends the OrderStatusValue enum member when a status filter is applied', async () => {
           const getOrders = vi
             .fn()
@@ -923,8 +909,6 @@ describe('My Orders — unified SF GQL orders (B2B-4613)', () => {
           });
         });
 
-        // OrdersFiltersInput has only status and dateRange. companyIds was filtering a
-        // customer-scoped list by the customer's own company — a no-op that 400s.
         it('never sends companyIds or companyName on the customer path', async () => {
           const getOrders = vi
             .fn()

--- a/apps/storefront/src/pages/MyOrders/unified-orders.test.tsx
+++ b/apps/storefront/src/pages/MyOrders/unified-orders.test.tsx
@@ -51,7 +51,7 @@ const buildSfGqlOrderWith = builder<Order>(() => ({
   entityId: faker.number.int({ min: 1000, max: 99999 }),
   orderedAt: { utc: faker.date.past().toISOString() },
   updatedAt: { utc: faker.date.past().toISOString() },
-  status: { value: 'PENDING', label: 'Pending' },
+  status: { value: 'AWAITING_FULFILLMENT', label: 'Awaiting fulfillment' },
   billingAddress: {
     firstName: faker.person.firstName(),
     lastName: faker.person.lastName(),
@@ -88,9 +88,7 @@ const buildSfGqlOrderWith = builder<Order>(() => ({
   company: { entityId: faker.number.int({ min: 1, max: 999 }), name: faker.company.name() },
   placedBy: buildPlacedByWith('WHATEVER_VALUES'),
   history: [],
-  quote: null,
   invoice: null,
-  extraFields: [],
 }));
 
 const buildSfGqlB2COrderWith = builder<Order>(() => ({
@@ -424,7 +422,7 @@ describe('My Orders — unified SF GQL orders (B2B-4613)', () => {
       });
 
       expect(await screen.findByRole('table')).toBeInTheDocument();
-      expect(screen.queryByPlaceholderText('Search')).toBeInTheDocument();
+      expect(screen.getByPlaceholderText('Search')).toBeInTheDocument();
       expect(screen.queryByRole('combobox', { name: /compan/i })).not.toBeInTheDocument();
     });
 

--- a/apps/storefront/src/pages/MyOrders/unified-orders.test.tsx
+++ b/apps/storefront/src/pages/MyOrders/unified-orders.test.tsx
@@ -951,6 +951,31 @@ describe('My Orders — unified SF GQL orders (B2B-4613)', () => {
             expect(screen.getByRole('row', { name: /66996/ })).toBeInTheDocument();
           });
         });
+
+        // OrdersFiltersInput has only status and dateRange. companyIds was filtering a
+        // customer-scoped list by the customer's own company — a no-op that 400s.
+        it('never sends companyIds or companyName on the customer path', async () => {
+          const getOrders = vi
+            .fn()
+            .mockReturnValue(buildSfGqlCustomerOrdersResponseWith('WHATEVER_VALUES'));
+
+          server.use(
+            graphql.query('GetCustomerOrders', ({ variables }) =>
+              HttpResponse.json(getOrders(variables)),
+            ),
+          );
+
+          renderWithProviders(<MyOrders />, { preloadedState: b2bStateWithFlag(flagOn) });
+
+          await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+
+          expect(getOrders).toHaveBeenCalled();
+          getOrders.mock.calls.forEach(([variables]) => {
+            const filters = (variables as { filters?: Record<string, unknown> }).filters ?? {};
+            expect(filters).not.toHaveProperty('companyIds');
+            expect(filters).not.toHaveProperty('companyName');
+          });
+        });
       });
     });
 

--- a/apps/storefront/src/pages/MyOrders/unified-orders.test.tsx
+++ b/apps/storefront/src/pages/MyOrders/unified-orders.test.tsx
@@ -362,6 +362,70 @@ describe('My Orders — unified SF GQL orders (B2B-4613)', () => {
       expect(headerTexts).toContain('Company');
     });
 
+    // Sorting is not available on customer.orders — the agreed schema puts sortBy on the
+    // company path only, and the upstream endpoint has no sort parameter. A header that
+    // still reports aria-sort tells the user the list sorted when it did not.
+    it('renders My Orders column headers as non-sortable when unified orders is enabled', async () => {
+      server.use(
+        graphql.query('GetCustomerOrders', () =>
+          HttpResponse.json(buildSfGqlCustomerOrdersResponseWith('WHATEVER_VALUES')),
+        ),
+      );
+
+      renderWithProviders(<MyOrders />, { preloadedState: b2bStateWithFlag(flagOn) });
+
+      expect(await screen.findByRole('columnheader', { name: 'Order' })).toBeInTheDocument();
+      screen.getAllByRole('columnheader').forEach((header) => {
+        expect(header).not.toHaveAttribute('aria-sort');
+        expect(header.querySelector('.MuiTableSortLabel-root')).toBeNull();
+      });
+    });
+
+    it('does not send sortBy on the customer orders query', async () => {
+      let capturedQuery = '';
+      let capturedVariables: Record<string, unknown> = {};
+
+      server.use(
+        graphql.query('GetCustomerOrders', ({ query, variables }) => {
+          capturedQuery = query;
+          capturedVariables = variables;
+          return HttpResponse.json(buildSfGqlCustomerOrdersResponseWith('WHATEVER_VALUES'));
+        }),
+      );
+
+      renderWithProviders(<MyOrders />, { preloadedState: b2bStateWithFlag(flagOn) });
+
+      await waitFor(() => expect(capturedQuery).not.toBe(''));
+      expect(capturedQuery).not.toContain('sortBy');
+      expect(capturedVariables).not.toHaveProperty('sortBy');
+    });
+
+    // OrdersFiltersInput has no `search`, and the company selector's filter field was
+    // removed. A visible control that cannot filter is worse than no control.
+    it('renders neither the search box nor the company selector on the unified customer path', async () => {
+      server.use(
+        graphql.query('GetCustomerOrders', () =>
+          HttpResponse.json(buildSfGqlCustomerOrdersResponseWith('WHATEVER_VALUES')),
+        ),
+      );
+
+      renderWithProviders(<MyOrders />, {
+        preloadedState: {
+          ...b2bStateWithFlag(flagOn),
+          company: buildCompanyStateWith({
+            customer: { role: CustomerRole.ADMIN, userType: UserTypes.MULTIPLE_B2C },
+            companyInfo: { id: '123', companyName: 'Test Corp', status: CompanyStatus.APPROVED },
+            companyHierarchyInfo: { isEnabledCompanyHierarchy: true },
+            pagesSubsidiariesPermission: { order: true },
+          }),
+        },
+      });
+
+      expect(await screen.findByRole('table')).toBeInTheDocument();
+      expect(screen.queryByPlaceholderText('Search')).not.toBeInTheDocument();
+      expect(screen.queryByRole('combobox', { name: /compan/i })).not.toBeInTheDocument();
+    });
+
     it("displays the order's own currency via formattedV2, ignoring the store's currency settings", async () => {
       const order = buildSfGqlOrderWith({
         entityId: 90909,

--- a/apps/storefront/src/pages/OrderDetail/components/CursorDetailPagination.tsx
+++ b/apps/storefront/src/pages/OrderDetail/components/CursorDetailPagination.tsx
@@ -99,7 +99,6 @@ async function fetchAdjacentPage(
   const result = await getCustomerOrders({
     ...paginationArgs,
     filters: filters as OrdersFiltersInput,
-    sortBy,
   });
   const orders = result.data?.customer?.orders;
   if (!orders) throw new Error('Unexpected API response: orders missing');

--- a/apps/storefront/src/pages/OrderDetail/index.unified.test.tsx
+++ b/apps/storefront/src/pages/OrderDetail/index.unified.test.tsx
@@ -261,11 +261,61 @@ describe('Order detail path with unified SF GQL flag ON', () => {
     return view;
   }
 
+  // OrderHistoryEvent exposes statusLabel; `status` and `createdBy` do not exist on it.
+  it('requests statusLabel on history and never createdBy', async () => {
+    let capturedQuery = '';
+    server.use(
+      graphql.query('GetOrderDetail', ({ query }) => {
+        capturedQuery = query;
+        return HttpResponse.json(
+          buildOrderDetailResponseWith({
+            data: {
+              site: {
+                order: buildUnifiedOrderWith({ entityId: 6696 }),
+              },
+            },
+          }),
+        );
+      }),
+    );
+
+    await renderOrderDetails();
+
+    expect(capturedQuery).toContain('statusLabel');
+    expect(capturedQuery).not.toMatch(/history\s*\{[^}]*\bstatus\b\s/);
+    expect(capturedQuery).not.toContain('createdBy');
+  });
+
   it('renders the order header', async () => {
     await renderOrderDetails();
 
     expect(await screen.findByRole('heading', { name: /Order #6696/ })).toBeVisible();
     expect(screen.getByText('Pending')).toBeVisible();
+  });
+
+  // Same casing trap as the list surfaces: the detail header looks the status up twice,
+  // once for colour and once for the merchant custom label, both by system label.
+  it('renders the status tag when the resolver returns a sentence-case label', async () => {
+    server.use(
+      graphql.query('GetOrderDetail', () =>
+        HttpResponse.json(
+          buildOrderDetailResponseWith({
+            data: {
+              site: {
+                order: buildUnifiedOrderWith({
+                  entityId: 6696,
+                  status: { value: 'AWAITING_FULFILLMENT', label: 'Awaiting fulfillment' },
+                }),
+              },
+            },
+          }),
+        ),
+      ),
+    );
+
+    await renderOrderDetails();
+
+    expect(await screen.findByText('Awaiting Fulfillment')).toBeInTheDocument();
   });
 
   it('can navigate back to the orders listing page', async () => {
@@ -1289,17 +1339,15 @@ describe('Order detail path with unified SF GQL flag ON', () => {
                       {
                         id: '1',
                         eventType: OrderHistoryEventType.ORDER_CREATED,
-                        status: 'Pending',
+                        statusLabel: 'Pending',
                         source: null,
-                        createdBy: null,
                         createdAt: '2025-05-01T03:44:00.000Z',
                       },
                       {
                         id: '2',
                         eventType: OrderHistoryEventType.ORDER_UPDATED,
-                        status: 'Shipped',
+                        statusLabel: 'Shipped',
                         source: null,
-                        createdBy: null,
                         createdAt: '2025-05-04T07:22:00.000Z',
                       },
                     ],

--- a/apps/storefront/src/pages/OrderDetail/index.unified.test.tsx
+++ b/apps/storefront/src/pages/OrderDetail/index.unified.test.tsx
@@ -120,9 +120,7 @@ const buildUnifiedOrderWith = builder<Order>(() => ({
   company: null,
   placedBy: null,
   history: [],
-  quote: null,
   invoice: null,
-  extraFields: [],
 }));
 
 const buildOrderDetailResponseWith = builder<GetOrderDetailResponse>(() => ({
@@ -261,6 +259,29 @@ describe('Order detail path with unified SF GQL flag ON', () => {
     return view;
   }
 
+  // Image.url takes a required width argument.
+  it('requests the line item image with an explicit width', async () => {
+    let capturedQuery = '';
+    server.use(
+      graphql.query('GetOrderDetail', ({ query }) => {
+        capturedQuery = query;
+        return HttpResponse.json(
+          buildOrderDetailResponseWith({
+            data: {
+              site: {
+                order: buildUnifiedOrderWith({ entityId: 6696 }),
+              },
+            },
+          }),
+        );
+      }),
+    );
+
+    await renderOrderDetails();
+
+    expect(capturedQuery).toContain('url(width: 80)');
+  });
+
   // OrderHistoryEvent exposes statusLabel; `status` and `createdBy` do not exist on it.
   it('requests statusLabel on history and never createdBy', async () => {
     let capturedQuery = '';
@@ -284,6 +305,32 @@ describe('Order detail path with unified SF GQL flag ON', () => {
     expect(capturedQuery).toContain('statusLabel');
     expect(capturedQuery).not.toMatch(/history\s*\{[^}]*\bstatus\b\s/);
     expect(capturedQuery).not.toContain('createdBy');
+  });
+
+  // These three are selected and never read. returnableQuantity additionally 500s, and
+  // being non-null it nulls the entire consignments tree with it.
+  it('does not select fields the UI never reads', async () => {
+    let capturedQuery = '';
+    server.use(
+      graphql.query('GetOrderDetail', ({ query }) => {
+        capturedQuery = query;
+        return HttpResponse.json(
+          buildOrderDetailResponseWith({
+            data: {
+              site: {
+                order: buildUnifiedOrderWith({ entityId: 6696 }),
+              },
+            },
+          }),
+        );
+      }),
+    );
+
+    await renderOrderDetails();
+
+    expect(capturedQuery).not.toContain('returnableQuantity');
+    expect(capturedQuery).not.toContain('quote');
+    expect(capturedQuery).not.toContain('extraFields');
   });
 
   it('renders the order header', async () => {
@@ -662,7 +709,6 @@ describe('Order detail path with unified SF GQL flag ON', () => {
                           subTotalSalePrice: buildSfGqlMoneyWith({ value: 75 }),
                           image: { url: 'https://example.com/widget.jpg' },
                           baseCatalogProduct: { path: '/widget/' },
-                          returnableQuantity: 0,
                         },
                       },
                     ],
@@ -690,7 +736,7 @@ describe('Order detail path with unified SF GQL flag ON', () => {
           },
           downloads: null,
         },
-        payments: [{ description: 'Credit Card' }],
+        payments: { edges: [{ node: { paymentMethodName: 'Credit Card' } }] },
         ...overrides,
       });
     }
@@ -784,7 +830,6 @@ describe('Order detail path with unified SF GQL flag ON', () => {
                           subTotalSalePrice: buildSfGqlMoneyWith({ value: 50 }),
                           image: null,
                           baseCatalogProduct: null,
-                          returnableQuantity: 0,
                         },
                       },
                     ],
@@ -866,7 +911,6 @@ describe('Order detail path with unified SF GQL flag ON', () => {
                           subTotalSalePrice: buildSfGqlMoneyWith({ value: 25 }),
                           image: null,
                           baseCatalogProduct: null,
-                          returnableQuantity: 0,
                         },
                       },
                     ],
@@ -909,7 +953,6 @@ describe('Order detail path with unified SF GQL flag ON', () => {
                           subTotalSalePrice: buildSfGqlMoneyWith({ value: 50 }),
                           image: null,
                           baseCatalogProduct: null,
-                          returnableQuantity: 0,
                         },
                       },
                     ],
@@ -973,7 +1016,6 @@ describe('Order detail path with unified SF GQL flag ON', () => {
                           subTotalSalePrice: buildSfGqlMoneyWith({ value: 125 }),
                           image: null,
                           baseCatalogProduct: null,
-                          returnableQuantity: 0,
                         },
                       },
                     ],
@@ -1053,7 +1095,6 @@ describe('Order detail path with unified SF GQL flag ON', () => {
                           subTotalSalePrice: buildSfGqlMoneyWith({ value: 75 }),
                           image: null,
                           baseCatalogProduct: null,
-                          returnableQuantity: 0,
                         },
                       },
                       {
@@ -1070,7 +1111,6 @@ describe('Order detail path with unified SF GQL flag ON', () => {
                           subTotalSalePrice: buildSfGqlMoneyWith({ value: 100 }),
                           image: null,
                           baseCatalogProduct: null,
-                          returnableQuantity: 0,
                         },
                       },
                     ],
@@ -1169,7 +1209,6 @@ describe('Order detail path with unified SF GQL flag ON', () => {
                           subTotalSalePrice: buildSfGqlMoneyWith({ value: 100 }),
                           image: null,
                           baseCatalogProduct: null,
-                          returnableQuantity: 0,
                         },
                       },
                     ],
@@ -1181,7 +1220,7 @@ describe('Order detail path with unified SF GQL flag ON', () => {
           },
           downloads: null,
         },
-        payments: [{ description: 'Visa ending in 1234' }],
+        payments: { edges: [{ node: { paymentMethodName: 'Visa ending in 1234' } }] },
       });
 
       server.use(
@@ -1206,6 +1245,35 @@ describe('Order detail path with unified SF GQL flag ON', () => {
       expect(screen.getByRole('heading', { name: 'Payment' })).toBeVisible();
       expect(screen.getByText(/Paid in full/)).toBeVisible();
       expect(screen.getByText(/Visa ending in 1234/)).toBeVisible();
+    });
+
+    // payments is a PaymentsConnection and Payment exposes paymentMethodName.
+    it('renders the payment method from the payments connection', async () => {
+      server.use(
+        graphql.query('GetOrderDetail', () =>
+          HttpResponse.json(
+            buildOrderDetailResponseWith({
+              data: {
+                site: {
+                  order: buildUnifiedOrderWith({
+                    payments: { edges: [{ node: { paymentMethodName: 'Purchase Order' } }] },
+                  }),
+                },
+              },
+            }),
+          ),
+        ),
+        graphql.query('GetCustomerOrderStatuses', () =>
+          HttpResponse.json(buildCustomerOrderStatusesWith('WHATEVER_VALUES')),
+        ),
+        graphql.query('AddressConfig', () =>
+          HttpResponse.json(buildAddressConfigResponseWith('WHATEVER_VALUES')),
+        ),
+      );
+
+      await renderOrderDetails();
+
+      expect(await screen.findByText(/Purchase Order/)).toBeInTheDocument();
     });
 
     it('renders payment details for a Purchase Order', async () => {
@@ -1251,7 +1319,6 @@ describe('Order detail path with unified SF GQL flag ON', () => {
                           subTotalSalePrice: buildSfGqlMoneyWith({ value: 100 }),
                           image: null,
                           baseCatalogProduct: null,
-                          returnableQuantity: 0,
                         },
                       },
                     ],
@@ -1263,7 +1330,7 @@ describe('Order detail path with unified SF GQL flag ON', () => {
           },
           downloads: null,
         },
-        payments: [{ description: 'Purchase Order' }],
+        payments: { edges: [{ node: { paymentMethodName: 'Purchase Order' } }] },
       });
 
       server.use(
@@ -1295,7 +1362,7 @@ describe('Order detail path with unified SF GQL flag ON', () => {
         reference: null,
         orderedAt: { utc: '2026-05-01T12:00:00Z' },
         status: { value: 'AWAITING_PAYMENT', label: 'Awaiting Payment' },
-        payments: [{ description: 'Cash on delivery' }],
+        payments: { edges: [{ node: { paymentMethodName: 'Cash on delivery' } }] },
       });
 
       server.use(
@@ -1410,19 +1477,14 @@ describe('Order detail path with unified SF GQL flag ON', () => {
       }>,
       physicalConsignment?: Order['consignments'],
     ) {
-      const downloads = {
-        edges: [
-          {
-            cursor: 'dc1',
-            node: {
-              entityId: 9001,
-              lineItems: {
-                edges: digitalItems.map((item) => ({ node: item })),
-              },
-            },
+      const downloads = [
+        {
+          recipientEmail: 'buyer@example.com',
+          lineItems: {
+            edges: digitalItems.map((item) => ({ node: item })),
           },
-        ],
-      };
+        },
+      ];
 
       const shipping = physicalConsignment?.shipping ?? { edges: [] };
 
@@ -1499,6 +1561,55 @@ describe('Order detail path with unified SF GQL flag ON', () => {
       expect(screen.getByText('Scare Floor Operations Manual (eBook)')).toBeVisible();
       expect(screen.getByText('112')).toBeVisible();
       expect(screen.getByText('Format: ePub')).toBeVisible();
+    });
+
+    // downloads is [OrderDownloadConsignment!]!, unlike its sibling `shipping`.
+    it('selects downloads as a plain list and renders its digital products', async () => {
+      let capturedQuery = '';
+      server.use(
+        graphql.query('GetOrderDetail', ({ query }) => {
+          capturedQuery = query;
+          return HttpResponse.json(
+            buildOrderDetailResponseWith({
+              data: {
+                site: {
+                  order: buildUnifiedOrderWith({
+                    entityId: 6696,
+                    consignments: {
+                      shipping: { edges: [] },
+                      downloads: [
+                        {
+                          recipientEmail: 'buyer@example.com',
+                          lineItems: {
+                            edges: [
+                              {
+                                node: {
+                                  entityId: 5001,
+                                  productEntityId: 3001,
+                                  name: 'Ebook',
+                                  quantity: 1,
+                                  productOptions: [],
+                                  subTotalListPrice: buildSfGqlMoneyWith({ value: 10 }),
+                                  subTotalSalePrice: buildSfGqlMoneyWith({ value: 10 }),
+                                },
+                              },
+                            ],
+                          },
+                        },
+                      ],
+                    },
+                  }),
+                },
+              },
+            }),
+          );
+        }),
+      );
+
+      await renderOrderDetails();
+
+      expect(await screen.findByText('Ebook')).toBeInTheDocument();
+      expect(capturedQuery).not.toMatch(/downloads\s*\{\s*edges/);
     });
 
     it('displays the view files link for digital products in an order', async () => {
@@ -1613,7 +1724,6 @@ describe('Order detail path with unified SF GQL flag ON', () => {
                         subTotalSalePrice: buildSfGqlMoneyWith({ value: 200 }),
                         image: null,
                         baseCatalogProduct: null,
-                        returnableQuantity: 0,
                       },
                     },
                   ],
@@ -1623,31 +1733,26 @@ describe('Order detail path with unified SF GQL flag ON', () => {
             },
           ],
         },
-        downloads: {
-          edges: [
-            {
-              cursor: 'dc1',
-              node: {
-                entityId: 9001,
-                lineItems: {
-                  edges: [
-                    {
-                      node: {
-                        entityId: 5001,
-                        productEntityId: 3002,
-                        name: 'How to meow',
-                        quantity: 1,
-                        productOptions: [],
-                        subTotalListPrice: buildSfGqlMoneyWith({ value: 10 }),
-                        subTotalSalePrice: buildSfGqlMoneyWith({ value: 10 }),
-                      },
-                    },
-                  ],
+        downloads: [
+          {
+            recipientEmail: 'buyer@example.com',
+            lineItems: {
+              edges: [
+                {
+                  node: {
+                    entityId: 5001,
+                    productEntityId: 3002,
+                    name: 'How to meow',
+                    quantity: 1,
+                    productOptions: [],
+                    subTotalListPrice: buildSfGqlMoneyWith({ value: 10 }),
+                    subTotalSalePrice: buildSfGqlMoneyWith({ value: 10 }),
+                  },
                 },
-              },
+              ],
             },
-          ],
-        },
+          },
+        ],
       };
 
       const orderWithBoth = buildUnifiedOrderWith({
@@ -1732,7 +1837,6 @@ describe('Order detail path with unified SF GQL flag ON', () => {
                         subTotalSalePrice: buildSfGqlMoneyWith({ value: p.quantity * 10 }),
                         image: null,
                         baseCatalogProduct: null,
-                        returnableQuantity: 0,
                       },
                     })),
                   },
@@ -2158,7 +2262,6 @@ describe('Order detail path with unified SF GQL flag ON', () => {
                         subTotalSalePrice: buildSfGqlMoneyWith({ value: p.quantity * 10 }),
                         image: null,
                         baseCatalogProduct: null,
-                        returnableQuantity: 0,
                       },
                     })),
                   },
@@ -2822,7 +2925,6 @@ describe('Order detail path with unified SF GQL flag ON', () => {
                         subTotalSalePrice: buildSfGqlMoneyWith({ value: p.quantity * 10 }),
                         image: null,
                         baseCatalogProduct: null,
-                        returnableQuantity: 0,
                       },
                     })),
                   },

--- a/apps/storefront/src/pages/OrderDetail/index.unified.test.tsx
+++ b/apps/storefront/src/pages/OrderDetail/index.unified.test.tsx
@@ -83,7 +83,7 @@ const buildUnifiedOrderWith = builder<Order>(() => ({
   entityId: faker.number.int({ min: 1000, max: 99999 }),
   orderedAt: { utc: faker.date.past().toISOString() },
   updatedAt: { utc: faker.date.past().toISOString() },
-  status: { value: 'PENDING', label: 'Pending' },
+  status: { value: 'AWAITING_FULFILLMENT', label: 'Awaiting fulfillment' },
   billingAddress: {
     firstName: faker.person.firstName(),
     lastName: faker.person.lastName(),
@@ -216,7 +216,7 @@ describe('Order detail path with unified SF GQL flag ON', () => {
               site: {
                 order: buildUnifiedOrderWith({
                   entityId: 6696,
-                  status: { value: 'PENDING', label: 'Pending' },
+                  status: { value: 'AWAITING_FULFILLMENT', label: 'Awaiting fulfillment' },
                   reference: '',
                 }),
               },
@@ -229,7 +229,10 @@ describe('Order detail path with unified SF GQL flag ON', () => {
           buildCustomerOrderStatusesWith({
             data: {
               bcOrderStatuses: [
-                buildOrderStatusWith({ systemLabel: 'Pending', customLabel: 'Pending' }),
+                buildOrderStatusWith({
+                  systemLabel: 'Awaiting Fulfillment',
+                  customLabel: 'Awaiting Fulfillment',
+                }),
                 buildOrderStatusWith('WHATEVER_VALUES'),
               ],
             },
@@ -337,7 +340,7 @@ describe('Order detail path with unified SF GQL flag ON', () => {
     await renderOrderDetails();
 
     expect(await screen.findByRole('heading', { name: /Order #6696/ })).toBeVisible();
-    expect(screen.getByText('Pending')).toBeVisible();
+    expect(screen.getByText('Awaiting Fulfillment')).toBeVisible();
   });
 
   // Same casing trap as the list surfaces: the detail header looks the status up twice,

--- a/apps/storefront/src/pages/OrderDetail/index.unified.test.tsx
+++ b/apps/storefront/src/pages/OrderDetail/index.unified.test.tsx
@@ -262,7 +262,6 @@ describe('Order detail path with unified SF GQL flag ON', () => {
     return view;
   }
 
-  // Image.url takes a required width argument.
   it('requests the line item image with an explicit width', async () => {
     let capturedQuery = '';
     server.use(
@@ -285,7 +284,6 @@ describe('Order detail path with unified SF GQL flag ON', () => {
     expect(capturedQuery).toContain('url(width: 80)');
   });
 
-  // OrderHistoryEvent exposes statusLabel; `status` and `createdBy` do not exist on it.
   it('requests statusLabel on history and never createdBy', async () => {
     let capturedQuery = '';
     server.use(
@@ -310,8 +308,6 @@ describe('Order detail path with unified SF GQL flag ON', () => {
     expect(capturedQuery).not.toContain('createdBy');
   });
 
-  // These three are selected and never read. returnableQuantity additionally 500s, and
-  // being non-null it nulls the entire consignments tree with it.
   it('does not select fields the UI never reads', async () => {
     let capturedQuery = '';
     server.use(
@@ -343,8 +339,6 @@ describe('Order detail path with unified SF GQL flag ON', () => {
     expect(screen.getByText('Awaiting Fulfillment')).toBeVisible();
   });
 
-  // Same casing trap as the list surfaces: the detail header looks the status up twice,
-  // once for colour and once for the merchant custom label, both by system label.
   it('renders the status tag when the resolver returns a sentence-case label', async () => {
     server.use(
       graphql.query('GetOrderDetail', () =>
@@ -1250,7 +1244,6 @@ describe('Order detail path with unified SF GQL flag ON', () => {
       expect(screen.getByText(/Visa ending in 1234/)).toBeVisible();
     });
 
-    // payments is a PaymentsConnection and Payment exposes paymentMethodName.
     it('renders the payment method from the payments connection', async () => {
       server.use(
         graphql.query('GetOrderDetail', () =>
@@ -1566,7 +1559,6 @@ describe('Order detail path with unified SF GQL flag ON', () => {
       expect(screen.getByText('Format: ePub')).toBeVisible();
     });
 
-    // downloads is [OrderDownloadConsignment!]!, unlike its sibling `shipping`.
     it('selects downloads as a plain list and renders its digital products', async () => {
       let capturedQuery = '';
       server.use(

--- a/apps/storefront/src/pages/OrderDetail/shared/convertOrderDetail.ts
+++ b/apps/storefront/src/pages/OrderDetail/shared/convertOrderDetail.ts
@@ -1,4 +1,5 @@
 import type { LangFormatFunction } from '@/lib/lang';
+import { orderStatusValueToSystemLabel } from '@/pages/order/shared/orderStatusValue';
 import type {
   Money,
   Order,
@@ -111,7 +112,7 @@ function mapHistoryEvents(history: Order['history']): OrderHistoryItem[] {
   return history.map((e) => ({
     id: Number(e.id),
     eventType: toNumericEventType(e.eventType),
-    status: e.status,
+    status: e.statusLabel,
     createdAt: Math.floor(new Date(e.createdAt).getTime() / 1000),
   }));
 }
@@ -489,7 +490,7 @@ export function convertOrderDetail(
 
   return {
     orderId: order.entityId,
-    status: order.status.label,
+    status: orderStatusValueToSystemLabel(order.status.value),
     statusCode: order.status.value ?? '',
     customStatus: '',
     poNumber: order.poNumber ?? '',

--- a/apps/storefront/src/pages/OrderDetail/shared/convertOrderDetail.ts
+++ b/apps/storefront/src/pages/OrderDetail/shared/convertOrderDetail.ts
@@ -266,10 +266,10 @@ function gatherAllProducts(order: Order): OrderProductItem[] {
     edge.node.lineItems.edges.map((le) => convertLineItemToProduct(le.node, edge.node.entityId)),
   );
 
-  const digital = (order.consignments?.downloads?.edges ?? []).flatMap((edge) =>
-    edge.node.lineItems.edges.map((le) =>
-      convertDigitalLineItemToProduct(le.node, edge.node.entityId),
-    ),
+  // OrderDownloadConsignment has no entityId, and digital items have no shipping
+  // address, so there is no consignment address id to carry.
+  const digital = (order.consignments?.downloads ?? []).flatMap((consignment) =>
+    consignment.lineItems.edges.map((le) => convertDigitalLineItemToProduct(le.node, 0)),
   );
 
   return [...physical, ...digital];
@@ -434,7 +434,7 @@ function buildPayment(order: Order): OrderPayment {
   return {
     dateCreateAt: String(dateCreateAt),
     billingAddress: convertAddress(order.billingAddress),
-    paymentMethod: order.payments?.[0]?.description ?? '',
+    paymentMethod: order.payments?.edges?.[0]?.node.paymentMethodName ?? '',
     updatedAt: order.updatedAt.utc,
   };
 }
@@ -507,9 +507,9 @@ export function convertOrderDetail(
     products,
     digitalProducts,
     billingAddress: convertAddress(order.billingAddress),
-    canReturn: (order.consignments?.shipping?.edges ?? []).some((edge) =>
-      edge.node.lineItems.edges.some((le) => le.node.returnableQuantity > 0),
-    ),
+    // returnableQuantity is not selected: it only fed the Return button, which is
+    // hidden unconditionally under BUN-1417, and the field 500s on the server.
+    canReturn: false,
     orderIsDigital: digitalProducts.length > 0,
     ipStatus: order.invoice ? 1 : 0,
     invoiceId: order.invoice ? Number(order.invoice.id) : 0,

--- a/apps/storefront/src/pages/OrderDetail/shared/convertOrderDetail.ts
+++ b/apps/storefront/src/pages/OrderDetail/shared/convertOrderDetail.ts
@@ -163,7 +163,7 @@ function buildOrderProduct(
     imageUrl: string;
   },
 ): OrderProductItem {
-  // Unit price from list price (per Jesse/Shayne decision — no unit price Money field exists)
+  // No unit price Money field exists on this type; derive it from list price.
   const unitListPrice = item.quantity > 0 ? item.subTotalListPrice.value / item.quantity : 0;
   const formattedUnitPrice = String(unitListPrice);
   const formattedTotal = String(item.subTotalSalePrice.value);
@@ -173,10 +173,8 @@ function buildOrderProduct(
   return {
     id: item.entityId,
     product_id: item.productEntityId,
-    // Fallback to 0 when variantEntityId is null (gist: "null for legacy
-    // orders or products without variants"). BE is adding variantEntityId
-    // to OrderPhysicalLineItem — until deployed, reorder sends 0 (honest
-    // "no variant") rather than an unrelated ID. Behind FF, tracked in B2B-4787.
+    // variantEntityId is null for legacy orders or products without variants;
+    // 0 signals "no variant" rather than an unrelated real id.
     variant_id: physicalFields?.variantEntityId ?? 0,
     sku: physicalFields?.sku ?? '',
     name: item.name,
@@ -507,8 +505,8 @@ export function convertOrderDetail(
     products,
     digitalProducts,
     billingAddress: convertAddress(order.billingAddress),
-    // returnableQuantity is not selected: it only fed the Return button, which is
-    // hidden unconditionally under BUN-1417, and the field 500s on the server.
+    // returnableQuantity is not selected — the Return button that used it is
+    // hidden, and selecting the field 500s the server.
     canReturn: false,
     orderIsDigital: digitalProducts.length > 0,
     ipStatus: order.invoice ? 1 : 0,

--- a/apps/storefront/src/pages/order/Order.tsx
+++ b/apps/storefront/src/pages/order/Order.tsx
@@ -121,7 +121,6 @@ function Order({ isCompanyOrder = false }: OrderProps) {
     orderStatuses: getOrderStatuses,
   });
   const customerFilterState = useCustomerOrdersState({
-    companyId: selectedCompanyId,
     orderStatuses: getOrderStatuses,
   });
   const companyFilterState = useCompanyOrdersState({
@@ -136,13 +135,17 @@ function Order({ isCompanyOrder = false }: OrderProps) {
     return legacyFilterState;
   };
 
-  const {
-    activeSort,
-    handleSearchChange,
-    handleFilterChange,
-    handleCompanyIdsChange,
-    handleSetOrderBy,
-  } = getActiveFilterState();
+  const { activeSort, handleFilterChange, handleSetOrderBy } = getActiveFilterState();
+
+  // The customer hook has no search or company-hierarchy filter, so resolve these
+  // directly from the company/legacy state rather than through the union above.
+  const handleSearchChange = isUnifiedCompanyPath
+    ? companyFilterState.handleSearchChange
+    : legacyFilterState.handleSearchChange;
+
+  const handleCompanyIdsChange = isUnifiedCompanyPath
+    ? companyFilterState.handleCompanyIdsChange
+    : legacyFilterState.handleCompanyIdsChange;
 
   const getFilterDataAndOrderBy = () => {
     if (isUnifiedCompanyPath) {
@@ -481,12 +484,19 @@ function Order({ isCompanyOrder = false }: OrderProps) {
             },
           }}
         >
-          {isEnabledCompanyHierarchy && (
+          {isEnabledCompanyHierarchy && !isUnifiedCustomerPath && (
             <Box sx={{ mr: isMobile ? 0 : '10px', mb: '30px' }}>
               <B2BAutoCompleteCheckbox handleChangeCompanyIds={handleCompanyIdsChange} />
             </Box>
           )}
           <B3Filter
+            filterMoreInfo={
+              // The customer filter state has no field to send a company filter to, so
+              // it's hidden here to avoid a visible-but-inert control — see B2B-5420.
+              isUnifiedCustomerPath
+                ? filterMoreInfo.filter((item) => item.name !== 'company')
+                : filterMoreInfo
+            }
             startPicker={{
               isEnabled: true,
               label: b3Lang('orders.from'),
@@ -499,7 +509,6 @@ function Order({ isCompanyOrder = false }: OrderProps) {
               defaultValue: filterData?.endDateAt || null,
               pickerKey: 'end',
             }}
-            filterMoreInfo={filterMoreInfo}
             handleChange={handleSearchChange}
             handleFilterChange={handleFilterChange}
             pcTotalWidth="100%"

--- a/apps/storefront/src/pages/order/Order.tsx
+++ b/apps/storefront/src/pages/order/Order.tsx
@@ -492,7 +492,7 @@ function Order({ isCompanyOrder = false }: OrderProps) {
           <B3Filter
             filterMoreInfo={
               // The customer filter state has no field to send a company filter to, so
-              // it's hidden here to avoid a visible-but-inert control — see B2B-5420.
+              // it's hidden here to avoid a visible-but-inert control
               isUnifiedCustomerPath
                 ? filterMoreInfo.filter((item) => item.name !== 'company')
                 : filterMoreInfo

--- a/apps/storefront/src/pages/order/Order.tsx
+++ b/apps/storefront/src/pages/order/Order.tsx
@@ -218,7 +218,6 @@ function Order({ isCompanyOrder = false }: OrderProps) {
     last?: number;
     before?: string;
     filters: OrdersFiltersInput;
-    sortBy: OrdersSortInput;
   }): Promise<{
     edges: ListItem[];
     totalCount: number;
@@ -324,7 +323,7 @@ function Order({ isCompanyOrder = false }: OrderProps) {
         key: 'orderId',
         title: b3Lang('orders.order'),
         width: '10%',
-        isSortable: true,
+        isSortable: !isUnifiedCustomerPath,
         render: ({ orderId }) => orderId,
       },
       {
@@ -342,7 +341,7 @@ function Order({ isCompanyOrder = false }: OrderProps) {
         title: b3Lang('orders.poReference'),
         render: ({ poNumber }) => <Box>{poNumber || '–'}</Box>,
         width: '10%',
-        isSortable: true,
+        isSortable: !isUnifiedCustomerPath,
       },
       {
         key: 'totalIncTax',
@@ -355,21 +354,22 @@ function Order({ isCompanyOrder = false }: OrderProps) {
         },
         align: 'right',
         width: '8%',
-        isSortable: true,
+        isSortable: !isUnifiedCustomerPath,
       },
       {
         key: 'status',
         title: b3Lang('orders.orderStatus'),
         render: ({ status, statusText }) => <OrderStatus text={statusText} code={status} />,
         width: '10%',
-        isSortable: true,
+        isSortable: !isUnifiedCustomerPath,
       },
       {
         key: 'placedBy',
         title: b3Lang('orders.placedBy'),
         render: ({ firstName, lastName }) => `${firstName} ${lastName}`,
         width: '10%',
-        isSortable: true,
+        // Placed-by sort is disabled under the unified flag — backend support is incomplete.
+        isSortable: !isUnifiedOrders,
         hidden: !isB2BUser || isSuperAdminNotAgenting || !isCompanyOrder,
       },
       {
@@ -377,10 +377,17 @@ function Order({ isCompanyOrder = false }: OrderProps) {
         title: b3Lang('orders.createdOn'),
         render: ({ createdAt }) => `${displayFormat(Number(createdAt))}`,
         width: '10%',
-        isSortable: true,
+        isSortable: !isUnifiedCustomerPath,
       },
     ],
-    [b3Lang, isB2BUser, isSuperAdminNotAgenting, isCompanyOrder],
+    [
+      b3Lang,
+      isB2BUser,
+      isSuperAdminNotAgenting,
+      isCompanyOrder,
+      isUnifiedCustomerPath,
+      isUnifiedOrders,
+    ],
   );
 
   const unifiedState = isUnifiedCompanyPath ? companyFilterState : customerFilterState;
@@ -417,7 +424,6 @@ function Order({ isCompanyOrder = false }: OrderProps) {
       return fetchUnifiedOrders({
         ...customerFilterState.paginationVariables,
         filters: customerFilterState.filters,
-        sortBy: customerFilterState.sortBy,
       });
     }
     return fetchLegacyOrders({ ...filterData, ...legacyPagination, orderBy });
@@ -529,7 +535,7 @@ function Order({ isCompanyOrder = false }: OrderProps) {
           onClickRow={navigateToOrderDetail}
           sortDirection={activeSort.dir}
           sortByFn={handleSetOrderBy}
-          orderBy={activeSort.key}
+          orderBy={isUnifiedCustomerPath ? undefined : activeSort.key}
         />
       </Box>
     </B3Spin>

--- a/apps/storefront/src/pages/order/Order.tsx
+++ b/apps/storefront/src/pages/order/Order.tsx
@@ -137,15 +137,10 @@ function Order({ isCompanyOrder = false }: OrderProps) {
 
   const { activeSort, handleFilterChange, handleSetOrderBy } = getActiveFilterState();
 
-  // The customer hook has no search or company-hierarchy filter, so resolve these
-  // directly from the company/legacy state rather than through the union above.
-  const handleSearchChange = isUnifiedCompanyPath
-    ? companyFilterState.handleSearchChange
-    : legacyFilterState.handleSearchChange;
+  const getSearchAndCompanyFilterState = () =>
+    isUnifiedCompanyPath ? companyFilterState : legacyFilterState;
 
-  const handleCompanyIdsChange = isUnifiedCompanyPath
-    ? companyFilterState.handleCompanyIdsChange
-    : legacyFilterState.handleCompanyIdsChange;
+  const { handleSearchChange, handleCompanyIdsChange } = getSearchAndCompanyFilterState();
 
   const getFilterDataAndOrderBy = () => {
     if (isUnifiedCompanyPath) {
@@ -461,6 +456,10 @@ function Order({ isCompanyOrder = false }: OrderProps) {
     ? (item: ListItem) => goToDetail(item, listItems)
     : legacyGoToDetail;
 
+  const filterMoreInfoWithoutInertCompanyControl = filterMoreInfo.filter(
+    (item) => item.name !== 'company',
+  );
+
   return (
     <B3Spin isSpinning={isFetching}>
       <Box
@@ -491,11 +490,7 @@ function Order({ isCompanyOrder = false }: OrderProps) {
           )}
           <B3Filter
             filterMoreInfo={
-              // The customer filter state has no field to send a company filter to, so
-              // it's hidden here to avoid a visible-but-inert control
-              isUnifiedCustomerPath
-                ? filterMoreInfo.filter((item) => item.name !== 'company')
-                : filterMoreInfo
+              isUnifiedCustomerPath ? filterMoreInfoWithoutInertCompanyControl : filterMoreInfo
             }
             startPicker={{
               isEnabled: true,

--- a/apps/storefront/src/pages/order/adaptUnifiedToLegacyFilterParams.ts
+++ b/apps/storefront/src/pages/order/adaptUnifiedToLegacyFilterParams.ts
@@ -29,13 +29,13 @@ export const adaptUnifiedToLegacyFilterParams = ({
   orderBy: string;
 } => ({
   filterData: {
-    q: filters.search ?? '',
+    q: '',
     statusCode: filters.status ?? '',
     beginDateAt: filters.dateRange?.from ?? null,
     endDateAt: filters.dateRange?.to ?? null,
-    companyName: filters.companyName ?? '',
+    companyName: '',
     // Legacy emits `companyIds: []` for "All"; restore that for B2B users.
-    companyIds: filters.companyIds?.map(Number) ?? (isB2BUser ? [] : undefined),
+    companyIds: isB2BUser ? [] : undefined,
     isShowMy: isB2BUser ? 1 : undefined,
   },
   orderBy: activeSort.dir === 'desc' ? `-${sortKeys[activeSort.key]}` : sortKeys[activeSort.key],

--- a/apps/storefront/src/pages/order/adaptUnifiedToLegacyParams.test.ts
+++ b/apps/storefront/src/pages/order/adaptUnifiedToLegacyParams.test.ts
@@ -15,25 +15,25 @@ const baseArgs: AdaptUnifiedToLegacyFilterParamsArgs = {
 
 describe('adaptUnifiedToLegacyFilterParams', () => {
   describe('filterData', () => {
-    it('maps all unified filter fields to the legacy shape', () => {
+    it('maps status and dateRange to the legacy shape', () => {
+      // search/companyName/companyIds are no longer part of the customer-path
+      // OrdersFiltersInput (B2B-5420) — q/companyName always default and companyIds
+      // is driven solely by isB2BUser (see the dedicated tests below).
       const { filterData } = adaptUnifiedToLegacyFilterParams({
         ...baseArgs,
         filters: {
-          search: 'widget',
           status: 'AWAITING_FULFILLMENT',
           dateRange: { from: '2026-01-01', to: '2026-02-01' },
-          companyName: 'Acme',
-          companyIds: ['1', '2', '3'],
         },
       });
 
       expect(filterData).toEqual({
-        q: 'widget',
+        q: '',
         statusCode: 'AWAITING_FULFILLMENT',
         beginDateAt: '2026-01-01',
         endDateAt: '2026-02-01',
-        companyName: 'Acme',
-        companyIds: [1, 2, 3],
+        companyName: '',
+        companyIds: undefined,
         isShowMy: undefined,
       });
     });
@@ -76,15 +76,6 @@ describe('adaptUnifiedToLegacyFilterParams', () => {
 
       expect(filterData.beginDateAt).toBe('2026-01-01');
       expect(filterData.endDateAt).toBeNull();
-    });
-
-    it('converts companyIds from strings to numbers', () => {
-      const { filterData } = adaptUnifiedToLegacyFilterParams({
-        ...baseArgs,
-        filters: { companyIds: ['10', '20'] },
-      });
-
-      expect(filterData.companyIds).toEqual([10, 20]);
     });
 
     it('leaves companyIds undefined when not provided for non-B2B users', () => {

--- a/apps/storefront/src/pages/order/mapSfGqlOrderToListItem.test.ts
+++ b/apps/storefront/src/pages/order/mapSfGqlOrderToListItem.test.ts
@@ -67,4 +67,28 @@ describe('mapSfGqlOrderToListItem', () => {
 
     expect(item.cursor).toBe('cursor-abc');
   });
+
+  // The live resolver returns a sentence-case label. `status` feeds getOrderStatus and
+  // the systemLabel match, both keyed in title case, so it must come from the enum.
+  it('derives status from the enum value, not the display label', () => {
+    const order: SfGqlOrder = {
+      ...baseOrder,
+      status: { value: 'AWAITING_FULFILLMENT', label: 'Awaiting fulfillment' },
+    };
+
+    const result = mapSfGqlOrderToListItem(order);
+
+    expect(result.status).toBe('Awaiting Fulfillment');
+  });
+
+  it('keeps the merchant-facing label as the display text', () => {
+    const order: SfGqlOrder = {
+      ...baseOrder,
+      status: { value: 'AWAITING_FULFILLMENT', label: 'Awaiting fulfillment' },
+    };
+
+    const result = mapSfGqlOrderToListItem(order);
+
+    expect(result.statusText).toBe('Awaiting fulfillment');
+  });
 });

--- a/apps/storefront/src/pages/order/mapSfGqlOrderToListItem.test.ts
+++ b/apps/storefront/src/pages/order/mapSfGqlOrderToListItem.test.ts
@@ -9,7 +9,7 @@ const baseOrder: SfGqlOrder = {
   entityId: 90909,
   orderedAt: { utc: '2026-01-01T00:00:00Z' },
   updatedAt: { utc: '2026-01-01T00:00:00Z' },
-  status: { value: 'PENDING', label: 'Pending' },
+  status: { value: 'AWAITING_FULFILLMENT', label: 'Awaiting fulfillment' },
   billingAddress: {
     firstName: null,
     lastName: null,

--- a/apps/storefront/src/pages/order/mapSfGqlOrderToListItem.test.ts
+++ b/apps/storefront/src/pages/order/mapSfGqlOrderToListItem.test.ts
@@ -49,9 +49,7 @@ const baseOrder: SfGqlOrder = {
   company: null,
   placedBy: null,
   history: [],
-  quote: null,
   invoice: null,
-  extraFields: [],
 };
 
 describe('mapSfGqlOrderToListItem', () => {

--- a/apps/storefront/src/pages/order/mapSfGqlOrderToListItem.ts
+++ b/apps/storefront/src/pages/order/mapSfGqlOrderToListItem.ts
@@ -1,5 +1,6 @@
 import type { Order as SfGqlOrder } from '@/shared/service/bc/graphql/orders';
 import type { CompanyInfoTypes } from '@/types/invoice';
+import { orderStatusValueToSystemLabel } from './shared/orderStatusValue';
 
 export interface ListItem {
   firstName: string;
@@ -23,7 +24,7 @@ export const mapSfGqlOrderToListItem = (order: SfGqlOrder, cursor?: string): Lis
   poNumber: order.poNumber || '',
   totalIncTax: String(order.totalIncTax.value),
   formattedTotalIncTax: order.totalIncTax.formattedV2,
-  status: order.status.label,
+  status: orderStatusValueToSystemLabel(order.status.value),
   statusText: order.status.label,
   createdAt: String(Math.floor(new Date(order.orderedAt.utc).getTime() / 1000)),
   firstName: order.placedBy?.firstName || '',

--- a/apps/storefront/src/pages/order/mapSfGqlOrderToListItem.ts
+++ b/apps/storefront/src/pages/order/mapSfGqlOrderToListItem.ts
@@ -1,5 +1,6 @@
 import type { Order as SfGqlOrder } from '@/shared/service/bc/graphql/orders';
 import type { CompanyInfoTypes } from '@/types/invoice';
+
 import { orderStatusValueToSystemLabel } from './shared/orderStatusValue';
 
 export interface ListItem {

--- a/apps/storefront/src/pages/order/shared/orderStatusValue.test.ts
+++ b/apps/storefront/src/pages/order/shared/orderStatusValue.test.ts
@@ -6,9 +6,6 @@ import {
 } from './orderStatusValue';
 
 describe('orderStatusValue', () => {
-  // The live resolver returns a lowercase-f label ("Awaiting fulfillment") while every
-  // lookup table in the app is keyed in title case. Keying off the enum is what stops
-  // a one-character casing change from blanking the status column.
   it('maps every OrderStatusValue member onto a key the status lookup tables recognise', () => {
     const values = Object.keys(ORDER_STATUS_SYSTEM_LABELS);
 
@@ -32,8 +29,6 @@ describe('orderStatusValue', () => {
     );
   });
 
-  // An unmatched status must render nothing rather than a mislabelled tag, which is
-  // what OrderStatus already does when `name` is falsy.
   it('returns an empty string for an unknown or absent value', () => {
     expect(orderStatusValueToSystemLabel('NOT_A_STATUS')).toBe('');
     expect(orderStatusValueToSystemLabel(null)).toBe('');
@@ -45,8 +40,6 @@ describe('orderStatusValue', () => {
     expect(systemLabelToOrderStatusValue('Shipped')).toBe('SHIPPED');
   });
 
-  // The status filter drops on miss rather than sending a display string into an
-  // enum-typed argument, which the server rejects at variable coercion.
   it('returns undefined when a system label has no enum member', () => {
     expect(systemLabelToOrderStatusValue('Awaiting fulfillment')).toBeUndefined();
     expect(systemLabelToOrderStatusValue('Backordered')).toBeUndefined();

--- a/apps/storefront/src/pages/order/shared/orderStatusValue.test.ts
+++ b/apps/storefront/src/pages/order/shared/orderStatusValue.test.ts
@@ -1,0 +1,54 @@
+import getOrderStatus, { orderStatusTranslationVariables } from './getOrderStatus';
+import {
+  ORDER_STATUS_SYSTEM_LABELS,
+  orderStatusValueToSystemLabel,
+  systemLabelToOrderStatusValue,
+} from './orderStatusValue';
+
+describe('orderStatusValue', () => {
+  // The live resolver returns a lowercase-f label ("Awaiting fulfillment") while every
+  // lookup table in the app is keyed in title case. Keying off the enum is what stops
+  // a one-character casing change from blanking the status column.
+  it('maps every OrderStatusValue member onto a key the status lookup tables recognise', () => {
+    const values = Object.keys(ORDER_STATUS_SYSTEM_LABELS);
+
+    expect(values).toHaveLength(15);
+
+    values.forEach((value) => {
+      const systemLabel = orderStatusValueToSystemLabel(value);
+      const status = getOrderStatus(systemLabel);
+
+      expect(status.color, `no color for ${value}`).toBeTruthy();
+      expect(status.textColor, `no textColor for ${value}`).toBeTruthy();
+      expect(status.name, `no name for ${value}`).toBeTruthy();
+      expect(orderStatusTranslationVariables[systemLabel], `no i18n key for ${value}`).toBeTruthy();
+    });
+  });
+
+  it('converts a multi-word enum member to its title-case system label', () => {
+    expect(orderStatusValueToSystemLabel('AWAITING_FULFILLMENT')).toBe('Awaiting Fulfillment');
+    expect(orderStatusValueToSystemLabel('MANUAL_VERIFICATION_REQUIRED')).toBe(
+      'Manual Verification Required',
+    );
+  });
+
+  // An unmatched status must render nothing rather than a mislabelled tag, which is
+  // what OrderStatus already does when `name` is falsy.
+  it('returns an empty string for an unknown or absent value', () => {
+    expect(orderStatusValueToSystemLabel('NOT_A_STATUS')).toBe('');
+    expect(orderStatusValueToSystemLabel(null)).toBe('');
+    expect(orderStatusValueToSystemLabel(undefined)).toBe('');
+  });
+
+  it('converts a system label back to the enum member for filtering', () => {
+    expect(systemLabelToOrderStatusValue('Awaiting Fulfillment')).toBe('AWAITING_FULFILLMENT');
+    expect(systemLabelToOrderStatusValue('Shipped')).toBe('SHIPPED');
+  });
+
+  // The status filter drops on miss rather than sending a display string into an
+  // enum-typed argument, which the server rejects at variable coercion.
+  it('returns undefined when a system label has no enum member', () => {
+    expect(systemLabelToOrderStatusValue('Awaiting fulfillment')).toBeUndefined();
+    expect(systemLabelToOrderStatusValue('Backordered')).toBeUndefined();
+  });
+});

--- a/apps/storefront/src/pages/order/shared/orderStatusValue.ts
+++ b/apps/storefront/src/pages/order/shared/orderStatusValue.ts
@@ -1,0 +1,45 @@
+/**
+ * SF GQL returns `status { value, label }` where `value` is the stable
+ * `OrderStatusValue` enum and `label` is a merchant-configurable display string.
+ *
+ * Every status lookup in this app — the colour/text tables in `getOrderStatus`, the
+ * `systemLabel` match against the legacy `orderStatuses` query — is keyed by the
+ * title-case system label. The live resolver returns `label` in sentence case
+ * ("Awaiting fulfillment"), so mapping `label` straight to a lookup key silently
+ * misses. Derive the key from `value` instead.
+ *
+ * Listed explicitly rather than title-cased algorithmically: this is the wire
+ * contract, all 15 members are asserted against the lookup tables in the tests, and
+ * a future member with an acronym would break a naive transform.
+ */
+export const ORDER_STATUS_SYSTEM_LABELS = {
+  AWAITING_FULFILLMENT: 'Awaiting Fulfillment',
+  AWAITING_PAYMENT: 'Awaiting Payment',
+  AWAITING_PICKUP: 'Awaiting Pickup',
+  AWAITING_SHIPMENT: 'Awaiting Shipment',
+  CANCELLED: 'Cancelled',
+  COMPLETED: 'Completed',
+  DECLINED: 'Declined',
+  DISPUTED: 'Disputed',
+  INCOMPLETE: 'Incomplete',
+  MANUAL_VERIFICATION_REQUIRED: 'Manual Verification Required',
+  PARTIALLY_REFUNDED: 'Partially Refunded',
+  PARTIALLY_SHIPPED: 'Partially Shipped',
+  PENDING: 'Pending',
+  REFUNDED: 'Refunded',
+  SHIPPED: 'Shipped',
+} as const;
+
+export type OrderStatusValueKey = keyof typeof ORDER_STATUS_SYSTEM_LABELS;
+
+const SYSTEM_LABEL_TO_VALUE: Record<string, string> = Object.fromEntries(
+  Object.entries(ORDER_STATUS_SYSTEM_LABELS).map(([value, systemLabel]) => [systemLabel, value]),
+);
+
+/** Enum member -> title-case system label. Empty string when unrecognised. */
+export const orderStatusValueToSystemLabel = (value: string | null | undefined): string =>
+  (value && ORDER_STATUS_SYSTEM_LABELS[value as OrderStatusValueKey]) || '';
+
+/** Title-case system label -> enum member. Undefined when unrecognised. */
+export const systemLabelToOrderStatusValue = (systemLabel: string): string | undefined =>
+  SYSTEM_LABEL_TO_VALUE[systemLabel];

--- a/apps/storefront/src/pages/order/shared/orderStatusValue.ts
+++ b/apps/storefront/src/pages/order/shared/orderStatusValue.ts
@@ -30,7 +30,7 @@ export const ORDER_STATUS_SYSTEM_LABELS = {
   SHIPPED: 'Shipped',
 } as const;
 
-export type OrderStatusValueKey = keyof typeof ORDER_STATUS_SYSTEM_LABELS;
+type OrderStatusValueKey = keyof typeof ORDER_STATUS_SYSTEM_LABELS;
 
 const SYSTEM_LABEL_TO_VALUE: Record<string, string> = Object.fromEntries(
   Object.entries(ORDER_STATUS_SYSTEM_LABELS).map(([value, systemLabel]) => [systemLabel, value]),

--- a/apps/storefront/src/pages/order/unifiedApiFiltersHelper.ts
+++ b/apps/storefront/src/pages/order/unifiedApiFiltersHelper.ts
@@ -12,15 +12,17 @@ export const getCompanyOrdersInitFilter = (companyId: number): CompanyOrdersFilt
   companyIds: companyId ? [String(companyId)] : undefined,
 });
 
-export const getCustomerOrdersInitFilter = (companyId: number): OrdersFiltersInput => {
-  return {
-    status: undefined,
-    dateRange: undefined,
-    search: undefined,
-    companyName: undefined,
-    companyIds: companyId ? [String(companyId)] : undefined,
-  };
-};
+// companyName and companyIds are permanently dropped from this input — the agreed
+// schema gist specified them for customer.orders, but the deployed server never
+// implemented them and the gist is being amended to match (B2B-5421). The company
+// selector is hidden on My Orders for the same reason (see Order.tsx).
+// WORKAROUND (B2B-5420): search is the one field still genuinely pending — it's
+// deferred to its own ticket and hidden in the UI until it lands. Restore it here
+// once that ticket ships.
+export const getCustomerOrdersInitFilter = (): OrdersFiltersInput => ({
+  status: undefined,
+  dateRange: undefined,
+});
 
 export const normalizeString = (value: string | number | null | undefined): string | undefined => {
   if (value === null || value === undefined) return undefined;

--- a/apps/storefront/src/pages/order/unifiedApiFiltersHelper.ts
+++ b/apps/storefront/src/pages/order/unifiedApiFiltersHelper.ts
@@ -14,9 +14,9 @@ export const getCompanyOrdersInitFilter = (companyId: number): CompanyOrdersFilt
 
 // companyName and companyIds are permanently dropped from this input — the agreed
 // schema gist specified them for customer.orders, but the deployed server never
-// implemented them and the gist is being amended to match (B2B-5421). The company
+// implemented them and the gist is being amended to match. The company
 // selector is hidden on My Orders for the same reason (see Order.tsx).
-// WORKAROUND (B2B-5420): search is the one field still genuinely pending — it's
+// WORKAROUND: search is the one field still genuinely pending — it's
 // deferred to its own ticket and hidden in the UI until it lands. Restore it here
 // once that ticket ships.
 export const getCustomerOrdersInitFilter = (): OrdersFiltersInput => ({

--- a/apps/storefront/src/pages/order/unifiedApiFiltersHelper.ts
+++ b/apps/storefront/src/pages/order/unifiedApiFiltersHelper.ts
@@ -12,13 +12,6 @@ export const getCompanyOrdersInitFilter = (companyId: number): CompanyOrdersFilt
   companyIds: companyId ? [String(companyId)] : undefined,
 });
 
-// companyName and companyIds are permanently dropped from this input — the agreed
-// schema gist specified them for customer.orders, but the deployed server never
-// implemented them and the gist is being amended to match. The company
-// selector is hidden on My Orders for the same reason (see Order.tsx).
-// WORKAROUND: search is the one field still genuinely pending — it's
-// deferred to its own ticket and hidden in the UI until it lands. Restore it here
-// once that ticket ships.
 export const getCustomerOrdersInitFilter = (): OrdersFiltersInput => ({
   status: undefined,
   dateRange: undefined,

--- a/apps/storefront/src/pages/order/useCustomerOrdersState.ts
+++ b/apps/storefront/src/pages/order/useCustomerOrdersState.ts
@@ -5,6 +5,7 @@ import { OrdersFiltersInput } from '@/shared/service/bc/graphql/orders';
 // schema doesn't expose one yet, so we depend on the legacy type here.
 import { OrderStatusItem } from '@/types';
 
+import { systemLabelToOrderStatusValue } from './shared/orderStatusValue';
 import {
   getCustomerOrdersInitFilter,
   normalizeString,
@@ -64,19 +65,21 @@ export const useCustomerOrdersState = ({
   };
 
   const handleFilterChange = (value: AppliedFilters) => {
-    let currentStatus = normalizeString(value.orderStatus);
-    if (currentStatus) {
-      const originalStatus = orderStatuses.find(
-        (status) => status.customLabel === currentStatus || status.systemLabel === currentStatus,
-      );
-      // Drop the filter on miss — never send a display label as the API status code.
-      currentStatus = originalStatus?.systemLabel || undefined;
-    }
+    const selected = normalizeString(value.orderStatus);
+    // Resolve the display label to its systemLabel, then to the OrderStatusValue enum
+    // member the schema requires. Drop the filter on either miss — sending a display
+    // string into an enum argument is rejected at variable coercion.
+    const matched = selected
+      ? orderStatuses.find(
+          (status) => status.customLabel === selected || status.systemLabel === selected,
+        )
+      : undefined;
+    const status = matched ? systemLabelToOrderStatusValue(matched.systemLabel) : undefined;
+
     pagination.resetPagination();
     setFilters((prev) => ({
       ...prev,
-      companyName: normalizeString(value.company),
-      status: currentStatus,
+      status,
       dateRange: packDateRange(value.startValue, value.endValue),
     }));
   };

--- a/apps/storefront/src/pages/order/useCustomerOrdersState.ts
+++ b/apps/storefront/src/pages/order/useCustomerOrdersState.ts
@@ -36,7 +36,6 @@ export interface UseCustomerOrdersStateResult
   extends UseUnifiedOrdersPaginationResult,
     UseUnifiedOrderSortingResult<BaseSortableColumnKey> {
   filters: OrdersFiltersInput;
-  handleSearchChange: (key: string, value: string) => void;
   handleFilterChange: (value: AppliedFilters) => void;
 }
 
@@ -47,12 +46,6 @@ export const useCustomerOrdersState = ({
 
   const pagination = useUnifiedOrdersPagination();
   const sorting = useUnifiedOrderSorting(BASE_SORT_MAP, pagination.resetPagination, 'orderId');
-
-  const handleSearchChange = (key: string, value: string) => {
-    if (key !== 'search') return;
-    pagination.resetPagination();
-    setFilters((prev) => ({ ...prev, search: value || undefined }));
-  };
 
   const handleFilterChange = (value: AppliedFilters) => {
     const selected = normalizeString(value.orderStatus);
@@ -78,7 +71,6 @@ export const useCustomerOrdersState = ({
     ...pagination,
     ...sorting,
     filters,
-    handleSearchChange,
     handleFilterChange,
   };
 };

--- a/apps/storefront/src/pages/order/useCustomerOrdersState.ts
+++ b/apps/storefront/src/pages/order/useCustomerOrdersState.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 
 import { OrdersFiltersInput } from '@/shared/service/bc/graphql/orders';
 // Status list still comes from the legacy `orderStatuses` query — the unified
@@ -26,11 +26,9 @@ interface AppliedFilters {
   startValue?: string;
   endValue?: string;
   orderStatus?: string | number;
-  company?: string;
 }
 
 interface UseCustomerOrdersStateArgs {
-  companyId: number;
   orderStatuses: OrderStatusItem[];
 }
 
@@ -40,23 +38,15 @@ export interface UseCustomerOrdersStateResult
   filters: OrdersFiltersInput;
   handleSearchChange: (key: string, value: string) => void;
   handleFilterChange: (value: AppliedFilters) => void;
-  handleCompanyIdsChange: (companyIds: number[]) => void;
 }
 
 export const useCustomerOrdersState = ({
-  companyId,
   orderStatuses,
 }: UseCustomerOrdersStateArgs): UseCustomerOrdersStateResult => {
-  const [filters, setFilters] = useState<OrdersFiltersInput>(() =>
-    getCustomerOrdersInitFilter(companyId),
-  );
+  const [filters, setFilters] = useState<OrdersFiltersInput>(() => getCustomerOrdersInitFilter());
 
   const pagination = useUnifiedOrdersPagination();
   const sorting = useUnifiedOrderSorting(BASE_SORT_MAP, pagination.resetPagination, 'orderId');
-
-  useEffect(() => {
-    setFilters(getCustomerOrdersInitFilter(companyId));
-  }, [companyId]);
 
   const handleSearchChange = (key: string, value: string) => {
     if (key !== 'search') return;
@@ -84,21 +74,11 @@ export const useCustomerOrdersState = ({
     }));
   };
 
-  const handleCompanyIdsChange = (companyIds: number[]) => {
-    const isAll = companyIds.length === 0 || companyIds.includes(-1);
-    pagination.resetPagination();
-    setFilters((prev) => ({
-      ...prev,
-      companyIds: isAll ? undefined : companyIds.map(String),
-    }));
-  };
-
   return {
     ...pagination,
     ...sorting,
     filters,
     handleSearchChange,
     handleFilterChange,
-    handleCompanyIdsChange,
   };
 };

--- a/apps/storefront/src/pages/order/usePlacedByUsers.test.ts
+++ b/apps/storefront/src/pages/order/usePlacedByUsers.test.ts
@@ -83,7 +83,7 @@ describe('usePlacedByUsers', () => {
     expect(mockGetCustomersWithOrders).toHaveBeenCalledTimes(1);
     expect(mockGetCustomersWithOrders).toHaveBeenCalledWith({
       filters: undefined,
-      first: 100,
+      first: 50,
       after: undefined,
     });
   });
@@ -105,7 +105,7 @@ describe('usePlacedByUsers', () => {
     expect(mockGetCustomersWithOrders).toHaveBeenCalledTimes(2);
     expect(mockGetCustomersWithOrders).toHaveBeenLastCalledWith({
       filters: undefined,
-      first: 100,
+      first: 50,
       after: 'cursor-2',
     });
   });
@@ -121,7 +121,7 @@ describe('usePlacedByUsers', () => {
     await waitFor(() => expect(result.current).toHaveLength(1));
     expect(mockGetCustomersWithOrders).toHaveBeenCalledWith({
       filters: { companyIds: ['10', '20'] },
-      first: 100,
+      first: 50,
       after: undefined,
     });
   });

--- a/apps/storefront/src/pages/order/usePlacedByUsers.ts
+++ b/apps/storefront/src/pages/order/usePlacedByUsers.ts
@@ -19,7 +19,7 @@ export function usePlacedByUsers({ enabled, companyIds }: UsePlacedByUsersArgs):
     queryFn: ({ pageParam }: { pageParam: string | undefined }) =>
       getCustomersWithOrders({
         filters: companyIds ? { companyIds } : undefined,
-        first: 100,
+        first: 50,
         after: pageParam,
       }),
     initialPageParam: undefined as string | undefined,

--- a/apps/storefront/src/shared/service/bc/graphql/orders.ts
+++ b/apps/storefront/src/shared/service/bc/graphql/orders.ts
@@ -157,9 +157,9 @@ export enum OrderHistoryEventType {
 export interface OrderHistoryEvent {
   id: string;
   eventType: OrderHistoryEventType;
-  status: string;
+  /** Title-case status label for the event, e.g. "Awaiting Fulfillment". */
+  statusLabel: string;
   source: string | null;
-  createdBy: OrderPlacedBy | null;
   createdAt: string;
 }
 
@@ -284,6 +284,7 @@ export interface CompanyOrdersFiltersInput {
  * Base: status, dateRange. Extension: search, companyName, companyIds.
  */
 export interface OrdersFiltersInput {
+  // OrderStatusValue enum member (e.g. 'AWAITING_FULFILLMENT'), not a display label.
   status?: string;
   dateRange?: OrderDateRangeFilterInput;
   search?: string;
@@ -535,14 +536,8 @@ const orderB2BFields = `reference
   history {
     id
     eventType
-    status
+    statusLabel
     source
-    createdBy {
-      entityId
-      firstName
-      lastName
-      email
-    }
     createdAt
   }
   quote {

--- a/apps/storefront/src/shared/service/bc/graphql/orders.ts
+++ b/apps/storefront/src/shared/service/bc/graphql/orders.ts
@@ -623,7 +623,6 @@ const GET_COMPANY_ORDERS = `query GetCompanyOrders(
  */
 const GET_CUSTOMER_ORDERS = `query GetCustomerOrders(
   $filters: OrdersFiltersInput
-  $sortBy: OrdersSortInput
   $first: Int
   $after: String
   $last: Int
@@ -632,7 +631,6 @@ const GET_CUSTOMER_ORDERS = `query GetCustomerOrders(
   customer {
     orders(
       filters: $filters
-      sortBy: $sortBy
       first: $first
       after: $after
       last: $last
@@ -736,7 +734,6 @@ export async function getCompanyOrders(variables: {
 /** My Orders — customer-scoped, unified for B2B and B2C. */
 export async function getCustomerOrders(variables: {
   filters?: OrdersFiltersInput;
-  sortBy?: OrdersSortInput;
   first?: number;
   after?: string;
   last?: number;

--- a/apps/storefront/src/shared/service/bc/graphql/orders.ts
+++ b/apps/storefront/src/shared/service/bc/graphql/orders.ts
@@ -272,7 +272,7 @@ export interface CompanyOrdersFiltersInput {
  * Filters for customer.orders, matching what the server currently accepts.
  * companyName and companyIds are permanently absent: the agreed schema gist specified
  * them, but the deployed server never implemented them and the gist is being amended
- * to match (B2B-5421). search is a genuine, temporary omission — it's deferred to its
+ * to match. search is a genuine, temporary omission — it's deferred to its
  * own ticket and should be restored here once that ticket ships.
  */
 export interface OrdersFiltersInput {
@@ -603,7 +603,7 @@ const GET_COMPANY_ORDERS = `query GetCompanyOrders(
  * There is no total to fetch: the upstream storefront orders endpoint returns cursors
  * and hasNext/hasPrevious with no count. My Orders keeps totalCount: -1, which
  * order/table/B3Table renders as a range without a total. This is the intended
- * contract, not a placeholder — do not "fix" it. See B2B-5421.
+ * contract, not a placeholder — do not "fix" it.
  */
 const GET_CUSTOMER_ORDERS = `query GetCustomerOrders(
   $filters: OrdersFiltersInput

--- a/apps/storefront/src/shared/service/bc/graphql/orders.ts
+++ b/apps/storefront/src/shared/service/bc/graphql/orders.ts
@@ -280,16 +280,16 @@ export interface CompanyOrdersFiltersInput {
 }
 
 /**
- * SF GQL OrdersFiltersInput (base) + B2B extension fields.
- * Base: status, dateRange. Extension: search, companyName, companyIds.
+ * Filters for customer.orders, matching what the server currently accepts.
+ * companyName and companyIds are permanently absent: the agreed schema gist specified
+ * them, but the deployed server never implemented them and the gist is being amended
+ * to match (B2B-5421). search is a genuine, temporary omission — it's deferred to its
+ * own ticket and should be restored here once that ticket ships.
  */
 export interface OrdersFiltersInput {
-  // OrderStatusValue enum member (e.g. 'AWAITING_FULFILLMENT'), not a display label.
+  /** An OrderStatusValue enum member, e.g. AWAITING_FULFILLMENT — not a display label. */
   status?: string;
   dateRange?: OrderDateRangeFilterInput;
-  search?: string;
-  companyName?: string;
-  companyIds?: string[];
 }
 
 export interface CustomerWithOrdersFiltersInput {

--- a/apps/storefront/src/shared/service/bc/graphql/orders.ts
+++ b/apps/storefront/src/shared/service/bc/graphql/orders.ts
@@ -60,7 +60,6 @@ export interface OrderLineItem {
   subTotalSalePrice: Money;
   image: { url: string } | null;
   baseCatalogProduct: { path: string } | null;
-  returnableQuantity: number;
 }
 
 export interface OrderShipmentTracking {
@@ -102,15 +101,16 @@ export interface OrderDigitalLineItem {
   subTotalSalePrice: Money;
 }
 
-/** Projects OrderDownloadConsignment. */
+/** Projects OrderDownloadConsignment — a plain list element, not a connection node. */
 export interface DownloadConsignment {
-  entityId: number;
+  recipientEmail: string;
   lineItems: { edges: Array<{ node: OrderDigitalLineItem }> };
 }
 
 export interface OrderConsignments {
   shipping: { edges: Array<{ cursor: string; node: ShippingConsignment }> };
-  downloads: { edges: Array<{ cursor: string; node: DownloadConsignment }> } | null;
+  /** A list in the schema, unlike `shipping`. */
+  downloads: DownloadConsignment[] | null;
 }
 
 /** Nested inside OrderDiscounts.couponDiscounts. */
@@ -163,21 +163,12 @@ export interface OrderHistoryEvent {
   createdAt: string;
 }
 
-export interface OrderQuote {
-  id: string;
-}
-
 export interface OrderInvoice {
   id: string;
 }
 
-export interface ExtraFieldValue {
-  name: string;
-  value: string;
-}
-
 export interface OrderPaymentInfo {
-  description: string;
+  paymentMethodName: string;
 }
 
 // ===========================================================================
@@ -209,7 +200,7 @@ export interface Order {
   consignments: OrderConsignments | null;
 
   // Payments (only on OrderWithPayments via site.order detail query)
-  payments?: OrderPaymentInfo[];
+  payments?: { edges: Array<{ node: OrderPaymentInfo }> } | null;
 
   // B2B extensions (null for B2C orders)
   reference: string | null;
@@ -217,9 +208,7 @@ export interface Order {
   company: OrderCompany | null;
   placedBy: OrderPlacedBy | null;
   history: OrderHistoryEvent[];
-  quote: OrderQuote | null;
   invoice: OrderInvoice | null;
-  extraFields: ExtraFieldValue[];
 }
 
 // ===========================================================================
@@ -389,12 +378,11 @@ const orderLineItemFields = `entityId
         ${moneyFields}
       }
       image {
-        url
+        url(width: 80)
       }
       baseCatalogProduct {
         path
-      }
-      returnableQuantity`;
+      }`;
 
 const orderShipmentFields = `entityId
       shippedAt {
@@ -449,28 +437,23 @@ const orderConsignmentsFields = `consignments {
       }
     }
     downloads {
-      edges {
-        cursor
-        node {
-          entityId
-          lineItems {
-            edges {
-              node {
-                entityId
-                productEntityId
-                name
-                quantity
-                productOptions {
-                  name
-                  value
-                }
-                subTotalListPrice {
-                  ${moneyFields}
-                }
-                subTotalSalePrice {
-                  ${moneyFields}
-                }
-              }
+      recipientEmail
+      lineItems {
+        edges {
+          node {
+            entityId
+            productEntityId
+            name
+            quantity
+            productOptions {
+              name
+              value
+            }
+            subTotalListPrice {
+              ${moneyFields}
+            }
+            subTotalSalePrice {
+              ${moneyFields}
             }
           }
         }
@@ -540,15 +523,8 @@ const orderB2BFields = `reference
     source
     createdAt
   }
-  quote {
-    id
-  }
   invoice {
     id
-  }
-  extraFields {
-    name
-    value
   }`;
 
 /** Lightweight fields for order list views. */
@@ -619,7 +595,15 @@ const GET_COMPANY_ORDERS = `query GetCompanyOrders(
  * My Orders (customer-scoped, B2B + B2C). Entry: customer.orders.
  * B2B fields auto-populate for B2B users, null for B2C.
  *
- * Note: OrdersConnection lacks collectionInfo; add once SF GQL team ships it.
+ * collectionInfo is deliberately not selected. The field exists on OrdersConnection,
+ * but the customer resolver returns totalItems: null (only the company resolver
+ * populates it), and selecting it raises no error — so a null total would look like
+ * working code.
+ *
+ * There is no total to fetch: the upstream storefront orders endpoint returns cursors
+ * and hasNext/hasPrevious with no count. My Orders keeps totalCount: -1, which
+ * order/table/B3Table renders as a range without a total. This is the intended
+ * contract, not a placeholder — do not "fix" it. See B2B-5421.
  */
 const GET_CUSTOMER_ORDERS = `query GetCustomerOrders(
   $filters: OrdersFiltersInput
@@ -673,7 +657,11 @@ const GET_ORDER_DETAIL = `query GetOrderDetail($entityId: Int!) {
       ${orderConsignmentsFields}
       ${orderB2BFields}
       payments {
-        description
+        edges {
+          node {
+            paymentMethodName
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
Jira: [B2B-5420](https://bigcommercecloud.atlassian.net/browse/B2B-5420)

## What/Why?
My Orders, Company Orders, and Order Detail were coded against a schema that diverged from what actually shipped. This fixes the mismatches so those three surfaces work against the live schema, and removes/hides the pieces the server genuinely doesn't support.

Root cause for most of it: the order status pill and status filter were keyed off `status.label`, a merchant-configurable display string the resolver returns in unpredictable casing. The stable value is the enum (`status.value`), so I added one shared mapping and pointed every status lookup at it.

My Orders was also sending fields the server rejects — `companyName`, `companyIds`, and `sortBy` on `customer.orders` don't exist there, so every request 400'd. I removed `sortBy` (unblocking everything else), stopped sending the other two, and hid the search box, company selector, and sort headers on My Orders since none of them can do anything now.

Order Detail had six separate query mismatches. The worst is `returnableQuantity` — it 500s server-side, and since it's a non-null field, that error nulls the entire line-items list, so no line items rendered at all. Removed it along with two other dead selections (`quote`, `extraFields`), and fixed wrong shapes on four more (`downloads`, `payments`, `image`, `history`) so they match what the live schema actually returns.

## Rollout/Rollback
All gated by `B2B-4613.buyer_portal_unified_sf_gql_orders`, off by default. Rollback is flipping the flag back off, no migrations.

Still need to verify live against a real store before this goes on anywhere — haven't done that yet.

## Testing
Unit tests updated/added across every touched surface, all passing. No live verification yet.


[B2B-5420]: https://bigcommercecloud.atlassian.net/browse/B2B-5420?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes GraphQL variables and field selections for order list/detail against the live API; incorrect status or filter mapping would break filtering and status pills, and Order Detail previously failed on bad fields like returnableQuantity.
> 
> **Overview**
> Aligns **My Orders**, **Company Orders**, and **Order Detail** with the deployed Storefront GraphQL schema so unified queries stop 400/500ing and status UI matches lookup tables.
> 
> **Status handling:** Adds `orderStatusValue` to map `status.value` (enum) to title-case system labels for colors/i18n, while keeping `status.label` for display. List/detail mappers and customer filters now send **`OrderStatusValue` enum members** (e.g. `PENDING`, `AWAITING_FULFILLMENT`) instead of display or system labels.
> 
> **My Orders (`customer.orders`):** Drops **`sortBy`** from the query and disables column sorting on the unified customer path. Removes **`search`**, **`companyName`**, and **`companyIds`** from customer filters and hides company selector / company filter field; status and date filters remain. **`CursorDetailPagination`** no longer passes `sortBy` for customer order fetches.
> 
> **Order Detail query & conversion:** Updates selections to live shapes—**payments** as a connection with `paymentMethodName`, **downloads** as a plain list (not `edges`), **history** uses `statusLabel` (not `status`/`createdBy`). Stops selecting **`returnableQuantity`** (server 500), **`quote`**, and **`extraFields`**; line item images use **`url(width: 80)`**. **`convertOrderDetail`** follows those shapes and sets **`canReturn: false`** without `returnableQuantity`.
> 
> **Company orders UI:** **Placed by** column sorting is turned off under unified orders (backend incomplete). **`usePlacedByUsers`** page size changes from 100 to 50.
> 
> All behind **`B2B-4613.buyer_portal_unified_sf_gql_orders`**; tests updated across touched surfaces.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0da2c5807ab2cb1ead8979b64f8b633a060eaf08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

