### PR TITLE
fix: B2B-5203 correct forgotPassword redirect on refresh

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -13,7 +13,7 @@
     "clickaway",
     "Enduser",
     "extrafields",
-    "forgotpassword",
+    "forgotPassword",
     "gql.tada",
     "msword",
     "purchasability",

--- a/apps/storefront/src/utils/b3logout.test.ts
+++ b/apps/storefront/src/utils/b3logout.test.ts
@@ -46,8 +46,8 @@ describe('b3logout utilities', () => {
       expect(isB2bTokenPage('/quoteDetail/123')).toBe(false);
     });
 
-    it('returns false for forgotpassword page URL', () => {
-      expect(isB2bTokenPage('/forgotpassword')).toBe(false);
+    it('returns false for forgotPassword page URL', () => {
+      expect(isB2bTokenPage('/forgotPassword')).toBe(false);
     });
 
     it('returns true for B2B token-required pages', () => {
@@ -153,8 +153,8 @@ describe('b3logout utilities', () => {
         expect(store.dispatch).not.toHaveBeenCalled();
       });
 
-      it('returns false for forgotpassword page and does not call logoutSession', async () => {
-        const result = await isUserGotoLogin('/forgotpassword');
+      it('returns false for forgotPassword page and does not call logoutSession', async () => {
+        const result = await isUserGotoLogin('/forgotPassword');
 
         expect(result).toBe(false);
         expect(store.dispatch).not.toHaveBeenCalled();

--- a/apps/storefront/src/utils/b3logout.ts
+++ b/apps/storefront/src/utils/b3logout.ts
@@ -3,7 +3,7 @@ import b2bLogger from './b3Logger';
 import { logoutSession } from './logoutSession';
 
 export const isB2bTokenPage = (gotoUrl?: string) => {
-  const noB2bTokenPages = ['quoteDraft', 'quoteDetail', 'register', 'login', 'forgotpassword'];
+  const noB2bTokenPages = ['quoteDraft', 'quoteDetail', 'register', 'login', 'forgotPassword'];
 
   if (gotoUrl) {
     return !noB2bTokenPages.some((item: string) => gotoUrl.includes(item));


### PR DESCRIPTION
Jira: [B2B-5203](https://bigcommercecloud.atlassian.net/browse/B2B-5203)

## What/Why?

The Forgot Password page (`/#/forgotPassword`) incorrectly redirects to `/login` on every browser refresh.

The `noB2bTokenPages` allowlist in `isB2bTokenPage()` used `'forgotpassword'` (all lowercase), but the actual route is `/forgotPassword` (camelCase). Since `String.includes()` is case-sensitive, the match always failed, causing the page to be treated as a B2B-token-required page and triggering a redirect.

This fix corrects the casing to `'forgotPassword'` and updates the corresponding test assertions and cspell dictionary entry.

Based on the work from https://github.com/bigcommerce/b2b-buyer-portal/pull/805.

## Rollout/Rollback

Revert this PR if there are issues. No feature flags or migrations involved.

## Testing

- Updated unit tests pass (`vitest run src/utils/b3logout.test.ts` — 22 tests passing).
- Manual testing: navigate to `/#/forgotPassword` and refresh the browser — should stay on the page instead of redirecting to `/login`.


https://github.com/user-attachments/assets/b6b21c8e-3403-4535-a3d5-d125c65336ff


[B2B-5203]: https://bigcommercecloud.atlassian.net/browse/B2B-5203?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tiny casing fix in a public-page allowlist; no auth logic or data handling changes.
> 
> **Overview**
> Fixes Forgot Password refresh redirecting to login. `isB2bTokenPage` treated `/forgotPassword` as a token-required page because the allowlist used lowercase `forgotpassword`, and `includes()` is case-sensitive.
> 
> Updates `noB2bTokenPages` to `forgotPassword`, plus matching tests and the cspell dictionary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2255cb2af902a4be95861c077f0a2efb43decba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->