### PR TITLE
fix(quotes): BACK-852 use order snapshot for backorder qty on ordered quotes

### DIFF
--- a/apps/storefront/src/pages/quote/components/QuoteDetailTable.tsx
+++ b/apps/storefront/src/pages/quote/components/QuoteDetailTable.tsx
@@ -315,7 +315,9 @@ function QuoteDetailTable(props: ShoppingDetailTableProps, ref: Ref<unknown>) {
       key: 'Qty',
       title: b3Lang('quoteDetail.table.qty'),
       render: (row) => {
-        const backorderFields = getQuoteBackorderDisplayFields(row);
+        const backorderFields = getQuoteBackorderDisplayFields(row, {
+          useOrderSnapshot: isOrdered,
+        });
         const picklistSelections = backorderContextEnabled
           ? getPicklistSelectionsFromStoredOptions(row)
           : [];
@@ -477,6 +479,7 @@ function QuoteDetailTable(props: ShoppingDetailTableProps, ref: Ref<unknown>) {
             showBackorderDetails={showBackorderDetails}
             picklistProductsById={picklistProductsById}
             historyByProductId={isOrdered ? getRowPicklistBackorderHistory(row) : undefined}
+            useOrderSnapshot={isOrdered}
           />
         )}
       />

--- a/apps/storefront/src/pages/quote/components/QuoteDetailTableCard.tsx
+++ b/apps/storefront/src/pages/quote/components/QuoteDetailTableCard.tsx
@@ -28,6 +28,7 @@ interface QuoteTableCardProps {
   showBackorderDetails?: boolean;
   picklistProductsById?: Record<number, ProductSearch>;
   historyByProductId?: Record<number, PicklistBackorderHistoryChild>;
+  useOrderSnapshot?: boolean;
 }
 
 const StyledImage = styled('img')(() => ({
@@ -48,6 +49,7 @@ function QuoteDetailTableCard(props: QuoteTableCardProps) {
     showBackorderDetails = false,
     picklistProductsById = {},
     historyByProductId,
+    useOrderSnapshot = false,
   } = props;
   const b3Lang = useB3Lang();
   const enteredInclusiveTax = useAppSelector(
@@ -68,7 +70,7 @@ function QuoteDetailTableCard(props: QuoteTableCardProps) {
     productsSearch: { productUrl, variants = [] },
   } = quoteTableItem;
 
-  const backorderFields = getQuoteBackorderDisplayFields(quoteTableItem);
+  const backorderFields = getQuoteBackorderDisplayFields(quoteTableItem, { useOrderSnapshot });
   const backorderContextEnabled = isBackorderMessagingContextEnabled && hasAnyBackorderDisplay;
   const picklistSelections = backorderContextEnabled
     ? getPicklistSelectionsFromStoredOptions(quoteTableItem)

--- a/apps/storefront/src/pages/quote/hooks/useQuoteDetailBackorderState.ts
+++ b/apps/storefront/src/pages/quote/hooks/useQuoteDetailBackorderState.ts
@@ -50,7 +50,9 @@ export function useQuoteDetailBackorderState(
 
   const hasBackorderedItems = useMemo(
     () =>
-      quoteDetailListHasBackorderedItemsForDisplay(productList) ||
+      quoteDetailListHasBackorderedItemsForDisplay(productList, {
+        useOrderSnapshot: isOrdered,
+      }) ||
       (isOrdered
         ? quoteDetailListHasPicklistBackorderHistory(productList)
         : catalogListHasPicklistBackorderedItemsForDisplay(

--- a/apps/storefront/src/pages/quote/utils/getQuoteBackorderDisplayFields.test.ts
+++ b/apps/storefront/src/pages/quote/utils/getQuoteBackorderDisplayFields.test.ts
@@ -315,6 +315,34 @@ describe('getQuoteBackorderDisplayFields for quote detail rows', () => {
     });
   });
 
+  it('uses the order snapshot when useOrderSnapshot is set', () => {
+    const row = {
+      quantity: 8,
+      variantSku: 'V1',
+      totalOnHand: 5,
+      quantityBackordered: 3,
+      backorderMessage: 'Ships in 2 weeks',
+      productsSearch: {
+        inventoryTracking: 'product',
+        totalOnHand: 0,
+        availableToSell: 7,
+        backorderMessage: 'Live message',
+        unlimitedBackorder: false,
+      },
+    };
+
+    expect(getQuoteBackorderDisplayFields(row)).toEqual({
+      totalOnHand: 5,
+      quantityBackordered: 2,
+      backorderMessage: 'Ships in 2 weeks',
+    });
+    expect(getQuoteBackorderDisplayFields(row, { useOrderSnapshot: true })).toEqual({
+      totalOnHand: 5,
+      quantityBackordered: 3,
+      backorderMessage: 'Ships in 2 weeks',
+    });
+  });
+
   it('prefers API history totalOnHand and backorderMessage over productsSearch values', () => {
     const row = {
       quantity: 10,
@@ -450,6 +478,24 @@ describe('quoteDetailListHasBackorderedItemsForDisplay', () => {
     };
 
     expect(quoteDetailListHasBackorderedItemsForDisplay([row])).toBe(true);
+  });
+
+  it('uses the order snapshot when useOrderSnapshot is set', () => {
+    const row = {
+      quantity: 8,
+      variantSku: 'V1',
+      totalOnHand: 5,
+      quantityBackordered: 3,
+      productsSearch: {
+        inventoryTracking: 'product',
+        availableToSell: 7,
+        unlimitedBackorder: false,
+      },
+    };
+
+    expect(quoteDetailListHasBackorderedItemsForDisplay([row], { useOrderSnapshot: true })).toBe(
+      true,
+    );
   });
 });
 

--- a/apps/storefront/src/pages/quote/utils/getQuoteBackorderDisplayFields.ts
+++ b/apps/storefront/src/pages/quote/utils/getQuoteBackorderDisplayFields.ts
@@ -128,7 +128,12 @@ function getQuoteBackorderDisplayFieldsFromApi(
 
 export function getQuoteBackorderDisplayFields(
   row: QuoteBackorderRow,
+  options?: { useOrderSnapshot?: boolean },
 ): BackorderDisplayFields | null {
+  if (options?.useOrderSnapshot) {
+    return getQuoteBackorderDisplayFieldsFromApi(row);
+  }
+
   const tracking = getQuoteBackorderTracking(row);
   if (!tracking) {
     return getQuoteBackorderDisplayFieldsFromApi(row);
@@ -164,8 +169,9 @@ export function getDraftBackorderDisplayFields(
 
 export function quoteDetailListHasBackorderedItemsForDisplay(
   productList: QuoteBackorderRow[],
+  options?: { useOrderSnapshot?: boolean },
 ): boolean {
-  return productList.some((item) => Boolean(getQuoteBackorderDisplayFields(item)));
+  return productList.some((item) => Boolean(getQuoteBackorderDisplayFields(item, options)));
 }
 
 interface PicklistBackorderHistoryRow {


### PR DESCRIPTION
Jira: [BACK-852](https://bigcommercecloud.atlassian.net/browse/BACK-852)

## What/Why?
Ordered quote detail was recapping “will be backordered” against live ATS after checkout, so that line no longer matched the order. Snapshot on-hand and backordered quantity are used when the quote is ordered, non-ordered quotes still cap against ATS.

## Rollout/Rollback
Merge/revert.

## Testing
Product with `5` on-hand, `10` backorder limit.

<img width="1258" height="206" alt="Screenshot 2026-08-19 at 3 55 38 pm" src="https://github.com/user-attachments/assets/b9bd027e-0826-4f6c-8d64-da9c5833cf36" />

Submit quote for `8` (i.e. `5` on-hand, `3` will be backordered).

<img width="758" height="363" alt="Screenshot 2026-08-19 at 3 56 13 pm" src="https://github.com/user-attachments/assets/be6a46e4-2c55-434f-b017-7c713cd41cf7" />

Submit order, product has `0` on-hand, `10` backorder limit, `3` backordered, so `0 + 10 - 3 = 7` ATS.

<img width="1259" height="203" alt="Screenshot 2026-08-19 at 4 00 10 pm" src="https://github.com/user-attachments/assets/de4758a7-9c38-4405-b87a-176384bf7085" />

### Before
Ordered quote uses live ATS, `7 ATS - 5 on-hand = 2 will be backordered`.

<img width="758" height="363" alt="Screenshot 2026-08-19 at 4 00 53 pm" src="https://github.com/user-attachments/assets/c9c230ae-087c-422e-897e-7e4374ded44b" />

### After
Ordered quote uses order snapshot, displays expected `3 will be backordered`.

<img width="753" height="358" alt="Screenshot 2026-08-19 at 4 01 08 pm" src="https://github.com/user-attachments/assets/80ddd1d4-e183-4397-8bb1-39819d8affc4" />

Ping @benpratt77 @animesh1987 

[BACK-852]: https://bigcommercecloud.atlassian.net/browse/BACK-852?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only backorder messaging on quote detail; no auth, checkout, or inventory mutation. Wrong snapshot wiring could still show incorrect backorder qty on ordered quotes.
> 
> **Overview**
> Stops ordered quote detail from recapping “will be backordered” against **live ATS** after checkout, which made the line no longer match the order.
> 
> When the quote is ordered, `getQuoteBackorderDisplayFields` now takes `useOrderSnapshot` and returns the API snapshot (`totalOnHand`, `quantityBackordered`, message) instead of capping qty against current ATS. Non-ordered quotes still use the live cap. The same flag is passed from quote detail table/card and into `quoteDetailListHasBackorderedItemsForDisplay` so the backorder-details toggle stays consistent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a36f50a017c718a0f44001c404c7e07c35dbe2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->