### PR TITLE
feat(shopping-lists): BACK-830 Implement backorders display for picklist children in the shopping list page.

### DIFF
--- a/apps/storefront/src/pages/ShoppingListDetails/components/ShoppingDetailCard.tsx
+++ b/apps/storefront/src/pages/ShoppingListDetails/components/ShoppingDetailCard.tsx
@@ -3,13 +3,17 @@ import { Delete, Edit, StickyNote2 } from '@mui/icons-material';
 import { Box, CardContent, styled, TextField, Typography } from '@mui/material';
 
 import BackorderMessage from '@/components/BackorderMessage';
+import PicklistBackorderMessages from '@/components/PicklistBackorderMessages';
 import { PRODUCT_DEFAULT_IMAGE } from '@/constants';
 import { useB3Lang } from '@/lib/lang';
-import type { CatalogQuickVariantSku } from '@/shared/service/b2b/graphql/product';
+import type { CatalogQuickVariantSku, ProductSearch } from '@/shared/service/b2b/graphql/product';
 import b2bGetVariantImageByVariantInfo from '@/utils/b2bGetVariantImageByVariantInfo';
 import { currencyFormat } from '@/utils/b3CurrencyFormat';
 import { getBCPrice } from '@/utils/b3Product/b3Product';
-import { getCatalogProductRowDisplayState } from '@/utils/catalogBackorderDisplay';
+import {
+  getCatalogProductRowDisplayState,
+  getPicklistSelectionsFromStoredOptions,
+} from '@/utils/catalogBackorderDisplay';
 
 import { getProductOptionsFields } from '../../../utils/b3Product/shared/config';
 
@@ -30,6 +34,7 @@ interface ShoppingDetailCardProps {
   showPrice: (price: string, row: CustomFieldItems) => string | number;
   b2bAndBcShoppingListActionsPermissions: boolean;
   inventoryBySku?: Record<string, CatalogQuickVariantSku>;
+  picklistProductsById?: Record<number, ProductSearch>;
   backorderUiEnabled?: boolean;
   showBackorderDetails?: boolean;
 }
@@ -59,6 +64,7 @@ function ShoppingDetailCard(props: ShoppingDetailCardProps) {
     showPrice,
     b2bAndBcShoppingListActionsPermissions,
     inventoryBySku = {},
+    picklistProductsById = {},
     backorderUiEnabled = false,
     showBackorderDetails = false,
   } = props;
@@ -106,6 +112,11 @@ function ShoppingDetailCard(props: ShoppingDetailCardProps) {
     inventoryRow,
     backorderUiEnabled,
     formatOnlyAvailable: () => '',
+  });
+
+  const picklistSelections = getPicklistSelectionsFromStoredOptions({
+    options: optionList,
+    productsSearch,
   });
 
   return (
@@ -242,6 +253,13 @@ function ShoppingDetailCard(props: ShoppingDetailCardProps) {
               />
             </Box>
           )}
+          <PicklistBackorderMessages
+            selections={picklistSelections}
+            picklistProductsById={picklistProductsById}
+            qty={Number(quantity) || 0}
+            visible={showBackorderDetails}
+            backorderUiEnabled={backorderUiEnabled}
+          />
           <Typography
             sx={{
               color: '#212121',

--- a/apps/storefront/src/pages/ShoppingListDetails/components/ShoppingDetailTable.tsx
+++ b/apps/storefront/src/pages/ShoppingListDetails/components/ShoppingDetailTable.tsx
@@ -15,6 +15,7 @@ import { Box, FormControlLabel, Grid, styled, Switch, TextField, Typography } fr
 import cloneDeep from 'lodash-es/cloneDeep';
 
 import BackorderMessage from '@/components/BackorderMessage';
+import PicklistBackorderMessages from '@/components/PicklistBackorderMessages';
 import {
   B3PaginationTable,
   GetRequestList,
@@ -24,6 +25,7 @@ import { TableColumnItem } from '@/components/table/B3Table';
 import { PRODUCT_DEFAULT_IMAGE } from '@/constants';
 import { useBackorderStorefrontMessaging } from '@/hooks/useBackorderStorefrontMessaging';
 import { useMobile } from '@/hooks/useMobile';
+import { usePicklistInventory } from '@/hooks/usePicklistInventory';
 import { useSort } from '@/hooks/useSort';
 import { useB3Lang } from '@/lib/lang';
 import { updateB2BShoppingListsItem, updateBcShoppingListsItem } from '@/shared/service/b2b';
@@ -39,7 +41,9 @@ import { getProductOptionsFields, ProductsProps } from '@/utils/b3Product/shared
 import { snackbar } from '@/utils/b3Tip';
 import {
   catalogListHasBackorderedItemsForDisplay,
+  catalogListHasPicklistBackorderedItemsForDisplay,
   getCatalogProductRowDisplayState,
+  getPicklistSelectionsFromStoredOptions,
 } from '@/utils/catalogBackorderDisplay';
 
 import B3FilterSearch from '../../../components/filter/B3FilterSearch';
@@ -223,6 +227,9 @@ function ShoppingDetailTable(props: ShoppingDetailTableProps, ref: Ref<unknown>)
   } = useBackorderStorefrontMessaging();
   const backorderUiEnabled = isBackorderMessagingContextEnabled && hasAnyBackorderDisplay;
 
+  const [picklistProductIds, setPicklistProductIds] = useState<number[]>([]);
+  const picklistProductsById = usePicklistInventory(picklistProductIds);
+
   const inventoryBySku = useMemo(() => {
     const map: Record<string, CatalogQuickVariantSku> = {};
     variantInfoList.forEach((row) => {
@@ -269,10 +276,19 @@ function ShoppingDetailTable(props: ShoppingDetailTableProps, ref: Ref<unknown>)
       variantSku: node.variantSku,
     }));
 
-    return catalogListHasBackorderedItemsForDisplay(items, inventoryBySku);
+    if (catalogListHasBackorderedItemsForDisplay(items, inventoryBySku)) {
+      return true;
+    }
+
+    const picklistRows = cacheList.map(({ node }) => ({
+      qty: Number(node.quantity) || 0,
+      selections: getPicklistSelectionsFromStoredOptions(node),
+    }));
+
+    return catalogListHasPicklistBackorderedItemsForDisplay(picklistRows, picklistProductsById);
     // tableDataVersion drives re-evaluation when list or qty changes
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [inventoryBySku, isBackorderMessagingEnabled, tableDataVersion]);
+  }, [inventoryBySku, picklistProductsById, isBackorderMessagingEnabled, tableDataVersion]);
 
   const showBackorderToggle = backorderUiEnabled && hasBackorderedItems;
 
