### PR TITLE
fix(quotes): BACK-822 left-align qty columns across product tables and modals

### DIFF
--- a/apps/storefront/src/components/B3ProductList.tsx
+++ b/apps/storefront/src/components/B3ProductList.tsx
@@ -16,6 +16,7 @@ import {
   getCatalogProductRowDisplayState,
   productRequiresChooseOptionsBeforeAdd,
 } from '@/utils/catalogBackorderDisplay';
+import { getProductListColumnAlignments } from '@/utils/getProductListColumnAlignments';
 
 import { MoneyFormat, ProductItem } from '../types';
 
@@ -122,6 +123,7 @@ interface BackorderLayoutStyles {
   qtyColumn: ProductListItemStyle['qty'];
   qtyColumnSx: FlexItemProps['sx'];
   numericColumn: ProductListItemStyle['default'];
+  priceColumnSx: FlexItemProps['sx'];
   productColumnPadding: string;
   productColumnSx: FlexItemProps['sx'];
 }
@@ -135,13 +137,28 @@ function getBackorderLayoutStyles(
   if (isMobile) {
     productColumnPadding = '0';
   } else if (desktopBackorderLayoutEnabled) {
-    productColumnPadding = '0 16px 0 0';
+    productColumnPadding = '0 1rem 0 0';
   }
+
+  const desktopPriceQtyGapSx = isMobile
+    ? undefined
+    : {
+        paddingRight: '1rem',
+      };
+  const desktopQtyGapSx = isMobile
+    ? undefined
+    : {
+        paddingLeft: '1rem',
+      };
 
   return {
     qtyColumn: desktopBackorderLayoutEnabled ? { width: '16%' } : itemStyle.qty,
-    qtyColumnSx: desktopBackorderLayoutEnabled ? { minWidth: '140px' } : undefined,
+    qtyColumnSx: {
+      ...(desktopBackorderLayoutEnabled ? { minWidth: '8.75rem' } : {}),
+      ...desktopQtyGapSx,
+    },
     numericColumn: desktopBackorderLayoutEnabled ? { width: '12%' } : itemStyle.default,
+    priceColumnSx: desktopPriceQtyGapSx,
     productColumnPadding,
     productColumnSx: desktopBackorderLayoutEnabled ? { flex: '1 1 42%', minWidth: 0 } : undefined,
   };
@@ -162,7 +179,6 @@ interface ProductProps<T extends ProductItem = ProductItem> {
   selectAllText?: string;
   totalText?: string;
   canToProduct?: boolean;
-  textAlign?: string;
   type?: string;
   getCurrentProductUrls?: (productId: number | undefined) => void;
   catalogBackorderUiEnabled?: boolean;
@@ -182,7 +198,7 @@ export function B3ProductList<T extends ProductItem>(props: ProductProps<T>) {
     products,
     renderAction,
     quantityKey = 'quantity',
-    actionWidth = '100px',
+    actionWidth = '6.25rem',
     quantityEditable = false,
     onProductQuantityChange = noop,
     showCheckbox = false,
@@ -190,7 +206,6 @@ export function B3ProductList<T extends ProductItem>(props: ProductProps<T>) {
     selectAllText = 'Select all products',
     totalText = 'Total',
     canToProduct = false,
-    textAlign = 'left',
     money,
     currencyCode,
     type,
@@ -206,7 +221,12 @@ export function B3ProductList<T extends ProductItem>(props: ProductProps<T>) {
   const [isMobile] = useMobile();
   const b3Lang = useB3Lang();
   const showInclusiveTaxPrice = useAppSelector(({ global }) => global.showInclusiveTaxPrice);
-  const quantityStackItemsAlignment = textAlign === 'right' ? 'flex-end' : 'flex-start';
+  const {
+    qtyTextAlign,
+    numericTextAlign,
+    qtyStackItemsAlignment: quantityStackItemsAlignment,
+    numericStackItemsAlignment,
+  } = getProductListColumnAlignments(isMobile);
 
   const getQuantity = (product: any) => parseInt(product[quantityKey]?.toString() || '', 10) || '';
 
@@ -277,6 +297,7 @@ export function B3ProductList<T extends ProductItem>(props: ProductProps<T>) {
     qtyColumn: desktopQtyColumnStyle,
     qtyColumnSx: desktopQtyColumnExtraSx,
     numericColumn: desktopNumericColumnStyle,
+    priceColumnSx: desktopPriceColumnExtraSx,
     productColumnPadding: desktopProductColumnPadding,
     productColumnSx: desktopProductColumnSx,
   } = getBackorderLayoutStyles(backorderLayoutEnabled && !isMobile, isMobile, itemStyle);
@@ -312,17 +333,21 @@ export function B3ProductList<T extends ProductItem>(props: ProductProps<T>) {
           <FlexItem padding={desktopProductColumnPadding} sx={desktopProductColumnSx}>
             <ProductHead>{b3Lang('global.searchProduct.product')}</ProductHead>
           </FlexItem>
-          <FlexItem textAlignLocation={textAlign} {...desktopNumericColumnStyle}>
+          <FlexItem
+            textAlignLocation={numericTextAlign}
+            {...desktopNumericColumnStyle}
+            sx={desktopPriceColumnExtraSx}
+          >
             <ProductHead>{b3Lang('global.searchProduct.price')}</ProductHead>
           </FlexItem>
           <FlexItem
-            textAlignLocation={textAlign}
+            textAlignLocation={qtyTextAlign}
             {...desktopQtyColumnStyle}
             sx={desktopQtyColumnExtraSx}
           >
             <ProductHead>{b3Lang('global.searchProduct.qty')}</ProductHead>
           </FlexItem>
-          <FlexItem textAlignLocation={textAlign} {...desktopNumericColumnStyle}>
+          <FlexItem textAlignLocation={numericTextAlign} {...desktopNumericColumnStyle}>
             <ProductHead>{b3Lang('global.searchProduct.total')}</ProductHead>
           </FlexItem>
           {renderAction && (
@@ -443,26 +468,28 @@ export function B3ProductList<T extends ProductItem>(props: ProductProps<T>) {
           priceValue: number,
           priceDiscountedValue: number,
           preFormatted?: string,
+          columnSx?: FlexItemProps['sx'],
         ) => {
           return (
             <FlexItem
-              textAlignLocation={textAlign}
-              padding={quantityEditable ? '10px 0 0' : ''}
+              textAlignLocation={numericTextAlign}
+              padding={quantityEditable ? '0.625rem 0 0' : ''}
               {...desktopNumericColumnStyle}
-              sx={
-                isMobile
+              sx={{
+                ...columnSx,
+                ...(isMobile
                   ? {
                       fontSize: '14px',
                     }
-                  : {}
-              }
+                  : {}),
+              }}
             >
               <Box
                 sx={{
                   display: 'flex',
                   flexDirection: 'column',
-                  alignItems: 'flex-end',
-                  justifyContent: textAlign === 'right' ? 'flex-end' : 'flex-start',
+                  alignItems: numericStackItemsAlignment,
+                  justifyContent: numericStackItemsAlignment,
                 }}
               >
                 <Box
@@ -551,9 +578,15 @@ export function B3ProductList<T extends ProductItem>(props: ProductProps<T>) {
               </Box>
             </FlexItem>
 
-            {renderPrice('Price', productPrice, discountedPrice, safeFormattedPrice)}
+            {renderPrice(
+              'Price',
+              productPrice,
+              discountedPrice,
+              safeFormattedPrice,
+              desktopPriceColumnExtraSx,
+            )}
             <FlexItem
-              textAlignLocation={textAlign}
+              textAlignLocation={qtyTextAlign}
               {...desktopQtyColumnStyle}
               sx={{
                 ...desktopQtyColumnExtraSx,
@@ -586,7 +619,7 @@ export function B3ProductList<T extends ProductItem>(props: ProductProps<T>) {
                     onBlur={handleNumberInputBlur(product)}
                     size="small"
                     sx={{
-                      width: isMobile ? '110px' : '72px',
+                      width: isMobile ? '6.875rem' : '100%',
                       '& .MuiFormHelperText-root': {
                         marginLeft: '0',
                         marginRight: '0',
@@ -602,7 +635,7 @@ export function B3ProductList<T extends ProductItem>(props: ProductProps<T>) {
                         width: '100%',
                         maxWidth: '100%',
                         minWidth: 0,
-                        textAlign,
+                        textAlign: qtyTextAlign,
                         alignSelf: quantityStackItemsAlignment,
                       }}
                     >
@@ -625,7 +658,7 @@ export function B3ProductList<T extends ProductItem>(props: ProductProps<T>) {
                     sx={{
                       mt: 1,
                       width: '100%',
-                      textAlign,
+                      textAlign: qtyTextAlign,
                       alignSelf: quantityStackItemsAlignment,
                     }}
                   >

--- a/apps/storefront/src/pages/OrderDetail/components/OrderBilling.tsx
+++ b/apps/storefront/src/pages/OrderDetail/components/OrderBilling.tsx
@@ -2,7 +2,6 @@ import { useContext, useEffect, useState } from 'react';
 import { Box, Card, CardContent, Stack, Typography } from '@mui/material';
 
 import { B3ProductList } from '@/components/B3ProductList';
-import { useMobile } from '@/hooks/useMobile';
 import { useB3Lang } from '@/lib/lang';
 
 import { Address, OrderProductItem } from '../../../types';
@@ -26,8 +25,6 @@ export function OrderBilling({ isCurrentCompany }: OrderBillingProps) {
       currencyCode,
     },
   } = useContext(OrderDetailsContext);
-
-  const [isMobile] = useMobile();
 
   const b3Lang = useB3Lang();
 
@@ -152,7 +149,6 @@ export function OrderBilling({ isCurrentCompany }: OrderBillingProps) {
             }
             totalText="Total"
             canToProduct={isCurrentCompany}
-            textAlign={isMobile ? 'left' : 'right'}
             money={money}
             currencyCode={currencyCode}
             getCurrentProductUrls={getCurrentProductUrls}

--- a/apps/storefront/src/pages/OrderDetail/components/OrderCheckboxProduct.tsx
+++ b/apps/storefront/src/pages/OrderDetail/components/OrderCheckboxProduct.tsx
@@ -14,6 +14,7 @@ import {
   getCatalogProductRowDisplayState,
   type PicklistSelection,
 } from '@/utils/catalogBackorderDisplay';
+import { getProductListColumnAlignments } from '@/utils/getProductListColumnAlignments';
 
 import { EditableProductItem, OrderProductOption } from '../../../types';
 import { formatCurrency } from '../shared/convertOrderDetail';
@@ -39,7 +40,6 @@ interface OrderCheckboxProductProps {
   checkedArr?: number[];
   setCheckedArr?: (items: number[]) => void;
   setReturnArr?: (items: ReturnListProps[]) => void;
-  textAlign?: string;
   type?: string;
   catalogInventoryBySku?: Record<string, CatalogQuickVariantSku>;
   backorderUiEnabled?: boolean;
@@ -76,7 +76,6 @@ export default function OrderCheckboxProduct(props: OrderCheckboxProductProps) {
     checkedArr = [],
     setCheckedArr = () => {},
     setReturnArr = () => {},
-    textAlign = 'left',
     type,
     catalogInventoryBySku,
     backorderUiEnabled = false,
@@ -104,9 +103,10 @@ export default function OrderCheckboxProduct(props: OrderCheckboxProductProps) {
   };
 
   const itemStyle = isMobile ? mobileItemStyle : defaultItemStyle;
-  const qtyStackAlignItems = textAlign === 'right' ? 'flex-end' : 'flex-start';
+  const { qtyTextAlign, numericTextAlign, qtyStackItemsAlignment } =
+    getProductListColumnAlignments(isMobile);
   const desktopQtyColumnStyle =
-    backorderUiEnabled && !isMobile ? { width: '22%', minWidth: '160px' } : itemStyle.default;
+    backorderUiEnabled && !isMobile ? { width: '22%', minWidth: '10rem' } : itemStyle.default;
 
   const handleSelectAllChange = () => {
     if (checkedArr.length === products.length) {
@@ -208,13 +208,21 @@ export default function OrderCheckboxProduct(props: OrderCheckboxProductProps) {
           <FlexItem>
             <ProductHead>{b3Lang('orderDetail.reorder.product')}</ProductHead>
           </FlexItem>
-          <FlexItem textAlignLocation={textAlign} {...itemStyle.default}>
+          <FlexItem
+            textAlignLocation={numericTextAlign}
+            {...itemStyle.default}
+            padding={isMobile ? undefined : '0 1rem 0 0'}
+          >
             <ProductHead>{b3Lang('orderDetail.reorder.price')}</ProductHead>
           </FlexItem>
-          <FlexItem textAlignLocation={textAlign} {...desktopQtyColumnStyle}>
+          <FlexItem
+            textAlignLocation={qtyTextAlign}
+            {...desktopQtyColumnStyle}
+            padding={isMobile ? undefined : '0 0 0 1rem'}
+          >
             <ProductHead>{b3Lang('orderDetail.reorder.qty')}</ProductHead>
           </FlexItem>
-          <FlexItem textAlignLocation={textAlign} {...itemStyle.default}>
+          <FlexItem textAlignLocation={numericTextAlign} {...itemStyle.default}>
             <ProductHead>{b3Lang('orderDetail.reorder.total')}</ProductHead>
           </FlexItem>
         </Flex>
@@ -287,20 +295,24 @@ export default function OrderCheckboxProduct(props: OrderCheckboxProductProps) {
                 ))}
               </Box>
             </FlexItem>
-            <FlexItem textAlignLocation={textAlign} padding="10px 0 0" {...itemStyle.default}>
+            <FlexItem
+              textAlignLocation={numericTextAlign}
+              padding={isMobile ? '0.625rem 0 0' : '0.625rem 1rem 0 0'}
+              {...itemStyle.default}
+            >
               {isMobile && <span>{b3Lang('orderDetail.reorder.price')} </span>}
               {product.formattedPrice || formatPrice(product.base_price)}
             </FlexItem>
             <FlexItem
-              textAlignLocation={textAlign}
-              padding={isMobile ? undefined : '10px 0 0'}
+              textAlignLocation={qtyTextAlign}
+              padding={isMobile ? undefined : '0.625rem 0 0 1rem'}
               {...desktopQtyColumnStyle}
             >
               <Box
                 sx={{
                   display: 'flex',
                   flexDirection: 'column',
-                  alignItems: qtyStackAlignItems,
+                  alignItems: qtyStackItemsAlignment,
                   width: '100%',
                   maxWidth: '100%',
                   minWidth: 0,
@@ -317,7 +329,7 @@ export default function OrderCheckboxProduct(props: OrderCheckboxProductProps) {
                   onBlur={handleNumberInputBlur(product)}
                   size="small"
                   sx={{
-                    width: isMobile ? '60%' : '80px',
+                    width: isMobile ? '60%' : '100%',
                     '& .MuiFormHelperText-root': {
                       marginLeft: '0',
                       marginRight: '0',
@@ -333,8 +345,8 @@ export default function OrderCheckboxProduct(props: OrderCheckboxProductProps) {
                       width: '100%',
                       maxWidth: '100%',
                       minWidth: 0,
-                      textAlign,
-                      alignSelf: qtyStackAlignItems,
+                      textAlign: qtyTextAlign,
+                      alignSelf: qtyStackItemsAlignment,
                     }}
                   >
                     <BackorderMessage
@@ -353,8 +365,8 @@ export default function OrderCheckboxProduct(props: OrderCheckboxProductProps) {
                       width: '100%',
                       maxWidth: '100%',
                       minWidth: 0,
-                      textAlign,
-                      alignSelf: qtyStackAlignItems,
+                      textAlign: qtyTextAlign,
+                      alignSelf: qtyStackItemsAlignment,
                     }}
                   >
                     <Typography sx={{ color: '#616161', typography: 'body2', fontWeight: 600 }}>
@@ -370,7 +382,11 @@ export default function OrderCheckboxProduct(props: OrderCheckboxProductProps) {
                 ))}
               </Box>
             </FlexItem>
-            <FlexItem textAlignLocation={textAlign} padding="10px 0 0" {...itemStyle.default}>
+            <FlexItem
+              textAlignLocation={numericTextAlign}
+              padding="0.625rem 0 0"
+              {...itemStyle.default}
+            >
               {isMobile && <span>{b3Lang('orderDetail.reorder.total')} </span>}
               {formatPrice(getProductTotals(getProductQuantity(product), product.base_price))}
             </FlexItem>

--- a/apps/storefront/src/pages/OrderDetail/components/OrderDialog.tsx
+++ b/apps/storefront/src/pages/OrderDetail/components/OrderDialog.tsx
@@ -671,7 +671,6 @@ export default function OrderDialog({
             checkedArr={checkedArr}
             setCheckedArr={setCheckedArr}
             setReturnArr={setReturnArr}
-            textAlign={isMobile ? 'left' : 'right'}
             type={type}
             catalogInventoryBySku={catalogInventoryBySku}
             backorderUiEnabled={backorderUiEnabled}

--- a/apps/storefront/src/pages/OrderDetail/components/OrderShipping.tsx
+++ b/apps/storefront/src/pages/OrderDetail/components/OrderShipping.tsx
@@ -6,7 +6,6 @@ import { getTracking } from 'ts-tracking-number';
 
 import { B3ProductList } from '@/components/B3ProductList';
 import { useBackorderStorefrontMessaging } from '@/hooks/useBackorderStorefrontMessaging';
-import { useMobile } from '@/hooks/useMobile';
 import { useB3Lang } from '@/lib/lang';
 import type { BackorderDisplayFields } from '@/utils/backorderDisplayFromInventory';
 
@@ -27,8 +26,6 @@ export function OrderShipping({ isCurrentCompany }: OrderShippingProps) {
   const {
     state: { shippings = [], addressLabelPermission, money, currencyCode },
   } = useContext(OrderDetailsContext);
-
-  const [isMobile] = useMobile();
 
   const b3Lang = useB3Lang();
 
@@ -192,7 +189,6 @@ export function OrderShipping({ isCurrentCompany }: OrderShippingProps) {
                     currencyCode={currencyCode}
                     totalText="Total"
                     canToProduct={isCurrentCompany}
-                    textAlign="right"
                   />
                 </Fragment>
               ) : null,
@@ -217,7 +213,6 @@ export function OrderShipping({ isCurrentCompany }: OrderShippingProps) {
                   currencyCode={currencyCode}
                   totalText="Total"
                   canToProduct={isCurrentCompany}
-                  textAlign={isMobile ? 'left' : 'right'}
                   backorderFieldsForProduct={
                     showOrderBackorder ? backorderFieldsForProduct : undefined
                   }

--- a/apps/storefront/src/pages/QuickOrder/components/ProductListDialog.tsx
+++ b/apps/storefront/src/pages/QuickOrder/components/ProductListDialog.tsx
@@ -220,7 +220,6 @@ export default function ProductListDialog(props: ProductListDialogProps) {
               products={productList}
               quantityEditable
               type="quickOrder"
-              textAlign={isMobile ? 'left' : 'right'}
               canToProduct
               catalogBackorderUiEnabled={backorderUiEnabled}
               catalogInventoryBySku={inventoryBySku}

--- a/apps/storefront/src/pages/QuickOrder/components/QuickOrderB2BTable.tsx
+++ b/apps/storefront/src/pages/QuickOrder/components/QuickOrderB2BTable.tsx
@@ -521,7 +521,7 @@ function QuickOrderTable({
             sx={{
               display: 'flex',
               flexDirection: 'column',
-              alignItems: 'flex-end',
+              alignItems: 'flex-start',
               width: '100%',
             }}
           >
@@ -529,6 +529,9 @@ function QuickOrderTable({
               size="small"
               type="number"
               variant="filled"
+              sx={{
+                width: '100%',
+              }}
               value={qty}
               inputProps={{
                 inputMode: 'numeric',
@@ -539,7 +542,7 @@ function QuickOrderTable({
               }}
             />
             {backorderFields && (
-              <Box sx={{ mt: 1, width: '100%', textAlign: 'right' }}>
+              <Box sx={{ mt: 1, width: '100%', textAlign: 'left' }}>
                 <BackorderMessage
                   totalOnHand={backorderFields.totalOnHand}
                   quantityBackordered={backorderFields.quantityBackordered}
@@ -549,7 +552,7 @@ function QuickOrderTable({
               </Box>
             )}
             {picklistSelections.length > 0 && (
-              <Box sx={{ width: '100%', textAlign: 'right' }}>
+              <Box sx={{ width: '100%', textAlign: 'left' }}>
                 <PicklistBackorderMessages
                   selections={picklistSelections}
                   picklistProductsById={picklistProductsById}
@@ -564,7 +567,7 @@ function QuickOrderTable({
       },
       width: backorderUiEnabled ? '18%' : '15%',
       style: {
-        textAlign: 'right',
+        textAlign: 'left',
       },
     },
     {

--- a/apps/storefront/src/pages/ShoppingListDetails/components/B3QuantityTextField.tsx
+++ b/apps/storefront/src/pages/ShoppingListDetails/components/B3QuantityTextField.tsx
@@ -7,7 +7,7 @@ import { useB3Lang } from '@/lib/lang';
 
 const StyledNumberNoTopTextField = styled(TextField)(() => ({
   '& input': {
-    paddingRight: '6px',
+    paddingRight: '0.375rem',
   },
 }));
 
@@ -32,7 +32,7 @@ export function B3QuantityTextField({
   const [isMobile] = useMobile();
 
   const sx = {
-    width: isMobile ? '110px' : '72px',
+    width: isMobile ? '6.875rem' : '100%',
     '& .MuiFormHelperText-root': {
       marginLeft: '0',
       marginRight: '0',

--- a/apps/storefront/src/pages/ShoppingListDetails/components/ProductListDialog.tsx
+++ b/apps/storefront/src/pages/ShoppingListDetails/components/ProductListDialog.tsx
@@ -256,7 +256,6 @@ export default function ProductListDialog(props: ProductListDialogProps) {
               products={productList}
               quantityEditable
               type={type}
-              textAlign={isMobile ? 'left' : 'right'}
               canToProduct
               catalogBackorderUiEnabled={backorderUiEnabled}
               catalogInventoryBySku={inventoryBySku}

--- a/apps/storefront/src/pages/ShoppingListDetails/components/ReAddToCart.tsx
+++ b/apps/storefront/src/pages/ShoppingListDetails/components/ReAddToCart.tsx
@@ -21,6 +21,7 @@ import {
   buildVariantSkuDependencyKey,
   getCatalogBackorderFieldsForVariantSku,
 } from '@/utils/catalogBackorderDisplay';
+import { getProductListColumnAlignments } from '@/utils/getProductListColumnAlignments';
 
 import { B3QuantityTextField } from './B3QuantityTextField';
 
@@ -171,11 +172,11 @@ export default function ReAddToCart({
     useBackorderStorefrontMessaging();
   const backorderUiEnabled = isBackorderMessagingContextEnabled && hasAnyBackorderDisplay;
 
-  const textAlign = isMobile ? 'left' : 'right';
+  const { qtyTextAlign, numericTextAlign, qtyStackItemsAlignment } =
+    getProductListColumnAlignments(isMobile);
   const itemStyle = isMobile ? mobileItemStyle : defaultItemStyle;
-  const qtyStackAlignItems = textAlign === 'right' ? 'flex-end' : 'flex-start';
   const desktopQtyColumnStyle =
-    backorderUiEnabled && !isMobile ? { width: '22%', minWidth: '160px' } : itemStyle.default;
+    backorderUiEnabled && !isMobile ? { width: '22%', minWidth: '10rem' } : itemStyle.default;
 
   const [internalProducts, setInternalProducts] = useState<ProductsProps[]>([]);
 
@@ -348,19 +349,21 @@ export default function ReAddToCart({
                   <FlexItem>
                     <ProductHead>{b3Lang('shoppingList.reAddToCart.product')}</ProductHead>
                   </FlexItem>
-                  <FlexItem {...itemStyle.default} textAlignLocation={textAlign}>
+                  <FlexItem
+                    {...itemStyle.default}
+                    textAlignLocation={numericTextAlign}
+                    {...(!isMobile ? { padding: '0 1rem 0 0' } : {})}
+                  >
                     <ProductHead>{b3Lang('shoppingList.reAddToCart.price')}</ProductHead>
                   </FlexItem>
                   <FlexItem
-                    sx={{
-                      justifyContent: 'center',
-                    }}
                     {...desktopQtyColumnStyle}
-                    textAlignLocation={textAlign}
+                    textAlignLocation={qtyTextAlign}
+                    {...(!isMobile ? { padding: '0 0 0 1rem' } : {})}
                   >
                     <ProductHead>{b3Lang('shoppingList.reAddToCart.quantity')}</ProductHead>
                   </FlexItem>
-                  <FlexItem {...itemStyle.default} textAlignLocation={textAlign}>
+                  <FlexItem {...itemStyle.default} textAlignLocation={numericTextAlign}>
                     <ProductHead>{b3Lang('shoppingList.reAddToCart.total')}</ProductHead>
                   </FlexItem>
                   <FlexItem {...itemStyle.delete}>
@@ -436,16 +439,24 @@ export default function ReAddToCart({
                           ))}
                       </Box>
                     </FlexItem>
-                    <FlexItem {...itemStyle.default} textAlignLocation={textAlign}>
+                    <FlexItem
+                      {...itemStyle.default}
+                      textAlignLocation={numericTextAlign}
+                      {...(!isMobile ? { padding: '0 1rem 0 0' } : {})}
+                    >
                       {isMobile && <span>Price: </span>}
                       {currencyFormat(price)}
                     </FlexItem>
-                    <FlexItem {...desktopQtyColumnStyle} textAlignLocation={textAlign}>
+                    <FlexItem
+                      {...desktopQtyColumnStyle}
+                      textAlignLocation={qtyTextAlign}
+                      {...(!isMobile ? { padding: '0 0 0 1rem' } : {})}
+                    >
                       <Box
                         sx={{
                           display: 'flex',
                           flexDirection: 'column',
-                          alignItems: qtyStackAlignItems,
+                          alignItems: qtyStackItemsAlignment,
                           width: '100%',
                           maxWidth: '100%',
                           minWidth: 0,
@@ -468,8 +479,8 @@ export default function ReAddToCart({
                               width: '100%',
                               maxWidth: '100%',
                               minWidth: 0,
-                              textAlign,
-                              alignSelf: qtyStackAlignItems,
+                              textAlign: qtyTextAlign,
+                              alignSelf: qtyStackItemsAlignment,
                             }}
                           >
                             <BackorderMessage
@@ -482,7 +493,7 @@ export default function ReAddToCart({
                         )}
                       </Box>
                     </FlexItem>
-                    <FlexItem {...itemStyle.default} textAlignLocation={textAlign}>
+                    <FlexItem {...itemStyle.default} textAlignLocation={numericTextAlign}>
                       {isMobile && <div>Total: </div>}
                       {currencyFormat(total)}
                     </FlexItem>

--- a/apps/storefront/src/pages/ShoppingListDetails/components/ShoppingDetailTable.tsx
+++ b/apps/storefront/src/pages/ShoppingListDetails/components/ShoppingDetailTable.tsx
@@ -129,7 +129,7 @@ const StyledShoppingListTableContainer = styled('div')(() => ({
         paddingTop: '25px',
       },
     },
-    '& tr: hover': {
+    '& tr:hover': {
       '& #shoppingList-actionList': {
         opacity: 1,
       },
@@ -673,7 +673,7 @@ function ShoppingDetailTable(props: ShoppingDetailTableProps, ref: Ref<unknown>)
             sx={{
               display: 'flex',
               flexDirection: 'column',
-              alignItems: 'flex-end',
+              alignItems: 'flex-start',
               width: '100%',
             }}
           >
@@ -682,7 +682,7 @@ function ShoppingDetailTable(props: ShoppingDetailTableProps, ref: Ref<unknown>)
               type="number"
               variant="filled"
               sx={{
-                width: '72px',
+                width: '100%',
               }}
               disabled={
                 b2bAndBcShoppingListActionsPermissions ? isReadForApprove || isJuniorApprove : true
@@ -700,7 +700,7 @@ function ShoppingDetailTable(props: ShoppingDetailTableProps, ref: Ref<unknown>)
               }}
             />
             {backorderFields && (
-              <Box sx={{ mt: 1, width: '100%', textAlign: 'right' }}>
+              <Box sx={{ mt: 1, width: '100%', textAlign: 'left' }}>
                 <BackorderMessage
                   totalOnHand={backorderFields.totalOnHand}
                   quantityBackordered={backorderFields.quantityBackordered}
@@ -714,7 +714,7 @@ function ShoppingDetailTable(props: ShoppingDetailTableProps, ref: Ref<unknown>)
       },
       width: backorderUiEnabled ? '18%' : '15%',
       style: {
-        textAlign: 'right',
+        textAlign: 'left',
       },
       isSortable: true,
     },

--- a/apps/storefront/src/pages/quote/components/QuoteDetailTable.tsx
+++ b/apps/storefront/src/pages/quote/components/QuoteDetailTable.tsx
@@ -98,7 +98,7 @@ const StyledQuoteTableContainer = styled('div')(() => ({
         verticalAlign: 'inherit',
       },
     },
-    '& tr: hover': {
+    '& tr:hover': {
       '& #shoppingList-actionList': {
         opacity: 1,
       },

--- a/apps/storefront/src/pages/quote/components/QuoteTable.tsx
+++ b/apps/storefront/src/pages/quote/components/QuoteTable.tsx
@@ -44,11 +44,8 @@ const StyledQuoteTableContainer = styled('div')(() => ({
       '& td': {
         verticalAlign: 'top',
       },
-      '& td: first-of-type': {
-        verticalAlign: 'inherit',
-      },
     },
-    '& tr: hover': {
+    '& tr:hover': {
       '& #shoppingList-actionList': {
         opacity: 1,
       },
@@ -453,10 +450,10 @@ function QuoteTable({ total, items, updateSummary }: QuoteTableProps) {
                 handleCheckProductQty(row, Number(e.target.value));
               }}
               sx={{
-                width: '75%',
+                width: '100%',
                 '& input': {
-                  paddingTop: '12px',
-                  paddingRight: '6px',
+                  paddingTop: '0.75rem',
+                  paddingRight: '0.375rem',
                 },
               }}
             />
@@ -484,7 +481,7 @@ function QuoteTable({ total, items, updateSummary }: QuoteTableProps) {
       },
       width: '15%',
       style: {
-        textAlign: 'right',
+        textAlign: 'left',
       },
     },
     {

--- a/apps/storefront/src/utils/getProductListColumnAlignments.test.ts
+++ b/apps/storefront/src/utils/getProductListColumnAlignments.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+
+import { getProductListColumnAlignments } from './getProductListColumnAlignments';
+
+describe('getProductListColumnAlignments', () => {
+  it('left-aligns qty and right-aligns price/total on desktop', () => {
+    expect(getProductListColumnAlignments(false)).toEqual({
+      qtyTextAlign: 'left',
+      numericTextAlign: 'right',
+      qtyStackItemsAlignment: 'flex-start',
+      numericStackItemsAlignment: 'flex-end',
+    });
+  });
+
+  it('left-aligns qty and price/total on mobile', () => {
+    expect(getProductListColumnAlignments(true)).toEqual({
+      qtyTextAlign: 'left',
+      numericTextAlign: 'left',
+      qtyStackItemsAlignment: 'flex-start',
+      numericStackItemsAlignment: 'flex-start',
+    });
+  });
+});

--- a/apps/storefront/src/utils/getProductListColumnAlignments.ts
+++ b/apps/storefront/src/utils/getProductListColumnAlignments.ts
@@ -1,0 +1,21 @@
+type ProductListTextAlign = 'left' | 'right';
+type ProductListFlexAlign = 'flex-start' | 'flex-end';
+
+interface ProductListColumnAlignments {
+  qtyTextAlign: ProductListTextAlign;
+  numericTextAlign: ProductListTextAlign;
+  qtyStackItemsAlignment: ProductListFlexAlign;
+  numericStackItemsAlignment: ProductListFlexAlign;
+}
+
+/** Qty is left-aligned; Price/Total stay right-aligned on desktop to match product tables. */
+export function getProductListColumnAlignments(isMobile: boolean): ProductListColumnAlignments {
+  const numericTextAlign: ProductListTextAlign = isMobile ? 'left' : 'right';
+
+  return {
+    qtyTextAlign: 'left',
+    numericTextAlign,
+    qtyStackItemsAlignment: 'flex-start',
+    numericStackItemsAlignment: numericTextAlign === 'right' ? 'flex-end' : 'flex-start',
+  };
+}


### PR DESCRIPTION
Jira: [BACK-822](https://bigcommercecloud.atlassian.net/browse/BACK-822)

## What/Why?
As per designs, left-aligns qty headers, input values, and backorder text, and widens qty inputs to fill the column, across quote draft, shopping list, purchased products, add-to-quote/list and quick-order search modals, re-add to cart, and order detail product lists.

## Rollout/Rollback
Merge/revert.

## Testing
### Quote draft table
|Before|After|
|--|--|
|<img width="755" height="381" alt="Screenshot 2026-08-12 at 1 34 22 pm" src="https://github.com/user-attachments/assets/fff0fe12-3fa2-451f-9d27-28b4678e1f0f" />|<img width="754" height="384" alt="Screenshot 2026-08-12 at 1 22 35 pm" src="https://github.com/user-attachments/assets/08ba2553-6119-4867-82e4-a733a852b5f1" />|

### Add-to-quote modal
|Before|After|
|--|--|
|<img width="907" height="387" alt="Screenshot 2026-08-12 at 1 35 22 pm" src="https://github.com/user-attachments/assets/61859aec-6889-4f19-a15e-0b8ad9d93ac3" />|<img width="912" height="390" alt="Screenshot 2026-08-12 at 2 31 53 pm" src="https://github.com/user-attachments/assets/e5eedece-f06b-40df-b108-5c90851befc7" />|

### Shopping list table
|Before|After|
|--|--|
|<img width="805" height="440" alt="Screenshot 2026-08-12 at 1 36 49 pm" src="https://github.com/user-attachments/assets/01be845b-1870-4e32-9343-9c76143207ad" />|<img width="806" height="443" alt="Screenshot 2026-08-12 at 1 26 58 pm" src="https://github.com/user-attachments/assets/82e99cc0-5371-4c55-b045-94f63b3b06a8" />|

### Add-to-list modal
|Before|After|
|--|--|
|<img width="911" height="389" alt="Screenshot 2026-08-12 at 1 37 41 pm" src="https://github.com/user-attachments/assets/58711c15-f1e8-4b8c-9510-3d918c1e3355" />|<img width="911" height="391" alt="Screenshot 2026-08-12 at 2 32 30 pm" src="https://github.com/user-attachments/assets/ff10811c-e4ce-424a-96db-f3fcd20992be" />|

### Purchased products table
|Before|After|
|--|--|
|<img width="767" height="350" alt="Screenshot 2026-08-12 at 1 38 29 pm" src="https://github.com/user-attachments/assets/a1fa00aa-be6b-4244-b20e-e8c30b094d89" />|<img width="767" height="352" alt="Screenshot 2026-08-12 at 1 28 24 pm" src="https://github.com/user-attachments/assets/502e3cc5-426f-4fe5-80c1-7660e917cb89" />|

### Quick order pad modal
|Before|After|
|--|--|
|<img width="908" height="390" alt="Screenshot 2026-08-12 at 1 39 12 pm" src="https://github.com/user-attachments/assets/a1287c7e-21ec-4aa5-9bd9-8663139ddf97" />|<img width="912" height="392" alt="Screenshot 2026-08-12 at 2 32 54 pm" src="https://github.com/user-attachments/assets/064a13ba-b394-45b3-9224-8b2b3c7b38af" />|

### Re-add to cart dialog
|Before|After|
|--|--|
|<img width="655" height="475" alt="Screenshot 2026-08-12 at 1 40 05 pm" src="https://github.com/user-attachments/assets/7dc12fb1-f5d6-49f2-9711-4cc5f022dad4" />|<img width="717" height="478" alt="Screenshot 2026-08-12 at 2 22 09 pm" src="https://github.com/user-attachments/assets/34f088c5-e63c-45ab-b6f8-ba520899c372" />|

### Order detail table
|Before|After|
|--|--|
|<img width="805" height="290" alt="Screenshot 2026-08-12 at 1 40 57 pm" src="https://github.com/user-attachments/assets/3428bbc4-4476-4c6b-b1e6-dd613ffb942d" />|<img width="810" height="293" alt="Screenshot 2026-08-12 at 2 21 25 pm" src="https://github.com/user-attachments/assets/6cea41b2-b261-4eb5-ab17-6b9e36b1b999" />|

### Re-order dialog
|Before|After|
|--|--|
|<img width="908" height="404" alt="Screenshot 2026-08-12 at 1 41 54 pm" src="https://github.com/user-attachments/assets/bb9de18b-18ff-4288-b0cf-dcdd91e63ebb" />|<img width="912" height="407" alt="Screenshot 2026-08-12 at 2 21 42 pm" src="https://github.com/user-attachments/assets/59492181-01b7-4677-b7c7-916d54bf0878" />|

ping @JessicaHu51 @bc-jessebayley @animesh1987 @benpratt77 

[BACK-822]: https://bigcommercecloud.atlassian.net/browse/BACK-822?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only layout and alignment changes across storefront product tables; no changes to pricing, inventory, or checkout logic.
> 
> **Overview**
> Aligns quantity columns to the left per design while keeping **Price** and **Total** right-aligned on desktop, and standardizes layout across product lists, tables, and modals.
> 
> Introduces **`getProductListColumnAlignments`** so qty headers, inputs, backorder text, and stack alignment are consistent; **`B3ProductList`** and related screens no longer accept a **`textAlign`** prop—callers rely on the shared helper instead.
> 
> **Qty** inputs on desktop now use **full column width** (replacing fixed pixel widths), with **rem**-based gaps between price and qty columns in backorder layouts. The same left qty alignment is applied in quote draft, shopping list, purchased products, quick order, re-add to cart, and order detail (including reorder) UIs.
> 
> Includes a small **Vitest** suite for the alignment helper and fixes **`tr:hover`** CSS selectors in a few styled tables.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b691ff9c98b28da839c532e724a290346333c14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->