### PR TITLE
LOCAL-3421: Keep the active locale when following a product link

### DIFF
--- a/apps/storefront/src/components/B3ProductList.tsx
+++ b/apps/storefront/src/components/B3ProductList.tsx
@@ -7,6 +7,7 @@ import BackorderMessage from '@/components/BackorderMessage';
 import { PRODUCT_DEFAULT_IMAGE } from '@/constants';
 import { useMobile } from '@/hooks/useMobile';
 import { useB3Lang } from '@/lib/lang';
+import { withActiveLocaleUrl } from '@/lib/lang/withActiveLocaleUrl';
 import type { CatalogQuickVariantSku } from '@/shared/service/b2b/graphql/product';
 import { useAppSelector } from '@/store';
 import { currencyFormat, ordersCurrencyFormat } from '@/utils/b3CurrencyFormat';
@@ -544,7 +545,7 @@ export function B3ProductList<T extends ProductItem>(props: ProductProps<T>) {
                       } = window;
 
                       if (product?.productUrl)
-                        window.location.href = `${origin}${product?.productUrl}`;
+                        window.location.href = `${origin}${withActiveLocaleUrl(product.productUrl)}`;
                     }
                   }}
                   sx={{

--- a/apps/storefront/src/lib/lang/withActiveLocaleUrl.test.ts
+++ b/apps/storefront/src/lib/lang/withActiveLocaleUrl.test.ts
@@ -1,0 +1,70 @@
+import { store } from '@/store';
+
+import { withActiveLocaleUrl } from './withActiveLocaleUrl';
+
+const LOCALES = [
+  { code: 'fr', isDefault: true, fullPath: 'https://store.example.com/' },
+  { code: 'es', isDefault: false, fullPath: 'https://store.example.com/es' },
+];
+
+const mockState = (locales = LOCALES) =>
+  vi
+    .spyOn(store, 'getState')
+    .mockReturnValue({ global: { locales } } as unknown as ReturnType<typeof store.getState>);
+
+const setHref = (href: string) => {
+  Object.defineProperty(window, 'location', { value: { href }, writable: true });
+};
+
+describe('withActiveLocaleUrl', () => {
+  const originalLocation = window.location;
+
+  afterEach(() => {
+    Object.defineProperty(window, 'location', { value: originalLocation, writable: true });
+    vi.restoreAllMocks();
+  });
+
+  it('prefixes the path with the active non-default locale subfolder', () => {
+    setHref('https://store.example.com/es/some-page');
+    mockState();
+
+    expect(withActiveLocaleUrl('/producto-de-localizacion-es/')).toBe(
+      '/es/producto-de-localizacion-es/',
+    );
+  });
+
+  it('returns the path unchanged on the default locale', () => {
+    setHref('https://store.example.com/some-page');
+    mockState();
+
+    expect(withActiveLocaleUrl('/test-localization-product/')).toBe('/test-localization-product/');
+  });
+
+  it('returns the path unchanged when no locale matches the current URL', () => {
+    setHref('https://other-store.example.com/');
+    mockState();
+
+    expect(withActiveLocaleUrl('/some-product/')).toBe('/some-product/');
+  });
+
+  it('adds a leading slash if the path is missing one', () => {
+    setHref('https://store.example.com/es/some-page');
+    mockState();
+
+    expect(withActiveLocaleUrl('producto/')).toBe('/es/producto/');
+  });
+
+  it('does not double-prefix a path that already carries the locale subfolder', () => {
+    setHref('https://store.example.com/es/some-page');
+    mockState();
+
+    expect(withActiveLocaleUrl('/es/producto/')).toBe('/es/producto/');
+  });
+
+  it('returns an empty path unchanged', () => {
+    setHref('https://store.example.com/es/some-page');
+    mockState();
+
+    expect(withActiveLocaleUrl('')).toBe('');
+  });
+});

--- a/apps/storefront/src/lib/lang/withActiveLocaleUrl.ts
+++ b/apps/storefront/src/lib/lang/withActiveLocaleUrl.ts
@@ -1,0 +1,40 @@
+import { store } from '@/store';
+
+import { getActiveLocale } from './getActiveLocale';
+
+/**
+ * Prefix a canonical, locale-agnostic storefront path (e.g. a product `productUrl` returned by
+ * `productsSearch`) with the shopper's active locale subfolder, so following it keeps them on the
+ * locale they are currently browsing instead of dropping them back to the store's default
+ * language.
+ *
+ * B2B GraphQL's `productUrl`/`path` is always the canonical path with no locale subfolder (that is
+ * true regardless of the `Accept-Language` used to localize the product's `name`), so every
+ * consumer that navigates to it must re-apply the subfolder itself; this is not something the
+ * backend can generally do without knowing whether the requested locale is the channel default
+ * (which has no subfolder at all).
+ */
+export const withActiveLocaleUrl = (path: string): string => {
+  const { locales } = store.getState().global;
+  const activeLocale = getActiveLocale(locales);
+
+  if (!activeLocale || activeLocale.isDefault || !path) {
+    return path;
+  }
+
+  let subfolder: string;
+
+  try {
+    subfolder = new URL(activeLocale.fullPath).pathname;
+  } catch {
+    return path;
+  }
+
+  subfolder = subfolder.replace(/\/$/, '');
+
+  if (!subfolder || path.startsWith(subfolder)) {
+    return path;
+  }
+
+  return `${subfolder}${path.startsWith('/') ? path : `/${path}`}`;
+};

--- a/apps/storefront/src/pages/ShoppingListDetails/components/ShoppingDetailCard.tsx
+++ b/apps/storefront/src/pages/ShoppingListDetails/components/ShoppingDetailCard.tsx
@@ -6,6 +6,7 @@ import BackorderMessage from '@/components/BackorderMessage';
 import PicklistBackorderMessages from '@/components/PicklistBackorderMessages';
 import { PRODUCT_DEFAULT_IMAGE } from '@/constants';
 import { useB3Lang } from '@/lib/lang';
+import { withActiveLocaleUrl } from '@/lib/lang/withActiveLocaleUrl';
 import type { CatalogQuickVariantSku, ProductSearch } from '@/shared/service/b2b/graphql/product';
 import b2bGetVariantImageByVariantInfo from '@/utils/b2bGetVariantImageByVariantInfo';
 import { currencyFormat } from '@/utils/b3CurrencyFormat';
@@ -155,7 +156,7 @@ function ShoppingDetailCard(props: ShoppingDetailCardProps) {
                 location: { origin },
               } = window;
 
-              window.location.href = `${origin}${productUrl}`;
+              window.location.href = `${origin}${withActiveLocaleUrl(productUrl)}`;
             }}
             sx={{
               cursor: 'pointer',

--- a/apps/storefront/src/pages/ShoppingListDetails/components/ShoppingDetailTable.tsx
+++ b/apps/storefront/src/pages/ShoppingListDetails/components/ShoppingDetailTable.tsx
@@ -28,6 +28,7 @@ import { useMobile } from '@/hooks/useMobile';
 import { usePicklistInventory } from '@/hooks/usePicklistInventory';
 import { useSort } from '@/hooks/useSort';
 import { useB3Lang } from '@/lib/lang';
+import { withActiveLocaleUrl } from '@/lib/lang/withActiveLocaleUrl';
 import { updateB2BShoppingListsItem, updateBcShoppingListsItem } from '@/shared/service/b2b';
 import {
   type CatalogQuickVariantSku,
@@ -615,7 +616,7 @@ function ShoppingDetailTable(props: ShoppingDetailTableProps, ref: Ref<unknown>)
                     location: { origin },
                   } = window;
 
-                  window.location.href = `${origin}${row.productUrl}`;
+                  window.location.href = `${origin}${withActiveLocaleUrl(row.productUrl)}`;
                 }}
                 sx={{
                   cursor: 'pointer',

--- a/apps/storefront/src/pages/quote/components/QuoteDetailTable.tsx
+++ b/apps/storefront/src/pages/quote/components/QuoteDetailTable.tsx
@@ -7,6 +7,7 @@ import { B3PaginationTable, GetRequestList } from '@/components/table/B3Paginati
 import { TableColumnItem } from '@/components/table/B3Table';
 import { PRODUCT_DEFAULT_IMAGE } from '@/constants';
 import { useB3Lang } from '@/lib/lang';
+import { withActiveLocaleUrl } from '@/lib/lang/withActiveLocaleUrl';
 import { useAppSelector } from '@/store';
 import { currencyFormatConvert } from '@/utils/b3CurrencyFormat';
 import { getBCPrice, getDisplayPrice } from '@/utils/b3Product/b3Product';
@@ -195,7 +196,7 @@ function QuoteDetailTable(props: ShoppingDetailTableProps, ref: Ref<unknown>) {
                     location: { origin },
                   } = window;
                   if (productUrl) {
-                    window.location.href = `${origin}${productUrl}`;
+                    window.location.href = `${origin}${withActiveLocaleUrl(productUrl)}`;
                   }
                 }}
                 sx={{

--- a/apps/storefront/src/pages/quote/components/QuoteDetailTableCard.tsx
+++ b/apps/storefront/src/pages/quote/components/QuoteDetailTableCard.tsx
@@ -5,6 +5,7 @@ import PicklistBackorderMessages from '@/components/PicklistBackorderMessages';
 import { PRODUCT_DEFAULT_IMAGE } from '@/constants';
 import { useBackorderStorefrontMessaging } from '@/hooks/useBackorderStorefrontMessaging';
 import { useB3Lang } from '@/lib/lang';
+import { withActiveLocaleUrl } from '@/lib/lang/withActiveLocaleUrl';
 import { type ProductSearch } from '@/shared/service/b2b/graphql/product';
 import { useAppSelector } from '@/store';
 import { DisplayCurrency } from '@/types/currency';
@@ -125,7 +126,7 @@ function QuoteDetailTableCard(props: QuoteTableCardProps) {
               } = window;
 
               if (productUrl) {
-                window.location.href = `${origin}${productUrl}`;
+                window.location.href = `${origin}${withActiveLocaleUrl(productUrl)}`;
               }
             }}
             sx={{

--- a/apps/storefront/src/pages/quote/components/QuoteTable.tsx
+++ b/apps/storefront/src/pages/quote/components/QuoteTable.tsx
@@ -10,6 +10,7 @@ import PaginationTable from '@/components/table/PaginationTable';
 import { PRODUCT_DEFAULT_IMAGE } from '@/constants';
 import { useBackorderStorefrontMessaging } from '@/hooks/useBackorderStorefrontMessaging';
 import { LangFormatFunction, useB3Lang } from '@/lib/lang';
+import { withActiveLocaleUrl } from '@/lib/lang/withActiveLocaleUrl';
 import { deleteProductFromDraftQuoteList, setDraftProduct, useAppDispatch } from '@/store';
 import { Product } from '@/types';
 import { QuoteItem } from '@/types/quotes';
@@ -343,7 +344,7 @@ function QuoteTable({ total, items, updateSummary }: QuoteTableProps) {
                 color="#212121"
                 onClick={() => {
                   if (productUrl) {
-                    window.location.href = `${window.location.origin}${productUrl}`;
+                    window.location.href = `${window.location.origin}${withActiveLocaleUrl(productUrl)}`;
                   }
                 }}
                 sx={{

--- a/apps/storefront/src/pages/quote/components/QuoteTableCard.tsx
+++ b/apps/storefront/src/pages/quote/components/QuoteTableCard.tsx
@@ -5,6 +5,7 @@ import BackorderMessage from '@/components/BackorderMessage';
 import PicklistBackorderMessages from '@/components/PicklistBackorderMessages';
 import { PRODUCT_DEFAULT_IMAGE } from '@/constants';
 import { useB3Lang } from '@/lib/lang';
+import { withActiveLocaleUrl } from '@/lib/lang/withActiveLocaleUrl';
 import { type ProductSearch } from '@/shared/service/b2b/graphql/product';
 import { Product } from '@/types';
 import { QuoteItem } from '@/types/quotes';
@@ -128,7 +129,7 @@ function QuoteTableCard({
             color="#212121"
             onClick={() => {
               if (productUrl) {
-                window.location.href = `${window.location.origin}${productUrl}`;
+                window.location.href = `${window.location.origin}${withActiveLocaleUrl(productUrl)}`;
               }
             }}
             sx={{


### PR DESCRIPTION
Jira: [LOCAL-3421](https://bigcommercecloud.atlassian.net/browse/LOCAL-3421)

## What/Why?

Found while testing LOCAL-3421 product name translation: clicking a product from Quick order search, a shopping list, or a quote landed the shopper on the default-locale storefront page instead of the locale they were browsing in. Searching from `/es` and clicking a result navigated to `/product-slug/`, not `/es/product-slug/`.

B2B GraphQL's `productUrl`/`path` is always the canonical path with no locale subfolder, regardless of the `Accept-Language` used to localize the product's `name` (true for both the storefront-search-backed value and the by-id-lookup overlay added in b2b-edition-api [#7175](https://github.com/bigcommerce/b2b-edition-api/pull/7175)). Every place that builds `window.location.href` from it assumed the raw value was already a full, locale-correct path — seven of them:

- `components/B3ProductList.tsx` (Quick order search results)
- `pages/ShoppingListDetails/components/ShoppingDetailTable.tsx` and `ShoppingDetailCard.tsx`
- `pages/quote/components/QuoteTable.tsx`, `QuoteTableCard.tsx`, `QuoteDetailTable.tsx`, `QuoteDetailTableCard.tsx`

Added `withActiveLocaleUrl(path)` (`lib/lang/withActiveLocaleUrl.ts`), which prefixes the shopper's active locale subfolder onto a canonical path, resolved the same way `getStorefrontLanguageCode` already does (via `getActiveLocale`). No-op on the default locale (which has no subfolder) or when the path already carries one.

**Why fix this in the frontend rather than each backend resolver:** the frontend already holds the active-locale-vs-default state needed to decide whether to prefix at all (`store.getState().global.locales`, with `isDefault` flags). Every backend resolver that returns a `productUrl` (shopping lists, quotes, Quick order search, CSV upload, `productsLoad`) would need its own extra lookup to know the same thing, and would still need this same information to be told to the frontend to decide default-vs-not per shopper — duplicating the same logic 5+ times server-side instead of once here.

## Rollout/Rollback

No feature flag or experiment. Pure client-side navigation fix, no backend/data changes. Revert to restore the previous (locale-losing) behavior.

## Testing

New unit tests in `withActiveLocaleUrl.test.ts` (6 cases: prefixes a non-default locale, no-ops on default, no-ops when no locale matches the URL, adds a leading slash if missing, doesn't double-prefix an already-prefixed path, handles an empty path).

Existing tests for the touched components still pass unmodified: `QuoteTable.test.tsx`, `QuoteDetailTable.test.tsx`, `ShoppingListDetails/index.test.tsx`, `index.quickadd.test.tsx` — 74 tests, all green.

`npx eslint` and `npx tsc --noEmit` clean on all changed/added files.

Refs LOCAL-3421

[LOCAL-3421]: https://bigcommercecloud.atlassian.net/browse/LOCAL-3421?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