### PR TITLE
fix(orders): B2B-5502 fix add to shopping list from orders sending invalid GQL items

### DIFF
--- a/apps/storefront/src/pages/OrderDetail/components/OrderDialog.tsx
+++ b/apps/storefront/src/pages/OrderDetail/components/OrderDialog.tsx
@@ -465,31 +465,30 @@ export default function OrderDialog({
   const handleShoppingConfirm = async (id: string) => {
     setIsRequestLoading(true);
     try {
-      const items = editableProducts.map((product) => {
-        const {
-          id: lineItemId,
-          product_id: productId,
-          variant_id: variantId,
-          editQuantity,
-          product_options: productOptions,
-        } = product;
+      const params = editableProducts
+        .filter((product) => checkedArr.includes(product.id))
+        .map((product) => {
+          const {
+            product_id: productId,
+            variant_id: variantId,
+            editQuantity,
+            product_options: productOptions,
+          } = product;
 
-        return {
-          lineItemId,
-          productId: Number(productId),
-          variantId,
-          quantity: Number(editQuantity),
-          optionList: productOptions.map((option) => {
-            const { product_option_id: optionId, value: optionValue } = option;
+          return {
+            productId: Number(productId),
+            variantId,
+            quantity: Number(editQuantity),
+            optionList: productOptions.map((option) => {
+              const { product_option_id: optionId, value: optionValue } = option;
 
-            return {
-              optionId: `attribute[${optionId}]`,
-              optionValue,
-            };
-          }),
-        };
-      });
-      const params = items.filter((item) => checkedArr.includes(item.lineItemId));
+              return {
+                optionId: `attribute[${optionId}]`,
+                optionValue,
+              };
+            }),
+          };
+        });
 
       const addToShoppingList = isB2BUser ? addProductToShoppingList : addProductToBcShoppingList;
 


### PR DESCRIPTION
Jira: [B2B-5502](https://bigcommercecloud.atlassian.net/browse/B2B-5502)

## What/Why?
Stop sending `lineItemId` on shopping list items from Order Detail (introduced in https://github.com/bigcommerce/b2b-buyer-portal/pull/925). That field is only used locally to track selected rows, but `ShoppingListsItemsInputType` does not define it, so GraphQL rejected the request and add-to-list failed. Selection still uses `product.id`, the mutation now sends only `productId`, `variantId`, `quantity`, and `optionList`.

## Rollout/Rollback
Merge/revert.

## Testing
Can add to shopping list successfully.

https://github.com/user-attachments/assets/b4e3139e-9a7b-44be-b6e8-c5626a95c090

[B2B-5502]: https://bigcommercecloud.atlassian.net/browse/B2B-5502?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-path fix in Order Detail shopping-list confirm; removes an invalid field from the mutation payload with no auth or broader API changes.
> 
> **Overview**
> Fixes **add to shopping list** from Order Detail so the GraphQL mutation no longer fails.
> 
> `handleShoppingConfirm` previously put **`lineItemId`** on each shopping-list item and used it for row selection. That field is only for local checkbox state (`checkedArr` still keys off `product.id`); **`ShoppingListsItemsInputType`** does not accept it, so the API rejected the request.
> 
> The payload is now built by filtering selected products and sending only **`productId`**, **`variantId`**, **`quantity`**, and **`optionList`**—matching the schema and restoring add-to-list from orders.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66232975eba8131a62cf4007d90cd9bae98d4e50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->