### PR TITLE
feat(quotes): BACK-823 enabled backorder display by default

### DIFF
--- a/apps/storefront/src/pages/quote/components/QuoteTable.test.tsx
+++ b/apps/storefront/src/pages/quote/components/QuoteTable.test.tsx
@@ -152,7 +152,7 @@ const withBackorderContextAndMessaging = (featureEnabled: boolean) => ({
 });
 
 describe('QuoteTable backorder messaging', () => {
-  it('shows the backorder details toggle when items are backordered for display and messaging is enabled', () => {
+  it('shows the backorder details toggle checked by default when items are backordered for display and messaging is enabled', () => {
     const updateSummary = vi.fn();
     renderWithProviders(
       <QuoteTable total={1} items={[lineItemWithBackorder]} updateSummary={updateSummary} />,
@@ -160,6 +160,7 @@ describe('QuoteTable backorder messaging', () => {
     );
 
     expect(screen.getByText('Backorder details')).toBeInTheDocument();
+    expect(screen.getByRole('checkbox', { name: 'Backorder details' })).toBeChecked();
   });
 
   it('hides the backorder details toggle when storefront backorder messaging is disabled, even with backordered items', () => {
@@ -172,7 +173,21 @@ describe('QuoteTable backorder messaging', () => {
     expect(screen.queryByText('Backorder details')).not.toBeInTheDocument();
   });
 
-  it('fetches picklist child products and shows their backorder message when the toggle is on', async () => {
+  it('hides backorder messages when the toggle is turned off', async () => {
+    const updateSummary = vi.fn();
+    renderWithProviders(
+      <QuoteTable total={1} items={[lineItemWithBackorder]} updateSummary={updateSummary} />,
+      withBackorderContextAndMessaging(true),
+    );
+
+    expect(screen.getByText('7 will be backordered')).toBeVisible();
+
+    await userEvent.click(screen.getByRole('checkbox', { name: 'Backorder details' }));
+
+    expect(screen.queryByText('7 will be backordered')).not.toBeInTheDocument();
+  });
+
+  it('fetches picklist child products and shows their backorder message by default', async () => {
     vi.mocked(searchProducts).mockResolvedValue({
       productsSearch: [
         {
@@ -193,11 +208,9 @@ describe('QuoteTable backorder messaging', () => {
       withPicklistMessagingEnabled,
     );
 
-    const toggle = await screen.findByText('Backorder details');
-
-    expect(searchProducts).toHaveBeenCalledWith(expect.objectContaining({ productIds: [555] }));
-
-    await userEvent.click(toggle);
+    await waitFor(() => {
+      expect(searchProducts).toHaveBeenCalledWith(expect.objectContaining({ productIds: [555] }));
+    });
 
     await waitFor(() => {
       expect(screen.getByText('PickleFest:')).toBeVisible();
@@ -229,9 +242,6 @@ describe('QuoteTable backorder messaging', () => {
       />,
       withPicklistMessagingEnabled,
     );
-
-    const toggle = await screen.findByText('Backorder details');
-    await userEvent.click(toggle);
 
     await waitFor(() => {
       expect(screen.getByText('Ice Pick ships in 3 weeks')).toBeVisible();
@@ -272,13 +282,11 @@ describe('QuoteTable backorder messaging', () => {
       withPicklistMessagingEnabled,
     );
 
-    const toggle = await screen.findByText('Backorder details');
-
-    expect(searchProducts).toHaveBeenCalledWith(
-      expect.objectContaining({ productIds: expect.arrayContaining([999, 555]) }),
-    );
-
-    await userEvent.click(toggle);
+    await waitFor(() => {
+      expect(searchProducts).toHaveBeenCalledWith(
+        expect.objectContaining({ productIds: expect.arrayContaining([999, 555]) }),
+      );
+    });
 
     await waitFor(() => {
       expect(screen.getByText('Kit ships next week')).toBeVisible();

--- a/apps/storefront/src/pages/quote/components/QuoteTable.tsx
+++ b/apps/storefront/src/pages/quote/components/QuoteTable.tsx
@@ -172,7 +172,7 @@ function QuoteTable({ total, items, updateSummary }: QuoteTableProps) {
     hasAnyBackorderDisplay,
   } = useBackorderStorefrontMessaging();
 
-  const [showBackorderDetails, setShowBackorderDetails] = useState(false);
+  const [showBackorderDetails, setShowBackorderDetails] = useState(true);
 
   const draftQuoteBackorderContextEnabled =
     isBackorderMessagingContextEnabled && hasAnyBackorderDisplay;


### PR DESCRIPTION
Jira: [BACK-823](https://bigcommercecloud.atlassian.net/browse/BACK-823)

## What/Why?
Showing backorder info by default on the quote draft page (so buyers don't have to discover and enabled the toggle).

## Rollout/Rollback
Merge/revert. Backorder messaging is gated by `BACK-134` experiment.

## Testing
### Before
Backorder messaging is off by default.

https://github.com/user-attachments/assets/4bde664f-999a-4333-9351-50c52ae0eab4

### After
Backorder messaging is on by default.

https://github.com/user-attachments/assets/e4ca317d-bde9-49bf-8e9b-31e7d2e04cdf


[BACK-823]: https://bigcommercecloud.atlassian.net/browse/BACK-823?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single UI default flip behind existing BACK-134 gating; toggle behavior unchanged and tests updated accordingly.
> 
> **Overview**
> On the quote **draft** table, **backorder messaging is now visible by default** when the storefront backorder experiment and display settings allow it. The **Backorder details** switch still appears for backordered lines but starts **on** instead of off.
> 
> Buyers see quantity-on-backorder text and picklist child messages immediately without toggling. Unchecking the switch hides those messages as before. No API or inventory logic changes—only the initial state of `showBackorderDetails` in `QuoteTable`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1aace92f0574b5f379f162e0376ef7f5fdad7359. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->