### PR TITLE
chore(docs): B2B-5609 update setup docs - fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,14 @@ If you do not have access to the B2B edition app please reach out to your accoun
 After installing the B2B Edition App, go to the app's dashboard and select the 'Storefronts' section.
 
 <img width="200" alt="b2bNav" src="public/images/b2bNav.png">
+
+To enable the Multi-storefront feature on your local dev store, follow [Enable MSF in local dev CDVM](https://docs.dev.bigcommerce.net/domains/b2b/setup/cdvm/msf.html) — it covers both the BC-side store config flags and the B2B-side Django Admin toggle.
+
+> Alternative to the Talisman steps in the guide above:
+> - Log in at https://store-{storeHash}.store.bcdev/admin/staff with staff credentials
+> - Go to https://store-{storeHash}.store.bcdev/manage/ninja/msf → click "Enable all"
+> - Raise AdditionalStorefronts/BaseStorefronts via https://store-{storeHash}.store.bcdev/tools/assetsmanager.php
+> - Control Panel → Channels tab → "Enable storefront seats" → create additional storefronts
   
 ### Step 3: Enable B2B on Your Channel
 

--- a/docs/stencil.md
+++ b/docs/stencil.md
@@ -10,7 +10,7 @@
   - Delete the scripts: with the following names:
     - `B2BEdition Header Script`
     - `B2BEdition Footer Script`
-  - Add a the header script with the following values
+  - Add the header script with the following values
     - Name: `B2B Edition Header Script`
     - Location: `Header`
     - Pages: `All Pages`
@@ -36,7 +36,7 @@
 </script>
 <script type="module" src="http://localhost:3001/@vite/client"></script>
 ```
-  - Add a the footer script with the following values
+  - Add the footer script with the following values
     - Name: `B2B Edition Footer Script`
     - Location: `Footer`
     - Pages: `All Pages`
@@ -56,13 +56,13 @@
 ```
 
 3. Navigate to the B2B Edition App Dashboard and set the following values (not needed for single storefront):
-  - Global Config: In B2B Edition App dashboard -> Settings -> Buyer Portal for global config
+  - Global Config: In B2B Edition App dashboard -> Settings -> Buyer Portal, set the Buyer Portal type to `Custom` for global config
 ![Buyer portal type global settings](../public/images/buyer-portal-type-settings-global.png)
-  - Or B2B Edition App dashboard -> Storefront -> Desired channel -> Buyer Portal for specific channel config
-![Buyer portal type channel settings](../public/images/buyer-portal-type-settings-channel.png) [alt text](README.md)
+  - Or B2B Edition App dashboard -> Storefront -> Desired channel -> Buyer Portal for specific channel config; a channel left on its default inherits the global config
+![Buyer portal type channel settings](../public/images/buyer-portal-type-settings-channel.png)
 
 
-4. Visit the headless storefront and attempt to sign in.
+4. Visit the storefront and attempt to sign in.
 
 **FAQs:**
 - linters are not working: run `yarn prepare` first.


### PR DESCRIPTION
Jira: [B2B-5609](https://bigcommercecloud.atlassian.net/browse/B2B-5609)

## What/Why?

**docs/stencil.md:**
- Fixed minor typos and surfaced info upfront for clear context.

## Rollout/Rollback

Documentation-only; no code or runtime changes. Rollback is a straight revert.

## Testing

No testing needed. Fixed types

[B2B-5609]: https://bigcommercecloud.atlassian.net/browse/B2B-5609?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no application code, configuration, or runtime impact.
> 
> **Overview**
> **Documentation-only** updates to the Stencil local-dev guide (`docs/stencil.md`), with a trivial whitespace fix in `README.md`.
> 
> The Stencil guide now spells out setting **Buyer Portal type to `Custom`** in global settings, notes that **per-channel configs inherit the global default** when left unchanged, and fixes **header/footer script wording** (“Add the …” instead of “Add a the …”). A **broken channel-settings image link** (`[alt text](README.md)`) is removed so the screenshot renders correctly. Step 4 is broadened from “headless storefront” to **“storefront”** so single-channel Stencil setups match the instructions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ec10d022c997e685ee41f2834c2588537e68451. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->