@@ -290,12 +306,24 @@ function ShoppingDetailTable(props: ShoppingDetailTableProps, ref: Ref<unknown>)
       const result = await getShoppingListDetails(params);
       const listProducts = result?.edges as ListItemProps[] | undefined;
 
-      if (backorderUiEnabled && listProducts?.length) {
+      if (!backorderUiEnabled) {
+        setPicklistProductIds((prev) => (prev.length === 0 ? prev : []));
+      } else if (listProducts?.length) {
         const skus = listProducts
           .map((item) => item.node.variantSku)
           .filter((sku): sku is string => Boolean(sku));
         fetchInventoryForSkus(skus).catch(() => {
           // Inventory fetch failure should not block the product list
+        });
+
+        const pagePicklistProductIds = listProducts.flatMap((item) =>
+          getPicklistSelectionsFromStoredOptions(item.node).map((selection) => selection.productId),
+        );
+        setPicklistProductIds((prev) => {
+          const merged = [...new Set([...prev, ...pagePicklistProductIds])];
+          // The merge is a union of two deduplicated sets, so an unchanged length means no new
+          // ids — keep the old reference so pages without picklists don't force a re-render.
+          return merged.length === prev.length ? prev : merged;
         });
       }
 
@@ -668,6 +696,8 @@ function ShoppingDetailTable(props: ShoppingDetailTableProps, ref: Ref<unknown>)
           formatOnlyAvailable: () => '',
         });
 
+        const picklistSelections = getPicklistSelectionsFromStoredOptions(row);
+
         return (
           <Box
             sx={{
@@ -706,6 +736,17 @@ function ShoppingDetailTable(props: ShoppingDetailTableProps, ref: Ref<unknown>)
                   quantityBackordered={backorderFields.quantityBackordered}
                   backorderMessage={backorderFields.backorderMessage}
                   visible={showBackorderDetails}
+                />
+              </Box>
+            )}
+            {picklistSelections.length > 0 && (
+              <Box sx={{ width: '100%', textAlign: 'left' }}>
+                <PicklistBackorderMessages
+                  selections={picklistSelections}
+                  picklistProductsById={picklistProductsById}
+                  qty={Number(row.quantity) || 0}
+                  visible={showBackorderDetails}
+                  backorderUiEnabled={backorderUiEnabled}
                 />
               </Box>
             )}
@@ -938,6 +979,7 @@ function ShoppingDetailTable(props: ShoppingDetailTableProps, ref: Ref<unknown>)
             isReadForApprove={isReadForApprove || isJuniorApprove}
             b2bAndBcShoppingListActionsPermissions={b2bAndBcShoppingListActionsPermissions}
             inventoryBySku={inventoryBySku}
+            picklistProductsById={picklistProductsById}
             backorderUiEnabled={backorderUiEnabled}
             showBackorderDetails={showBackorderDetails}
           />

--- a/apps/storefront/src/pages/ShoppingListDetails/index.test.tsx
+++ b/apps/storefront/src/pages/ShoppingListDetails/index.test.tsx
@@ -3661,6 +3661,227 @@ describe('when backorder messaging is enabled on shopping list products', () => 
   });
 });
 
