### PR TITLE
chore(quotes): BACK-850 cleanup BACK-593 experiment

### DIFF
--- a/apps/storefront/src/pages/QuoteDetail/index.test.tsx
+++ b/apps/storefront/src/pages/QuoteDetail/index.test.tsx
@@ -1511,27 +1511,6 @@ describe('when the user is a B2B customer', () => {
       expect(screen.queryByText(/backorder details/i)).not.toBeInTheDocument();
     });
 
-    it('hides the toggle on an ordered quote with backordered items when the BACK-593 experiment is off', async () => {
-      const quote = buildQuoteWith({
-        data: {
-          quote: {
-            id: '272989',
-            status: 4,
-            productsList: [buildQuoteProductWith({ quantityBackordered: 3 })],
-          },
-        },
-      });
-
-      server.use(graphql.query('GetQuoteInfoB2B', () => HttpResponse.json(quote)));
-      vitest.mocked(useParams).mockReturnValue({ id: '272989' });
-
-      renderWithProviders(<QuoteDetail />, { preloadedState: backorderPreloadedState });
-
-      await waitForElementToBeRemoved(() => screen.queryByText(/loading/i));
-
-      expect(screen.queryByText(/backorder details/i)).not.toBeInTheDocument();
-    });
-
     it('shows the toggle on an ordered quote with backordered items', async () => {
       const quote = buildQuoteWith({
         data: {
@@ -1546,18 +1525,7 @@ describe('when the user is a B2B customer', () => {
       server.use(graphql.query('GetQuoteInfoB2B', () => HttpResponse.json(quote)));
       vitest.mocked(useParams).mockReturnValue({ id: '272989' });
 
-      renderWithProviders(<QuoteDetail />, {
-        preloadedState: {
-          ...backorderPreloadedState,
-          global: {
-            ...backorderPreloadedState.global,
-            featureFlags: {
-              ...backorderPreloadedState.global.featureFlags,
-              'BACK-593.surface_order_backorder_info_on_quotes': true,
-            },
-          },
-        },
-      });
+      renderWithProviders(<QuoteDetail />, { preloadedState: backorderPreloadedState });
 
       await waitForElementToBeRemoved(() => screen.queryByText(/loading/i));
 

--- a/apps/storefront/src/pages/quote/components/QuoteDetailTable.tsx
+++ b/apps/storefront/src/pages/quote/components/QuoteDetailTable.tsx
@@ -125,13 +125,8 @@ function QuoteDetailTable(props: ShoppingDetailTableProps, ref: Ref<unknown>) {
     status,
   } = props;
 
-  const {
-    isOrdered,
-    shouldDisplayBackorderInformation,
-    backorderContextEnabled,
-    picklistProductsById,
-    hasBackorderedItems,
-  } = useQuoteDetailBackorderState(productList, status);
+  const { isOrdered, backorderContextEnabled, picklistProductsById, hasBackorderedItems } =
+    useQuoteDetailBackorderState(productList, status);
 
   const isEnableProduct = useAppSelector(
     ({ global }) => global.blockPendingQuoteNonPurchasableOOS.isEnableProduct,
@@ -476,7 +471,6 @@ function QuoteDetailTable(props: ShoppingDetailTableProps, ref: Ref<unknown>) {
             displayDiscount={displayDiscount}
             getTaxRate={getTaxRate}
             showBackorderDetails={showBackorderDetails}
-            shouldDisplayBackorderInformation={shouldDisplayBackorderInformation}
             picklistProductsById={picklistProductsById}
             historyByProductId={isOrdered ? getRowPicklistBackorderHistory(row) : undefined}
           />

--- a/apps/storefront/src/pages/quote/components/QuoteDetailTableCard.tsx
+++ b/apps/storefront/src/pages/quote/components/QuoteDetailTableCard.tsx
@@ -26,7 +26,6 @@ interface QuoteTableCardProps {
   displayDiscount: boolean;
   currency: CurrencyProps | DisplayCurrency;
   showBackorderDetails?: boolean;
-  shouldDisplayBackorderInformation?: boolean;
   picklistProductsById?: Record<number, ProductSearch>;
   historyByProductId?: Record<number, PicklistBackorderHistoryChild>;
 }
@@ -47,7 +46,6 @@ function QuoteDetailTableCard(props: QuoteTableCardProps) {
     currency,
     displayDiscount,
     showBackorderDetails = false,
-    shouldDisplayBackorderInformation = true,
     picklistProductsById = {},
     historyByProductId,
   } = props;
@@ -71,10 +69,7 @@ function QuoteDetailTableCard(props: QuoteTableCardProps) {
   } = quoteTableItem;
 
   const backorderFields = getQuoteBackorderDisplayFields(quoteTableItem);
-  const backorderContextEnabled =
-    isBackorderMessagingContextEnabled &&
-    hasAnyBackorderDisplay &&
-    shouldDisplayBackorderInformation;
+  const backorderContextEnabled = isBackorderMessagingContextEnabled && hasAnyBackorderDisplay;
   const picklistSelections = backorderContextEnabled
     ? getQuotePicklistSelections(quoteTableItem)
     : [];
@@ -165,17 +160,14 @@ function QuoteDetailTableCard(props: QuoteTableCardProps) {
           <Typography variant="body1" color="#616161">
             {notes}
           </Typography>
-          {isBackorderMessagingContextEnabled &&
-            hasAnyBackorderDisplay &&
-            shouldDisplayBackorderInformation &&
-            backorderFields && (
-              <BackorderMessage
-                totalOnHand={backorderFields.totalOnHand}
-                quantityBackordered={backorderFields.quantityBackordered}
-                backorderMessage={backorderFields.backorderMessage}
-                visible={showBackorderDetails}
-              />
-            )}
+          {isBackorderMessagingContextEnabled && hasAnyBackorderDisplay && backorderFields && (
+            <BackorderMessage
+              totalOnHand={backorderFields.totalOnHand}
+              quantityBackordered={backorderFields.quantityBackordered}
+              backorderMessage={backorderFields.backorderMessage}
+              visible={showBackorderDetails}
+            />
+          )}
           {picklistSelections.length > 0 && (
             <PicklistBackorderMessages
               selections={picklistSelections}

--- a/apps/storefront/src/pages/quote/hooks/useQuoteDetailBackorderState.test.ts
+++ b/apps/storefront/src/pages/quote/hooks/useQuoteDetailBackorderState.test.ts
@@ -15,10 +15,6 @@ vi.mock('@/hooks/useBackorderStorefrontMessaging', () => ({
   useBackorderStorefrontMessaging: () => messaging,
 }));
 
-vi.mock('@/hooks/useFeatureFlag', () => ({
-  useFeatureFlag: () => false,
-}));
-
 const picklistModifier = {
   id: 100,
   type: 'product_list',
@@ -120,6 +116,7 @@ describe('useQuoteDetailBackorderState', () => {
     const { result } = renderState([orderedRowWithSnapshotChild], QuoteStatus.ORDERED);
 
     expect(result.result.current.isOrdered).toBe(true);
+    expect(result.result.current.backorderContextEnabled).toBe(true);
     expect(result.result.current.hasBackorderedItems).toBe(true);
     expect(b2bService.searchProducts).not.toHaveBeenCalled();
   });

--- a/apps/storefront/src/pages/quote/hooks/useQuoteDetailBackorderState.ts
+++ b/apps/storefront/src/pages/quote/hooks/useQuoteDetailBackorderState.ts
@@ -1,7 +1,6 @@
 import { useMemo } from 'react';
 
 import { useBackorderStorefrontMessaging } from '@/hooks/useBackorderStorefrontMessaging';
-import { useFeatureFlag } from '@/hooks/useFeatureFlag';
 import { usePicklistInventory } from '@/hooks/usePicklistInventory';
 import { type ProductSearch } from '@/shared/service/b2b/graphql/product';
 import { QuoteStatus } from '@/shared/service/b2b/graphql/quote';
@@ -18,7 +17,6 @@ type QuoteDetailBackorderRow = QuoteBackorderRow & Parameters<typeof getQuotePic
 
 interface QuoteDetailBackorderState {
   isOrdered: boolean;
-  shouldDisplayBackorderInformation: boolean;
   backorderContextEnabled: boolean;
   picklistProductsById: Record<number, ProductSearch>;
   hasBackorderedItems: boolean;
@@ -29,17 +27,10 @@ export function useQuoteDetailBackorderState(
   status: string | number,
 ): QuoteDetailBackorderState {
   const isOrdered = Number(status) === QuoteStatus.ORDERED;
-  const surfaceOrderedQuoteBackorders = useFeatureFlag(
-    'BACK-593.surface_order_backorder_info_on_quotes',
-  );
-  const shouldDisplayBackorderInformation = !isOrdered || surfaceOrderedQuoteBackorders;
 
   const { isBackorderMessagingContextEnabled, hasAnyBackorderDisplay } =
     useBackorderStorefrontMessaging();
-  const backorderContextEnabled =
-    isBackorderMessagingContextEnabled &&
-    hasAnyBackorderDisplay &&
-    shouldDisplayBackorderInformation;
+  const backorderContextEnabled = isBackorderMessagingContextEnabled && hasAnyBackorderDisplay;
 
   // Ordered quotes read picklist-child backorders from the frozen history on each row, so they
   // never fetch live inventory; only submitted quotes resolve children against current stock.
@@ -71,7 +62,6 @@ export function useQuoteDetailBackorderState(
 
   return {
     isOrdered,
-    shouldDisplayBackorderInformation,
     backorderContextEnabled,
     picklistProductsById,
     hasBackorderedItems,

--- a/apps/storefront/src/utils/featureFlags.ts
+++ b/apps/storefront/src/utils/featureFlags.ts
@@ -56,10 +56,6 @@ export const featureFlags = [
     name: 'useTbdPriceOnQuotesList',
   },
   {
-    key: 'BACK-593.surface_order_backorder_info_on_quotes',
-    name: 'surfaceOrderBackorderInfoOnQuotes',
-  },
-  {
     key: 'B2B-4912.buyer_portal_native_link_interception',
     name: 'buyerPortalNativeLinkInterception',
   },


### PR DESCRIPTION
Jira: [BACK-850](https://bigcommercecloud.atlassian.net/browse/BACK-850)

## What/Why?
BACK-593 (`surface_order_backorder_info_on_quotes`) is rolled out to 100%. This removes the flag and makes ordered quote backorder details the default behaviour. This PR will be merged first, and a `b2b-edition-api` cleanup will follow.

## Rollout/Rollback
Merge/revert.

## Testing
Ordered quote backorder details appear as expected.

<img width="1151" height="740" alt="Screenshot 2026-08-19 at 10 19 42 am" src="https://github.com/user-attachments/assets/1490d8ac-06e8-4449-a037-1847e512f364" />

Ping @benpratt77 

[BACK-850]: https://bigcommercecloud.atlassian.net/browse/BACK-850?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Experiment cleanup with behavior aligned to a flag already at 100%; no new auth or data paths, revertible by merge/revert.
> 
> **Overview**
> Removes the rolled-out experiment **`BACK-593.surface_order_backorder_info_on_quotes`** and treats **ordered** quote backorder UI as always on when backorder messaging is enabled.
> 
> The flag entry is dropped from **`featureFlags.ts`**, and **`useQuoteDetailBackorderState`** no longer reads it or exposes **`shouldDisplayBackorderInformation`**. **`backorderContextEnabled`** now depends only on storefront backorder messaging settings, so ordered quotes with backordered lines get the backorder details toggle and line-level messages without a separate flag.
> 
> **`QuoteDetailTable`** and **`QuoteDetailTableCard`** stop passing or gating on **`shouldDisplayBackorderInformation`**. Tests drop the “flag off hides toggle on ordered quotes” case and assert the toggle shows on ordered quotes with the default preloaded state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fcb6a74d2a316ded54e08be0b04eac4907150aa4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->