### PR TITLE
feat(common): BACK-832 default backorder details toggle on for shopping list and quick order

### DIFF
--- a/apps/storefront/src/pages/QuickOrder/components/QuickOrderB2BTable.tsx
+++ b/apps/storefront/src/pages/QuickOrder/components/QuickOrderB2BTable.tsx
@@ -147,7 +147,7 @@ function QuickOrderTable({
 
   const [total, setTotalCount] = useState<number>(0);
   const [variantInfoList, setVariantInfoList] = useState<CatalogQuickVariantSku[]>([]);
-  const [showBackorderDetails, setShowBackorderDetails] = useState(false);
+  const [showBackorderDetails, setShowBackorderDetails] = useState(true);
   const [tableDataVersion, setTableDataVersion] = useState(0);
 
   const [isMobile] = useMobile();

--- a/apps/storefront/src/pages/QuickOrder/index.main.test.tsx
+++ b/apps/storefront/src/pages/QuickOrder/index.main.test.tsx
@@ -5458,7 +5458,31 @@ describe('when backorder messaging is enabled on purchased products', () => {
     return { orderedProduct };
   };
 
-  it('shows backorder lines when toggle is on and qty exceeds on hand', async () => {
+  it('shows backorder lines by default when qty exceeds on hand', async () => {
+    setupPurchasedProductsTable();
+
+    renderWithProviders(<QuickOrder />, { preloadedState: backorderPreloadedState });
+
+    expect(await screen.findByText('Laugh Canister')).toBeInTheDocument();
+
+    const table = screen.getByRole('table');
+    const quantityInput = within(table).getByRole('spinbutton');
+
+    await userEvent.type(quantityInput, '10', {
+      initialSelectionStart: 0,
+      initialSelectionEnd: Infinity,
+    });
+
+    expect(await screen.findByRole('checkbox', { name: /Backorder details/i })).toBeChecked();
+
+    await waitFor(() => {
+      expect(screen.getByText('2 ready to ship')).toBeVisible();
+    });
+    expect(screen.getByText('2 will be backordered')).toBeVisible();
+    expect(screen.getByText('Lead time: 2-4 weeks')).toBeVisible();
+  });
+
+  it('hides backorder lines when toggle is turned off', async () => {
     setupPurchasedProductsTable();
 
     renderWithProviders(<QuickOrder />, { preloadedState: backorderPreloadedState });
@@ -5474,31 +5498,10 @@ describe('when backorder messaging is enabled on purchased products', () => {
     });
 
     const backorderToggle = await screen.findByRole('checkbox', { name: /Backorder details/i });
+    expect(backorderToggle).toBeChecked();
+    expect(await screen.findByText('2 will be backordered')).toBeVisible();
+
     await userEvent.click(backorderToggle);
-
-    await waitFor(() => {
-      expect(screen.getByText('2 ready to ship')).toBeVisible();
-    });
-    expect(screen.getByText('2 will be backordered')).toBeVisible();
-    expect(screen.getByText('Lead time: 2-4 weeks')).toBeVisible();
-  });
-
-  it('hides backorder lines when toggle is off', async () => {
-    setupPurchasedProductsTable();
-
-    renderWithProviders(<QuickOrder />, { preloadedState: backorderPreloadedState });
-
-    expect(await screen.findByText('Laugh Canister')).toBeInTheDocument();
-
-    const table = screen.getByRole('table');
-    const quantityInput = within(table).getByRole('spinbutton');
-
-    await userEvent.type(quantityInput, '10', {
-      initialSelectionStart: 0,
-      initialSelectionEnd: Infinity,
-    });
-
-    await screen.findByRole('checkbox', { name: /Backorder details/i });
 
     expect(screen.queryByText('2 ready to ship')).not.toBeInTheDocument();
     expect(screen.queryByText('2 will be backordered')).not.toBeInTheDocument();
@@ -5570,7 +5573,32 @@ describe('when backorder messaging is enabled on purchased products', () => {
     expect(screen.queryByText('will be backordered', { exact: false })).not.toBeInTheDocument();
   });
 
-  it('shows a labeled picklist backorder block when toggle is on and qty exceeds picklist on hand', async () => {
+  it('shows a labeled picklist backorder block by default when qty exceeds picklist on hand', async () => {
+    setupPurchasedProductsTableWithPicklist();
+
+    renderWithProviders(<QuickOrder />, { preloadedState: backorderPreloadedState });
+
+    expect(await screen.findByText('Laugh Canister')).toBeInTheDocument();
+
+    const table = screen.getByRole('table');
+    const quantityInput = within(table).getByRole('spinbutton');
+
+    await userEvent.type(quantityInput, '10', {
+      initialSelectionStart: 0,
+      initialSelectionEnd: Infinity,
+    });
+
+    expect(await screen.findByRole('checkbox', { name: /Backorder details/i })).toBeChecked();
+
+    await waitFor(() => {
+      expect(screen.getByText('Bundle option 1:')).toBeVisible();
+    });
+    expect(screen.getByText('9 ready to ship')).toBeVisible();
+    expect(screen.getByText('1 will be backordered')).toBeVisible();
+    expect(screen.getByText('Picklist lead time: 6 weeks')).toBeVisible();
+  });
+
+  it('hides the picklist backorder block when toggle is turned off', async () => {
     setupPurchasedProductsTableWithPicklist();
 
     renderWithProviders(<QuickOrder />, { preloadedState: backorderPreloadedState });
@@ -5586,32 +5614,10 @@ describe('when backorder messaging is enabled on purchased products', () => {
     });
 
     const backorderToggle = await screen.findByRole('checkbox', { name: /Backorder details/i });
+    expect(backorderToggle).toBeChecked();
+    expect(await screen.findByText('Bundle option 1:')).toBeVisible();
+
     await userEvent.click(backorderToggle);
-
-    await waitFor(() => {
-      expect(screen.getByText('Bundle option 1:')).toBeVisible();
-    });
-    expect(screen.getByText('9 ready to ship')).toBeVisible();
-    expect(screen.getByText('1 will be backordered')).toBeVisible();
-    expect(screen.getByText('Picklist lead time: 6 weeks')).toBeVisible();
-  });
-
-  it('hides the picklist backorder block when toggle is off', async () => {
-    setupPurchasedProductsTableWithPicklist();
-
-    renderWithProviders(<QuickOrder />, { preloadedState: backorderPreloadedState });
-
-    expect(await screen.findByText('Laugh Canister')).toBeInTheDocument();
-
-    const table = screen.getByRole('table');
-    const quantityInput = within(table).getByRole('spinbutton');
-
-    await userEvent.type(quantityInput, '10', {
-      initialSelectionStart: 0,
-      initialSelectionEnd: Infinity,
-    });
-
-    await screen.findByRole('checkbox', { name: /Backorder details/i });
 
     expect(screen.queryByText('Bundle option 1:')).not.toBeInTheDocument();
     expect(screen.queryByText('Picklist lead time: 6 weeks')).not.toBeInTheDocument();
@@ -5622,7 +5628,7 @@ describe('when backorder messaging is enabled on purchased products', () => {
       vi.spyOn(document.body, 'clientWidth', 'get').mockReturnValue(500);
     });
 
-    it('shows backorder lines in the card view when toggle is on and qty exceeds on hand', async () => {
+    it('shows backorder lines in the card view by default when qty exceeds on hand', async () => {
       setupPurchasedProductsTable();
 
       renderWithProviders(<QuickOrder />, { preloadedState: backorderPreloadedState });
@@ -5641,8 +5647,7 @@ describe('when backorder messaging is enabled on purchased products', () => {
         initialSelectionEnd: Infinity,
       });
 
-      const backorderToggle = await screen.findByRole('checkbox', { name: /Backorder details/i });
-      await userEvent.click(backorderToggle);
+      expect(await screen.findByRole('checkbox', { name: /Backorder details/i })).toBeChecked();
 
       await waitFor(() => {
         expect(screen.getByText('2 ready to ship')).toBeVisible();

--- a/apps/storefront/src/pages/ShoppingListDetails/components/ShoppingDetailTable.tsx
+++ b/apps/storefront/src/pages/ShoppingListDetails/components/ShoppingDetailTable.tsx
@@ -211,7 +211,7 @@ function ShoppingDetailTable(props: ShoppingDetailTableProps, ref: Ref<unknown>)
   const [priceHidden, setPriceHidden] = useState<boolean>(false);
   const [variantInfoList, setVariantInfoList] = useState<CatalogQuickVariantSku[]>([]);
   const fetchedInventorySkusRef = useRef<Set<string>>(new Set());
-  const [showBackorderDetails, setShowBackorderDetails] = useState(false);
+  const [showBackorderDetails, setShowBackorderDetails] = useState(true);
   const [tableDataVersion, setTableDataVersion] = useState(0);
 
   const [handleSetOrderBy, order, orderBy] = useSort(sortKeys, defaultSortKey, search, setSearch);

--- a/apps/storefront/src/pages/ShoppingListDetails/index.test.tsx
+++ b/apps/storefront/src/pages/ShoppingListDetails/index.test.tsx
@@ -3485,7 +3485,35 @@ describe('when backorder messaging is enabled on shopping list products', () => 
     );
   };
 
-  it('shows backorder lines when toggle is on and qty exceeds on hand', async () => {
+  it('shows backorder lines by default when qty exceeds on hand', async () => {
+    setupShoppingListTable();
+
+    renderWithProviders(<ShoppingListDetailsContent setOpenPage={() => {}} />, {
+      preloadedState: backorderPreloadedState,
+    });
+
+    await waitForElementToBeRemoved(() => screen.queryByText(/loading/i));
+
+    expect(await screen.findByText('Bistro Pro Literide Clog')).toBeInTheDocument();
+
+    const table = screen.getByRole('table');
+    const quantityInput = within(table).getByRole('spinbutton');
+
+    await userEvent.type(quantityInput, '10', {
+      initialSelectionStart: 0,
+      initialSelectionEnd: Infinity,
+    });
+
+    expect(await screen.findByRole('checkbox', { name: /Backorder details/i })).toBeChecked();
+
+    await waitFor(() => {
+      expect(screen.getByText('2 ready to ship')).toBeVisible();
+    });
+    expect(screen.getByText('2 will be backordered')).toBeVisible();
+    expect(screen.getByText('Lead time: 2-4 weeks')).toBeVisible();
+  });
+
+  it('hides backorder lines when toggle is turned off', async () => {
     setupShoppingListTable();
 
     renderWithProviders(<ShoppingListDetailsContent setOpenPage={() => {}} />, {
@@ -3505,35 +3533,10 @@ describe('when backorder messaging is enabled on shopping list products', () => 
     });
 
     const backorderToggle = await screen.findByRole('checkbox', { name: /Backorder details/i });
+    expect(backorderToggle).toBeChecked();
+    expect(await screen.findByText('2 will be backordered')).toBeVisible();
+
     await userEvent.click(backorderToggle);
-
-    await waitFor(() => {
-      expect(screen.getByText('2 ready to ship')).toBeVisible();
-    });
-    expect(screen.getByText('2 will be backordered')).toBeVisible();
-    expect(screen.getByText('Lead time: 2-4 weeks')).toBeVisible();
-  });
-
-  it('hides backorder lines when toggle is off', async () => {
-    setupShoppingListTable();
-
-    renderWithProviders(<ShoppingListDetailsContent setOpenPage={() => {}} />, {
-      preloadedState: backorderPreloadedState,
-    });
-
-    await waitForElementToBeRemoved(() => screen.queryByText(/loading/i));
-
-    expect(await screen.findByText('Bistro Pro Literide Clog')).toBeInTheDocument();
-
-    const table = screen.getByRole('table');
-    const quantityInput = within(table).getByRole('spinbutton');
-
-    await userEvent.type(quantityInput, '10', {
-      initialSelectionStart: 0,
-      initialSelectionEnd: Infinity,
-    });
-
-    await screen.findByRole('checkbox', { name: /Backorder details/i });
 
     expect(screen.queryByText('2 ready to ship')).not.toBeInTheDocument();
     expect(screen.queryByText('2 will be backordered')).not.toBeInTheDocument();
@@ -3622,7 +3625,7 @@ describe('when backorder messaging is enabled on shopping list products', () => 
       vi.spyOn(document.body, 'clientWidth', 'get').mockReturnValue(500);
     });
 
-    it('shows backorder lines in the card view when toggle is on and qty exceeds on hand', async () => {
+    it('shows backorder lines in the card view by default when qty exceeds on hand', async () => {
       setupShoppingListTable();
 
       renderWithProviders(<ShoppingListDetailsContent setOpenPage={() => {}} />, {
@@ -3647,8 +3650,7 @@ describe('when backorder messaging is enabled on shopping list products', () => 
         initialSelectionEnd: Infinity,
       });
 
-      const backorderToggle = await screen.findByRole('checkbox', { name: /Backorder details/i });
-      await userEvent.click(backorderToggle);
+      expect(await screen.findByRole('checkbox', { name: /Backorder details/i })).toBeChecked();
 
       await waitFor(() => {
         expect(screen.getByText('2 ready to ship')).toBeVisible();


### PR DESCRIPTION
Jira: [BACK-832](https://bigcommercecloud.atlassian.net/browse/BACK-832)

## What/Why?
Sets the “backorder details” toggle to ON by default on shopping list and quick order (matching draft quotes) for better discoverability.

## Rollout/Rollback
Merge/revert. Backorder messaging is gated by `BACK-134` experiment.

## Testing
Toggle is on by default for shopping list and quick order.

https://github.com/user-attachments/assets/7a9dec74-6653-40df-91bb-b70d7694fab8


[BACK-832]: https://bigcommercecloud.atlassian.net/browse/BACK-832?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI default-only change behind the existing backorder messaging feature flag; no auth, data, or business-logic changes.
> 
> **Overview**
> Defaults the **Backorder details** toggle to **on** for Quick Order and Shopping List, matching draft quotes so backorder messaging is visible without an extra click.
> 
> Updates related tests to assert the toggle starts checked and that users can still turn it off to hide the lines.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf282abbb3571eb3285dd167e82f64582c2d6f7c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->