### PR TITLE
LOCAL-3402: Pass storefront language in Accept-Language header

### DIFF
--- a/apps/storefront/src/lib/lang/getStorefrontLanguageCode.test.ts
+++ b/apps/storefront/src/lib/lang/getStorefrontLanguageCode.test.ts
@@ -1,0 +1,49 @@
+import { store } from '@/store';
+
+import { getStorefrontLanguageCode } from './getStorefrontLanguageCode';
+
+const LOCALES = [
+  { code: 'en', isDefault: true, fullPath: 'https://store.example.com/' },
+  { code: 'fr', isDefault: false, fullPath: 'https://store.example.com/fr' },
+];
+
+const mockState = (featureFlags: Record<string, boolean>, locales = LOCALES) =>
+  vi
+    .spyOn(store, 'getState')
+    .mockReturnValue({ global: { featureFlags, locales } } as unknown as ReturnType<
+      typeof store.getState
+    >);
+
+const setHref = (href: string) => {
+  Object.defineProperty(window, 'location', { value: { href }, writable: true });
+};
+
+describe('getStorefrontLanguageCode', () => {
+  const originalLocation = window.location;
+
+  afterEach(() => {
+    Object.defineProperty(window, 'location', { value: originalLocation, writable: true });
+    vi.restoreAllMocks();
+  });
+
+  it('returns undefined when the multi-language feature flag is disabled', () => {
+    setHref('https://store.example.com/fr');
+    mockState({ 'LOCAL-3280.B2B_email_multi_language': false });
+
+    expect(getStorefrontLanguageCode()).toBeUndefined();
+  });
+
+  it('returns the active locale code when the flag is enabled and the URL matches a locale', () => {
+    setHref('https://store.example.com/fr/some-page');
+    mockState({ 'LOCAL-3280.B2B_email_multi_language': true });
+
+    expect(getStorefrontLanguageCode()).toBe('fr');
+  });
+
+  it('returns undefined when the flag is enabled but no locale matches the URL', () => {
+    setHref('https://other-store.example.com/');
+    mockState({ 'LOCAL-3280.B2B_email_multi_language': true });
+
+    expect(getStorefrontLanguageCode()).toBeUndefined();
+  });
+});

--- a/apps/storefront/src/lib/lang/getStorefrontLanguageCode.ts
+++ b/apps/storefront/src/lib/lang/getStorefrontLanguageCode.ts
@@ -1,0 +1,14 @@
+import { store } from '@/store';
+
+import { getActiveLocale } from './getActiveLocale';
+
+export const getStorefrontLanguageCode = () => {
+  const { locales, featureFlags } = store.getState().global;
+  const isMultiLanguageEnabled = Boolean(featureFlags['LOCAL-3280.B2B_email_multi_language']);
+
+  if (!isMultiLanguageEnabled) {
+    return undefined;
+  }
+
+  return getActiveLocale(locales)?.code;
+};