+describe('when a shopping list product is a picklist with a backordered child', () => {
+  const parentVariantSku = 'SL-PICK-PARENT';
+  const parentProductId = 73737;
+  const modifierId = 70;
+  const optionValueId = 501;
+  const picklistProductId = 70000;
+
+  const backorderPreloadedState = {
+    company: b2bCompanyWithShoppingListPermissions,
+    global: buildGlobalStateWith({
+      backorderEnabled: true,
+      backorderDisplaySettings: {
+        showQuantityOnBackorder: true,
+        showQuantityOnHand: true,
+        showBackorderMessage: true,
+        showDefaultShippingExpectationPrompt: false,
+        defaultShippingExpectationPrompt: '',
+      },
+      featureFlags: {
+        'BACK-134.backorders_phase_1_1_control_messaging_on_storefront': true,
+      },
+    }),
+  };
+
+  const setupPicklistShoppingList = ({
+    parentTotalOnHand = 20,
+    childTotalOnHand = 3,
+  }: { parentTotalOnHand?: number; childTotalOnHand?: number } = {}) => {
+    vitest.mocked(useParams).mockReturnValue({ id: '272989' });
+
+    const productEdge = buildShoppingListProductEdgeWith({
+      node: {
+        productName: 'PICKLE KIT',
+        productId: parentProductId,
+        variantSku: parentVariantSku,
+        quantity: 7,
+        basePrice: '22.00',
+        optionList: JSON.stringify([
+          { option_id: `attribute[${modifierId}]`, option_value: `${optionValueId}` },
+        ]),
+      },
+    });
+
+    const shoppingListResponse = buildShoppingListGraphQLResponseWith({
+      data: {
+        shoppingList: {
+          products: { totalCount: 1, edges: [productEdge] },
+          status: 0,
+          grandTotal: '154.00',
+          totalTax: '0',
+        },
+      },
+    });
+
+    const parentProduct = buildSearchB2BProductWith({
+      id: parentProductId,
+      name: 'PICKLE KIT',
+      sku: 'PK',
+      optionsV3: [],
+      isPriceHidden: false,
+      variants: [],
+      modifiers: [
+        {
+          id: modifierId,
+          type: 'product_list',
+          display_name: 'Pickly Picky',
+          option_values: [
+            {
+              id: optionValueId,
+              label: 'Mining Pick',
+              is_default: true,
+              option_id: modifierId,
+              value_data: { product_id: picklistProductId },
+            },
+          ],
+        },
+      ],
+    });
+
+    const picklistChildProduct = buildSearchB2BProductWith({
+      id: picklistProductId,
+      name: 'Mining Pick',
+      inventoryTracking: 'product',
+      availableToSell: 20,
+      unlimitedBackorder: false,
+      totalOnHand: childTotalOnHand,
+      backorderMessage: 'Backorders Schmackorders',
+      variants: [],
+    });
+
+    const parentVariantInfo = buildVariantInfoWith({
+      variantSku: parentVariantSku,
+      inventoryTracking: 'product',
+      availableToSell: 20,
+      unlimitedBackorder: false,
+      totalOnHand: parentTotalOnHand,
+      backorderMessage: 'Parent lead time: 2-4 weeks',
+    });
+
+    server.use(
+      graphql.query('B2BShoppingListDetails', () => HttpResponse.json(shoppingListResponse)),
+      graphql.query('SearchProducts', () =>
+        HttpResponse.json(
+          buildSearchProductsResponseWith({
+            data: { productsSearch: [parentProduct, picklistChildProduct] },
+          }),
+        ),
+      ),
+      graphql.query('GetVariantInfoBySkus', () =>
+        HttpResponse.json(
+          buildVariantInfoResponseWith({ data: { variantSku: [parentVariantInfo] } }),
+        ),
+      ),
+    );
+  };
+
+  it('shows the picklist child backorder lines by default', async () => {
+    setupPicklistShoppingList();
+
+    renderWithProviders(<ShoppingListDetailsContent setOpenPage={() => {}} />, {
+      preloadedState: backorderPreloadedState,
+    });
+
+    await waitForElementToBeRemoved(() => screen.queryByText(/loading/i));
+
+    expect(await screen.findByText('PICKLE KIT')).toBeVisible();
+
+    expect(await screen.findByRole('checkbox', { name: /Backorder details/i })).toBeChecked();
+
+    expect(await screen.findByText('Pickly Picky:')).toBeVisible();
+    expect(screen.getByText('3 ready to ship')).toBeVisible();
+    expect(screen.getByText('4 will be backordered')).toBeVisible();
+    expect(screen.getByText('Backorders Schmackorders')).toBeVisible();
+  });
+
+  it('hides the picklist child backorder lines when the toggle is turned off', async () => {
+    setupPicklistShoppingList();
+
+    renderWithProviders(<ShoppingListDetailsContent setOpenPage={() => {}} />, {
+      preloadedState: backorderPreloadedState,
+    });
+
+    await waitForElementToBeRemoved(() => screen.queryByText(/loading/i));
+
+    expect(await screen.findByText('PICKLE KIT')).toBeVisible();
+
+    const backorderToggle = await screen.findByRole('checkbox', { name: /Backorder details/i });
+    expect(backorderToggle).toBeChecked();
+    expect(await screen.findByText('Pickly Picky:')).toBeVisible();
+
+    await userEvent.click(backorderToggle);
+
+    expect(screen.queryByText('Pickly Picky:')).toBeNull();
+    expect(screen.queryByText('4 will be backordered')).toBeNull();
+    expect(screen.queryByText('Backorders Schmackorders')).toBeNull();
+  });
+
+  it('shows both the parent and the child backorder lines when both are backordered', async () => {
+    setupPicklistShoppingList({ parentTotalOnHand: 3 });
+
+    renderWithProviders(<ShoppingListDetailsContent setOpenPage={() => {}} />, {
+      preloadedState: backorderPreloadedState,
+    });
+
+    await waitForElementToBeRemoved(() => screen.queryByText(/loading/i));
+
+    expect(await screen.findByText('PICKLE KIT')).toBeVisible();
+
+    await screen.findByText('Pickly Picky:');
+    expect(screen.getAllByText('3 ready to ship')).toHaveLength(2);
+    expect(screen.getAllByText('4 will be backordered')).toHaveLength(2);
+    expect(screen.getByText('Parent lead time: 2-4 weeks')).toBeVisible();
+    expect(screen.getByText('Backorders Schmackorders')).toBeVisible();
+  });
+
+  it('hides the picklist child backorder lines when messaging is disabled', async () => {
+    setupPicklistShoppingList();
+
+    renderWithProviders(<ShoppingListDetailsContent setOpenPage={() => {}} />, {
+      preloadedState: { company: b2bCompanyWithShoppingListPermissions },
+    });
+
+    await waitForElementToBeRemoved(() => screen.queryByText(/loading/i));
+
+    expect(await screen.findByText('PICKLE KIT')).toBeVisible();
+
+    expect(screen.queryByRole('checkbox', { name: /Backorder details/i })).toBeNull();
+    expect(screen.queryByText('Pickly Picky:')).toBeNull();
+    expect(screen.queryByText('Backorders Schmackorders')).toBeNull();
+  });
+
+  describe('on mobile', () => {
+    beforeEach(() => {
+      vi.spyOn(document.body, 'clientWidth', 'get').mockReturnValue(500);
+    });
+
+    it('shows the picklist child backorder lines in the card view by default', async () => {
+      setupPicklistShoppingList();
+
+      renderWithProviders(<ShoppingListDetailsContent setOpenPage={() => {}} />, {
+        preloadedState: backorderPreloadedState,
+      });
+
+      await waitForElementToBeRemoved(() => screen.queryByText(/loading/i));
+
+      expect(await screen.findByText('PICKLE KIT')).toBeVisible();
+
+      await waitFor(() => {
+        expect(screen.queryByRole('table')).toBeNull();
+      });
+
+      expect(await screen.findByRole('checkbox', { name: /Backorder details/i })).toBeChecked();
+
+      expect(await screen.findByText('Pickly Picky:')).toBeVisible();
+      expect(screen.getByText('3 ready to ship')).toBeVisible();
+      expect(screen.getByText('4 will be backordered')).toBeVisible();
+      expect(screen.getByText('Backorders Schmackorders')).toBeVisible();
+    });
+  });
+});
+
 describe('when backorder messaging is enabled in add to list search modal', () => {
   const variantSku = 'SL-SEARCH-123';
   const productName = 'Cast Iron Skillet';

--- a/apps/storefront/src/pages/quote/components/QuoteDetailTable.tsx
+++ b/apps/storefront/src/pages/quote/components/QuoteDetailTable.tsx
@@ -10,12 +10,14 @@ import { useB3Lang } from '@/lib/lang';
 import { useAppSelector } from '@/store';
 import { currencyFormatConvert } from '@/utils/b3CurrencyFormat';
 import { getBCPrice, getDisplayPrice } from '@/utils/b3Product/b3Product';
-import { type PicklistBackorderHistoryChild } from '@/utils/catalogBackorderDisplay';
+import {
+  getPicklistSelectionsFromStoredOptions,
+  type PicklistBackorderHistoryChild,
+} from '@/utils/catalogBackorderDisplay';
 
 import { useQuoteDetailBackorderState } from '../hooks/useQuoteDetailBackorderState';
 import {
   getQuoteBackorderDisplayFields,
-  getQuotePicklistSelections,
   getRowPicklistBackorderHistory,
 } from '../utils/getQuoteBackorderDisplayFields';
 
@@ -319,7 +321,9 @@ function QuoteDetailTable(props: ShoppingDetailTableProps, ref: Ref<unknown>) {
       title: b3Lang('quoteDetail.table.qty'),
       render: (row) => {
         const backorderFields = getQuoteBackorderDisplayFields(row);
-        const picklistSelections = backorderContextEnabled ? getQuotePicklistSelections(row) : [];
+        const picklistSelections = backorderContextEnabled
+          ? getPicklistSelectionsFromStoredOptions(row)
+          : [];
         const historyByProductId = isOrdered ? getRowPicklistBackorderHistory(row) : undefined;
 
         return (

--- a/apps/storefront/src/pages/quote/components/QuoteDetailTableCard.tsx
+++ b/apps/storefront/src/pages/quote/components/QuoteDetailTableCard.tsx
@@ -10,12 +10,12 @@ import { useAppSelector } from '@/store';
 import { DisplayCurrency } from '@/types/currency';
 import { currencyFormatConvert } from '@/utils/b3CurrencyFormat';
 import { getBCPrice } from '@/utils/b3Product/b3Product';
-import type { PicklistBackorderHistoryChild } from '@/utils/catalogBackorderDisplay';
-
 import {
-  getQuoteBackorderDisplayFields,
-  getQuotePicklistSelections,
-} from '../utils/getQuoteBackorderDisplayFields';
+  getPicklistSelectionsFromStoredOptions,
+  type PicklistBackorderHistoryChild,
+} from '@/utils/catalogBackorderDisplay';
+
+import { getQuoteBackorderDisplayFields } from '../utils/getQuoteBackorderDisplayFields';
 
 interface QuoteTableCardProps {
   item: any;
@@ -76,7 +76,7 @@ function QuoteDetailTableCard(props: QuoteTableCardProps) {
     hasAnyBackorderDisplay &&
     shouldDisplayBackorderInformation;
   const picklistSelections = backorderContextEnabled
-    ? getQuotePicklistSelections(quoteTableItem)
+    ? getPicklistSelectionsFromStoredOptions(quoteTableItem)
     : [];
 
   const taxRate = getTaxRate(variants);

--- a/apps/storefront/src/pages/quote/hooks/useDraftQuoteBackorderState.ts
+++ b/apps/storefront/src/pages/quote/hooks/useDraftQuoteBackorderState.ts
@@ -5,12 +5,12 @@ import { type ProductSearch } from '@/shared/service/b2b/graphql/product';
 import { QuoteItem } from '@/types/quotes';
 import {
   catalogListHasPicklistBackorderedItemsForDisplay,
+  getPicklistSelectionsFromStoredOptions,
   type PicklistSelection,
 } from '@/utils/catalogBackorderDisplay';
 
 import {
   getDraftBackorderDisplayFields,
-  getQuotePicklistSelections,
   resolveDraftLineProductId,
 } from '../utils/getQuoteBackorderDisplayFields';
 
@@ -45,7 +45,7 @@ export function useDraftQuoteBackorderState({
       ? items.map((item) => ({
           id: String(item.node.id),
           qty: Number(item.node.quantity) || 0,
-          selections: getQuotePicklistSelections(item.node),
+          selections: getPicklistSelectionsFromStoredOptions(item.node),
         }))
       : [];
 

--- a/apps/storefront/src/pages/quote/hooks/useQuoteDetailBackorderState.ts
+++ b/apps/storefront/src/pages/quote/hooks/useQuoteDetailBackorderState.ts
@@ -5,16 +5,19 @@ import { useFeatureFlag } from '@/hooks/useFeatureFlag';
 import { usePicklistInventory } from '@/hooks/usePicklistInventory';
 import { type ProductSearch } from '@/shared/service/b2b/graphql/product';
 import { QuoteStatus } from '@/shared/service/b2b/graphql/quote';
-import { catalogListHasPicklistBackorderedItemsForDisplay } from '@/utils/catalogBackorderDisplay';
+import {
+  catalogListHasPicklistBackorderedItemsForDisplay,
+  getPicklistSelectionsFromStoredOptions,
+  type StoredPicklistOptionRow,
+} from '@/utils/catalogBackorderDisplay';
 
 import {
-  getQuotePicklistSelections,
   type QuoteBackorderRow,
   quoteDetailListHasBackorderedItemsForDisplay,
   quoteDetailListHasPicklistBackorderHistory,
 } from '../utils/getQuoteBackorderDisplayFields';
 
-type QuoteDetailBackorderRow = QuoteBackorderRow & Parameters<typeof getQuotePicklistSelections>[0];
+type QuoteDetailBackorderRow = QuoteBackorderRow & StoredPicklistOptionRow;
 
 interface QuoteDetailBackorderState {
   isOrdered: boolean;
@@ -47,7 +50,7 @@ export function useQuoteDetailBackorderState(
     () =>
       backorderContextEnabled && !isOrdered
         ? productList.flatMap((row) =>
-            getQuotePicklistSelections(row).map((selection) => selection.productId),
+            getPicklistSelectionsFromStoredOptions(row).map((selection) => selection.productId),
           )
         : [],
     [productList, backorderContextEnabled, isOrdered],
@@ -62,7 +65,7 @@ export function useQuoteDetailBackorderState(
         : catalogListHasPicklistBackorderedItemsForDisplay(
             productList.map((row) => ({
               qty: Number(row.quantity) || 0,
-              selections: getQuotePicklistSelections(row),
+              selections: getPicklistSelectionsFromStoredOptions(row),
             })),
             picklistProductsById,
           )),

--- a/apps/storefront/src/pages/quote/utils/getQuoteBackorderDisplayFields.test.ts
+++ b/apps/storefront/src/pages/quote/utils/getQuoteBackorderDisplayFields.test.ts
@@ -8,7 +8,6 @@ import {
   getQuoteBackorderDisplayFields,
   getQuoteBackorderDisplayQuantity,
   getQuoteItemBackendAvailability,
-  getQuotePicklistSelections,
   getRowPicklistBackorderHistory,
   type QuoteBackorderRow,
   quoteDetailListHasBackorderedItemsForDisplay,
@@ -433,109 +432,6 @@ describe('getQuoteBackorderDisplayFields for quote detail rows', () => {
       quantityBackordered: 8,
       backorderMessage: 'History message',
     });
-  });
-});
-
-describe('getQuotePicklistSelections', () => {
-  const picklistModifier = {
-    id: 100,
-    type: 'product_list',
-    display_name: 'Pick a pickle',
-    option_values: [{ id: 200, value_data: { product_id: 555 } }],
-  };
-
-  const buildRow = (optionList: string) =>
-    ({
-      quantity: 1,
-      optionList,
-      productsSearch: { modifiers: [picklistModifier] },
-    }) as unknown as QuoteItem['node'];
-
-  it('resolves a picklist selection from camelCase attribute-keyed optionList', () => {
-    const optionList = JSON.stringify([{ optionId: 'attribute[100]', optionValue: '200' }]);
-
-    expect(getQuotePicklistSelections(buildRow(optionList))).toEqual([
-      { modifierId: 100, displayName: 'Pick a pickle', productId: 555 },
-    ]);
-  });
-
-  it('resolves a picklist selection from snake_case option_id/option_value entries', () => {
-    const optionList = JSON.stringify([{ option_id: 100, option_value: 200 }]);
-
-    expect(getQuotePicklistSelections(buildRow(optionList))).toEqual([
-      { modifierId: 100, displayName: 'Pick a pickle', productId: 555 },
-    ]);
-  });
-
-  it('resolves a submitted quote selection from its options', () => {
-    const row = {
-      quantity: 1,
-      options: [
-        { optionId: 100, optionValue: 200, optionName: 'PickleFest', optionLabel: 'Ice Pick' },
-      ],
-      productsSearch: { modifiers: [picklistModifier] },
-    } as unknown as QuoteItem['node'];
-
-    expect(getQuotePicklistSelections(row)).toEqual([
-      { modifierId: 100, displayName: 'Pick a pickle', productId: 555 },
-    ]);
-  });
-
-  it('resolves a submitted quote selection from snake_case option_id/option_value options', () => {
-    const row = {
-      quantity: 1,
-      options: [{ option_id: 100, option_value: 200 }],
-      productsSearch: { modifiers: [picklistModifier] },
-    } as unknown as QuoteItem['node'];
-
-    expect(getQuotePicklistSelections(row)).toEqual([
-      { modifierId: 100, displayName: 'Pick a pickle', productId: 555 },
-    ]);
-  });
-
-  it('resolves a submitted quote selection even when a leftover draft optionList is present', () => {
-    const row = {
-      quantity: 1,
-      options: [{ optionId: 100, optionValue: 200 }],
-      optionList: '[]',
-      productsSearch: { modifiers: [picklistModifier] },
-    } as unknown as QuoteItem['node'];
-
-    expect(getQuotePicklistSelections(row)).toEqual([
-      { modifierId: 100, displayName: 'Pick a pickle', productId: 555 },
-    ]);
-  });
-
-  it('returns an empty array when the modifier is not a picklist', () => {
-    const optionList = JSON.stringify([{ optionId: 'attribute[100]', optionValue: '200' }]);
-    const row = {
-      quantity: 1,
-      optionList,
-      productsSearch: { modifiers: [{ ...picklistModifier, type: 'dropdown' }] },
-    } as unknown as QuoteItem['node'];
-
-    expect(getQuotePicklistSelections(row)).toEqual([]);
-  });
-
-  it('returns an empty array when optionList is empty', () => {
-    expect(getQuotePicklistSelections(buildRow('[]'))).toEqual([]);
-  });
-
-  it('returns an empty array when optionList is not valid JSON', () => {
-    expect(getQuotePicklistSelections(buildRow('not json'))).toEqual([]);
-  });
-
-  it('skips null and primitive entries without throwing on malformed optionList', () => {
-    const optionList = JSON.stringify([
-      null,
-      'x',
-      42,
-      { optionId: 'attribute[100]', optionValue: '200' },
-    ]);
-
-    expect(getQuotePicklistSelections(buildRow(optionList))).toEqual([
-      { modifierId: 100, displayName: 'Pick a pickle', productId: 555 },
-    ]);
   });
 });
 

--- a/apps/storefront/src/pages/quote/utils/getQuoteBackorderDisplayFields.ts
+++ b/apps/storefront/src/pages/quote/utils/getQuoteBackorderDisplayFields.ts
@@ -5,12 +5,10 @@ import type { BackorderDisplayFields } from '@/utils/backorderDisplayFromInvento
 import { getBackorderDisplayFieldsFromOnHand } from '@/utils/backorderDisplayFromInventory';
 import {
   getPicklistBackorderHistoryFields,
-  getProductDetailsForPicklistSelections,
+  getPicklistSelectionsFromStoredOptions,
   type PicklistBackorderHistoryChild,
-  type PicklistSelection,
-  type PicklistSelectionSource,
+  type StoredPicklistOptionRow,
 } from '@/utils/catalogBackorderDisplay';
-import { parseAttributeOptionId } from '@/utils/parseAttributeOptionId';
 
 export interface QuoteBackorderRow {
   quantity: number | string;
@@ -164,86 +162,6 @@ export function getDraftBackorderDisplayFields(
   });
 }
 
-interface QuoteOptionEntry {
-  option_id?: number | string;
-  optionId?: number | string;
-  option_value?: number | string;
-  optionValue?: number | string;
-}
-
-// Option ids arrive either as a bare number or shaped like "attribute[123]"; normalise the id and
-// its value into a numeric { option_id, value_id } pair, or null if either can't be parsed.
-function toQuoteOptionSelection(
-  rawId: number | string | undefined,
-  rawValue: number | string | undefined,
-): { option_id: number; value_id: number } | null {
-  if (rawId == null || rawValue == null) {
-    return null;
-  }
-
-  const optionId = parseAttributeOptionId(rawId);
-  const valueId = Number(rawValue);
-  if (optionId === null || Number.isNaN(valueId)) {
-    return null;
-  }
-
-  return { option_id: optionId, value_id: valueId };
-}
-
-function quoteOptionEntriesToSelections(
-  entries: QuoteOptionEntry[],
-): Array<{ option_id: number; value_id: number }> {
-  return entries.flatMap((entry) => {
-    const selection = toQuoteOptionSelection(
-      entry.option_id ?? entry.optionId,
-      entry.option_value ?? entry.optionValue,
-    );
-    return selection ? [selection] : [];
-  });
-}
-
-function parseQuoteOptionListSelections(
-  optionList: string | null | undefined,
-): Array<{ option_id: number; value_id: number }> {
-  if (!optionList) {
-    return [];
-  }
-
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(optionList);
-  } catch {
-    return [];
-  }
-
-  if (!Array.isArray(parsed)) {
-    return [];
-  }
-
-  const entries = parsed.filter(
-    (item): item is QuoteOptionEntry => item !== null && typeof item === 'object',
-  );
-  return quoteOptionEntriesToSelections(entries);
-}
-
-// Draft rows carry selections as `optionList` (a JSON string); saved/detail rows carry them as a
-// structured `options` array. Both shapes key entries as either option_id/option_value or
-// optionId/optionValue, and both translate to the resolver's {option_id, value_id} shape.
-export function getQuotePicklistSelections(row: {
-  optionList?: string | null;
-  options?: QuoteOptionEntry[] | null;
-  productsSearch?: PicklistSelectionSource['productsSearch'];
-}): PicklistSelection[] {
-  const optionSelections = row.options?.length
-    ? quoteOptionEntriesToSelections(row.options)
-    : parseQuoteOptionListSelections(row.optionList);
-
-  return getProductDetailsForPicklistSelections({
-    optionSelections,
-    productsSearch: row.productsSearch,
-  });
-}
-
 export function quoteDetailListHasBackorderedItemsForDisplay(
   productList: QuoteBackorderRow[],
 ): boolean {
@@ -272,16 +190,14 @@ export function getRowPicklistBackorderHistory(
 }
 
 export function quoteDetailListHasPicklistBackorderHistory(
-  productList: Array<
-    Parameters<typeof getQuotePicklistSelections>[0] & PicklistBackorderHistoryRow
-  >,
+  productList: Array<StoredPicklistOptionRow & PicklistBackorderHistoryRow>,
 ): boolean {
   return productList.some((row) => {
     const historyByProductId = getRowPicklistBackorderHistory(row);
     if (!historyByProductId) {
       return false;
     }
-    return getQuotePicklistSelections(row).some(
+    return getPicklistSelectionsFromStoredOptions(row).some(
       (selection) =>
         getPicklistBackorderHistoryFields(historyByProductId[selection.productId]) !== null,
     );

--- a/apps/storefront/src/utils/catalogBackorderDisplay.test.ts
+++ b/apps/storefront/src/utils/catalogBackorderDisplay.test.ts
@@ -15,10 +15,12 @@ import {
   getCatalogInventorySku,
   getCatalogProductRowDisplayState,
   getPicklistBackorderHistoryFields,
+  getPicklistSelectionsFromStoredOptions,
   getProductDetailsForPicklistSelections,
   productRequiresChooseOptionsBeforeAdd,
   quantityExceedsAvailableToSell,
   shouldBlockQuoteAtsAdd,
+  type StoredPicklistOptionRow,
 } from './catalogBackorderDisplay';
 
 describe('catalogBackorderDisplay', () => {
@@ -544,6 +546,117 @@ describe('catalogBackorderDisplay', () => {
       ).toEqual([
         { modifierId: 100, displayName: 'Bundle option 1', productId: 555 },
         { modifierId: 101, displayName: 'Bundle option 2', productId: 666 },
+      ]);
+    });
+  });
+
+  describe('getPicklistSelectionsFromStoredOptions', () => {
+    const picklistModifier = {
+      id: 100,
+      type: 'product_list',
+      display_name: 'Pick a pickle',
+      option_values: [{ id: 200, value_data: { product_id: 555 } }],
+    };
+
+    const buildRow = (optionList: string): StoredPicklistOptionRow => ({
+      optionList,
+      productsSearch: { modifiers: [picklistModifier] },
+    });
+
+    it('resolves a selection from a camelCase attribute-keyed optionList', () => {
+      const optionList = JSON.stringify([{ optionId: 'attribute[100]', optionValue: '200' }]);
+
+      expect(getPicklistSelectionsFromStoredOptions(buildRow(optionList))).toEqual([
+        { modifierId: 100, displayName: 'Pick a pickle', productId: 555 },
+      ]);
+    });
+
+    it('resolves a selection from snake_case option_id/option_value entries', () => {
+      const optionList = JSON.stringify([{ option_id: 100, option_value: 200 }]);
+
+      expect(getPicklistSelectionsFromStoredOptions(buildRow(optionList))).toEqual([
+        { modifierId: 100, displayName: 'Pick a pickle', productId: 555 },
+      ]);
+    });
+
+    it('resolves a selection from a structured options array', () => {
+      const row: StoredPicklistOptionRow = {
+        options: [{ optionId: 100, optionValue: 200 }],
+        productsSearch: { modifiers: [picklistModifier] },
+      };
+
+      expect(getPicklistSelectionsFromStoredOptions(row)).toEqual([
+        { modifierId: 100, displayName: 'Pick a pickle', productId: 555 },
+      ]);
+    });
+
+    it('resolves a selection from snake_case option_id/option_value options', () => {
+      const row: StoredPicklistOptionRow = {
+        options: [{ option_id: 100, option_value: 200 }],
+        productsSearch: { modifiers: [picklistModifier] },
+      };
+
+      expect(getPicklistSelectionsFromStoredOptions(row)).toEqual([
+        { modifierId: 100, displayName: 'Pick a pickle', productId: 555 },
+      ]);
+    });
+
+    it('prefers the options array when a leftover optionList is also present', () => {
+      const row: StoredPicklistOptionRow = {
+        options: [{ optionId: 100, optionValue: 200 }],
+        optionList: '[]',
+        productsSearch: { modifiers: [picklistModifier] },
+      };
+
+      expect(getPicklistSelectionsFromStoredOptions(row)).toEqual([
+        { modifierId: 100, displayName: 'Pick a pickle', productId: 555 },
+      ]);
+    });
+
+    it('returns an empty array when the modifier is not a picklist', () => {
+      const optionList = JSON.stringify([{ optionId: 'attribute[100]', optionValue: '200' }]);
+      const row: StoredPicklistOptionRow = {
+        optionList,
+        productsSearch: { modifiers: [{ ...picklistModifier, type: 'dropdown' }] },
+      };
+
+      expect(getPicklistSelectionsFromStoredOptions(row)).toEqual([]);
+    });
+
+    it('returns an empty array when optionList is empty', () => {
+      expect(getPicklistSelectionsFromStoredOptions(buildRow('[]'))).toEqual([]);
+    });
+
+    it('returns an empty array when optionList is not valid JSON', () => {
+      expect(getPicklistSelectionsFromStoredOptions(buildRow('not json'))).toEqual([]);
+    });
+
+    it('skips null and primitive entries without throwing on a malformed options array', () => {
+      const row = {
+        options: [
+          null,
+          'x',
+          42,
+          { optionId: 100, optionValue: 200 },
+        ] as StoredPicklistOptionRow['options'],
+        productsSearch: { modifiers: [picklistModifier] },
+      };
+
+      expect(getPicklistSelectionsFromStoredOptions(row)).toEqual([
+        { modifierId: 100, displayName: 'Pick a pickle', productId: 555 },
+      ]);
+    });
+
+    it('skips null and primitive entries without throwing on a malformed optionList', () => {
+      const optionList = JSON.stringify([
+        null,
+        'x',
+        42,
+        { optionId: 'attribute[100]', optionValue: '200' },
+      ]);
+
+      expect(getPicklistSelectionsFromStoredOptions(buildRow(optionList))).toEqual([
+        { modifierId: 100, displayName: 'Pick a pickle', productId: 555 },
       ]);
     });
   });

--- a/apps/storefront/src/utils/catalogBackorderDisplay.ts
+++ b/apps/storefront/src/utils/catalogBackorderDisplay.ts
@@ -3,6 +3,7 @@ import type { Variant } from '@/types/products';
 import type { ShoppingListProductItem } from '@/types/shoppingList';
 import type { BackorderDisplayFields } from '@/utils/backorderDisplayFromInventory';
 import { getBackorderDisplayFieldsFromOnHand } from '@/utils/backorderDisplayFromInventory';
+import { parseAttributeOptionId } from '@/utils/parseAttributeOptionId';
 
 export function buildVariantSkuDependencyKey(skus: readonly (string | undefined | null)[]): string {
   return [...new Set(skus.filter((sku): sku is string => Boolean(sku)))].sort().join('|');
@@ -204,7 +205,7 @@ interface PicklistModifier {
   option_values?: Array<{ id: number; value_data?: { product_id?: number } | null }> | null;
 }
 
-export interface PicklistSelectionSource {
+interface PicklistSelectionSource {
   optionSelections?: Array<{ option_id: number; value_id: number }> | null;
   productsSearch?: { modifiers?: PicklistModifier[] | null } | null;
 }
@@ -249,6 +250,89 @@ export function getProductDetailsForPicklistSelections(
         productId,
       },
     ];
+  });
+}
+
+interface StoredOptionEntry {
+  option_id?: number | string;
+  optionId?: number | string;
+  option_value?: number | string;
+  optionValue?: number | string;
+}
+
+function toStoredOptionSelection(
+  rawId: number | string | undefined,
+  rawValue: number | string | undefined,
+): { option_id: number; value_id: number } | null {
+  if (rawId == null || rawValue == null) {
+    return null;
+  }
+
+  const optionId = parseAttributeOptionId(rawId);
+  const valueId = Number(rawValue);
+  if (optionId === null || Number.isNaN(valueId)) {
+    return null;
+  }
+
+  return { option_id: optionId, value_id: valueId };
+}
+
+// Entries come from persisted/API data that callers may hand over unvalidated, so skip anything
+// that isn't an object rather than reading properties off it.
+function storedOptionEntriesToSelections(
+  entries: readonly unknown[],
+): Array<{ option_id: number; value_id: number }> {
+  return entries.flatMap((item) => {
+    if (item === null || typeof item !== 'object') {
+      return [];
+    }
+
+    const entry = item as StoredOptionEntry;
+    const selection = toStoredOptionSelection(
+      entry.option_id ?? entry.optionId,
+      entry.option_value ?? entry.optionValue,
+    );
+    return selection ? [selection] : [];
+  });
+}
+
+function parseStoredOptionList(
+  optionList: string | null | undefined,
+): Array<{ option_id: number; value_id: number }> {
+  if (!optionList) {
+    return [];
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(optionList);
+  } catch {
+    return [];
+  }
+
+  if (!Array.isArray(parsed)) {
+    return [];
+  }
+
+  return storedOptionEntriesToSelections(parsed);
+}
+
+export interface StoredPicklistOptionRow {
+  optionList?: string | null;
+  options?: StoredOptionEntry[] | null;
+  productsSearch?: PicklistSelectionSource['productsSearch'];
+}
+
+export function getPicklistSelectionsFromStoredOptions(
+  row: StoredPicklistOptionRow,
+): PicklistSelection[] {
+  const optionSelections = row.options?.length
+    ? storedOptionEntriesToSelections(row.options)
+    : parseStoredOptionList(row.optionList);
+
+  return getProductDetailsForPicklistSelections({
+    optionSelections,
+    productsSearch: row.productsSearch,
   });
 }
 


### PR DESCRIPTION
Jira: [BACK-830](https://bigcommercecloud.atlassian.net/browse/BACK-830)

## What/Why?
Implement backorder display for picklist children when on the shopping list page.
Previously this was not rendering.

Moved getQuotePicklistSelections out of pages/quote/utils into the shared `utils/catalogBackorderDisplay.ts` as getPicklistSelectionsFromStoredOptions, since the stored-option parsing is not quote-specific.

## Rollout/Rollback
Revert this PR if there are issues.

## Testing
Before:
When a child and parent form a picklist are both backordered:
Backordered child products were not rendered.
<img width="815" height="400" alt="Screenshot 2026-08-12 at 1 52 38 pm" src="https://github.com/user-attachments/assets/d0a14daa-072c-4920-b5f9-fc34bab62b25" />

After:
When both the parent and child are backordered:
Both products backordered information are rendered.
<img width="804" height="485" alt="Screenshot 2026-08-12 at 4 08 40 pm" src="https://github.com/user-attachments/assets/5b07996a-5daf-44e2-b501-c28a5a919d05" />

When only the parent is backordered:
Only the parent's backorder information is rendered:
<img width="864" height="529" alt="Screenshot 2026-08-12 at 4 38 47 pm" src="https://github.com/user-attachments/assets/9032312d-1579-4c1f-807e-629cdc7573f3" />

When only the child is backordered:
Only the child's backorder information is rendered:
<img width="818" height="430" alt="Screenshot 2026-08-12 at 4 38 03 pm" src="https://github.com/user-attachments/assets/a5ce0e01-92fa-4c52-80fd-0fbfb065fdd1" />

When neither parent or child are backordered:
Neither displays backorder information:
<img width="840" height="487" alt="Screenshot 2026-08-12 at 4 41 20 pm" src="https://github.com/user-attachments/assets/3a0a363b-92bc-467b-9811-5b697ebbbe1c" />


Ping TBA

[BACK-830]: https://bigcommercecloud.atlassian.net/browse/BACK-830?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes storefront inventory display and shared option parsing used by quotes and shopping lists; behavior is additive and mirrors existing quote picklist backorder patterns, with moderate scope across list loading and UI.
> 
> **Overview**
> Shopping list details now surfaces **picklist child** backorder messaging alongside the parent line, using the shared `PicklistBackorderMessages` component in table and mobile card views. The list loads picklist child inventory via `usePicklistInventory`, merges picklist product IDs as pages load, and treats picklist backorders when deciding whether to show the backorder details toggle.
> 
> **`getQuotePicklistSelections`** is consolidated into **`getPicklistSelectionsFromStoredOptions`** in `catalogBackorderDisplay.ts` so quote and shopping list rows parse stored `optionList` / `options` the same way; quote hooks and tables call the shared helper instead of quote-local parsing.
> 
> Tests cover default visibility, toggle off, parent+child backordered, messaging disabled, and mobile card layout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b75ad43ecc9c05e0965e1753c7a454bd5de7c814. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->