### PR TITLE
refactor(register): B2B-5401 remove derived-state and event-response useEffects from CompleteStep

### DIFF
--- a/apps/storefront/src/pages/Registered/RegisterSteps/steps/CompleteStep/index.tsx
+++ b/apps/storefront/src/pages/Registered/RegisterSteps/steps/CompleteStep/index.tsx
@@ -47,9 +47,7 @@ export default function CompleteStep(props: CompleteStepProps) {
   const b3Lang = useB3Lang();
   const isRegisterCompanyFlowEnabled = useFeatureFlag('B2B-4466.use_register_company_flow');
   const { handleBack, handleNext } = props;
-  const [personalInfo, setPersonalInfo] = useState<Array<CustomFieldItems>>([]);
   const [errorMessage, setErrorMessage] = useState<string>('');
-  const [enterEmail, setEnterEmail] = useState<string>('');
 
   const [captchaKey, setCaptchaKey] = useState('');
   const [isEnabledOnStorefront, setIsEnabledOnStorefront] = useState(false);
@@ -57,14 +55,19 @@ export default function CompleteStep(props: CompleteStepProps) {
 
   const [isCaptchaMissing, setIsCaptchaMissing] = useState(false);
 
-  const handleGetCaptchaKey = (key: string) => setCaptchaKey(key);
+  const handleGetCaptchaKey = (key: string) => {
+    setCaptchaKey(key);
+    if (key) setIsCaptchaMissing(false);
+  };
 
   useEffect(() => {
+    let ignore = false;
+
     const getIsEnabledOnStorefront = async () => {
       try {
         const response = await getStorefrontToken();
 
-        if (response) {
+        if (response && !ignore) {
           setIsEnabledOnStorefront(response.isEnabledOnStorefront);
           setStorefrontSiteKey(response.siteKey);
         }
@@ -74,11 +77,11 @@ export default function CompleteStep(props: CompleteStepProps) {
     };
 
     getIsEnabledOnStorefront();
-  }, []);
 
-  useEffect(() => {
-    if (captchaKey) setIsCaptchaMissing(false);
-  }, [captchaKey]);
+    return () => {
+      ignore = true;
+    };
+  }, []);
 
   const {
     control,
@@ -123,6 +126,11 @@ export default function CompleteStep(props: CompleteStepProps) {
 
   const passwordName = passwordInfo[0]?.groupName || '';
 
+  const personalInfo: Array<CustomFieldItems> = accountType ? passwordInfo : [];
+  const enterEmail = accountType
+    ? String(list?.find((item: RegisterFields) => item.name === 'email')?.default ?? '')
+    : '';
+
   const additionalInfo: CompleteStepList =
     accountType === RegisterAccountType.BUSINESS ? additionalInformation : bcAdditionalInformation;
 
@@ -146,18 +154,6 @@ export default function CompleteStep(props: CompleteStepProps) {
       'global.registerComplete.companyRegistrationGenericError',
     ),
   };
-
-  useEffect(() => {
-    if (!accountType) return;
-    if (list && list.length) {
-      const emailFields: CustomFieldItems =
-        list.find((item: RegisterFields) => item.name === 'email') || {};
-
-      setEnterEmail(emailFields?.default || '');
-    }
-
-    setPersonalInfo(passwordInfo);
-  }, [contactInformation, bcContactInformation, accountType, list, passwordInfo]);
 
   const getFileUrl = async (attachmentsList: RegisterFields[]) => {
     let attachments: File[] = [];

--- a/apps/storefront/src/pages/Registered/index.test.tsx
+++ b/apps/storefront/src/pages/Registered/index.test.tsx
@@ -29,6 +29,17 @@ import * as storefrontConfigModule from '@/utils/storefrontConfig';
 import { RegisteredProvider } from './Context';
 import Registered from '.';
 
+// The real Captcha renders into a theme-frame iframe and listens for `postMessage` with a
+// runtime-generated widget id, which is impractical to drive in jsdom. Replace it with a button
+// that fires the same `handleGetKey` callback the real widget calls on solve.
+vi.mock('@/components/captcha/Captcha', () => ({
+  Captcha: ({ handleGetKey }: { handleGetKey: (key: string) => void }) => (
+    <button type="button" onClick={() => handleGetKey('captcha-key')}>
+      solve captcha
+    </button>
+  ),
+}));
+
 const { server } = startMockServer();
 
 const buildUploadedCompanyFileWith = builder<UploadedCompanyFile>(() => ({
@@ -1188,6 +1199,42 @@ describe('Registered Page', () => {
     expect(
       screen.queryByRole('heading', { name: 'Registration complete!' }),
     ).not.toBeInTheDocument();
+  });
+
+  it('clears the missing-captcha message and allows submission once the captcha is solved', async () => {
+    vi.spyOn(recaptchaModule, 'getStorefrontToken').mockResolvedValue({
+      isEnabledOnStorefront: true,
+      siteKey: 'test-site-key',
+    });
+
+    const { user } = renderWithProviders(
+      <RegisteredProvider>
+        <Registered setOpenPage={vi.fn()} />
+      </RegisteredProvider>,
+      { preloadedState: preloadedStateB2bCompanyCreate },
+    );
+
+    await completeRegistration(user, { ...mockRegistrationData.b2c, businessDetails: undefined });
+
+    expect(
+      await screen.findByText('The captcha you entered is incorrect. Please try again.'),
+    ).toBeVisible();
+
+    await user.click(screen.getByRole('button', { name: 'solve captcha' }));
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText('The captcha you entered is incorrect. Please try again.'),
+      ).not.toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('button', { name: /Submit/i }));
+
+    expect(await screen.findByRole('heading', { name: 'Registration complete!' })).toBeVisible();
+    expect(b2bService.createBCCompanyUser).toHaveBeenCalledWith(
+      expectedPayloadType1,
+      'captcha-key',
+    );
   });
 
   it('renders and completes Business (B2B) registration flow with auto approval', async () => {


### PR DESCRIPTION
Jira: [B2B-5401](https://bigcommercecloud.atlassian.net/browse/B2B-5401)

## What?
- Removed the useEffect that mirrored list/passwordInfo/accountType into personalInfo/enterEmail state — replaced with plain const derivations.
- Removed the useEffect that reset isCaptchaMissing when captchaKey changed — moved the reset directly into handleGetCaptchaKey.
- Added a stale-response guard (ignore flag + cleanup) to the remaining useEffect that fetches storefront captcha config, so it can't set state after unmount.
- Added test coverage for the captcha solve path (previously only the missing-captcha case was tested).

## Why?
Two of the three effects weren't syncing with anything external — they were recomputing state that could be derived on every render (personalInfo/enterEmail) or responding to a local state change that already had a direct call site (isCaptchaMissing). Effects like these add an extra render pass, a wider dependency array to keep in sync, and are a common source of subtle bugs (e.g., stale closures, missed dependencies) for no benefit over just computing the value inline. This leaves the file with a single effect, used for its one legitimate purpose: fetching data on mount.


## Rollout/Rollback
Revert

## Testing
Unit test added, there is also Functional test
[] Will run the functional tests against the branch
[] Will manually validate


[B2B-5401]: https://bigcommercecloud.atlassian.net/browse/B2B-5401?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized refactor of registration complete-step React patterns plus test mocks; behavior is intended to stay the same aside from safer unmount handling for captcha config fetch.
> 
> **Overview**
> **CompleteStep** no longer keeps `personalInfo` and `enterEmail` in state or syncs them via `useEffect`; they are derived each render from registration context (`passwordInfo`, `list`, `accountType`). Clearing the missing-captcha error now happens in `handleGetCaptchaKey` when a key is received, instead of a separate effect on `captchaKey`.
> 
> The mount effect that loads storefront captcha config adds an **ignore** flag on cleanup so late `getStorefrontToken` responses cannot update state after unmount.
> 
> Tests mock **Captcha** with a solve button and add coverage that the incorrect-captcha message disappears after solve and registration can complete with the captcha key passed to `createBCCompanyUser`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7eca3e70fa657c489495b321a6d2bfcc2181478. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->