--- a/apps/storefront/src/pages/quote/utils/quoteCheckout.test.ts
+++ b/apps/storefront/src/pages/quote/utils/quoteCheckout.test.ts
@@ -11,7 +11,10 @@ import { handleQuoteCheckout, QUOTE_BACKORDER_CHANGE_STORAGE_KEY } from './quote
 vi.mock('@/store', () => ({
   store: {
     dispatch: vi.fn(),
-    getState: vi.fn(() => ({ company: { tokens: { B2BToken: 'test-token' } } })),
+    getState: vi.fn(() => ({
+      company: { tokens: { B2BToken: 'test-token' } },
+      global: { locales: [], featureFlags: {} },
+    })),
   },
   setQuoteDetailToCheckoutUrl: vi.fn((payload) => ({
     type: 'setQuoteDetailToCheckoutUrl',

--- a/apps/storefront/src/shared/service/request/b3Fetch.ts
+++ b/apps/storefront/src/shared/service/request/b3Fetch.ts
@@ -1,5 +1,6 @@
 import Cookies from 'js-cookie';
 
+import { getStorefrontLanguageCode } from '@/lib/lang/getStorefrontLanguageCode';
 import { store } from '@/store';
 import { snackbar } from '@/utils/b3Tip';
 import { BigCommerceStorefrontAPIBaseURL, channelId, storeHash } from '@/utils/basicConfig';
@@ -98,9 +99,15 @@ const B3Request = {
     suppressSnackbar = false,
   ): Promise<T extends DataWrapper ? T['data'] : T> {
     const { B2BToken } = store.getState().company.tokens;
-    const config = {
+    const locale = getStorefrontLanguageCode();
+
+    const config: Record<string, string> = {
       Authorization: `Bearer  ${B2BToken}`,
     };
+
+    if (locale) {
+      config['Accept-Language'] = locale;
+    }
 
     return graphqlRequest(RequestType.B2BGraphql, data, config).then((value: B2bGQLResponse) => {
       const error = value.errors?.[0];
@@ -145,9 +152,16 @@ const B3Request = {
    */
   graphqlBC: function post<T = any>(data: GQLRequest): Promise<T> {
     const { bcGraphqlToken } = store.getState().company.tokens;
-    const config = {
+    const locale = getStorefrontLanguageCode();
+
+    const config: Record<string, string> = {
       Authorization: `Bearer  ${bcGraphqlToken}`,
     };
+
+    if (locale) {
+      config['Accept-Language'] = locale;
+    }
+
     return graphqlRequest(RequestType.BCGraphql, data, config);
   },
   /**

--- a/apps/storefront/src/utils/featureFlags.ts
+++ b/apps/storefront/src/utils/featureFlags.ts
@@ -36,6 +36,10 @@ export const featureFlags = [
     name: 'b2bMultiLanguage',
   },
   {
+    key: 'LOCAL-3280.B2B_email_multi_language',
+    name: 'b2bEmailMultiLanguage',
+  },
+  {
     key: 'PROJECT-7920.use_bc_account_settings',
     name: 'useBcAccountSettings',
   },

--- a/apps/storefront/src/utils/loginInfo.test.ts
+++ b/apps/storefront/src/utils/loginInfo.test.ts
@@ -214,7 +214,8 @@ describe('ensureBcGraphqlToken', () => {
   it('coalesces concurrent storefront token requests into one network call', async () => {
     vi.spyOn(store, 'getState').mockReturnValue({
       company: { tokens: { B2BToken: '', bcGraphqlToken: '' } },
-    } as ReturnType<typeof store.getState>);
+      global: { locales: [], featureFlags: {} },
+    } as unknown as ReturnType<typeof store.getState>);
 
     let requestCount = 0;
     server.use(
@@ -233,7 +234,8 @@ describe('ensureBcGraphqlToken', () => {
   it('resets the in-flight state after a failed fetch, allowing a retry', async () => {
     vi.spyOn(store, 'getState').mockReturnValue({
       company: { tokens: { B2BToken: '', bcGraphqlToken: '' } },
-    } as ReturnType<typeof store.getState>);
+      global: { locales: [], featureFlags: {} },
+    } as unknown as ReturnType<typeof store.getState>);
 
     let callCount = 0;
     server.use(

--- a/apps/storefront/src/utils/storefrontConfig.ts
+++ b/apps/storefront/src/utils/storefrontConfig.ts
@@ -350,7 +350,10 @@ const setStorefrontConfig = async (dispatch: DispatchProps) => {
   const { featureFlags } = store.getState().global;
   const useCombinedQuery = featureFlags['B2B-3817.disable_masquerading_cleanup_on_login'] ?? false;
 
-  if (featureFlags['LOCAL-3191.B2B_multi_language']) {
+  if (
+    featureFlags['LOCAL-3191.B2B_multi_language'] ||
+    featureFlags['LOCAL-3280.B2B_email_multi_language']
+  ) {
     getLocales()
       .then((res) => store.dispatch(setLocales(res.data.site.settings.locales)))
       .catch(() => {});


### PR DESCRIPTION
Jira: [LOCAL-3402](https://bigcommercecloud.atlassian.net/browse/LOCAL-3402)

## What/Why?
The backend picks the locale for things like transactional emails from the request's `Accept-Language` header, but the storefront never sent one, so it always fell back to English.

`B3Request.graphqlB2B` and `B3Request.graphqlBC` (`apps/storefront/src/shared/service/request/b3Fetch.ts`) now attach an `Accept-Language` header, resolved by `getStorefrontLanguageCode`. This covers every B2B GraphQL and BigCommerce Storefront GraphQL request. It's gated by the `LOCAL-3280.B2B_email_multi_language` flag. When the flag is off, no header is sent and behavior is unchanged.

## Rollout/Rollback
Gated by the existing `LOCAL-3280.B2B_email_multi_language` flag. Backend already handles requests without `Accept-Language`, so this is a low-risk additive change. Rollback is a plain revert.

## Testing
- Added `getStorefrontLanguageCode.test.ts` covering flag disabled, flag enabled with a matching locale, and flag enabled with no matching locale.
- Ran the storefront test suite; existing tests still pass.
- Manual check: confirmed both B2B GraphQL and Storefront GraphQL requests carry `Accept-Language: <locale>` when multi-language is enabled and a locale matches the URL.

<details><summary>Screen Records</summary>
<p>

https://github.com/user-attachments/assets/88ee2ccf-4ce5-49b9-8d9c-9a3572fc559c

</p>
</details> 

[LOCAL-3402]: https://bigcommercecloud.atlassian.net/browse/LOCAL-3402?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive, flag-gated header on GraphQL clients; backend already tolerates missing Accept-Language, so rollout risk is low.
> 
> **Overview**
> When **`LOCAL-3280.B2B_email_multi_language`** is on, the storefront now resolves the active locale from the URL (via existing **`getActiveLocale`**) through new **`getStorefrontLanguageCode`**, and **`B3Request.graphqlB2B`** and **`graphqlBC`** attach **`Accept-Language`** on outbound requests so the backend can align transactional email locale with the shopper’s storefront language. With the flag off or no matching locale, no header is sent—behavior stays the same.
> 
> **`setStorefrontConfig`** also fetches and stores locales when the email multi-language flag is enabled (not only **`LOCAL-3191.B2B_multi_language`**), so locale data is available for header resolution. The new flag is registered in **`featureFlags`**, with unit tests for **`getStorefrontLanguageCode`** and updated store mocks in related tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8235c2758d826247b290444fc4c0e25348369cd5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->