### PR TITLE
LOCAL-3505: Show product search results in the shopper's language

### DIFF
--- a/apps/storefront/src/shared/service/b2b/graphql/localizedProductSearch.test.ts
+++ b/apps/storefront/src/shared/service/b2b/graphql/localizedProductSearch.test.ts
@@ -1,0 +1,278 @@
+import { builder, faker, graphql, HttpResponse, startMockServer } from 'tests/test-utils';
+
+import { store } from '@/store';
+
+import { LocalizableProduct, localizeProductSearchResults } from './localizedProductSearch';
+
+const { server } = startMockServer();
+
+const buildLocalizableProductWith = builder<LocalizableProduct>(() => ({
+  id: faker.number.int(),
+  name: faker.commerce.productName(),
+  productUrl: `/${faker.lorem.slug()}/`,
+}));
+
+interface LocalizedOption {
+  entityId: number;
+  displayName: string;
+  values: Array<{ entityId: number; label: string }>;
+}
+
+const buildLocalizedProductNodeWith = builder(() => ({
+  entityId: faker.number.int(),
+  name: faker.commerce.productName(),
+  path: `/${faker.lorem.slug()}/`,
+  options: [] as LocalizedOption[],
+}));
+
+const buildLocalizedProductsResponseWith = (
+  nodes: ReturnType<typeof buildLocalizedProductNodeWith>[],
+) => ({
+  data: {
+    site: {
+      products: {
+        edges: nodes.map(({ options, ...product }) => ({
+          node: {
+            ...product,
+            productOptions: {
+              edges: options.map(({ values, ...option }) => ({
+                node: {
+                  ...option,
+                  values: { edges: values.map((value) => ({ node: value })) },
+                },
+              })),
+            },
+          },
+        })),
+      },
+    },
+  },
+});
+
+const LOCALES = [
+  { code: 'en', isDefault: true, fullPath: 'https://store.example.com/' },
+  { code: 'fr', isDefault: false, fullPath: 'https://store.example.com/fr' },
+];
+
+const stubStoreState = (locales = LOCALES) =>
+  vi.spyOn(store, 'getState').mockReturnValue({
+    global: { locales, featureFlags: { 'LOCAL-3280.B2B_email_multi_language': true } },
+    company: { tokens: { bcGraphqlToken: 'bc-graphql-token' } },
+  } as unknown as ReturnType<typeof store.getState>);
+
+const setHref = (href: string) => {
+  Object.defineProperty(window, 'location', { value: { href }, writable: true });
+};
+
+describe('localizeProductSearchResults', () => {
+  const originalLocation = window.location;
+
+  afterEach(() => {
+    Object.defineProperty(window, 'location', { value: originalLocation, writable: true });
+  });
+
+  describe('when the shopper is browsing a non-default locale', () => {
+    beforeEach(() => {
+      setHref('https://store.example.com/fr/');
+      stubStoreState();
+    });
+
+    it('replaces the product name with the translation from the storefront API', async () => {
+      const product = buildLocalizableProductWith({ id: 123, name: 'Chair' });
+
+      server.use(
+        graphql.query('LocalizedProducts', () =>
+          HttpResponse.json(
+            buildLocalizedProductsResponseWith([
+              buildLocalizedProductNodeWith({ entityId: 123, name: 'Chaise' }),
+            ]),
+          ),
+        ),
+      );
+
+      const [localized] = await localizeProductSearchResults([product]);
+
+      expect(localized.name).toBe('Chaise');
+    });
+
+    it('prefixes the translated product path with the locale subfolder', async () => {
+      const product = buildLocalizableProductWith({ id: 123, productUrl: '/chair/' });
+
+      server.use(
+        graphql.query('LocalizedProducts', () =>
+          HttpResponse.json(
+            buildLocalizedProductsResponseWith([
+              buildLocalizedProductNodeWith({ entityId: 123, path: '/chaise/' }),
+            ]),
+          ),
+        ),
+      );
+
+      const [localized] = await localizeProductSearchResults([product]);
+
+      expect(localized.productUrl).toBe('/fr/chaise/');
+    });
+
+    it('translates option names and option value labels shown to the shopper', async () => {
+      const product = buildLocalizableProductWith({
+        id: 123,
+        options: [{ option_id: 7, display_name: 'Colour' }],
+        optionsV3: [
+          {
+            id: 7,
+            display_name: 'Colour',
+            option_values: [{ id: 71, label: 'Red' }],
+          },
+        ],
+        variants: [
+          {
+            option_values: [{ id: 71, label: 'Red', option_id: 7, option_display_name: 'Colour' }],
+          },
+        ],
+      });
+
+      server.use(
+        graphql.query('LocalizedProducts', () =>
+          HttpResponse.json(
+            buildLocalizedProductsResponseWith([
+              buildLocalizedProductNodeWith({
+                entityId: 123,
+                options: [
+                  {
+                    entityId: 7,
+                    displayName: 'Couleur',
+                    values: [{ entityId: 71, label: 'Rouge' }],
+                  },
+                ],
+              }),
+            ]),
+          ),
+        ),
+      );
+
+      const [localized] = await localizeProductSearchResults([product]);
+
+      expect(localized.options).toEqual([{ option_id: 7, display_name: 'Couleur' }]);
+      expect(localized.optionsV3).toEqual([
+        { id: 7, display_name: 'Couleur', option_values: [{ id: 71, label: 'Rouge' }] },
+      ]);
+      expect(localized.variants).toEqual([
+        {
+          option_values: [{ id: 71, label: 'Rouge', option_id: 7, option_display_name: 'Couleur' }],
+        },
+      ]);
+    });
+
+    it('translates modifier names and labels', async () => {
+      const product = buildLocalizableProductWith({
+        id: 123,
+        modifiers: [
+          {
+            id: 9,
+            type: 'dropdown',
+            display_name: 'Engraving',
+            option_values: [{ id: 91, label: 'None' }],
+          },
+        ],
+      });
+
+      server.use(
+        graphql.query('LocalizedProducts', () =>
+          HttpResponse.json(
+            buildLocalizedProductsResponseWith([
+              buildLocalizedProductNodeWith({
+                entityId: 123,
+                options: [
+                  {
+                    entityId: 9,
+                    displayName: 'Gravure',
+                    values: [{ entityId: 91, label: 'Aucune' }],
+                  },
+                ],
+              }),
+            ]),
+          ),
+        ),
+      );
+
+      const [localized] = await localizeProductSearchResults([product]);
+
+      expect(localized.modifiers).toEqual([
+        {
+          id: 9,
+          type: 'dropdown',
+          display_name: 'Gravure',
+          option_values: [{ id: 91, label: 'Aucune' }],
+        },
+      ]);
+    });
+
+    it('keeps the original text for products the storefront API does not return', async () => {
+      const product = buildLocalizableProductWith({ id: 123, name: 'Chair' });
+
+      server.use(
+        graphql.query('LocalizedProducts', () =>
+          HttpResponse.json(buildLocalizedProductsResponseWith([])),
+        ),
+      );
+
+      const [localized] = await localizeProductSearchResults([product]);
+
+      expect(localized).toEqual(product);
+    });
+
+    it('keeps the original text when the storefront API request fails', async () => {
+      const product = buildLocalizableProductWith({ id: 123, name: 'Chair' });
+
+      server.use(graphql.query('LocalizedProducts', () => HttpResponse.json({}, { status: 500 })));
+
+      const [localized] = await localizeProductSearchResults([product]);
+
+      expect(localized).toEqual(product);
+    });
+
+    it('requests products in batches of 50 to stay within the storefront API page size', async () => {
+      const products = Array.from({ length: 51 }, (_, index) =>
+        buildLocalizableProductWith({ id: index + 1 }),
+      );
+      const requestedBatches: number[][] = [];
+
+      server.use(
+        graphql.query('LocalizedProducts', ({ variables }) => {
+          requestedBatches.push(variables.entityIds);
+
+          return HttpResponse.json(buildLocalizedProductsResponseWith([]));
+        }),
+      );
+
+      await localizeProductSearchResults(products);
+
+      expect(requestedBatches.map((batch) => batch.length).sort((a, b) => b - a)).toEqual([50, 1]);
+    });
+  });
+
+  describe('when there is nothing to translate', () => {
+    it('returns the products untouched on the default locale', async () => {
+      setHref('https://store.example.com/');
+      stubStoreState();
+      const product = buildLocalizableProductWith({ id: 123, name: 'Chair' });
+
+      const [localized] = await localizeProductSearchResults([product]);
+
+      expect(localized).toEqual(product);
+    });
+
+    it('returns the products untouched when multi-language is disabled', async () => {
+      setHref('https://store.example.com/fr/');
+      vi.spyOn(store, 'getState').mockReturnValue({
+        global: { locales: LOCALES, featureFlags: {} },
+        company: { tokens: { bcGraphqlToken: 'bc-graphql-token' } },
+      } as unknown as ReturnType<typeof store.getState>);
+      const product = buildLocalizableProductWith({ id: 123, name: 'Chair' });
+
+      const [localized] = await localizeProductSearchResults([product]);
+
+      expect(localized).toEqual(product);
+    });
+  });
+});

