### PR TITLE
Revert "B2B-5366: guard app init effect against re-entrant runs"

### DIFF
--- a/apps/storefront/src/App.tsx
+++ b/apps/storefront/src/App.tsx
@@ -66,7 +66,6 @@ export default function App() {
   const isClickEnterBtn = useAppSelector(({ global }) => global.isClickEnterBtn);
   const isPageComplete = useAppSelector(({ global }) => global.isPageComplete);
   const isDefaultLoginStyling = useRef(shouldUseDefaultLoginStyling()).current;
-  const hasInitialized = useRef(false);
   const currentClickedUrl = useAppSelector(({ global }) => global.currentClickedUrl);
   const isRegisterAndLogin = useAppSelector(({ global }) => global.isRegisterAndLogin);
   const { quotesCreateActionsPermission, shoppingListCreateActionsPermission } =
@@ -169,11 +168,6 @@ export default function App() {
   useEffect(() => {
     storeDispatch(setOpenPageReducer(setOpenPage));
     loginAndRegister();
-
-    // getCompanyInfo() below can change isB2BUser mid-run and retrigger this effect.
-    if (hasInitialized.current) return;
-    hasInitialized.current = true;
-
     const init = async () => {
       try {
         // Verify BC session is still valid when we have a rehydrated customerId.
@@ -184,8 +178,6 @@ export default function App() {
           if (!isBcLogin) {
             logoutSession();
             showPageMask(false);
-            // didn't actually initialize; let the retriggered run (now a guest) finish it
-            hasInitialized.current = false;
             return;
           }
         }
@@ -265,8 +257,6 @@ export default function App() {
       } catch (e) {
         b2bLogger.error(e);
         showPageMask(false);
-        // didn't actually initialize; let a future dep change retry it
-        hasInitialized.current = false;
         storeDispatch(
           setGlobalCommonState({
             isPageComplete: true,
@@ -280,7 +270,7 @@ export default function App() {
     // due they are functions that do not depend on any reactive value
     // ignore href because is not a reactive value
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [b2bId, customerId, emailAddress, isAgenting, role]);
+  }, [b2bId, customerId, emailAddress, isAgenting, isB2BUser, role]);
 
   useEffect(() => {
     if (quoteConfig.length > 0 && storefrontConfig) {
@@ -321,11 +311,12 @@ export default function App() {
   ]);
 
   useEffect(() => {
-    if (isPageComplete) {
+    if (isOpen) {
       showPageMask(false);
     }
+    // ignore dispatch due it's function that doesn't not depend on any reactive value
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isPageComplete]);
+  }, [isOpen]);
 
   // Remove the pre-mount login mask only once initialization has finished. The
   // mask sits just below the iframe, so keeping it until init completes is


### PR DESCRIPTION
Reverts bigcommerce/b2b-buyer-portal#1005

After PR#1005

https://github.com/user-attachments/assets/066346d6-6e18-418b-80bb-9f0ebebee64f

Expect behaviour

https://github.com/user-attachments/assets/f19a3ad3-ff68-496f-bcb7-1543542d3ea2


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Restores duplicate init work and race-prone behavior when `isB2BUser` or session state changes during bootstrap, which motivated the original guard; mask timing on `isOpen` may reintroduce login flicker the guard was meant to avoid.
> 
> **Overview**
> **Reverts the B2B-5366 change** that used a `hasInitialized` ref to run the main `App` bootstrap `useEffect` only once, including resets on failed BC login or init errors.
> 
> Init again runs whenever its dependency list changes, with **`isB2BUser` added back** so a mid-init flip from `getCompanyInfo()` can trigger a full re-run instead of being skipped.
> 
> The loading mask is again cleared when the **portal iframe opens** (`isOpen`) rather than when `isPageComplete` becomes true; the separate effect that removes the **pre-mount login mask** still waits for `isPageComplete` so the native `login.php` form does not flicker through.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a015690968467f07a45cd16f1290b4c238b5b0b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->