### PR TITLE
chore(products): B2B-4231 Remove false-path for chunked searches; rem…

### DIFF
--- a/apps/storefront/src/pages/quote/components/AddToQuote.tsx
+++ b/apps/storefront/src/pages/quote/components/AddToQuote.tsx
@@ -9,7 +9,6 @@ import CustomButton from '@/components/button/CustomButton';
 import { B3Upload } from '@/components/upload/B3Upload';
 import { PRODUCT_DEFAULT_IMAGE } from '@/constants';
 import { useBlockPendingAccountViewPrice } from '@/hooks/useBlockPendingAccountViewPrice';
-import { useFeatureFlag } from '@/hooks/useFeatureFlag';
 import { useB3Lang } from '@/lib/lang';
 import { searchProducts } from '@/shared/service/b2b';
 import { useAppSelector } from '@/store';

--- a/apps/storefront/src/pages/quote/components/AddToQuote.tsx
+++ b/apps/storefront/src/pages/quote/components/AddToQuote.tsx
@@ -187,6 +187,8 @@ export default function AddToQuote(props: AddToListProps) {
       const chunkedProductIds = chunk(productIds, 50);
       // Search with batches and await all.
       const chunkedProductSearches = await Promise.all(
+        // A PR suggestion during FF removal is to set a concurrency limit on in-flight requests,
+        // since the CSV size is not currently limited.
         chunkedProductIds.map((chunkOfProductIds) =>
           searchProducts({
             productIds: chunkOfProductIds,

--- a/apps/storefront/src/pages/quote/components/AddToQuote.tsx
+++ b/apps/storefront/src/pages/quote/components/AddToQuote.tsx
@@ -41,10 +41,6 @@ export default function AddToQuote(props: AddToListProps) {
 
   const b3Lang = useB3Lang();
 
-  const breakProductSearchesIntoChunks = useFeatureFlag(
-    'B2B-4231.chunk_product_searches_in_csv_upload',
-  );
-
   const getNewQuoteProduct = (products: CustomFieldItems[]) =>
     products.map((product) => {
       const {
@@ -188,30 +184,21 @@ export default function AddToQuote(props: AddToListProps) {
       });
 
       let productsSearch: Product[] = [];
-      if (breakProductSearchesIntoChunks) {
-        // TODO(B2B-4256): SearchProducts will only return 50 products at a time.
-        const chunkedProductIds = chunk(productIds, 50);
-        // Search with batches and await all.
-        const chunkedProductSearches = await Promise.all(
-          chunkedProductIds.map((chunkOfProductIds) =>
-            searchProducts({
-              productIds: chunkOfProductIds,
-              companyId,
-              customerGroupId,
-            }),
-          ),
-        );
-        productsSearch = chunkedProductSearches.flatMap(
-          (result) => result.productsSearch,
-        ) as Product[];
-      } else {
-        const { productsSearch: ps } = await searchProducts({
-          productIds,
-          companyId,
-          customerGroupId,
-        });
-        productsSearch = ps;
-      }
+      // TODO(B2B-4256): SearchProducts will only return 50 products at a time.
+      const chunkedProductIds = chunk(productIds, 50);
+      // Search with batches and await all.
+      const chunkedProductSearches = await Promise.all(
+        chunkedProductIds.map((chunkOfProductIds) =>
+          searchProducts({
+            productIds: chunkOfProductIds,
+            companyId,
+            customerGroupId,
+          }),
+        ),
+      );
+      productsSearch = chunkedProductSearches.flatMap(
+        (result) => result.productsSearch,
+      ) as Product[];
 
       const newProductInfo: CustomFieldItems = conversionProductsList(productsSearch);
 

--- a/apps/storefront/src/utils/featureFlags.ts
+++ b/apps/storefront/src/utils/featureFlags.ts
@@ -12,10 +12,6 @@ export const featureFlags = [
     name: 'passWithModifiersToProductUpload',
   },
   {
-    key: 'B2B-4231.chunk_product_searches_in_csv_upload',
-    name: 'chunkProductSearchesInCsvUpload',
-  },
-  {
     key: 'B2B-3705.increase_graphql_limits_inline_with_platform_api',
     name: 'increaseGraphQLLimitsInlineWithPlatformApi',
   },


### PR DESCRIPTION
…ove FF from front-end code

Jira: [B2B-4231](https://bigcommercecloud.atlassian.net/browse/B2B-4231)

## What/Why?
Remove use of FF in frontend for chunked searches.

## Rollout/Rollback
Removes false-only path for FF; revert the PR - note there is a related backend PR for the actual FF removal from API.

## Testing

<img width="296" height="394" alt="image" src="https://github.com/user-attachments/assets/b15bff6e-9e2d-4488-b34c-bebc9ca2dfa6" />

_Uploading 55 SKUs for unique products_

<img width="744" height="884" alt="image" src="https://github.com/user-attachments/assets/966d427b-ff58-44a4-b445-b2126edef1f3" />

_The SKUs are all valid_

<img width="715" height="362" alt="image" src="https://github.com/user-attachments/assets/dcd4ba9f-3ea4-4755-9f35-25280ad53f3d" />

_Two requests are made in batches of 50 items_

<img width="711" height="486" alt="image" src="https://github.com/user-attachments/assets/5b6307d0-0e54-4ff9-ae2f-5fed7f6a0573" />

_The first contains the first 50 items_

<img width="920" height="539" alt="image" src="https://github.com/user-attachments/assets/34dd2fd9-d9b9-43dc-a297-f0b7687933e1" />

_The second contains the remainder of 5 items_



[B2B-4231]: https://bigcommercecloud.atlassian.net/browse/B2B-4231?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change only removes the disabled code path; chunked search was the intended rollout behavior and is already validated in testing.
> 
> **Overview**
> **Quote CSV bulk upload** now always resolves products via **batched `searchProducts` calls** (50 product IDs per request), instead of branching on the `B2B-4231.chunk_product_searches_in_csv_upload` feature flag.
> 
> The flag entry is removed from `featureFlags.ts`, and `AddToQuote` drops the `useFeatureFlag` import and the single-request fallback path. A comment notes a possible follow-up to cap concurrency when many CSV rows trigger parallel batch requests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0534a0c81863ce66b4b802f3bf778f9bb0678b99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->