--- a/apps/storefront/src/shared/service/b2b/graphql/localizedProductSearch.ts
+++ b/apps/storefront/src/shared/service/b2b/graphql/localizedProductSearch.ts
@@ -1,0 +1,179 @@
+import { getActiveLocale } from '@/lib/lang/getActiveLocale';
+import { getStorefrontLanguageCode } from '@/lib/lang/getStorefrontLanguageCode';
+import { store } from '@/store';
+import b2bLogger from '@/utils/b3Logger';
+
+import { getLocalizedProducts, LocalizedProduct } from '../../bc/graphql/product';
+
+interface OptionValue {
+  id: number;
+  label: string;
+}
+
+interface VariantOptionValue extends OptionValue {
+  option_id: number;
+  option_display_name: string;
+}
+
+/**
+ * The localizable subset of a `productsSearch` result. Everything else (pricing, inventory,
+ * backorder data) stays as returned by B2B GraphQL.
+ */
+export interface LocalizableProduct {
+  id: number;
+  name: string;
+  productUrl: string;
+  options?: Array<{ option_id: number; display_name: string }>;
+  optionsV3?: Array<{ id: number; display_name: string; option_values: OptionValue[] }>;
+  modifiers?: unknown[];
+  variants?: Array<{ option_values: VariantOptionValue[] }>;
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null;
+
+/**
+ * The active locale, or `undefined` when there is nothing to localize — multi-language is disabled,
+ * or the shopper is browsing the store's default language, which is what B2B GraphQL already returns.
+ */
+const getLocaleToLocalize = () => {
+  if (!getStorefrontLanguageCode()) {
+    return undefined;
+  }
+
+  const activeLocale = getActiveLocale(store.getState().global.locales);
+
+  return activeLocale && !activeLocale.isDefault ? activeLocale : undefined;
+};
+
+/**
+ * Storefront GraphQL returns `path` without the locale subfolder, so the subfolder of the active
+ * locale is re-applied to keep product links inside the shopper's language.
+ */
+const withLocaleSubfolder = (path: string, localeFullPath: string) => {
+  let subfolder: string;
+
+  try {
+    subfolder = new URL(localeFullPath).pathname;
+  } catch {
+    return path;
+  }
+
+  if (subfolder === '/' || path.startsWith(subfolder)) {
+    return path;
+  }
+
+  return `${subfolder.replace(/\/$/, '')}${path}`;
+};
+
+const localizeOptionsV3 = (
+  optionsV3: LocalizableProduct['optionsV3'],
+  optionNames: Map<number, string>,
+  optionValueLabels: Map<number, string>,
+) =>
+  optionsV3?.map((option) => ({
+    ...option,
+    display_name: optionNames.get(option.id) ?? option.display_name,
+    option_values: option.option_values?.map((value) => ({
+      ...value,
+      label: optionValueLabels.get(value.id) ?? value.label,
+    })),
+  }));
+
+/**
+ * Modifiers share the shape of `optionsV3`, but are typed as `unknown[]` by the search response, so
+ * each entry is localized defensively.
+ */
+const localizeModifiers = (
+  modifiers: unknown[] | undefined,
+  optionNames: Map<number, string>,
+  optionValueLabels: Map<number, string>,
+) =>
+  modifiers?.map((modifier) => {
+    if (!isRecord(modifier) || typeof modifier.id !== 'number') {
+      return modifier;
+    }
+
+    const displayName = optionNames.get(modifier.id);
+    const optionValues = Array.isArray(modifier.option_values)
+      ? modifier.option_values.map((value: unknown) => {
+          if (!isRecord(value) || typeof value.id !== 'number') {
+            return value;
+          }
+
+          return { ...value, label: optionValueLabels.get(value.id) ?? value.label };
+        })
+      : modifier.option_values;
+
+    return {
+      ...modifier,
+      display_name: displayName ?? modifier.display_name,
+      option_values: optionValues,
+    };
+  });
+
+const localizeProduct = <T extends LocalizableProduct>(
+  product: T,
+  localized: LocalizedProduct,
+  localeFullPath: string,
+): T => {
+  const optionNames = new Map<number, string>();
+  const optionValueLabels = new Map<number, string>();
+
+  localized.options.forEach((option) => {
+    optionNames.set(option.entityId, option.displayName);
+    option.values.forEach((value) => optionValueLabels.set(value.entityId, value.label));
+  });
+
+  return {
+    ...product,
+    name: localized.name || product.name,
+    productUrl: localized.path
+      ? withLocaleSubfolder(localized.path, localeFullPath)
+      : product.productUrl,
+    options: product.options?.map((option) => ({
+      ...option,
+      display_name: optionNames.get(option.option_id) ?? option.display_name,
+    })),
+    optionsV3: localizeOptionsV3(product.optionsV3, optionNames, optionValueLabels),
+    modifiers: localizeModifiers(product.modifiers, optionNames, optionValueLabels),
+    variants: product.variants?.map((variant) => ({
+      ...variant,
+      option_values: variant.option_values?.map((value) => ({
+        ...value,
+        label: optionValueLabels.get(value.id) ?? value.label,
+        option_display_name: optionNames.get(value.option_id) ?? value.option_display_name,
+      })),
+    })),
+  };
+};
+
+/**
+ * Replaces the translatable text of B2B `productsSearch` results with the shopper's language, which
+ * only the storefront GraphQL API resolves. Commerce data is left untouched, and any failure falls
+ * back to the untranslated results rather than breaking product search.
+ */
+export const localizeProductSearchResults = async <T extends LocalizableProduct>(
+  products: T[],
+): Promise<T[]> => {
+  const locale = getLocaleToLocalize();
+
+  if (!locale || products.length === 0) {
+    return products;
+  }
+
+  try {
+    const localizedProducts = await getLocalizedProducts(products.map(({ id }) => Number(id)));
+    const localizedById = new Map(localizedProducts.map((product) => [product.entityId, product]));
+
+    return products.map((product) => {
+      const localized = localizedById.get(Number(product.id));
+
+      return localized ? localizeProduct(product, localized, locale.fullPath) : product;
+    });
+  } catch (error) {
+    b2bLogger.error(error);
+
+    return products;
+  }
+};

--- a/apps/storefront/src/shared/service/b2b/graphql/product.ts
+++ b/apps/storefront/src/shared/service/b2b/graphql/product.ts
@@ -5,6 +5,8 @@ import { convertArrayToGraphql } from '@/utils/graphqlDataConvert';
 
 import B3Request from '../../request/b3Fetch';
 
+import { localizeProductSearchResults } from './localizedProductSearch';
+
 interface ProductPurchasable {
   productId: number;
   isProduct: boolean;
@@ -484,7 +486,22 @@ interface ValidateProductsResponse {
   };
 }
 
-export const searchProducts = (data: CustomFieldItems = {}) => {
+/**
+ * Product names, URLs and option labels come back from B2B GraphQL in the store's default language,
+ * so they are replaced with the shopper's language from the storefront GraphQL API. This is a no-op
+ * on the default locale and when multi-language is disabled.
+ */
+const withLocalizedText = async (response: CustomFieldItems) => {
+  const products = response?.productsSearch;
+
+  if (!Array.isArray(products)) {
+    return response;
+  }
+
+  return { ...response, productsSearch: await localizeProductSearchResults(products) };
+};
+
+export const searchProducts = async (data: CustomFieldItems = {}) => {
   const { currency_code: currencyCode } = getActiveCurrencyInfo();
 
   const { featureFlags } = store.getState().global;
@@ -495,7 +512,7 @@ export const searchProducts = (data: CustomFieldItems = {}) => {
     featureFlags['B2B-3705.increase_graphql_limits_inline_with_platform_api'];
 
   if (separateQueryAndVariablesForProductSearches) {
-    return B3Request.graphqlB2B({
+    const response = await B3Request.graphqlB2B({
       query: getSearchProductsQuery(data, true),
       variables: {
         search: data?.search || '',
@@ -513,8 +530,11 @@ export const searchProducts = (data: CustomFieldItems = {}) => {
         ...(data?.categoryFilter ? { categoryFilter: data?.categoryFilter } : {}),
       },
     });
+
+    return withLocalizedText(response);
   }
-  return B3Request.graphqlB2B({
+
+  const response = await B3Request.graphqlB2B({
     query: getSearchProductsQuery(
       {
         ...data,
@@ -523,6 +543,8 @@ export const searchProducts = (data: CustomFieldItems = {}) => {
       false,
     ),
   });
+
+  return withLocalizedText(response);
 };
 
 export type ValidationTarget = 'QUOTE' | 'CART';

--- a/apps/storefront/src/shared/service/bc/graphql/product.ts
+++ b/apps/storefront/src/shared/service/bc/graphql/product.ts
@@ -1,0 +1,138 @@
+import { storefrontGQLRequest } from './client';
+
+/**
+ * `site.products` is capped server-side at 50 products per page, so product ids are requested in
+ * batches of this size.
+ */
+const PRODUCTS_PER_REQUEST = 50;
+
+/**
+ * Options and option values are requested with an explicit page size, as the connections default to
+ * a smaller server-side limit.
+ */
+const OPTIONS_PER_PRODUCT = 50;
+
+interface LocalizedProductOptionNode {
+  entityId: number;
+  displayName: string;
+  // `values` only exists on MultipleChoiceOption; field type options (text, date, file, ...) have no
+  // values to localize.
+  values?: {
+    edges: Array<{ node: { entityId: number; label: string } }> | null;
+  } | null;
+}
+
+interface LocalizedProductsResponse {
+  data: {
+    site: {
+      products: {
+        edges: Array<{
+          node: {
+            entityId: number;
+            name: string;
+            path: string;
+            productOptions: {
+              edges: Array<{ node: LocalizedProductOptionNode }> | null;
+            };
+          };
+        }> | null;
+      };
+    };
+  };
+}
+
+export interface LocalizedProductOption {
+  entityId: number;
+  displayName: string;
+  values: Array<{ entityId: number; label: string }>;
+}
+
+export interface LocalizedProduct {
+  entityId: number;
+  name: string;
+  path: string;
+  options: LocalizedProductOption[];
+}
+
+const getLocalizedProductsQuery = `
+query LocalizedProducts($entityIds: [Int!]!, $first: Int!, $optionsFirst: Int!) {
+  site {
+    products(entityIds: $entityIds, first: $first) {
+      edges {
+        node {
+          entityId
+          name
+          path
+          productOptions(first: $optionsFirst) {
+            edges {
+              node {
+                entityId
+                displayName
+                ... on MultipleChoiceOption {
+                  values(first: $optionsFirst) {
+                    edges {
+                      node {
+                        entityId
+                        label
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}`;
+
+const toLocalizedProducts = (response: LocalizedProductsResponse): LocalizedProduct[] =>
+  (response?.data?.site?.products?.edges ?? []).map(({ node }) => ({
+    entityId: node.entityId,
+    name: node.name,
+    path: node.path,
+    options: (node.productOptions?.edges ?? []).map(({ node: option }) => ({
+      entityId: option.entityId,
+      displayName: option.displayName,
+      values: (option.values?.edges ?? []).map(({ node: value }) => value),
+    })),
+  }));
+
+const chunk = <T>(items: T[], size: number): T[][] => {
+  const chunks: T[][] = [];
+
+  for (let index = 0; index < items.length; index += size) {
+    chunks.push(items.slice(index, index + size));
+  }
+
+  return chunks;
+};
+
+/**
+ * Fetches product names, URL paths and option labels from the storefront GraphQL API, which resolves
+ * catalog translations for the shopper's active locale. B2B GraphQL returns this text in the store's
+ * default language only.
+ */
+export const getLocalizedProducts = async (productIds: number[]): Promise<LocalizedProduct[]> => {
+  const uniqueIds = Array.from(new Set(productIds));
+
+  if (uniqueIds.length === 0) {
+    return [];
+  }
+
+  const responses = await Promise.all(
+    chunk(uniqueIds, PRODUCTS_PER_REQUEST).map((entityIds) =>
+      storefrontGQLRequest<LocalizedProductsResponse>({
+        query: getLocalizedProductsQuery,
+        variables: {
+          entityIds,
+          first: entityIds.length,
+          optionsFirst: OPTIONS_PER_PRODUCT,
+        },
+      }),
+    ),
+  );
+
+  return responses.flatMap(toLocalizedProducts);
+};

--- a/apps/storefront/src/shared/service/bc/index.ts
+++ b/apps/storefront/src/shared/service/bc/index.ts
@@ -1,6 +1,7 @@
 export * from './api/login';
 export { default as getActiveBcCurrency } from './graphql/currency';
 export { default as getLocales } from './graphql/locales';
+export * from './graphql/product';
 export * from './graphql/login';
 export * from './graphql/company';
 export * from './graphql/user';

--- a/apps/storefront/src/shared/service/request/b3Fetch.ts
+++ b/apps/storefront/src/shared/service/request/b3Fetch.ts
@@ -169,8 +169,9 @@ const B3Request = {
    */
   graphqlBCProxy: function post<T = any>(data: GQLRequest): Promise<T> {
     const { B2BToken } = store.getState().company.tokens;
+    const locale = getStorefrontLanguageCode();
 
-    const config = B2BToken
+    const config: Record<string, string | number> = B2BToken
       ? {
           Authorization: `Bearer  ${B2BToken}`,
         }
@@ -178,6 +179,10 @@ const B3Request = {
           'Store-Hash': storeHash,
           'BC-Channel-Id': channelId,
         };
+
+    if (locale) {
+      config['Accept-Language'] = locale;
+    }
 
     return graphqlRequest(RequestType.BCProxyGraphql, data, config);
   },


### PR DESCRIPTION
Jira: [LOCAL-3505](https://bigcommercecloud.atlassian.net/browse/LOCAL-3505)

## What/Why?

B2B GraphQL `productsSearch` returns product names, URL paths and option labels in the store's default language, so shoppers on a translated storefront see untranslated text in quick order, shopping lists and quotes. The storefront GraphQL API does resolve catalog translations (`ProductTranslationService` in the storefront service keys off the locale subfolder, falling back to `Accept-Language`), and `graphqlBC` already sends that header.

This enriches `productsSearch` results with the translated text instead of moving product search onto storefront GraphQL wholesale. A full swap is not viable: storefront GraphQL has no `costPrice`, product-level `backorderMessage` or `taxClassId`; its prices come from the shopper session (`gqlReq.shopper.customerGroupIdMaybe`), so `companyId`/`customerGroupId` pricing cannot be requested and masquerading reps would get their own group's prices; and `options`/`variants` are Relay connections with a different shape from the REST v3 payloads this app renders.

Notes for review:

- The merge is keyed by product id, so it uses `site.products(entityIds:)`, not `site.search.searchProducts`, which has no `entityIds` filter. Ids are batched at 50 to match `MaxLimitForProducts` in the storefront service.
- Only translatable text is replaced: `name`, `productUrl`, `options[].display_name`, `optionsV3[].display_name` and its `option_values[].label`, `modifiers[]` names and labels, and `variants[].option_values[]` labels. Pricing, inventory and backorder fields are untouched.
- Storefront GraphQL `path` has no locale subfolder, so the active locale's subfolder is re-applied to keep product links in the shopper's language.
- `modifiers` is typed `unknown[]` in the search response, so those entries are localized defensively and passed through unchanged when the shape does not match.
- `graphqlBCProxy` now sends `Accept-Language` too, so the headless proxy path gets translated data as well.

Refs LOCAL-3505

## Rollout/Rollback

Gated by the existing `LOCAL-3280.B2B_email_multi_language` flag via `getStorefrontLanguageCode`, and it is a no-op for shoppers on the store's default locale, so no new flag is introduced. Behavior on the default locale is unchanged.

Failures are contained: a storefront GraphQL error or timeout is logged through `b2bLogger` and the untranslated B2B results are returned, so product search keeps working. Rollback is a revert of this commit; there is no state to migrate.

Risk to watch is the extra storefront GraphQL round trip per product search on non-default locales, one request per 50 products.

## Testing

Unit tests in `apps/storefront/src/shared/service/b2b/graphql/localizedProductSearch.test.ts` cover the translated name, the locale-prefixed URL, option/modifier/variant label translation, products missing from the storefront response, a failing storefront request, batching at 50, the default locale and the flag being off.

```
yarn vitest run src/shared/service src/hooks
Test Files  11 passed (11)
     Tests  70 passed (70)
```

`yarn tsc --noEmit` is clean. `src/pages/QuickOrder`, `src/pages/ShoppingListDetails` and `src/pages/quote` pass; the 2 failures in `src/pages/QuoteDraft/index.test.tsx` also fail on a clean `main` and are unrelated.

Manual test: on a store with a non-default locale configured and the multi-language flag on, browse the buyer portal under the locale subfolder (for example `/fr/`), then search products in quick order and add a product with options to a shopping list. Product names, option names and option value labels should render in the storefront language, prices and stock should match the default-locale values, and clicking a product should land on the locale-prefixed storefront URL. On the default locale, confirm no `LocalizedProducts` request is issued.

[LOCAL-3505]: https://bigcommercecloud.atlassian.net/browse/LOCAL-3505?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