### PR TITLE
LOCAL-3505: Preserve locale path on logo/home/close navigation

### DIFF
--- a/apps/storefront/src/components/RegisteredCloseButton.tsx
+++ b/apps/storefront/src/components/RegisteredCloseButton.tsx
@@ -2,8 +2,10 @@ import { useContext } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Box } from '@mui/material';
 
+import { getHomeUrl } from '@/lib/lang/getHomeUrl';
 import { type SetOpenPage } from '@/pages/SetOpenPage';
 import { GlobalContext } from '@/shared/global';
+import { useAppSelector } from '@/store';
 
 import { CloseButton } from './styled';
 
@@ -14,6 +16,8 @@ interface CloseButtonProps {
 export default function RegisteredCloseButton(props: CloseButtonProps) {
   const { setOpenPage } = props;
 
+  const locales = useAppSelector(({ global }) => global.locales);
+
   const {
     state: { isCloseGotoBCHome },
   } = useContext(GlobalContext);
@@ -22,7 +26,7 @@ export default function RegisteredCloseButton(props: CloseButtonProps) {
   const handleCloseForm = () => {
     const isInLoginPage = window.location.hash.startsWith('#/login');
     if (isCloseGotoBCHome || isInLoginPage) {
-      window.location.href = '/';
+      window.location.href = getHomeUrl(locales);
     } else {
       navigate('/');
       setOpenPage({

--- a/apps/storefront/src/components/layout/B3CloseAppButton.tsx
+++ b/apps/storefront/src/components/layout/B3CloseAppButton.tsx
@@ -2,6 +2,7 @@ import { useContext } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import { useMobile } from '@/hooks/useMobile';
+import { getHomeUrl } from '@/lib/lang/getHomeUrl';
 import { GlobalContext } from '@/shared/global';
 import { useAppSelector } from '@/store';
 
@@ -11,6 +12,7 @@ export default function B3CloseAppButton() {
   const [isMobile] = useMobile();
 
   const setOpenPageFn = useAppSelector(({ global }) => global.setOpenPageFn);
+  const locales = useAppSelector(({ global }) => global.locales);
 
   const {
     state: { isCloseGotoBCHome },
@@ -19,7 +21,7 @@ export default function B3CloseAppButton() {
 
   const handleCloseForm = () => {
     if (isCloseGotoBCHome || window.location.search.includes('action=order_status')) {
-      window.location.href = '/';
+      window.location.href = getHomeUrl(locales);
     } else {
       navigate('/');
       setOpenPageFn?.({

--- a/apps/storefront/src/components/layout/B3Logo.tsx
+++ b/apps/storefront/src/components/layout/B3Logo.tsx
@@ -2,7 +2,9 @@ import { useContext } from 'react';
 import { Box, ImageListItem } from '@mui/material';
 
 import { useMobile } from '@/hooks/useMobile';
+import { getHomeUrl } from '@/lib/lang/getHomeUrl';
 import { GlobalContext } from '@/shared/global';
+import { useAppSelector } from '@/store';
 
 export default function B3Logo() {
   const {
@@ -10,6 +12,7 @@ export default function B3Logo() {
   } = useContext(GlobalContext);
 
   const [isMobile] = useMobile();
+  const locales = useAppSelector(({ global }) => global.locales);
 
   return (
     <Box
@@ -52,7 +55,7 @@ export default function B3Logo() {
             },
           }}
           onClick={() => {
-            window.location.href = '/';
+            window.location.href = getHomeUrl(locales);
           }}
         >
           <img src={logo} alt="logo" />

--- a/apps/storefront/src/components/layout/B3MainHeader.tsx
+++ b/apps/storefront/src/components/layout/B3MainHeader.tsx
@@ -6,6 +6,7 @@ import { CART_URL } from '@/constants';
 import { dispatchEvent } from '@/hooks/useB2BCallback';
 import { useMobile } from '@/hooks/useMobile';
 import { useB3Lang } from '@/lib/lang';
+import { getHomeUrl } from '@/lib/lang/getHomeUrl';
 import { CustomStyleContext } from '@/shared/customStyleButton';
 import { isB2BUserSelector, rolePermissionSelector, useAppSelector } from '@/store';
 import b3TriggerCartNumber from '@/utils/b3TriggerCartNumber';
@@ -25,6 +26,7 @@ export default function MainHeader({ title }: { title: string }) {
     ({ b2bFeatures }) => b2bFeatures.masqueradeCompany.companyName,
   );
   const cartNumber = useAppSelector(({ global }) => global.cartNumber);
+  const locales = useAppSelector(({ global }) => global.locales);
   const navigate = useNavigate();
   const b3Lang = useB3Lang();
   const [isMobile] = useMobile();
@@ -121,7 +123,7 @@ export default function MainHeader({ title }: { title: string }) {
                 fontSize: '16px',
               }}
               onClick={() => {
-                window.location.href = '/';
+                window.location.href = getHomeUrl(locales);
               }}
             >
               {b3Lang('global.B3MainHeader.home')}

--- a/apps/storefront/src/lib/lang/getHomeUrl.test.ts
+++ b/apps/storefront/src/lib/lang/getHomeUrl.test.ts
@@ -1,0 +1,44 @@
+import { getHomeUrl } from './getHomeUrl';
+
+const LOCALES = [
+  { code: 'fr', isDefault: true, fullPath: 'https://store.example.com/' },
+  { code: 'fr-CA', isDefault: false, fullPath: 'https://store.example.com/fr-ca' },
+  { code: 'en', isDefault: false, fullPath: 'https://store.example.com/en' },
+];
+
+const setHref = (href: string) => {
+  Object.defineProperty(window, 'location', {
+    value: { href },
+    writable: true,
+  });
+};
+
+describe('getHomeUrl', () => {
+  const originalLocation = window.location;
+
+  afterEach(() => {
+    Object.defineProperty(window, 'location', { value: originalLocation, writable: true });
+  });
+
+  it('returns the fullPath of the active locale', () => {
+    setHref('https://store.example.com/fr-ca/orders');
+    expect(getHomeUrl(LOCALES)).toBe('https://store.example.com/fr-ca');
+  });
+
+  it('falls back to the default locale when no locale matches the current URL', () => {
+    setHref('https://other-store.example.com/orders');
+    expect(getHomeUrl(LOCALES)).toBe('https://store.example.com/');
+  });
+
+  it('returns "/" when there are no locales', () => {
+    setHref('https://store.example.com/orders');
+    expect(getHomeUrl([])).toBe('/');
+  });
+
+  it('returns "/" when neither an active nor a default locale is available', () => {
+    setHref('https://other-store.example.com/orders');
+    expect(
+      getHomeUrl([{ code: 'en', isDefault: false, fullPath: 'https://store.example.com/en' }]),
+    ).toBe('/');
+  });
+});

--- a/apps/storefront/src/lib/lang/getHomeUrl.ts
+++ b/apps/storefront/src/lib/lang/getHomeUrl.ts
@@ -1,0 +1,8 @@
+import type { Locales } from '@/store/slices/global';
+
+import { getActiveLocale } from './getActiveLocale';
+
+export const getHomeUrl = (locales: Locales): string => {
+  const activeLocale = getActiveLocale(locales) ?? locales.find((locale) => locale.isDefault);
+  return activeLocale?.fullPath || '/';
+};


### PR DESCRIPTION
Jira: [LOCAL-3505](https://bigcommercecloud.atlassian.net/browse/LOCAL-3505)

## What/Why?
On a channel with multiple active locales (e.g. `en` + `fr`), clicking Close (X) correctly kept the user on `{channel-domain}/fr`, but clicking the logo or the Home button dropped back to `{channel-domain}` and lost the locale.
Use locale Full url (if available) and always navigate to domain + subfolder. In some cases subfolder may be empty. For example example.com/ - connected to en locale. 

## Rollout/Rollback
Standard deploy, no feature flag or experiment involved. Pure client-side navigation fix, no backend/data changes. Rollback is a straight revert.

## Testing

Manual testing

https://github.com/user-attachments/assets/473ed921-d3e0-4eb7-ba9b-b6a64567f73e



[LOCAL-3505]: https://bigcommercecloud.atlassian.net/browse/LOCAL-3505?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Related PRs

Part of the Buyer Portal product localization work (LOCAL-3421 / LOCAL-3505). Suggested merge order:

1. **b2b-edition-api [#7175](https://github.com/bigcommerce/b2b-edition-api/pull/7175)** — forwards the buyer locale into the Storefront GraphQL relevance search so `productsSearch` returns translated product names and paths.
2. **b2b-buyer-portal [#1014](https://github.com/bigcommerce/b2b-buyer-portal/pull/1014)** (this PR) — keeps the active locale subfolder on logo, Home and Close navigation. Independent of the other two, so it can land in any order.
3. **functional-tests [#3278](https://github.com/bigcommerce/functional-tests/pull/3278)** — permanent-store coverage for the translated Quick order product search. Land after #7175 reaches integration.

Also open on the same epic: b2b-buyer-portal [#1015](https://github.com/bigcommerce/b2b-buyer-portal/pull/1015) is an alternative client-side implementation of the product name translation covered by #7175, so those two should not both be merged. b2b-buyer-portal [#1012](https://github.com/bigcommerce/b2b-buyer-portal/pull/1012) is superseded and can be closed.
