### PR TITLE
B2B-5366: guard app init effect against re-entrant runs

### DIFF
--- a/apps/storefront/src/App.tsx
+++ b/apps/storefront/src/App.tsx
@@ -265,6 +265,8 @@ export default function App() {
       } catch (e) {
         b2bLogger.error(e);
         showPageMask(false);
+        // didn't actually initialize; let a future dep change retry it
+        hasInitialized.current = false;
         storeDispatch(
           setGlobalCommonState({
             isPageComplete: true,
@@ -278,7 +280,7 @@ export default function App() {
     // due they are functions that do not depend on any reactive value
     // ignore href because is not a reactive value
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [b2bId, customerId, emailAddress, isAgenting, isB2BUser, role]);
+  }, [b2bId, customerId, emailAddress, isAgenting, role]);
 
   useEffect(() => {
     if (quoteConfig.length > 0 && storefrontConfig) {

--- a/apps/storefront/src/App.tsx
+++ b/apps/storefront/src/App.tsx
@@ -66,7 +66,7 @@ export default function App() {
   const isClickEnterBtn = useAppSelector(({ global }) => global.isClickEnterBtn);
   const isPageComplete = useAppSelector(({ global }) => global.isPageComplete);
   const isDefaultLoginStyling = useRef(shouldUseDefaultLoginStyling()).current;
-  const hasInitialized = useRef(false);
+  const isInitRunning = useRef(false);
   const currentClickedUrl = useAppSelector(({ global }) => global.currentClickedUrl);
   const isRegisterAndLogin = useAppSelector(({ global }) => global.isRegisterAndLogin);
   const { quotesCreateActionsPermission, shoppingListCreateActionsPermission } =
@@ -171,8 +171,8 @@ export default function App() {
     loginAndRegister();
 
     // getCompanyInfo() below can change isB2BUser mid-run and retrigger this effect.
-    if (hasInitialized.current) return;
-    hasInitialized.current = true;
+    if (isInitRunning.current) return;
+    isInitRunning.current = true;
 
     const init = async () => {
       try {
@@ -268,6 +268,8 @@ export default function App() {
             isPageComplete: true,
           }),
         );
+      } finally {
+        isInitRunning.current = false;
       }
     };
 

--- a/apps/storefront/src/App.tsx
+++ b/apps/storefront/src/App.tsx
@@ -66,7 +66,7 @@ export default function App() {
   const isClickEnterBtn = useAppSelector(({ global }) => global.isClickEnterBtn);
   const isPageComplete = useAppSelector(({ global }) => global.isPageComplete);
   const isDefaultLoginStyling = useRef(shouldUseDefaultLoginStyling()).current;
-  const isInitRunning = useRef(false);
+  const hasInitialized = useRef(false);
   const currentClickedUrl = useAppSelector(({ global }) => global.currentClickedUrl);
   const isRegisterAndLogin = useAppSelector(({ global }) => global.isRegisterAndLogin);
   const { quotesCreateActionsPermission, shoppingListCreateActionsPermission } =
@@ -171,8 +171,8 @@ export default function App() {
     loginAndRegister();
 
     // getCompanyInfo() below can change isB2BUser mid-run and retrigger this effect.
-    if (isInitRunning.current) return;
-    isInitRunning.current = true;
+    if (hasInitialized.current) return;
+    hasInitialized.current = true;
 
     const init = async () => {
       try {
@@ -184,6 +184,8 @@ export default function App() {
           if (!isBcLogin) {
             logoutSession();
             showPageMask(false);
+            // didn't actually initialize; let the retriggered run (now a guest) finish it
+            hasInitialized.current = false;
             return;
           }
         }
@@ -268,8 +270,6 @@ export default function App() {
             isPageComplete: true,
           }),
         );
-      } finally {
-        isInitRunning.current = false;
       }
     };
 

--- a/apps/storefront/src/App.tsx
+++ b/apps/storefront/src/App.tsx
@@ -66,6 +66,7 @@ export default function App() {
   const isClickEnterBtn = useAppSelector(({ global }) => global.isClickEnterBtn);
   const isPageComplete = useAppSelector(({ global }) => global.isPageComplete);
   const isDefaultLoginStyling = useRef(shouldUseDefaultLoginStyling()).current;
+  const hasInitialized = useRef(false);
   const currentClickedUrl = useAppSelector(({ global }) => global.currentClickedUrl);
   const isRegisterAndLogin = useAppSelector(({ global }) => global.isRegisterAndLogin);
   const { quotesCreateActionsPermission, shoppingListCreateActionsPermission } =
@@ -168,6 +169,11 @@ export default function App() {
   useEffect(() => {
     storeDispatch(setOpenPageReducer(setOpenPage));
     loginAndRegister();
+
+    // getCompanyInfo() below can change isB2BUser mid-run and retrigger this effect.
+    if (hasInitialized.current) return;
+    hasInitialized.current = true;
+
     const init = async () => {
       try {
         // Verify BC session is still valid when we have a rehydrated customerId.
@@ -311,12 +317,11 @@ export default function App() {
   ]);
 
   useEffect(() => {
-    if (isOpen) {
+    if (isPageComplete) {
       showPageMask(false);
     }
-    // ignore dispatch due it's function that doesn't not depend on any reactive value
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isOpen]);
+  }, [isPageComplete]);
 
   // Remove the pre-mount login mask only once initialization has finished. The
   // mask sits just below the iframe, so keeping it until init completes is


### PR DESCRIPTION
Jira: [B2B-5366](https://bigcommercecloud.atlassian.net/browse/B2B-5366)

## What/Why?
The app's init effect in `App.tsx` depends on `isB2BUser`, which the effect itself changes partway through a run — `getCompanyInfo()` dispatches `setCompanyStatus`, and `isB2BUser` is derived from that. That retriggers the whole fetch-then-navigate sequence before the first run finishes, so a second run's `gotoPage()` call can fire after the user has already navigated elsewhere in the app, silently redirecting them back to the default page mid-interaction. Added a ref guard so the sequence only runs once per mount.

The loading mask was also tied to `isOpen`, which flips true as soon as a navigation decision is made rather than when init actually finishes, so the redirect happened with no visual indicator. The mask now waits for `isPageComplete`.

## Rollout/Rollback
Merge/revert.

## Testing

### Tested on Catalyst store 
No impact

https://github.com/user-attachments/assets/db584e6d-8c7e-44d7-b11b-e3cde7c49466



Traced with a Playwright trace of the original bug (background init racing the user's own navigation to Company Orders). Full unit suite passes: 110/110 files, 1391 tests. No new test added for the specific re-entrant-effect scenario — flag if you want one before merge.

[B2B-5366]: https://bigcommercecloud.atlassian.net/browse/B2B-5366?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core app bootstrap, session verification, and default navigation on mount; incorrect guard behavior could block init or leave users stuck behind the mask, but the change is localized and revertible.
> 
> **Overview**
> Fixes **mid-session redirects** during buyer portal startup by ensuring the mount-time init sequence in `App.tsx` runs only once per successful completion.
> 
> The init `useEffect` used to depend on `isB2BUser`, which `getCompanyInfo()` can update partway through the same run. That retriggered the full fetch-and-`gotoPage()` flow and could override navigation the user had already started (e.g. opening Company Orders). A **`hasInitialized` ref** blocks repeat runs; it is cleared when BC session verification fails or init errors so a later dependency change can retry. **`isB2BUser` is removed** from the effect dependency list.
> 
> The **loading mask** now clears when **`isPageComplete`** is set instead of when **`isOpen`** flips, so the mask stays up until init finishes rather than disappearing as soon as a navigation decision is made.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fcda8785e305e8425e45b05292a1b6b9d57d8194. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->