### PR TITLE
refactor(account): B2B-5401 Update and replace magic numbers with Enum

### DIFF
--- a/apps/storefront/src/pages/Registered/RegisterSteps/RegisterStep.tsx
+++ b/apps/storefront/src/pages/Registered/RegisterSteps/RegisterStep.tsx
@@ -7,6 +7,7 @@ import { useB3Lang } from '@/lib/lang';
 
 import { steps } from '../config';
 import { RegisteredContext } from '../Context';
+import { RegisterAccountType } from '../types';
 
 interface RegisterStepProps {
   children: ReactNode;
@@ -28,7 +29,9 @@ export default function RegisterStep(props: RegisterStepProps) {
   const pageTitle = useMemo(() => {
     return submitSuccess
       ? b3Lang(
-          accountType === '1' ? 'register.title.registerComplete' : 'register.title.accountCreated',
+          accountType === RegisterAccountType.BUSINESS
+            ? 'register.title.registerComplete'
+            : 'register.title.accountCreated',
         )
       : b3Lang('register.title.accountRegister');
   }, [submitSuccess, accountType, b3Lang]);

--- a/apps/storefront/src/pages/Registered/RegisterSteps/index.tsx
+++ b/apps/storefront/src/pages/Registered/RegisterSteps/index.tsx
@@ -16,7 +16,7 @@ import { getStoreConfigs } from '@/utils/storefrontConfig';
 
 import { b2bAddressRequiredFields, companyAttachmentsFields } from '../config';
 import { RegisteredContext } from '../Context';
-import { RegisterFields } from '../types';
+import { RegisterAccountType, type RegisterFields } from '../types';
 
 import RegisterContent from './RegisterContent';
 import RegisterStep from './RegisterStep';
@@ -124,7 +124,9 @@ export function RegisterSteps({ backgroundColor, handleFinish }: RegisterStepsPr
           dispatch({
             type: 'all',
             payload: {
-              accountType: accountB2cEnabledInfo ? '2' : '1',
+              accountType: accountB2cEnabledInfo
+                ? RegisterAccountType.PERSONAL
+                : RegisterAccountType.BUSINESS,
               isLoading: false,
               contactInformation: [
                 ...(b2bAccountFormFields.contactInformation || []),

--- a/apps/storefront/src/pages/Registered/RegisterSteps/steps/AccountStep.tsx
+++ b/apps/storefront/src/pages/Registered/RegisterSteps/steps/AccountStep.tsx
@@ -18,7 +18,7 @@ import { channelId } from '@/utils/basicConfig';
 
 import { emailError } from '../../config';
 import { RegisteredContext } from '../../Context';
-import { RegisterFields } from '../../types';
+import { RegisterAccountType, type RegisterFields } from '../../types';
 import { PrimaryButton } from '../PrimaryButton';
 import { InformationFourLabels, TipContent } from '../styled';
 
@@ -62,13 +62,18 @@ export default function AccountStep({ handleNext }: AccountStepProps) {
     mode: 'onSubmit',
   });
 
-  const additionName = accountType === '1' ? 'additionalInformation' : 'bcAdditionalInformation';
+  const additionName =
+    accountType === RegisterAccountType.BUSINESS
+      ? 'additionalInformation'
+      : 'bcAdditionalInformation';
   const additionalInfo: RegisterFields[] =
-    accountType === '1' ? additionalInformation || [] : bcAdditionalInformation || [];
+    accountType === RegisterAccountType.BUSINESS
+      ? additionalInformation || []
+      : bcAdditionalInformation || [];
 
   const newContactInformation = contactInformation?.map((contactInfo: RegisterFields) => {
     const info = contactInfo;
-    if (contactInfo.fieldId === 'field_email' && accountType === '1') {
+    if (contactInfo.fieldId === 'field_email' && accountType === RegisterAccountType.BUSINESS) {
       info.isTip = true;
       info.tipText = b3Lang('register.tip.emailSignIn');
     }
@@ -77,8 +82,13 @@ export default function AccountStep({ handleNext }: AccountStepProps) {
   });
 
   const contactInfo: RegisterFields[] =
-    accountType === '1' ? (newContactInformation ?? []) : bcContactInformation || [];
-  const contactName = accountType === '1' ? 'contactInformation' : 'bcContactInformationFields';
+    accountType === RegisterAccountType.BUSINESS
+      ? (newContactInformation ?? [])
+      : bcContactInformation || [];
+  const contactName =
+    accountType === RegisterAccountType.BUSINESS
+      ? 'contactInformation'
+      : 'bcContactInformationFields';
 
   const contactInformationLabel = contactInfo.length ? contactInfo[0]?.groupName : '';
 
@@ -107,7 +117,7 @@ export default function AccountStep({ handleNext }: AccountStepProps) {
     'email';
 
   const validateEmailValue = async (email: string) => {
-    const isRegisterAsB2BUser = accountType === '1';
+    const isRegisterAsB2BUser = accountType === RegisterAccountType.BUSINESS;
     try {
       showLoading(true);
       const {
@@ -160,7 +170,7 @@ export default function AccountStep({ handleNext }: AccountStepProps) {
 
       try {
         showLoading(true);
-        if (accountType === '1') {
+        if (accountType === RegisterAccountType.BUSINESS) {
           const extraCompanyUserInformation = newContactInfo.filter(
             (item: RegisterFields) => !!item.custom,
           );

--- a/apps/storefront/src/pages/Registered/RegisterSteps/steps/DetailStep.tsx
+++ b/apps/storefront/src/pages/Registered/RegisterSteps/steps/DetailStep.tsx
@@ -11,7 +11,7 @@ import { getIsStateRequired } from '@/utils/b2bGetIsStateRequired';
 
 import { Country, State, validateExtraFields } from '../../config';
 import { RegisteredContext } from '../../Context';
-import { RegisterFields } from '../../types';
+import { RegisterAccountType, type RegisterFields } from '../../types';
 import { PrimaryButton } from '../PrimaryButton';
 import { InformationFourLabels, TipContent } from '../styled';
 
@@ -36,7 +36,7 @@ export default function DetailStep({ handleBack, handleNext }: DetailStepProps) 
   const [errorMessage, setErrorMessage] = useState('');
 
   const {
-    accountType = '1',
+    accountType = RegisterAccountType.BUSINESS,
     companyInformation = [],
     companyAttachment = [],
     addressBasicFields = [],
@@ -55,10 +55,13 @@ export default function DetailStep({ handleBack, handleNext }: DetailStepProps) 
   } = useForm({
     mode: 'all',
   });
-  const businessDetailsName = accountType === '1' ? companyInformation[0]?.groupName : '';
+  const businessDetailsName =
+    accountType === RegisterAccountType.BUSINESS ? companyInformation[0]?.groupName : '';
 
-  const addressBasicName = accountType === '1' ? 'addressBasicFields' : 'bcAddressBasicFields';
-  const addressBasicList = accountType === '1' ? addressBasicFields : bcAddressBasicFields;
+  const addressBasicName =
+    accountType === RegisterAccountType.BUSINESS ? 'addressBasicFields' : 'bcAddressBasicFields';
+  const addressBasicList =
+    accountType === RegisterAccountType.BUSINESS ? addressBasicFields : bcAddressBasicFields;
 
   const addressName = addressBasicList[0]?.groupName || '';
 
@@ -177,7 +180,7 @@ export default function DetailStep({ handleBack, handleNext }: DetailStepProps) 
   };
 
   const handleValidateAttachmentFiles = () => {
-    if (accountType === '1') {
+    if (accountType === RegisterAccountType.BUSINESS) {
       const formData = getValues();
       const attachmentsFilesFiled = companyInformation.find(
         (info) => info.fieldId === 'field_attachments',
@@ -209,7 +212,7 @@ export default function DetailStep({ handleBack, handleNext }: DetailStepProps) 
       if (hasAttachmentsFilesError) return;
       showLoading(true);
       try {
-        if (accountType === '1') {
+        if (accountType === RegisterAccountType.BUSINESS) {
           await Promise.all([
             validateExtraFields({
               fields: companyInformation,
@@ -270,7 +273,7 @@ export default function DetailStep({ handleBack, handleNext }: DetailStepProps) 
           <TipContent>{errorMessage}</TipContent>
         </Alert>
       )}
-      {accountType === '1' ? (
+      {accountType === RegisterAccountType.BUSINESS ? (
         <Box>
           <InformationFourLabels>{businessDetailsName}</InformationFourLabels>
           <B3CustomForm

--- a/apps/storefront/src/pages/Registered/RegisterSteps/steps/FinishStep.tsx
+++ b/apps/storefront/src/pages/Registered/RegisterSteps/steps/FinishStep.tsx
@@ -9,6 +9,7 @@ import { GlobalContext } from '@/shared/global';
 import { B3SStorage } from '@/utils/b3Storage';
 
 import { RegisteredContext } from '../../Context';
+import { RegisterAccountType } from '../../types';
 import { PrimaryButton } from '../PrimaryButton';
 import { StyleTipContainer } from '../styled';
 
@@ -40,7 +41,7 @@ export default function FinishStep({ handleFinish, isBCToB2B = false }: FinishSt
 
   const renderB2BSuccessPage = () => {
     // Business Account
-    if (accountType === '1') {
+    if (accountType === RegisterAccountType.BUSINESS) {
       if (isAutoApproval) {
         shouldAutoLogin.current = true;
         return (
@@ -81,7 +82,7 @@ export default function FinishStep({ handleFinish, isBCToB2B = false }: FinishSt
     }
 
     // Personal Account
-    if (accountType === '2') {
+    if (accountType === RegisterAccountType.PERSONAL) {
       shouldAutoLogin.current = true;
       return (
         <StyleTipContainer>

--- a/apps/storefront/src/pages/RegisteredBCToB2B/RegistrationForm/useRegistrationForm.ts
+++ b/apps/storefront/src/pages/RegisteredBCToB2B/RegistrationForm/useRegistrationForm.ts
@@ -7,7 +7,7 @@ import { useMobile } from '@/hooks/useMobile';
 import { useB3Lang } from '@/lib/lang';
 import { Country, State } from '@/pages/Registered/config';
 import { RegisteredContext } from '@/pages/Registered/Context';
-import type { RegisterFields } from '@/pages/Registered/types';
+import { RegisterAccountType, type RegisterFields } from '@/pages/Registered/types';
 import { CustomStyleContext } from '@/shared/customStyleButton';
 import { GlobalContext } from '@/shared/global';
 import {
@@ -398,7 +398,7 @@ export function useRegistrationForm({ onRegistrationSuccess }: UseRegistrationFo
           dispatch({
             type: 'all',
             payload: {
-              accountType: '1',
+              accountType: RegisterAccountType.BUSINESS,
             },
           });
           await getCurrentCustomerInfo();


### PR DESCRIPTION
Jira: [B2B-5401](https://bigcommercecloud.atlassian.net/browse/B2B-5401)

## What/Why?
In previous PR the magic strings `1` / `2` was replaced by RegisterAccountType (BUSINESS / PERSONAL) Enum but only for one file.
In this PR, all instances have been replaced to keep the refactoring short, focused, and easy to review.

## Rollout/Rollback
Revert

## Testing
Will be relying on existing tests


[B2B-5401]: https://bigcommercecloud.atlassian.net/browse/B2B-5401?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical enum substitution with identical string values; registration logic paths are unchanged.
> 
> **Overview**
> Extends the **RegisterAccountType** enum (`BUSINESS` / `PERSONAL`, still `'1'` / `'2'`) across the storefront registration flow so business vs personal branching no longer uses raw `'1'` and `'2'` literals.
> 
> **Register steps** (`RegisterStep`, `index`, `AccountStep`, `DetailStep`, `FinishStep`) and **BC-to-B2B** `useRegistrationForm` now compare and set `accountType` via `RegisterAccountType.BUSINESS` and `RegisterAccountType.PERSONAL` for titles, initial account type, form field sets, validation paths, and success messaging. No intended behavior change—readability and consistency with the prior partial refactor.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de3589e367886c55f35e198dfa84381e5956e5e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->